### PR TITLE
fix: prevent TodoItem text clicks from toggling checkbox

### DIFF
--- a/e2e/todo-app.spec.ts
+++ b/e2e/todo-app.spec.ts
@@ -187,4 +187,44 @@ test.describe('TODO App E2E Tests', () => {
       // Skip this assertion when todos exist
     }
   })
+
+  test('should only toggle completion when clicking checkbox, not text', async ({
+    page,
+  }) => {
+    const todoText = `CheckboxOnlyTest-${Date.now()}-${Math.random().toString(36).substring(7)}`
+
+    // Add a new TODO
+    await page.getByPlaceholder('Enter a new todo...').fill(todoText)
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+
+    // Wait for the TODO to appear and get initial checkbox state
+    await page.waitForTimeout(1000) // Wait for creation
+    const todoCheckbox = page.getByRole('checkbox', { name: todoText })
+    await expect(todoCheckbox).toBeVisible()
+    await expect(todoCheckbox).not.toBeChecked()
+
+    // Test 1: Click the TODO text (not checkbox) and verify it does NOT toggle
+    const todoTextElement = page
+      .locator('div')
+      .filter({ hasText: new RegExp(`^${todoText}$`) })
+      .first()
+    await expect(todoTextElement).toBeVisible()
+    await todoTextElement.click()
+    await page.waitForTimeout(500)
+
+    // Checkbox should STILL be unchecked (clicking text did nothing)
+    await expect(todoCheckbox).not.toBeChecked()
+
+    // Test 2: Now click the actual checkbox to toggle it
+    await todoCheckbox.click()
+    await page.waitForTimeout(1000) // Wait for state update
+    await expect(todoCheckbox).toBeChecked()
+
+    // Test 3: Click the TODO text again while checked - verify it does NOT toggle
+    await todoTextElement.click()
+    await page.waitForTimeout(500)
+
+    // Checkbox should STILL be checked (clicking text did nothing)
+    await expect(todoCheckbox).toBeChecked()
+  })
 })

--- a/src/app/home/_components/TodoItem.tsx
+++ b/src/app/home/_components/TodoItem.tsx
@@ -49,18 +49,18 @@ export function TodoItem({
           checked={todo.completed}
           onCheckedChange={() => onToggleComplete(todo.id)}
           id={`todo-${todo.id}`}
+          aria-label={todo.text}
         />
         <div className="min-w-0 flex-1">
-          <label
-            htmlFor={`todo-${todo.id}`}
-            className={`block cursor-pointer ${
+          <div
+            className={`block ${
               todo.completed
                 ? 'text-muted-foreground line-through'
                 : 'text-foreground'
             }`}
           >
             {todo.text}
-          </label>
+          </div>
           <p className="text-muted-foreground mt-1 text-xs">
             {todo.createdAt.toLocaleDateString('en-US')}
           </p>


### PR DESCRIPTION
## 🐛 Problem

Previously, clicking anywhere on the TODO text would toggle the completion status due to the `<label>` element with `htmlFor` attribute being associated with the checkbox. This caused accidental toggles when users tried to select text or click near the TODO item.

## ✅ Solution

- **Removed label association**: Changed `<label htmlFor={...}>` to `<div>` to make text non-interactive
- **Maintained accessibility**: Added `aria-label={todo.text}` to the checkbox for screen readers
- **Preserved styling**: Kept all visual styling (line-through, colors) intact
- **Added E2E test**: Created comprehensive test to verify checkbox-only toggle behavior

## 🧪 Testing

- ✅ TypeScript: No errors
- ✅ ESLint: No warnings (max-warnings 0)  
- ✅ Unit Tests: 12/12 passed
- ✅ Build: Successful
- ✅ E2E Test: Created test verifying text clicks don't toggle checkbox

## 📝 Changes

**Before:**
- Clicking checkbox OR text → toggles completion
- Label wraps text with `htmlFor` attribute

**After:**
- Clicking checkbox only → toggles completion ✅
- Text is non-interactive but maintains visual style
- Accessibility preserved with `aria-label`

## 🎯 Impact

- Improves UX by preventing accidental toggles when selecting text
- Maintains full keyboard accessibility
- Preserves screen reader compatibility
- Follows best practices for task list interfaces
