### PR TITLE
chore: unify environment variables format in e2e.electron.yml

### DIFF
--- a/.github/workflows/e2e.electron.yml
+++ b/.github/workflows/e2e.electron.yml
@@ -19,35 +19,18 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Set environment variables 🌍
-        env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
-          NEXT_PUBLIC_CLERK_SIGN_IN_URL: ${{ secrets.NEXT_PUBLIC_CLERK_SIGN_IN_URL }}
-          NEXT_PUBLIC_CLERK_SIGN_UP_URL: ${{ secrets.NEXT_PUBLIC_CLERK_SIGN_UP_URL }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
-          POSTGRES_PRISMA_URL: ${{ secrets.POSTGRES_PRISMA_URL }}
-          E2E_CLERK_USER_USERNAME: ${{ secrets.E2E_CLERK_USER_USERNAME }}
-          E2E_CLERK_USER_PASSWORD: ${{ secrets.E2E_CLERK_USER_PASSWORD }}
-          E2E_CLERK_USER_EMAIL: ${{ secrets.E2E_CLERK_USER_EMAIL }}
         run: |
           touch .env
-          : "${CI:=true}"
-          : "${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:=pk_test_dummy}"
-          : "${NEXT_PUBLIC_CLERK_SIGN_IN_URL:=/login}"
-          : "${NEXT_PUBLIC_CLERK_SIGN_UP_URL:=/sign-up}"
-          : "${CLERK_SECRET_KEY:=sk_test_dummy}"
-          : "${WEBHOOK_SECRET:=whsec_dummy}"
-          : "${POSTGRES_PRISMA_URL:=postgresql://postgres:password@localhost:5432/corelive?schema=public}"
-          echo "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}" >> .env
-          echo "NEXT_PUBLIC_CLERK_SIGN_IN_URL=${NEXT_PUBLIC_CLERK_SIGN_IN_URL}" >> .env
-          echo "NEXT_PUBLIC_CLERK_SIGN_UP_URL=${NEXT_PUBLIC_CLERK_SIGN_UP_URL}" >> .env
+          echo "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}" >> .env
+          echo "NEXT_PUBLIC_CLERK_SIGN_IN_URL=${{ secrets.NEXT_PUBLIC_CLERK_SIGN_IN_URL }}" >> .env
+          echo "NEXT_PUBLIC_CLERK_SIGN_UP_URL=${{ secrets.NEXT_PUBLIC_CLERK_SIGN_UP_URL }}" >> .env
           echo "NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home" >> .env
-          echo "CLERK_SECRET_KEY=${CLERK_SECRET_KEY}" >> .env
-          echo "WEBHOOK_SECRET=${WEBHOOK_SECRET}" >> .env
-          echo "POSTGRES_PRISMA_URL=${POSTGRES_PRISMA_URL}" >> .env
-          echo "E2E_CLERK_USER_USERNAME=${E2E_CLERK_USER_USERNAME}" >> .env
-          echo "E2E_CLERK_USER_PASSWORD=${E2E_CLERK_USER_PASSWORD}" >> .env
-          echo "E2E_CLERK_USER_EMAIL=${E2E_CLERK_USER_EMAIL}" >> .env
+          echo "CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}" >> .env
+          echo "WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }}" >> .env
+          echo "POSTGRES_PRISMA_URL=${{ secrets.POSTGRES_PRISMA_URL }}" >> .env
+          echo "E2E_CLERK_USER_USERNAME=${{ secrets.E2E_CLERK_USER_USERNAME }}" >> .env
+          echo "E2E_CLERK_USER_PASSWORD=${{ secrets.E2E_CLERK_USER_PASSWORD }}" >> .env
+          echo "E2E_CLERK_USER_EMAIL=${{ secrets.E2E_CLERK_USER_EMAIL }}" >> .env
 
       - name: Start Postgres via Docker Compose 🐳
         run: |


### PR DESCRIPTION
## 変更内容

環境変数の書き方を統一しました。

### 変更点

- すべての環境変数参照を `${{ secrets.XXX }}` 形式に統一
- 不一貫なシェル変数構文（`${XXX}`）を削除
- 不要な `env` セクションとデフォルト値の割り当てを削除
- 環境設定ステップを簡潔化し、可読性を向上

### 理由

GitHub Actions ワークフローで複数の書き方が混在していたため、一つの統一された形式に統一することで、メンテナンス性と可読性を向上させます。