### PR TITLE
feat(category): enforce mandatory default category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ _trials/
 
 # Cursor
 .cursor
+.gstack/

--- a/e2e/web/category.spec.ts
+++ b/e2e/web/category.spec.ts
@@ -153,7 +153,7 @@ test.describe('Category Feature E2E Tests', () => {
   })
 
   test.describe('Category Sidebar', () => {
-    test('should display category sidebar with "All" item', async ({
+    test('should display category sidebar with General selected by default', async ({
       page,
     }) => {
       // Category section is visible in the app sidebar
@@ -163,8 +163,12 @@ test.describe('Category Feature E2E Tests', () => {
       // "Categories" group label should be present
       await expect(sidebar.getByText('Categories')).toBeVisible()
 
-      // "All" item should always be present
-      await expect(sidebar.getByText('All')).toBeVisible()
+      // General (default) category should be visible and active
+      await expect(sidebar.getByText('General')).toBeVisible()
+      const generalButton = sidebar
+        .locator('[data-slot="sidebar-menu-button"]')
+        .filter({ hasText: 'General' })
+      await expect(generalButton).toHaveAttribute('data-active', 'true')
 
       // "Add category" button (+ icon) should be visible
       await expect(
@@ -180,62 +184,46 @@ test.describe('Category Feature E2E Tests', () => {
 
     test('should filter todos by category selection', async ({ page }) => {
       const categoryName = uniqueName('CatFilter')
-      const todoWithCategory = uniqueName('TodoCat')
-      const todoWithoutCategory = uniqueName('TodoNoCat')
+      const todoInGeneral = uniqueName('TodoGen')
+      const todoInCategory = uniqueName('TodoCat')
 
-      // Step 1: Create a category
       const sidebar = getSidebar(page)
-      await createCategory(page, sidebar, categoryName)
 
-      // Step 2: Select the new category in sidebar
-      // Wait for real server ID (optimistic IDs are negative) before clicking
-      await selectCategory(page, sidebar, categoryName)
-
-      // Step 3: Add a todo (should be auto-assigned to the selected category)
-      await page.getByPlaceholder('Enter a new todo...').fill(todoWithCategory)
+      // Step 1: General is auto-selected on load — add a todo to General
+      await selectCategory(page, sidebar, 'General')
+      await page.getByPlaceholder('Enter a new todo...').fill(todoInGeneral)
       await page.getByRole('button', { name: 'Add', exact: true }).click()
-
-      // Wait for todo to appear with server-confirmed ID
-      const catTodoCheckbox = page.getByRole('checkbox', {
-        name: todoWithCategory,
-      })
-      await expect(catTodoCheckbox).toBeVisible({ timeout: 5000 })
-      await expect(catTodoCheckbox).toHaveAttribute('id', /^todo-[^-]/, {
-        timeout: 10000,
-      })
-
-      // Step 4: Switch to "All" view
-      await sidebar.getByText('All').click()
-      await page.waitForTimeout(500)
-
-      // Step 5: Add a todo without category (while "All" is selected)
-      await page
-        .getByPlaceholder('Enter a new todo...')
-        .fill(todoWithoutCategory)
-      await page.getByRole('button', { name: 'Add', exact: true }).click()
-
-      // Wait for the uncategorized todo to appear
-      const noCatTodoCheckbox = page.getByRole('checkbox', {
-        name: todoWithoutCategory,
-      })
-      await expect(noCatTodoCheckbox).toBeVisible({ timeout: 5000 })
-
-      // Step 6: Both todos should be visible in "All" view
-      await expect(catTodoCheckbox).toBeVisible()
-      await expect(noCatTodoCheckbox).toBeVisible()
-
-      // Step 7: Filter by the category
-      await sidebar.getByText(categoryName).click()
-      await page.waitForTimeout(1000)
-
-      // The categorized todo should still be visible
       await expect(
-        page.getByRole('checkbox', { name: todoWithCategory }),
+        page.getByRole('checkbox', { name: todoInGeneral }),
       ).toBeVisible({ timeout: 5000 })
 
-      // The uncategorized todo should NOT be visible
+      // Step 2: Create a new category and add a todo to it
+      await createCategory(page, sidebar, categoryName)
+      await selectCategory(page, sidebar, categoryName)
+      await page.getByPlaceholder('Enter a new todo...').fill(todoInCategory)
+      await page.getByRole('button', { name: 'Add', exact: true }).click()
       await expect(
-        page.getByRole('checkbox', { name: todoWithoutCategory }),
+        page.getByRole('checkbox', { name: todoInCategory }),
+      ).toBeVisible({ timeout: 5000 })
+
+      // Step 3: Filter by General — only General's todo should be visible
+      await selectCategory(page, sidebar, 'General')
+      await page.waitForTimeout(1000)
+      await expect(
+        page.getByRole('checkbox', { name: todoInGeneral }),
+      ).toBeVisible({ timeout: 5000 })
+      await expect(
+        page.getByRole('checkbox', { name: todoInCategory }),
+      ).not.toBeVisible({ timeout: 5000 })
+
+      // Step 4: Filter by the new category — only its todo should be visible
+      await selectCategory(page, sidebar, categoryName)
+      await page.waitForTimeout(1000)
+      await expect(
+        page.getByRole('checkbox', { name: todoInCategory }),
+      ).toBeVisible({ timeout: 5000 })
+      await expect(
+        page.getByRole('checkbox', { name: todoInGeneral }),
       ).not.toBeVisible({ timeout: 5000 })
     })
 
@@ -262,11 +250,7 @@ test.describe('Category Feature E2E Tests', () => {
         page.getByRole('checkbox', { name: todoText }),
       ).toHaveAttribute('id', /^todo-[^-]/, { timeout: 10000 })
 
-      // Switch to "All" view to see the category badge
-      await sidebar.getByText('All').click()
-      await page.waitForTimeout(1000)
-
-      // The todo item should display the category name
+      // The todo item should display the category name badge
       // TodoItem renders categoryName in a <span> near the date
       const todoItem = page.locator('.rounded-lg.border').filter({
         has: page.getByRole('checkbox', { name: todoText }),
@@ -331,23 +315,23 @@ test.describe('Category Feature E2E Tests', () => {
       const sidebar = getSidebar(page)
       await createCategory(page, sidebar, categoryName)
 
-      // "All" should be active by default
-      const allButton = sidebar
+      // General should be active by default
+      const generalButton = sidebar
         .locator('[data-slot="sidebar-menu-button"]')
-        .filter({ hasText: 'All' })
-      await expect(allButton).toHaveAttribute('data-active', 'true')
+        .filter({ hasText: 'General' })
+      await expect(generalButton).toHaveAttribute('data-active', 'true')
 
-      // Click category — it becomes active, "All" becomes inactive
+      // Click category — it becomes active, General becomes inactive
       await selectCategory(page, sidebar, categoryName)
       const categoryButton = sidebar
         .locator('[data-slot="sidebar-menu-button"]')
         .filter({ hasText: categoryName })
       await expect(categoryButton).toHaveAttribute('data-active', 'true')
-      await expect(allButton).not.toHaveAttribute('data-active', 'true')
+      await expect(generalButton).not.toHaveAttribute('data-active', 'true')
 
-      // Click "All" — it becomes active again
-      await sidebar.getByText('All').click()
-      await expect(allButton).toHaveAttribute('data-active', 'true')
+      // Click General — it becomes active again
+      await selectCategory(page, sidebar, 'General')
+      await expect(generalButton).toHaveAttribute('data-active', 'true')
       await expect(categoryButton).not.toHaveAttribute('data-active', 'true')
     })
 
@@ -592,17 +576,13 @@ test.describe('Category Feature E2E Tests', () => {
       await expect(sidebar.getByText('General')).toBeVisible({ timeout: 15000 })
     })
 
-    test('should auto-assign new todo to General when no category selected', async ({
+    test('should auto-assign new todo to General by default', async ({
       page,
     }) => {
       const todoText = uniqueName('TodoGen')
       const sidebar = getSidebar(page)
 
-      // Ensure "All" is selected (default state)
-      await sidebar.getByText('All').click()
-      await page.waitForTimeout(500)
-
-      // Add a todo without selecting any specific category
+      // General is auto-selected on page load — add a todo directly
       await page.getByPlaceholder('Enter a new todo...').fill(todoText)
       await page.getByRole('button', { name: 'Add', exact: true }).click()
 
@@ -646,8 +626,8 @@ test.describe('Category Feature E2E Tests', () => {
         timeout: 5000,
       })
 
-      // Switch to "All" view before deleting
-      await sidebar.getByText('All').click()
+      // Switch to General before deleting the category
+      await selectCategory(page, sidebar, 'General')
       await page.waitForTimeout(500)
 
       // Delete the category
@@ -678,23 +658,18 @@ test.describe('Category Feature E2E Tests', () => {
         timeout: 5000,
       })
 
-      // The todo should still exist in "All" view
+      // The todo should be reassigned to General and visible
+      await selectCategory(page, sidebar, 'General')
+      await page.waitForTimeout(1000)
       await expect(page.getByRole('checkbox', { name: todoText })).toBeVisible({
         timeout: 10000,
       })
 
-      // The todo should now show "General" as its category (reassigned from deleted category)
+      // The todo should show "General" as its category (reassigned from deleted category)
       const todoItem = page.locator('.rounded-lg.border').filter({
         has: page.getByRole('checkbox', { name: todoText }),
       })
       await expect(todoItem.getByText('General')).toBeVisible({
-        timeout: 5000,
-      })
-
-      // Filter by General — the todo should be visible
-      await sidebar.getByText('General').click()
-      await page.waitForTimeout(1000)
-      await expect(page.getByRole('checkbox', { name: todoText })).toBeVisible({
         timeout: 5000,
       })
     })
@@ -739,7 +714,7 @@ test.describe('Category Feature E2E Tests', () => {
       // Wait for page to fully load before interacting with todo input
       await page.waitForLoadState('networkidle')
 
-      // Create a todo to ensure at least one pending task exists
+      // General is auto-selected — create a todo to ensure at least one pending task
       const todoInput = page.getByPlaceholder('Enter a new todo...')
       await expect(todoInput).toBeVisible({ timeout: 10000 })
       await todoInput.fill(todoText)
@@ -748,15 +723,15 @@ test.describe('Category Feature E2E Tests', () => {
         timeout: 10000,
       })
 
-      // The "All" item should show a count badge
-      const allItem = sidebar
+      // General should show a count badge
+      const generalItem = sidebar
         .locator('[data-slot="sidebar-menu-item"]')
-        .filter({ hasText: 'All' })
+        .filter({ hasText: 'General' })
         .first()
 
       // Should have a badge with a numeric count
       await expect(
-        allItem.locator('[data-slot="sidebar-menu-badge"]'),
+        generalItem.locator('[data-slot="sidebar-menu-badge"]'),
       ).toBeVisible({ timeout: 10000 })
     })
 
@@ -776,8 +751,8 @@ test.describe('Category Feature E2E Tests', () => {
         timeout: 5000,
       })
 
-      // Switch to "All" view first
-      await sidebar.getByText('All').click()
+      // Switch to General before deleting the category
+      await selectCategory(page, sidebar, 'General')
       await page.waitForTimeout(500)
 
       // Delete the category (openManageDialog waits for real server IDs)
@@ -813,7 +788,9 @@ test.describe('Category Feature E2E Tests', () => {
         timeout: 5000,
       })
 
-      // The todo should still exist (now reassigned to General) in "All" view
+      // The todo should still exist (now reassigned to General)
+      await selectCategory(page, sidebar, 'General')
+      await page.waitForTimeout(1000)
       await expect(page.getByRole('checkbox', { name: todoText })).toBeVisible({
         timeout: 10000,
       })

--- a/prisma/migrations/20260413175551_make_categoryid_not_null/migration.sql
+++ b/prisma/migrations/20260413175551_make_categoryid_not_null/migration.sql
@@ -26,6 +26,27 @@ WHERE comp."categoryId" IS NULL
   AND c."userId" = comp."userId"
   AND c."isDefault" = true;
 
+-- Guard: abort if any user with NULL categoryId has no default category
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      SELECT DISTINCT "userId" FROM "Todo" WHERE "categoryId" IS NULL
+      UNION
+      SELECT DISTINCT "userId" FROM "Completed" WHERE "categoryId" IS NULL
+    ) u
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM "Category" c
+      WHERE c."userId" = u."userId"
+        AND c."isDefault" = true
+    )
+  ) THEN
+    RAISE EXCEPTION 'Cannot set categoryId NOT NULL: some users have NULL categoryId but no default category';
+  END IF;
+END $$;
+
 -- AlterTable
 ALTER TABLE "Completed" ALTER COLUMN "categoryId" SET NOT NULL;
 

--- a/prisma/migrations/20260413175551_make_categoryid_not_null/migration.sql
+++ b/prisma/migrations/20260413175551_make_categoryid_not_null/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - Made the column `categoryId` on table `Completed` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `categoryId` on table `Todo` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Completed" DROP CONSTRAINT "Completed_categoryId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Todo" DROP CONSTRAINT "Todo_categoryId_fkey";
+
+-- Backfill: Assign any remaining NULL categoryId rows to their user's default category
+UPDATE "Todo" t
+SET "categoryId" = c.id
+FROM "Category" c
+WHERE t."categoryId" IS NULL
+  AND c."userId" = t."userId"
+  AND c."isDefault" = true;
+
+UPDATE "Completed" comp
+SET "categoryId" = c.id
+FROM "Category" c
+WHERE comp."categoryId" IS NULL
+  AND c."userId" = comp."userId"
+  AND c."isDefault" = true;
+
+-- AlterTable
+ALTER TABLE "Completed" ALTER COLUMN "categoryId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Todo" ALTER COLUMN "categoryId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Completed" ADD CONSTRAINT "Completed_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Todo" ADD CONSTRAINT "Todo_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,15 +14,15 @@ datasource db {
 }
 
 model Completed {
-  id         Int       @id @default(autoincrement())
-  archived   Boolean   @default(false)
-  title      String    @db.VarChar(255)
-  user       User      @relation(fields: [userId], references: [id])
+  id         Int      @id @default(autoincrement())
+  archived   Boolean  @default(false)
+  title      String   @db.VarChar(255)
+  user       User     @relation(fields: [userId], references: [id])
   userId     Int
-  category   Category? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
-  categoryId Int?
-  createdAt  DateTime  @default(now())
-  updatedAt  DateTime  @updatedAt
+  category   Category @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  categoryId Int
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
   @@index([categoryId])
 }
@@ -57,17 +57,17 @@ model User {
 }
 
 model Todo {
-  id         Int       @id @default(autoincrement())
-  text       String    @db.VarChar(255)
-  completed  Boolean   @default(false)
-  notes      String?   @db.Text
-  order      Int?      // Sort order for drag-and-drop reordering (nullable for backwards compatibility)
-  user       User      @relation(fields: [userId], references: [id])
+  id         Int      @id @default(autoincrement())
+  text       String   @db.VarChar(255)
+  completed  Boolean  @default(false)
+  notes      String?  @db.Text
+  order      Int?     // Sort order for drag-and-drop reordering (nullable for backwards compatibility)
+  user       User     @relation(fields: [userId], references: [id])
   userId     Int
-  category   Category? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
-  categoryId Int?
-  createdAt  DateTime  @default(now())
-  updatedAt  DateTime  @updatedAt
+  category   Category @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  categoryId Int
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
   @@index([categoryId])
 }

--- a/src/app/home/_components/AddTodoForm.tsx
+++ b/src/app/home/_components/AddTodoForm.tsx
@@ -32,9 +32,11 @@ type TodoFormValues = z.infer<typeof todoFormSchema>
 
 interface AddTodoFormProps {
   onAddTodo: (text: string, notes?: string) => void
+  /** Disables the form (e.g. while category selection is loading). */
+  disabled?: boolean
 }
 
-export function AddTodoForm({ onAddTodo }: AddTodoFormProps) {
+export function AddTodoForm({ onAddTodo, disabled }: AddTodoFormProps) {
   const [isNotesOpen, setIsNotesOpen] = useState(false)
 
   const form = useForm<TodoFormValues>({
@@ -95,7 +97,9 @@ export function AddTodoForm({ onAddTodo }: AddTodoFormProps) {
               <Button
                 type="submit"
                 disabled={
-                  !form.formState.isValid || form.formState.isSubmitting
+                  disabled ||
+                  !form.formState.isValid ||
+                  form.formState.isSubmitting
                 }
               >
                 <Plus className="h-4 w-4" />

--- a/src/app/home/_components/AddTodoForm.tsx
+++ b/src/app/home/_components/AddTodoForm.tsx
@@ -31,15 +31,10 @@ const todoFormSchema = z.object({
 type TodoFormValues = z.infer<typeof todoFormSchema>
 
 interface AddTodoFormProps {
-  onAddTodo: (text: string, notes?: string, categoryId?: number | null) => void
-  /** Category ID to auto-assign to new todos (from sidebar selection) */
-  selectedCategoryId?: number | null
+  onAddTodo: (text: string, notes?: string) => void
 }
 
-export function AddTodoForm({
-  onAddTodo,
-  selectedCategoryId,
-}: AddTodoFormProps) {
+export function AddTodoForm({ onAddTodo }: AddTodoFormProps) {
   const [isNotesOpen, setIsNotesOpen] = useState(false)
 
   const form = useForm<TodoFormValues>({
@@ -51,7 +46,7 @@ export function AddTodoForm({
   })
 
   const handleSubmit = (values: TodoFormValues) => {
-    onAddTodo(values.text, values.notes || undefined, selectedCategoryId)
+    onAddTodo(values.text, values.notes || undefined)
     form.reset()
     setIsNotesOpen(false)
   }

--- a/src/app/home/_components/Category.tsx
+++ b/src/app/home/_components/Category.tsx
@@ -24,7 +24,10 @@ import {
 } from '@/components/ui/sidebar'
 import { useCategoryMutations } from '@/hooks/useCategoryMutations'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
-import { useSelectedCategory } from '@/hooks/useSelectedCategory'
+import {
+  useAutoSelectDefaultCategory,
+  useSelectedCategory,
+} from '@/hooks/useSelectedCategory'
 import { getColorDotClass } from '@/lib/category-colors'
 import { subscribeToCategorySync } from '@/lib/category-sync-channel'
 import { orpc } from '@/lib/orpc/client-query'
@@ -69,14 +72,11 @@ export function Category({
   const categories: CategoryWithCount[] = data?.categories ?? []
 
   // Auto-select the default (General) category when none is selected
-  useEffect(() => {
-    if (selectedCategoryId === null && categories.length > 0) {
-      const defaultCategory = categories.find((c) => c.isDefault)
-      if (defaultCategory) {
-        setSelectedCategoryId(defaultCategory.id)
-      }
-    }
-  }, [selectedCategoryId, categories, setSelectedCategoryId])
+  useAutoSelectDefaultCategory(
+    selectedCategoryId,
+    setSelectedCategoryId,
+    categories,
+  )
 
   // Cross-tab sync for categories
   useEffect(() => {

--- a/src/app/home/_components/Category.tsx
+++ b/src/app/home/_components/Category.tsx
@@ -36,7 +36,8 @@ import {
 
 /**
  * Category section for the app Sidebar.
- * Displays "All" + user categories with color dots and pending todo counts.
+ * Displays user categories with color dots and pending todo counts.
+ * Auto-selects the default (General) category when none is selected.
  * Uses shadcn Sidebar primitives (SidebarMenu, SidebarMenuBadge, etc.).
  *
  * @param onOpenManageAction - Opens the category management dialog (Next.js: `*Action` suffix for callable props)
@@ -67,10 +68,15 @@ export function Category({
   })
   const categories: CategoryWithCount[] = data?.categories ?? []
 
-  // Total pending = categorized + uncategorized
-  const totalPendingCount =
-    categories.reduce((sum, cat) => sum + cat._count.todos, 0) +
-    (data?.uncategorizedCount ?? 0)
+  // Auto-select the default (General) category when none is selected
+  useEffect(() => {
+    if (selectedCategoryId === null && categories.length > 0) {
+      const defaultCategory = categories.find((c) => c.isDefault)
+      if (defaultCategory) {
+        setSelectedCategoryId(defaultCategory.id)
+      }
+    }
+  }, [selectedCategoryId, categories, setSelectedCategoryId])
 
   // Cross-tab sync for categories
   useEffect(() => {
@@ -83,9 +89,9 @@ export function Category({
 
   /**
    * Handles selecting a category and closing mobile sidebar.
-   * @param categoryId - Category ID to select, or null for "All"
+   * @param categoryId - Category ID to select.
    */
-  const handleSelect = (categoryId: number | null) => {
+  const handleSelect = (categoryId: number) => {
     setSelectedCategoryId(categoryId)
     if (isMobile) {
       setOpenMobile(false)
@@ -166,20 +172,6 @@ export function Category({
       </Popover>
       <SidebarGroupContent>
         <SidebarMenu>
-          {/* "All" item */}
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              isActive={selectedCategoryId === null}
-              onClick={() => handleSelect(null)}
-            >
-              <span className="h-2 w-2 shrink-0 rounded-full bg-foreground" />
-              <span>All</span>
-            </SidebarMenuButton>
-            {totalPendingCount > 0 && (
-              <SidebarMenuBadge>{totalPendingCount}</SidebarMenuBadge>
-            )}
-          </SidebarMenuItem>
-
           {/* Category items */}
           {categories.map((category) => (
             <SidebarMenuItem key={category.id}>

--- a/src/app/home/_components/TodoList.tsx
+++ b/src/app/home/_components/TodoList.tsx
@@ -112,6 +112,7 @@ export function TodoList() {
 
   /**
    * Adds a new todo item using the create mutation.
+   * Always assigns the currently selected category (auto-selected to General on load).
    * @param text - Todo title to create.
    * @param notes - Optional notes to attach to the todo.
    * @returns
@@ -119,15 +120,12 @@ export function TodoList() {
    * @example
    * addTodo('Buy milk')
    */
-  const addTodo = (
-    text: string,
-    notes?: string,
-    categoryId?: number | null,
-  ) => {
+  const addTodo = (text: string, notes?: string) => {
+    if (selectedCategoryId === null) return
     createMutation.mutate({
       text,
       notes,
-      ...(categoryId !== null && categoryId !== undefined && { categoryId }),
+      categoryId: selectedCategoryId,
     })
   }
 
@@ -293,10 +291,7 @@ export function TodoList() {
             <CardDescription>Manage your tasks efficiently</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <AddTodoForm
-              onAddTodo={addTodo}
-              selectedCategoryId={selectedCategoryId}
-            />
+            <AddTodoForm onAddTodo={addTodo} />
           </CardContent>
         </Card>
 

--- a/src/app/home/_components/TodoList.tsx
+++ b/src/app/home/_components/TodoList.tsx
@@ -71,7 +71,7 @@ export function TodoList() {
     }),
   )
 
-  // Mutations with optimistic updates
+  // Mutations with optimistic updates (pass categoryId for correct cache key)
   const {
     createMutation,
     toggleMutation,
@@ -79,7 +79,7 @@ export function TodoList() {
     updateMutation,
     clearCompletedMutation,
     reorderMutation,
-  } = useTodoMutations()
+  } = useTodoMutations(selectedCategoryId)
 
   // Local state for optimistic reordering
   const [localPendingTodos, setLocalPendingTodos] = useState<Todo[]>([])
@@ -291,7 +291,10 @@ export function TodoList() {
             <CardDescription>Manage your tasks efficiently</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <AddTodoForm onAddTodo={addTodo} />
+            <AddTodoForm
+              onAddTodo={addTodo}
+              disabled={selectedCategoryId === null}
+            />
           </CardContent>
         </Card>
 

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -276,19 +276,16 @@ export function FloatingNavigator({
         </div>
 
         {/* Category filter dropdown */}
-        {categories.length > 0 && onCategoryChange && (
+        {categories.length > 0 && onCategoryChange && selectedCategoryId && (
           <div className="pointer-events-auto mr-1">
             <Select
-              value={selectedCategoryId?.toString() ?? 'all'}
-              onValueChange={(value) =>
-                onCategoryChange(value === 'all' ? null : Number(value))
-              }
+              value={selectedCategoryId.toString()}
+              onValueChange={(value) => onCategoryChange(Number(value))}
             >
               <SelectTrigger className="h-6 w-24 border-0 bg-transparent px-2 text-xs">
-                <SelectValue placeholder="All" />
+                <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All</SelectItem>
                 {categories.map((cat) => (
                   <SelectItem key={cat.id} value={cat.id.toString()}>
                     <span className="flex items-center gap-1.5">

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -276,30 +276,32 @@ export function FloatingNavigator({
         </div>
 
         {/* Category filter dropdown */}
-        {categories.length > 0 && onCategoryChange && selectedCategoryId && (
-          <div className="pointer-events-auto mr-1">
-            <Select
-              value={selectedCategoryId.toString()}
-              onValueChange={(value) => onCategoryChange(Number(value))}
-            >
-              <SelectTrigger className="h-6 w-24 border-0 bg-transparent px-2 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {categories.map((cat) => (
-                  <SelectItem key={cat.id} value={cat.id.toString()}>
-                    <span className="flex items-center gap-1.5">
-                      <span
-                        className={`h-2 w-2 rounded-full ${COLOR_DOT_CLASSES[cat.color] ?? 'bg-muted-foreground'}`}
-                      />
-                      {cat.name}
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
+        {categories.length > 0 &&
+          onCategoryChange &&
+          selectedCategoryId !== null && (
+            <div className="pointer-events-auto mr-1">
+              <Select
+                value={selectedCategoryId.toString()}
+                onValueChange={(value) => onCategoryChange(Number(value))}
+              >
+                <SelectTrigger className="h-6 w-24 border-0 bg-transparent px-2 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {categories.map((cat) => (
+                    <SelectItem key={cat.id} value={cat.id.toString()}>
+                      <span className="flex items-center gap-1.5">
+                        <span
+                          className={`h-2 w-2 rounded-full ${COLOR_DOT_CLASSES[cat.color] ?? 'bg-muted-foreground'}`}
+                        />
+                        {cat.name}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
         {isFloatingNavigatorEnvironment() && (
           <div

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -88,7 +88,7 @@ interface FloatingNavigatorProps {
   onTaskReorder?: (activeId: string, overId: string) => void
   /** Categories for the filter dropdown */
   categories?: CategoryWithCount[]
-  /** Currently selected category ID (null = All) */
+  /** Currently selected category ID (null = no category selected yet) */
   selectedCategoryId?: number | null
   /** Callback when category filter changes */
   onCategoryChange?: (id: number | null) => void

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -6,7 +6,10 @@ import React, { useEffect, useState } from 'react'
 
 import { useMounted } from '@/hooks/use-mounted'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
-import { useSelectedCategory } from '@/hooks/useSelectedCategory'
+import {
+  useAutoSelectDefaultCategory,
+  useSelectedCategory,
+} from '@/hooks/useSelectedCategory'
 import { useTodoMutations } from '@/hooks/useTodoMutations'
 import { subscribeToCategorySync } from '@/lib/category-sync-channel'
 import { orpc } from '@/lib/orpc/client-query'
@@ -69,14 +72,11 @@ export function FloatingNavigatorContainer() {
   const categories: CategoryWithCount[] = categoryData?.categories ?? []
 
   // Auto-select the default (General) category when none is selected
-  useEffect(() => {
-    if (selectedCategoryId === null && categories.length > 0) {
-      const defaultCategory = categories.find((c) => c.isDefault)
-      if (defaultCategory) {
-        setSelectedCategoryId(defaultCategory.id)
-      }
-    }
-  }, [selectedCategoryId, categories, setSelectedCategoryId])
+  useAutoSelectDefaultCategory(
+    selectedCategoryId,
+    setSelectedCategoryId,
+    categories,
+  )
 
   // Fetch todos filtered by selected category
   const { data, isLoading, error } = useQuery({

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -68,6 +68,16 @@ export function FloatingNavigatorContainer() {
   })
   const categories: CategoryWithCount[] = categoryData?.categories ?? []
 
+  // Auto-select the default (General) category when none is selected
+  useEffect(() => {
+    if (selectedCategoryId === null && categories.length > 0) {
+      const defaultCategory = categories.find((c) => c.isDefault)
+      if (defaultCategory) {
+        setSelectedCategoryId(defaultCategory.id)
+      }
+    }
+  }, [selectedCategoryId, categories, setSelectedCategoryId])
+
   // Fetch todos filtered by selected category
   const { data, isLoading, error } = useQuery({
     ...orpc.todo.list.queryOptions({
@@ -105,9 +115,10 @@ export function FloatingNavigatorContainer() {
    * handleTaskCreate('Write report')
    */
   const handleTaskCreate = (title: string) => {
+    if (selectedCategoryId === null) return
     createMutation.mutate({
       text: title,
-      ...(selectedCategoryId !== null && { categoryId: selectedCategoryId }),
+      categoryId: selectedCategoryId,
     })
   }
 

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -45,14 +45,14 @@ export function FloatingNavigatorContainer() {
   // Category filter state (shared with main app via localStorage)
   const [selectedCategoryId, setSelectedCategoryId] = useSelectedCategory()
 
-  // Mutations with optimistic updates
+  // Mutations with optimistic updates (pass categoryId for correct cache key)
   const {
     createMutation,
     toggleMutation,
     deleteMutation,
     updateMutation,
     reorderMutation,
-  } = useTodoMutations()
+  } = useTodoMutations(selectedCategoryId)
 
   // Local state for optimistic reordering
   const [localPendingTodos, setLocalPendingTodos] = useState<FloatingTodo[]>([])

--- a/src/hooks/useCategoryMutations.ts
+++ b/src/hooks/useCategoryMutations.ts
@@ -12,7 +12,6 @@ import type { CategoryWithCount } from '@/server/schemas/category'
  */
 interface CategoryListResponse {
   categories: CategoryWithCount[]
-  uncategorizedCount: number
 }
 
 /**
@@ -148,7 +147,7 @@ export function useCategoryMutations() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: categoryKey })
-      // Also invalidate todos since deleted category's todos become uncategorized
+      // Also invalidate todos since deleted category's todos are reassigned to default
       queryClient.invalidateQueries({ queryKey: todoBaseKey })
       broadcastCategorySync()
     },

--- a/src/hooks/useSelectedCategory.ts
+++ b/src/hooks/useSelectedCategory.ts
@@ -123,7 +123,13 @@ export function useAutoSelectDefaultCategory(
 ) {
   /* eslint-disable react-you-might-not-need-an-effect/no-pass-data-to-parent -- writes to localStorage external store, not React parent state */
   useEffect(() => {
-    if (selectedCategoryId === null && categories.length > 0) {
+    if (categories.length === 0) return
+
+    const hasValidSelection =
+      selectedCategoryId !== null &&
+      categories.some((c) => c.id === selectedCategoryId)
+
+    if (!hasValidSelection) {
       const defaultCategory = categories.find((c) => c.isDefault)
       if (defaultCategory) {
         setSelectedCategoryId(defaultCategory.id)

--- a/src/hooks/useSelectedCategory.ts
+++ b/src/hooks/useSelectedCategory.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
 
 const STORAGE_KEY = 'corelive-selected-category'
 
@@ -21,7 +21,7 @@ const emitChange = () => {
 
 /**
  * Reads the selected category ID from localStorage.
- * @returns The selected category ID, or null for "All" categories
+ * @returns The selected category ID, or null when no category is selected yet
  */
 const getSnapshot = (): number | null => {
   try {
@@ -35,7 +35,7 @@ const getSnapshot = (): number | null => {
 }
 
 /**
- * SSR fallback — always returns null (show all categories).
+ * SSR fallback — always returns null (no category selected during SSR).
  */
 const getServerSnapshot = (): number | null => null
 
@@ -67,14 +67,14 @@ const subscribe = (callback: () => void): (() => void) => {
  * Uses useSyncExternalStore for SSR-safe subscription.
  *
  * @returns [selectedCategoryId, setSelectedCategoryId]
- * - selectedCategoryId: number | null (null = "All" categories)
+ * - selectedCategoryId: number | null (null = no category selected yet)
  * - setSelectedCategoryId: (id: number | null) => void
  *
  * @example
  * const [categoryId, setCategoryId] = useSelectedCategory()
  * // Select a category
  * setCategoryId(3)
- * // Show all categories
+ * // Clear selection
  * setCategoryId(null)
  */
 export function useSelectedCategory(): [
@@ -101,4 +101,34 @@ export function useSelectedCategory(): [
   }, [])
 
   return [selectedCategoryId, setSelectedCategoryId]
+}
+
+/**
+ * Auto-selects the default (isDefault=true) category when none is selected.
+ * Extracts the shared auto-select logic used by both Category sidebar and FloatingNavigator.
+ *
+ * @param selectedCategoryId - Current selected category ID from useSelectedCategory
+ * @param setSelectedCategoryId - Setter from useSelectedCategory
+ * @param categories - Categories with an isDefault flag
+ *
+ * @example
+ * const [selectedCategoryId, setSelectedCategoryId] = useSelectedCategory()
+ * const categories = useCategoryQuery()
+ * useAutoSelectDefaultCategory(selectedCategoryId, setSelectedCategoryId, categories)
+ */
+export function useAutoSelectDefaultCategory(
+  selectedCategoryId: number | null,
+  setSelectedCategoryId: (id: number | null) => void,
+  categories: { id: number; isDefault: boolean }[],
+) {
+  /* eslint-disable react-you-might-not-need-an-effect/no-pass-data-to-parent -- writes to localStorage external store, not React parent state */
+  useEffect(() => {
+    if (selectedCategoryId === null && categories.length > 0) {
+      const defaultCategory = categories.find((c) => c.isDefault)
+      if (defaultCategory) {
+        setSelectedCategoryId(defaultCategory.id)
+      }
+    }
+  }, [selectedCategoryId, categories, setSelectedCategoryId])
+  /* eslint-enable react-you-might-not-need-an-effect/no-pass-data-to-parent */
 }

--- a/src/hooks/useTodoMutations.ts
+++ b/src/hooks/useTodoMutations.ts
@@ -15,7 +15,7 @@ interface Todo {
   text: string
   completed: boolean
   notes: string | null
-  categoryId: number | null
+  categoryId: number
   userId: number
   createdAt: Date
   updatedAt: Date

--- a/src/hooks/useTodoMutations.ts
+++ b/src/hooks/useTodoMutations.ts
@@ -31,9 +31,6 @@ interface TodoResponse {
   nextOffset?: number
 }
 
-/** Query input for pending todos list. */
-const PENDING_INPUT = { completed: false, limit: 100, offset: 0 } as const
-
 /**
  * Custom hook providing TODO mutations with optimistic updates.
  *
@@ -42,28 +39,31 @@ const PENDING_INPUT = { completed: false, limit: 100, offset: 0 } as const
  * 2. onError: Rollback using snapshot
  * 3. onSettled: Always invalidate to sync with server
  *
+ * @param categoryId - Currently selected category ID for correct cache key matching.
+ *   Must match the categoryId used in the todo list query so optimistic updates
+ *   target the right cache entry.
  * @returns Object containing all todo mutations with optimistic updates
- * @returns createMutation - Add new todo with instant UI feedback
- * @returns toggleMutation - Toggle completion with instant list transfer
- * @returns deleteMutation - Remove todo with instant disappearance
- * @returns updateMutation - Update todo with instant in-place change
- * @returns clearCompletedMutation - Clear all completed with instant removal
  *
  * @example
- * const { createMutation, toggleMutation } = useTodoMutations()
- * createMutation.mutate({ text: 'New task' })
+ * const { createMutation, toggleMutation } = useTodoMutations(selectedCategoryId)
+ * createMutation.mutate({ text: 'New task', categoryId: 5 })
  * toggleMutation.mutate({ id: 42 })
  */
-export function useTodoMutations() {
+export function useTodoMutations(categoryId: number | null) {
   const queryClient = useQueryClient()
 
   // Query keys for cache operations
-  // - pendingKey: exact match for useQuery in TodoList
+  // - pendingKey: exact match for useQuery in TodoList (includes categoryId filter)
   // - completedBaseKey: partial match for useInfiniteQuery in CompletedTodos
   //   (infiniteOptions with function input generates unpredictable keys,
   //    so we use partial matching for completed list operations)
   const pendingKey = orpc.todo.list.queryOptions({
-    input: PENDING_INPUT,
+    input: {
+      completed: false,
+      limit: 100,
+      offset: 0,
+      ...(categoryId !== null && { categoryId }),
+    },
   }).queryKey
   const completedBaseKey = orpc.todo.list.key({ input: { completed: true } })
   // ============================================

--- a/src/hooks/useTodoMutations.ts
+++ b/src/hooks/useTodoMutations.ts
@@ -83,7 +83,7 @@ export function useTodoMutations() {
         id: -Date.now(), // Negative temp ID to avoid collision
         text: newTodo.text,
         notes: newTodo.notes ?? null,
-        categoryId: newTodo.categoryId ?? null,
+        categoryId: newTodo.categoryId,
         completed: false,
         userId: 0,
         createdAt: new Date(),

--- a/src/server/procedures/category.ts
+++ b/src/server/procedures/category.ts
@@ -46,25 +46,19 @@ export const listCategories = authMiddleware
     try {
       const { user } = context
 
-      const [categories, uncategorizedCount] = await Promise.all([
-        prisma.category.findMany({
-          where: { userId: user.id },
-          include: {
-            _count: {
-              select: { todos: { where: { completed: false } } },
-            },
+      const categories = await prisma.category.findMany({
+        where: { userId: user.id },
+        include: {
+          _count: {
+            select: { todos: { where: { completed: false } } },
           },
-          orderBy: { createdAt: 'asc' },
-        }),
-        prisma.todo.count({
-          where: { userId: user.id, completed: false, categoryId: null },
-        }),
-      ])
+        },
+        orderBy: { createdAt: 'asc' },
+      })
 
       // Prisma returns color as string; cast to satisfy the enum-typed output schema
       return {
         categories: categories as CategoryWithCount[],
-        uncategorizedCount,
       }
     } catch (error) {
       log.error({ error }, 'Error in listCategories')

--- a/src/server/procedures/category.ts
+++ b/src/server/procedures/category.ts
@@ -173,12 +173,6 @@ export const updateCategory = authMiddleware
   })
 
 /**
- * Delete a category. Tasks in this category become uncategorized (categoryId: null).
- *
- * @param input.id - Category ID to delete
- * @returns Success status
- */
-/**
  * Delete a category. Tasks in this category are reassigned to the user's default (General) category.
  * The default category itself cannot be deleted.
  *

--- a/src/server/procedures/todo.ts
+++ b/src/server/procedures/todo.ts
@@ -58,11 +58,10 @@ export const listTodos = authMiddleware
 
 /**
  * Create a new todo for the authenticated user.
- * If no categoryId is provided, auto-assigns to the user's default (General) category.
  *
  * @param input.text - Todo text (1-255 chars)
  * @param input.notes - Optional notes
- * @param input.categoryId - Category to assign (auto-fills with default if omitted)
+ * @param input.categoryId - Category to assign (required, must belong to the user)
  * @returns The newly created todo
  */
 export const createTodo = authMiddleware

--- a/src/server/procedures/todo.ts
+++ b/src/server/procedures/todo.ts
@@ -71,28 +71,16 @@ export const createTodo = authMiddleware
   .handler(async ({ input, context }) => {
     try {
       const { user } = context
-      let categoryId = input.categoryId
-
-      // Auto-assign to default (General) category if not specified
-      if (!categoryId) {
-        const defaultCategory = await prisma.category.findFirst({
-          where: { userId: user.id, isDefault: true },
-        })
-        if (defaultCategory) {
-          categoryId = defaultCategory.id
-        }
-      }
+      const { categoryId } = input
 
       // Verify category ownership
-      if (categoryId) {
-        const category = await prisma.category.findFirst({
-          where: { id: categoryId, userId: user.id },
+      const category = await prisma.category.findFirst({
+        where: { id: categoryId, userId: user.id },
+      })
+      if (!category) {
+        throw new ORPCError('NOT_FOUND', {
+          message: 'Category not found',
         })
-        if (!category) {
-          throw new ORPCError('NOT_FOUND', {
-            message: 'Category not found',
-          })
-        }
       }
 
       const todo = await prisma.todo.create({

--- a/src/server/schemas/category.ts
+++ b/src/server/schemas/category.ts
@@ -74,9 +74,7 @@ export type CategoryWithCount = z.infer<typeof CategoryWithCountSchema>
 
 /**
  * Response schema for the list categories endpoint.
- * Includes uncategorizedCount for computing the total "All" badge.
  */
 export const CategoryListResponseSchema = z.object({
   categories: z.array(CategoryWithCountSchema),
-  uncategorizedCount: z.number().int().min(0),
 })

--- a/src/server/schemas/todo.ts
+++ b/src/server/schemas/todo.ts
@@ -6,7 +6,7 @@ export const TodoSchema = z.object({
   completed: z.boolean(),
   notes: z.string().optional().nullable(),
   order: z.number().int().min(0).optional().nullable(),
-  categoryId: z.number().int().positive().optional().nullable(),
+  categoryId: z.number().int().positive(),
   userId: z.number().int().positive(),
   createdAt: z
     .union([z.date(), z.string()])
@@ -33,7 +33,7 @@ export const TodoListSchema = z.object({
   limit: z.number().int().min(1).max(100).default(10),
   offset: z.number().int().min(0).default(0),
   completed: z.boolean().optional(),
-  categoryId: z.number().int().positive().optional().nullable(),
+  categoryId: z.number().int().positive().optional(),
 })
 
 export const TodoResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Removes the "All" category filter and enforces every todo belongs to a category. The General (default) category is auto-selected on first load.

**Database**
- `categoryId` is now NOT NULL on both `Todo` and `Completed` tables
- Migration backfills any existing nulls before applying the constraint
- `onDelete: Restrict` replaces `SetNull` to prevent orphaned todos

**Server**
- `CreateTodoSchema.categoryId` is required (no longer optional)
- Removed `uncategorizedCount` from category list response
- Removed auto-assign fallback logic from `createTodo` (client always sends categoryId)
- Cleaned up stale docstrings referencing nullable categoryId

**Frontend**
- Removed "All" filter from Category sidebar and FloatingNavigator dropdown
- Extracted shared `useAutoSelectDefaultCategory` hook (was duplicated in 2 components)
- Fixed falsy check `selectedCategoryId &&` to explicit `selectedCategoryId !== null &&`
- Removed dead `?? null` fallback in optimistic update (categoryId is always present)

**E2E Tests**
- Updated 8 category tests to work without "All" filter

## Test plan
- [x] `pnpm validate` passes (24 tests, lint clean, build + typecheck)
- [ ] New user signup creates General category, auto-selected
- [ ] Existing users see General selected by default (no "All")
- [ ] Create todo always assigned to selected category
- [ ] FloatingNavigator dropdown has no "All" option
- [ ] Category delete reassigns todos to General
- [ ] General category cannot be deleted

---
*Generated with [Claude Code](https://claude.ai/code)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic default category selection on app load and when no category is currently selected.

* **Changes**
  * Removed the "All" category view; sidebar now displays only named categories.
  * All todos now require explicit category assignment; uncategorized tasks are no longer supported.
  * Improved category validation during task creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->