### PR TITLE
refactor(skill-tree): add domain-rich type aliases

### DIFF
--- a/src/app/(main)/skill-tree/SkillTreeView.tsx
+++ b/src/app/(main)/skill-tree/SkillTreeView.tsx
@@ -23,6 +23,7 @@ import { ConstellationCanvas } from './components/ConstellationCanvas'
 import { DragOverlayCard } from './components/DragOverlayCard'
 import { NodePopover } from './components/NodePopover'
 import { TaskPoolDrawer } from './components/TaskPoolDrawer'
+import type { SkillNodeId, TodoId, TodoText } from './lib/domain-types'
 import {
   applyAssignment,
   buildInitialState,
@@ -54,10 +55,9 @@ import './styles.css'
 export function SkillTreeView() {
   const queryClient = useQueryClient()
   const [drawerOpen, setDrawerOpen] = useState(false)
-  const [activeDragId, setActiveDragId] = useState<number | null>(null)
-  const [activePopoverNodeId, setActivePopoverNodeId] = useState<number | null>(
-    null,
-  )
+  const [activeDragId, setActiveDragId] = useState<TodoId | null>(null)
+  const [activePopoverNodeId, setActivePopoverNodeId] =
+    useState<SkillNodeId | null>(null)
   const [, startTransition] = useTransition()
 
   const {
@@ -94,7 +94,7 @@ export function SkillTreeView() {
   // The tree side uses the `todoText` snapshot column which is populated at
   // assign time and survives the source todo being deleted.
   const todoTextById = useMemo(() => {
-    const map = new Map<number, string>()
+    const map = new Map<TodoId, TodoText>()
     pool?.forEach((t) => map.set(t.id, t.text))
     tree?.nodes.forEach((node) => {
       node.assignments.forEach((a) => {
@@ -185,7 +185,7 @@ export function SkillTreeView() {
     })
   }
 
-  function handleUnassign(nodeId: number, todoId: number) {
+  function handleUnassign(nodeId: SkillNodeId, todoId: TodoId) {
     startTransition(async () => {
       applyOptimistic({ type: 'unassign', nodeId, todoId })
       await unassignMutation.mutateAsync({ nodeId, todoId }).catch(() => {})
@@ -415,7 +415,7 @@ export function SkillTreeView() {
  * parseTodoDragId('todo-0')    // => null
  * parseTodoDragId('node-3')    // => null
  */
-function parseTodoDragId(id: UniqueIdentifier): number | null {
+function parseTodoDragId(id: UniqueIdentifier): TodoId | null {
   const s = String(id)
   if (!s.startsWith('todo-')) return null
   const n = Number(s.slice('todo-'.length))
@@ -438,7 +438,7 @@ function parseTodoDragId(id: UniqueIdentifier): number | null {
  * parseNodeDropId('node-0')    // => null
  * parseNodeDropId('todo-42')   // => null
  */
-function parseNodeDropId(id: UniqueIdentifier): number | null {
+function parseNodeDropId(id: UniqueIdentifier): SkillNodeId | null {
   const s = String(id)
   if (!s.startsWith('node-')) return null
   const n = Number(s.slice('node-'.length))

--- a/src/app/(main)/skill-tree/components/ConstellationCanvas.tsx
+++ b/src/app/(main)/skill-tree/components/ConstellationCanvas.tsx
@@ -1,5 +1,16 @@
 'use client'
 
+import type {
+  EdgeFromNodeId,
+  EdgeToNodeId,
+  NodeCoordinate,
+  NodeEdgeId,
+  NodeXp,
+  SkillNodeId,
+  SkillNodeName,
+  ViewboxCoordinate,
+} from '../lib/domain-types'
+
 import { SkillNodeCircle } from './SkillNodeCircle'
 
 /**
@@ -7,23 +18,23 @@ import { SkillNodeCircle } from './SkillNodeCircle'
  * Kept separate from the Prisma type to avoid pulling server types into client code.
  */
 export interface CanvasNode {
-  id: number
-  name: string
-  x: number // 0-1 normalized
-  y: number // 0-1 normalized
-  xp: number
+  id: SkillNodeId
+  name: SkillNodeName
+  x: NodeCoordinate // 0-1 normalized
+  y: NodeCoordinate // 0-1 normalized
+  xp: NodeXp
 }
 
 export interface CanvasEdge {
-  id: number
-  fromNodeId: number
-  toNodeId: number
+  id: NodeEdgeId
+  fromNodeId: EdgeFromNodeId
+  toNodeId: EdgeToNodeId
 }
 
 export interface ConstellationCanvasProps {
   nodes: CanvasNode[]
   edges: CanvasEdge[]
-  onNodeClick?: (nodeId: number) => void
+  onNodeClick?: (nodeId: SkillNodeId) => void
 }
 
 const VIEWBOX = 1000 // logical units — actual size is controlled by CSS
@@ -37,7 +48,7 @@ const VIEWBOX = 1000 // logical units — actual size is controlled by CSS
  * toViewboxUnits(0.5) // => 500
  * toViewboxUnits(0)   // => 0
  */
-function toViewboxUnits(n: number) {
+function toViewboxUnits(n: NodeCoordinate): ViewboxCoordinate {
   return n * VIEWBOX
 }
 

--- a/src/app/(main)/skill-tree/components/NodePopover.tsx
+++ b/src/app/(main)/skill-tree/components/NodePopover.tsx
@@ -10,14 +10,22 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 
+import type {
+  NodeXp,
+  SkillNodeId,
+  SkillNodeName,
+  TodoId,
+  TodoText,
+} from '../lib/domain-types'
+
 import { XpBadge } from './XpBadge'
 
 /** A single todo that has been assigned to a skill node. */
 export interface AssignedTodo {
   /** The unique identifier of the todo. */
-  id: number
+  id: TodoId
   /** The display text of the todo. */
-  text: string
+  text: TodoText
 }
 
 /** Props for the NodePopover component. */
@@ -30,14 +38,14 @@ export interface NodePopoverProps {
    */
   onOpenChange: (open: boolean) => void
   /** The skill node to display: id, name, and current accumulated XP. */
-  node: { id: number; name: string; xp: number }
+  node: { id: SkillNodeId; name: SkillNodeName; xp: NodeXp }
   /** Todos currently assigned to this node. */
   assignedTodos: AssignedTodo[]
   /**
    * Called with the todo's id when the user clicks the × button next to a row.
    * The parent is responsible for removing the assignment optimistically.
    */
-  onUnassign: (todoId: number) => void
+  onUnassign: (todoId: TodoId) => void
   /** The trigger element the popover is anchored to (rendered via PopoverTrigger asChild). */
   children: ReactNode
 }

--- a/src/app/(main)/skill-tree/components/SkillNodeCircle.tsx
+++ b/src/app/(main)/skill-tree/components/SkillNodeCircle.tsx
@@ -4,6 +4,12 @@ import { useDroppable } from '@dnd-kit/core'
 import React from 'react'
 import { match } from 'ts-pattern'
 
+import type {
+  NodeXp,
+  SkillNodeId,
+  SkillNodeName,
+  ViewboxCoordinate,
+} from '../lib/domain-types'
 import { LEVEL_LABEL, xpToLevel } from '../lib/xp'
 
 /**
@@ -23,12 +29,12 @@ import { LEVEL_LABEL, xpToLevel } from '../lib/xp'
  * <SkillNodeCircle id={1} name="APIs" cx={50} cy={50} xp={30} onClick={(id) => console.log(id)} />
  */
 export interface SkillNodeCircleProps {
-  id: number
-  name: string
-  cx: number
-  cy: number
-  xp: number
-  onClick?: (nodeId: number) => void
+  id: SkillNodeId
+  name: SkillNodeName
+  cx: ViewboxCoordinate
+  cy: ViewboxCoordinate
+  xp: NodeXp
+  onClick?: (nodeId: SkillNodeId) => void
 }
 
 export function SkillNodeCircle({

--- a/src/app/(main)/skill-tree/components/TaskPoolCard.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolCard.tsx
@@ -3,6 +3,8 @@
 import { useDraggable } from '@dnd-kit/core'
 import { CSS } from '@dnd-kit/utilities'
 
+import type { TodoId, TodoText } from '../lib/domain-types'
+
 /**
  * A draggable card representing a completed Todo in the pool drawer.
  * Uses `useDraggable` for DnD and renders as a button for a11y.
@@ -18,8 +20,8 @@ import { CSS } from '@dnd-kit/utilities'
  * </DndContext>
  */
 export interface TaskPoolCardProps {
-  id: number
-  text: string
+  id: TodoId
+  text: TodoText
 }
 
 export function TaskPoolCard({ id, text }: TaskPoolCardProps) {

--- a/src/app/(main)/skill-tree/components/TaskPoolDrawer.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolDrawer.tsx
@@ -11,14 +11,16 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 
+import type { TodoId, TodoText } from '../lib/domain-types'
+
 import { TaskPoolCard } from './TaskPoolCard'
 
 /**
  * Minimal Todo shape used by the drawer. Kept loose so stories can use mocks.
  */
 export interface PoolTodo {
-  id: number
-  text: string
+  id: TodoId
+  text: TodoText
 }
 
 export interface TaskPoolDrawerProps {

--- a/src/app/(main)/skill-tree/lib/domain-types.ts
+++ b/src/app/(main)/skill-tree/lib/domain-types.ts
@@ -1,0 +1,71 @@
+import type { NodeEdge, SkillNode } from '@/server/schemas/skillTree'
+
+/**
+ * @description Positive integer identifier of a skill node in the skill tree.
+ * @example
+ * const nodeId: SkillNodeId = 12
+ */
+export type SkillNodeId = SkillNode['id']
+
+/**
+ * @description Human-readable display name of a skill node.
+ * @example
+ * const skillName: SkillNodeName = 'API Design'
+ */
+export type SkillNodeName = SkillNode['name']
+
+/**
+ * @description Normalized node position value (0 to 1) used by the SVG layout.
+ * @example
+ * const x: NodeCoordinate = 0.42
+ */
+export type NodeCoordinate = SkillNode['x']
+
+/**
+ * @description A completed Todo id that can be assigned to a skill node.
+ * @example
+ * const todoId: TodoId = 101
+ */
+export type TodoId = NonNullable<SkillNode['assignments'][number]['todoId']>
+
+/**
+ * @description Snapshot display text stored for an assigned completed Todo.
+ * @example
+ * const text: TodoText = 'Refactor login flow'
+ */
+export type TodoText = SkillNode['assignments'][number]['todoText']
+
+/**
+ * @description XP amount displayed for a node in the constellation UI.
+ * @example
+ * const xp: NodeXp = 8
+ */
+export type NodeXp = number
+
+/**
+ * @description SVG viewbox coordinate value after converting normalized layout positions.
+ * @example
+ * const cx: ViewboxCoordinate = 500
+ */
+export type ViewboxCoordinate = number
+
+/**
+ * @description Unique identifier of an edge connecting two skill nodes.
+ * @example
+ * const edgeId: NodeEdgeId = 7
+ */
+export type NodeEdgeId = NodeEdge['id']
+
+/**
+ * @description Source skill node id of a directed edge.
+ * @example
+ * const from: EdgeFromNodeId = 2
+ */
+export type EdgeFromNodeId = NodeEdge['fromNodeId']
+
+/**
+ * @description Destination skill node id of a directed edge.
+ * @example
+ * const to: EdgeToNodeId = 3
+ */
+export type EdgeToNodeId = NodeEdge['toNodeId']

--- a/src/app/(main)/skill-tree/lib/optimistic.ts
+++ b/src/app/(main)/skill-tree/lib/optimistic.ts
@@ -1,16 +1,32 @@
+import type { SkillNode } from '@/server/schemas/skillTree'
+
+import type { SkillNodeId, TodoId } from './domain-types'
+
+/**
+ * A minimal assignment row in the optimistic reducer state.
+ */
+export interface OptimisticAssignment {
+  todoId: TodoId
+}
+
+/**
+ * Server skill-node slice required to construct optimistic assignment state.
+ */
+type SkillNodeWithAssignments = Pick<SkillNode, 'id' | 'assignments'>
+
 /**
  * A lightweight snapshot of assignment state used by the optimistic reducer.
  * Holds only the derived data the UI needs: per-node assignments and the
  * unassigned pool. Not persisted — rebuilt from server state on each query.
  */
 export interface OptimisticState {
-  assignmentsByNode: Record<number, { todoId: number }[]>
-  unassignedTodoIds: number[]
+  assignmentsByNode: Record<SkillNodeId, OptimisticAssignment[]>
+  unassignedTodoIds: TodoId[]
 }
 
 export type OptimisticAction =
-  | { type: 'assign'; nodeId: number; todoId: number }
-  | { type: 'unassign'; nodeId: number; todoId: number }
+  | { type: 'assign'; nodeId: SkillNodeId; todoId: TodoId }
+  | { type: 'unassign'; nodeId: SkillNodeId; todoId: TodoId }
 
 /**
  * Pure reducer for optimistic drag-and-drop assignments.
@@ -82,16 +98,16 @@ export function applyAssignment(
  * const state = buildInitialState(skillTree.nodes, poolTodoIds)
  */
 export function buildInitialState(
-  nodes: Array<{
-    id: number
-    assignments: Array<{ todoId: number | null }>
-  }>,
-  poolTodoIds: number[],
+  nodes: SkillNodeWithAssignments[],
+  poolTodoIds: TodoId[],
 ): OptimisticState {
-  const assignmentsByNode: Record<number, { todoId: number }[]> = {}
+  const assignmentsByNode: Record<SkillNodeId, OptimisticAssignment[]> = {}
   for (const node of nodes) {
     assignmentsByNode[node.id] = node.assignments
-      .filter((a): a is { todoId: number } => a.todoId !== null)
+      .filter(
+        (a): a is SkillNode['assignments'][number] & { todoId: TodoId } =>
+          a.todoId !== null,
+      )
       .map((a) => ({ todoId: a.todoId }))
   }
   return { assignmentsByNode, unassignedTodoIds: poolTodoIds }


### PR DESCRIPTION
## Summary
- add a dedicated `domain-types.ts` for skill-tree identifiers and value aliases
- replace colorless `number` / `string` annotations with domain aliases in skill-tree components and optimistic reducer
- keep runtime behavior unchanged while improving type readability and intent

## Verification
- pnpm typecheck
- pnpm lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened internal type safety across the skill-tree feature to improve code reliability and maintainability. Updated various components and state management to use more specific domain-level types, ensuring consistency throughout the feature while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->