### PR TITLE
test(argos): make theme visual test fully deterministic

### DIFF
--- a/e2e/web/theme.spec.ts
+++ b/e2e/web/theme.spec.ts
@@ -8,6 +8,15 @@ test.describe('Theme Visual Test', () => {
     // This is required for Clerk to work properly in test mode
     await setupClerkTestingToken({ page })
 
+    // Freeze the browser clock so client-side `new Date()` calls render
+    // deterministically across runs. Without this, `ContributionGraph`'s
+    // `endDate` (computed via `useMemo(() => normalizeDate(new Date()))`)
+    // shifts day-by-day and produces false-positive Argos diffs.
+    // The fixed reference is in the past relative to any realistic CI run
+    // so Clerk session token validation (which compares `iat`/`exp` against
+    // the browser clock) still treats real tokens as freshly issued.
+    await page.clock.install({ time: new Date('2026-01-15T12:00:00Z') })
+
     // Navigate to the TODO app home page
     // Authentication state is automatically loaded from playwright/.auth/user.json
     await page.goto('/home')
@@ -35,8 +44,14 @@ test.describe('Theme Visual Test', () => {
       await expect(page.getByText('Todo List')).toBeVisible({ timeout: 10000 })
     }
 
-    // Add a new TODO item
-    const todoText = `ThemeTest-${Date.now()}-${Math.random().toString(36).substring(7)}`
+    // Add a new TODO item.
+    //
+    // The text is intentionally a fixed constant — embedding `Date.now()` /
+    // `Math.random()` here would render a different label every run and
+    // surface as an Argos visual diff even when the UI itself has not
+    // changed. `globalSetup` resets the database before each `pnpm e2e:web`
+    // invocation, so a stable string never collides with prior fixtures.
+    const todoText = 'Theme test todo'
     await page.getByPlaceholder('Enter a new todo...').fill(todoText)
     await page.getByRole('button', { name: 'Add', exact: true }).click()
 
@@ -47,8 +62,14 @@ test.describe('Theme Visual Test', () => {
     // Wait for UI to stabilize before taking screenshot
     await page.waitForTimeout(1000)
 
+    // Mask any TODO `createdAt` date displays — those are stamped by the
+    // server when the TODO is added during this test, so the value is
+    // inherently the test execution date and cannot be fixed via
+    // `page.clock.install`.
+    const createdAtMask = [page.locator('[data-testid="todo-created-at"]')]
+
     // Capture screenshot of light theme (default)
-    await argosScreenshot(page, 'home-light-theme')
+    await argosScreenshot(page, 'home-light-theme', { mask: createdAtMask })
 
     // Open user menu dropdown (click on avatar button in sidebar header)
     // The avatar button is in the sidebar header, which contains the user's avatar and name
@@ -91,7 +112,7 @@ test.describe('Theme Visual Test', () => {
       timeout: 5000,
     })
 
-    // Capture screenshot of dark theme
-    await argosScreenshot(page, 'home-dark-theme')
+    // Capture screenshot of dark theme (same mask as light theme)
+    await argosScreenshot(page, 'home-dark-theme', { mask: createdAtMask })
   })
 })

--- a/src/app/(main)/home/_components/TodoItem.tsx
+++ b/src/app/(main)/home/_components/TodoItem.tsx
@@ -99,7 +99,9 @@ export function TodoItem({
             {todo.text}
           </div>
           <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-            <span>{todo.createdAt.toLocaleDateString('en-US')}</span>
+            <span data-testid="todo-created-at">
+              {todo.createdAt.toLocaleDateString('en-US')}
+            </span>
             {todo.categoryName && (
               <span className="flex items-center gap-1">
                 <span


### PR DESCRIPTION
## Summary

Eliminate three sources of false-positive Argos diffs in `theme.spec.ts`. After this change, Argos should only flag a build when the rendered UI has actually changed.

### Root causes

| # | Where | What happened on every run |
|---|---|---|
| (a) | `e2e/web/theme.spec.ts:39` | The TODO label embedded `Date.now()` + `Math.random()` directly in the visible text — every run rendered a different string. |
| (b) | `src/app/(main)/home/_components/ContributionGraph.tsx:150` | `endDate = useMemo(() => normalizeDate(new Date()), [])` shifts the year-long heatmap day-by-day. |
| (c) | `src/app/(main)/home/_components/TodoItem.tsx:102` | The TODO is created during the test, so the displayed `createdAt` was always the test's calendar day. |

### Fixes (layered, lightest first)

1. **Deterministic fixture text** — replaced `\`ThemeTest-${Date.now()}-${Math.random().toString(36).substring(7)}\`` with a fixed `'Theme test todo'`. Safe because `globalSetup` runs `db:reset && prisma:seed` before every `pnpm e2e:web` invocation (`playwright.config.ts:84`).
2. **Browser clock freeze** — added `await page.clock.install({ time: new Date('2026-01-15T12:00:00Z') })` to `test.beforeEach`, *after* `setupClerkTestingToken` and *before* `page.goto`. Pins `ContributionGraph`'s `endDate` and any future client-side `new Date()` rendering. The reference is fixed in the past so real Clerk tokens still validate fresh.
3. **Mask server-stamped dates** — added `data-testid="todo-created-at"` to the date span in `TodoItem.tsx`, then passed `{ mask: [page.locator('[data-testid="todo-created-at"]')] }` to both `argosScreenshot` calls. Server-side `createdAt` cannot be reached by `page.clock`, so masking is the only path.

### Reference

- Original Argos failure: https://app.argos-ci.com/ryota-murakami/corelive/builds/211 (PR #26)
- Plan file: `~/.claude/plans/snazzy-hugging-gosling.md`

## Test plan

- [ ] CI green on this PR (`lint`, `build`, `test`, `typecheck`, `e2e-web-tests`, `storybook-test`)
- [ ] Argos build shows **0 changed** screenshots on this PR
- [ ] Re-running the workflow on a different calendar day still produces 0 changes (manual verification — re-run `lint` job a day later and confirm)
- [ ] A follow-up PR that genuinely modifies `ContributionGraph` or `TodoItem` *does* surface as an Argos diff (false-negative check, performed when such a PR organically arrives)