### PR TITLE
chore(release): 0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corelive",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A comprehensive design system and web application built with Next.js, featuring authentication, database integration, and desktop support",
   "author": "Ryota Murakami <dojce1048@gmail.com> (https://github.com/ryota-murakami)",
   "private": true,


### PR DESCRIPTION
## Summary

Patch version bump 0.3.2 → 0.3.3 to ship the Electron startup sync fix from PR #28.

## What's included in this release

PR #28 — `fix(electron): apply persisted hide-app-icon setting at startup` (merged in `a3ba591`)

- Fixes startup-time divergence between Settings UI ("Hide App Icon" toggle) and the macOS Dock state
- macOS dock policy `app.setActivationPolicy()` is runtime-only and resets to `regular` on every launch — this PR adds `<ElectronStartupSync />` to forward the persisted Redux value to the main process via IPC after Redux hydrates from localStorage
- CodeRabbit-flagged improvement in commit `ce704bf`: handle the IPC `false`-resolve path (preload bridge swallows errors and resolves to `false` instead of rejecting)

## Release flow after merge

1. Tag the merge commit: `git tag v0.3.3 && git push --tags`
2. GitHub Actions `Build and Release Electron App` workflow auto-triggers on `v*` tag push
3. Builds, signs, notarizes (afterSign hook via `scripts/notarize.js`), and publishes the release

## Test plan

- [x] PR #28 already merged with full CI green (lint, typecheck, test 60/60, build, e2e, storybook, security-scan)
- [x] CodeRabbit review completed and resolved
- [x] argos visual diff tracked in #29 (unrelated to this PR — `<ElectronStartupSync />` returns `null`)
- [ ] After merge: tag push triggers release workflow