### PR TITLE
fix(electron): drop IpcRendererEvent in preload on() to match type contract

### DIFF
--- a/electron/__tests__/preload-security.test.mjs
+++ b/electron/__tests__/preload-security.test.mjs
@@ -468,11 +468,14 @@ describe('Preload Script Security Tests', () => {
         return data
       }
 
+      // Mirrors preload.ts: the IpcRendererEvent is intentionally dropped so
+      // renderer listeners receive only the sanitized payload (matching the
+      // typed `on<C>()` contract in electron-api.d.ts).
       const createSecureCallback = (userCallback) => {
-        return (event, ...args) => {
+        return (_event, ...args) => {
           try {
             const sanitizedArgs = args.map((arg) => sanitizeData(arg))
-            userCallback(event, ...sanitizedArgs)
+            userCallback(...sanitizedArgs)
           } catch (error) {
             log.error('Error in event callback:', error)
           }
@@ -485,7 +488,7 @@ describe('Preload Script Security Tests', () => {
       // Test callback with sanitized data
       secureCallback({}, '  test data  ', 123, true)
 
-      expect(mockUserCallback).toHaveBeenCalledWith({}, 'test data', 123, true)
+      expect(mockUserCallback).toHaveBeenCalledWith('test data', 123, true)
     })
 
     it('should provide cleanup functions for event listeners', () => {
@@ -498,8 +501,8 @@ describe('Preload Script Security Tests', () => {
           return null
         }
 
-        const wrappedCallback = (event, ...args) => {
-          callback(event, ...args)
+        const wrappedCallback = (_event, ...args) => {
+          callback(...args)
         }
 
         // Store the listener

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1621,10 +1621,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
   },
 
-  // Secure event listener management
+  // Secure event listener management.
+  //
+  // Callbacks receive only the sanitized main-process payload — the
+  // IpcRendererEvent argument is intentionally dropped so listeners can be
+  // written as `(data) => …` to match the typed `on<C>()` contract in
+  // `electron-api.d.ts` (`callback: (data: IPCEventData<C>) => void`). This
+  // also aligns with the BrainDump preload's behavior.
   on: (
     channel: string,
-    callback: (event: IpcRendererEvent, ...args: unknown[]) => void,
+    callback: (...args: unknown[]) => void,
   ): (() => void) | undefined => {
     if (!validateChannel(channel)) {
       log.error(`Attempted to listen to unauthorized channel: ${channel}`)
@@ -1636,14 +1642,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return
     }
 
-    // Wrap callback to sanitize incoming data
     const wrappedCallback = (
-      event: IpcRendererEvent,
+      _event: IpcRendererEvent,
       ...args: unknown[]
     ): void => {
       try {
         const sanitizedArgs = args.map((arg) => sanitizeData(arg))
-        callback(event, ...sanitizedArgs)
+        callback(...sanitizedArgs)
       } catch (error) {
         log.error('Error in event callback:', error)
       }


### PR DESCRIPTION
## Summary

Addresses the **Pre-existing bugs noticed** section of #33 — but the actual fix is one layer below where that PR description placed it.

**Root cause:** the generic `electronAPI.on()` runtime in `electron/preload.ts` forwarded `(event, ...sanitizedArgs)` to consumer callbacks, while the renderer-facing type contract in `electron/types/electron-api.d.ts` already declared:

```ts
on: <C extends IPCEventChannel>(
  channel: C,
  callback: (data: IPCEventData<C>) => void,
) => () => void
```

The hooks (`useElectronMenu`, `useElectronDeepLink`, `useElectronShortcuts`) were written **to match the type** — `(data) => …` — so the prepended `IpcRendererEvent` shifted their payload by one position. Menu actions and deep-link events silently no-op'd at runtime even though TypeScript was happy.

**Fix is in preload, not in the hooks:** drop the `IpcRendererEvent` argument before forwarding sanitized args, so listeners receive only the payload they were typed for. The hooks were already correct against the contract.

This also aligns with `electron/preload-braindump.ts`, which was added in #33 and already uses the `callback(...sanitizedArgs)` pattern.

## Changes

- `electron/preload.ts` — `on()` strips `IpcRendererEvent` before invoking the listener; updated callback type from `(event, ...args)` to `(...args)`; comment block explaining the contract.
- `electron/__tests__/preload-security.test.mjs` — updated the self-contained mocks (lines 463–532) to reflect the new shape so the documented behavior matches what preload now does.

## Test plan

- [x] `pnpm test:electron` — 140 tests pass (8 files)
- [x] `pnpm validate` — typecheck + lint + build + unit tests all green
- [ ] Manual: trigger a menu action (e.g. `Cmd+N` → New Task) in Electron dev and confirm the renderer hook fires
- [ ] Manual: open a `corelive://` deep link and confirm the deep-link hook receives the payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Event listeners registered via the IPC interface now receive only the payload arguments, with the internal event object no longer forwarded to user callbacks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/34)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->