### PR TITLE
chore: remove Argos CI integration

### DIFF
--- a/.github/workflows/e2e.web.yml
+++ b/.github/workflows/e2e.web.yml
@@ -133,18 +133,6 @@ jobs:
           # `"${SPEC}"` keeps the value as a single literal argument.
           # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           SPEC: ${{ matrix.spec }}
-          # Argos parallel mode — roll up every matrix shard's screenshots
-          # into ONE Argos build. Without this, each shard creates a
-          # separate build; the 4 specs that take no screenshots surface as
-          # "2 removed — waiting for your decision" because Argos compares
-          # those empty builds against the baseline. NONCE must be unique
-          # per workflow run (re-runs need a fresh build, hence
-          # `run_attempt`); TOTAL is the number of parallel shards, sourced
-          # from `detect-specs` so adding a spec file auto-updates the
-          # count. See https://argos-ci.com/docs/parallel-testing.
-          ARGOS_PARALLEL: 'true'
-          ARGOS_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
-          ARGOS_PARALLEL_TOTAL: ${{ needs.detect-specs.outputs.total }}
         # The `setup` project (auth.setup.ts) auto-runs because the `web`
         # project declares `dependencies: ['setup']` — file-path filters do
         # NOT skip dependency projects. Verified via `playwright test --list`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Typecheck](https://github.com/laststance/unfarely/actions/workflows/typecheck.yml/badge.svg)](https://github.com/laststance/unfarely/actions/workflows/typecheck.yml)
 [![E2E Tests (Web)](https://github.com/laststance/corelive/actions/workflows/e2e.web.yml/badge.svg)](https://github.com/laststance/corelive/actions/workflows/e2e.web.yml)
 [![Storybook Testing](https://github.com/laststance/corelive/actions/workflows/storybook-test.yml/badge.svg)](https://github.com/laststance/corelive/actions/workflows/storybook-test.yml)
-[![Covered by Argos Visual Testing](https://argos-ci.com/badge-large.svg)](https://app.argos-ci.com/ryota-murakami/corelive/reference)
 
 # 🚧 It is a work in progress 🚧
 

--- a/e2e/web/_helpers/db.ts
+++ b/e2e/web/_helpers/db.ts
@@ -12,8 +12,8 @@ const exec = util.promisify(execCb)
  * defined in `prisma/seed.ts`.
  *
  * Call this in `test.beforeAll` so each spec file starts from an identical
- * known state — no leftover rows from earlier specs polluting Argos
- * screenshots, no random IDs bleeding across test boundaries.
+ * known state — no leftover rows from earlier specs and no random IDs
+ * bleeding across test boundaries.
  *
  * In CI matrix mode (`.github/workflows/e2e.web.yml`) each runner only
  * executes ONE spec, so `e2e/global-setup.ts`'s up-front reset is already

--- a/e2e/web/skill-tree.spec.ts
+++ b/e2e/web/skill-tree.spec.ts
@@ -97,7 +97,6 @@ test.describe('Skill Tree E2E', () => {
     //
     // Fixed string — `test.beforeAll(resetDatabase)` guarantees a fresh DB
     // each spec run, so we no longer need Date.now/Math.random for isolation.
-    // Stable text also keeps Argos screenshots deterministic (see Issue #31).
     const todoText = 'Skill tree happy path todo'
     await seedCompletedTodo(page, todoText)
     await page.getByRole('link', { name: /skill tree/i }).click()
@@ -292,8 +291,7 @@ test.describe('Skill Tree E2E', () => {
  * @param page - The Playwright Page instance.
  * @param todoText - The text to enter into the new-todo input. Pass a fixed
  *   string (not a Date.now/Math.random suffix) — `test.beforeAll(resetDatabase)`
- *   guarantees per-spec DB isolation, and stable text keeps Argos screenshots
- *   deterministic (see Issue #31).
+ *   guarantees per-spec DB isolation.
  * @example
  * await seedCompletedTodo(page, 'Skill tree happy path todo')
  */

--- a/e2e/web/theme.spec.ts
+++ b/e2e/web/theme.spec.ts
@@ -1,38 +1,31 @@
-import { argosScreenshot } from '@argos-ci/playwright'
 import { setupClerkTestingToken } from '@clerk/testing/playwright'
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 
 import { resetDatabase } from './_helpers/db'
 
 test.describe('Theme Visual Test', () => {
-  // Reset the database once before this spec runs so the screenshots capture
-  // exactly the seeded fixture TODOs (see `prisma/seed.ts`) plus the one
-  // todo this test adds. Without this, leftover rows from prior spec files
-  // (random IDs from todo-app/category/qa-fixes/skill-tree) bleed into the
-  // Argos snapshot and produce false-positive visual diffs.
+  // Reset the database once before this spec runs so the captured CSS state
+  // reflects exactly the seeded fixture TODOs (see `prisma/seed.ts`) plus the
+  // one todo this test adds. Without this, leftover rows from prior spec
+  // files could shift which DOM nodes are mounted and confuse the
+  // theme-driven style assertions below.
   test.beforeAll(resetDatabase)
 
   test.beforeEach(async ({ page }) => {
-    // Setup Clerk testing token for each test
-    // This is required for Clerk to work properly in test mode
     await setupClerkTestingToken({ page })
 
     // Freeze the browser clock so client-side `new Date()` calls render
-    // deterministically across runs. Without this, `ContributionGraph`'s
-    // `endDate` (computed via `useMemo(() => normalizeDate(new Date()))`)
-    // shifts day-by-day and produces false-positive Argos diffs.
-    // The fixed reference is in the past relative to any realistic CI run
-    // so Clerk session token validation (which compares `iat`/`exp` against
-    // the browser clock) still treats real tokens as freshly issued.
+    // deterministically across runs. The fixed reference is in the past
+    // relative to any realistic CI run so Clerk session token validation
+    // (which compares `iat`/`exp` against the browser clock) still treats
+    // real tokens as freshly issued.
     await page.clock.install({ time: new Date('2026-01-15T12:00:00Z') })
 
-    // Navigate to the TODO app home page
-    // Authentication state is automatically loaded from playwright/.auth/user.json
     await page.goto('/home')
     await page.waitForLoadState('networkidle')
   })
 
-  test('should capture screenshots for light and dark themes', async ({
+  test('switches from light to dark theme and applies CSS variables', async ({
     page,
   }) => {
     // Arrange — wait for the authenticated TODO app to render fully
@@ -45,51 +38,65 @@ test.describe('Theme Visual Test', () => {
       await expect(page.getByText('Todo List')).toBeVisible({ timeout: 10000 })
     }
 
-    // Arrange — seed a todo whose label is a fixed constant. Embedding
-    // `Date.now()` / `Math.random()` here would render a different label every
-    // run and surface as an Argos visual diff even when the UI itself has not
-    // changed. `globalSetup` resets the database before each `pnpm e2e:web`
-    // invocation, so a stable string never collides with prior fixtures.
+    // Arrange — seed a todo so the list area has at least one row, matching
+    // the realistic state we want the theme to be applied to.
     const todoText = 'Theme test todo'
     await page.getByPlaceholder('Enter a new todo...').fill(todoText)
     await page.getByRole('button', { name: 'Add', exact: true }).click()
-    const todoCheckbox = page.getByRole('checkbox', { name: todoText })
-    await expect(todoCheckbox).toBeVisible({ timeout: 5000 })
-    await page.waitForTimeout(1000) // let UI settle before screenshotting
+    await expect(page.getByRole('checkbox', { name: todoText })).toBeVisible({
+      timeout: 5000,
+    })
 
-    // Arrange — `createdAt` is stamped server-side at insert time, so its
-    // value is the test execution date and cannot be fixed via `page.clock`.
-    // Mask the visible field for both light and dark snapshots.
-    const createdAtMask = [page.locator('[data-testid="todo-created-at"]')]
+    // Assert — light theme is the default. `next-themes` sets `data-theme`
+    // on the `<html>` element from `ThemeProvider` (see
+    // src/providers/ThemeProvider.tsx).
+    const html = page.locator('html')
+    await expect(html).toHaveAttribute('data-theme', 'light', {
+      timeout: 5000,
+    })
+    const lightBackground = await readBackgroundColor(page)
 
-    // Act 1 — capture the light theme (default) screenshot
-    await argosScreenshot(page, 'home-light-theme', { mask: createdAtMask })
-
-    // Act 2 — open the user menu and switch to dark theme
+    // Act — open the user menu and switch to dark theme
     const sidebarHeader = page.locator('[data-sidebar="header"]').first()
     await expect(sidebarHeader).toBeVisible({ timeout: 5000 })
     const avatarButton = sidebarHeader.locator('button').first()
     await expect(avatarButton).toBeVisible({ timeout: 5000 })
     await avatarButton.click()
-    await page.waitForTimeout(500) // dropdown animation
     const changeThemeTrigger = page.getByText('Change Theme', { exact: false })
     await expect(changeThemeTrigger).toBeVisible()
     await changeThemeTrigger.click()
-    await page.waitForTimeout(500) // submenu animation
     const darkThemeOption = page
       .locator('[role="menuitem"]')
       .filter({ hasText: 'Dark' })
       .first()
     await expect(darkThemeOption).toBeVisible()
     await darkThemeOption.click()
-    await page.waitForTimeout(1500) // theme change triggers re-renders
 
-    // Assert — html element reflects the new theme
-    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark', {
-      timeout: 5000,
-    })
-
-    // Act 3 — capture the dark theme screenshot (same mask as light)
-    await argosScreenshot(page, 'home-dark-theme', { mask: createdAtMask })
+    // Assert — `data-theme` flipped to dark, and the body background-color
+    // (driven by the `--background` CSS variable in src/globals.css) actually
+    // changed. Comparing the computed colors catches a regression where the
+    // attribute swaps but the variables don't repaint.
+    await expect(html).toHaveAttribute('data-theme', 'dark', { timeout: 5000 })
+    await expect
+      .poll(async () => readBackgroundColor(page), { timeout: 5000 })
+      .not.toBe(lightBackground)
   })
 })
+
+/**
+ * Returns the computed `background-color` of the document body as a string.
+ * Used to assert the theme actually swaps CSS variables (not just the
+ * `data-theme` attribute on `<html>`).
+ *
+ * @param page - The Playwright Page instance.
+ * @returns The body's computed `background-color` (e.g. `"rgb(255, 255, 255)"`).
+ * @example
+ * const before = await readBackgroundColor(page)
+ * await switchToDark(page)
+ * expect(await readBackgroundColor(page)).not.toBe(before)
+ */
+async function readBackgroundColor(page: Page): Promise<string> {
+  return page.evaluate(
+    () => window.getComputedStyle(document.body).backgroundColor,
+  )
+}

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     }
   },
   "devDependencies": {
-    "@argos-ci/playwright": "^6.6.2",
     "@chromatic-com/storybook": "^5.1.2",
     "@clerk/testing": "^2.0.21",
     "@electron/notarize": "^3.1.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,23 +43,6 @@ export default defineConfig({
     // (Playwright default) without producing artifacts. See
     // https://playwright.dev/docs/test-sharding#merging-reports-from-multiple-shards.
     process.env.CI ? ['blob'] : ['list'],
-    // Add Argos reporter.
-    //
-    // The matrix-shard workflow at `.github/workflows/e2e.web.yml` sets
-    // `ARGOS_PARALLEL` / `ARGOS_PARALLEL_NONCE` / `ARGOS_PARALLEL_TOTAL` so
-    // every shard's `argosScreenshot` calls collate into a single Argos
-    // build. Without parallel mode, the 4 spec files that take no
-    // screenshots would each create an empty Argos build that diffs as
-    // "2 removed" against the baseline. See
-    // https://argos-ci.com/docs/parallel-testing.
-    [
-      '@argos-ci/playwright/reporter',
-      {
-        // Upload to Argos on CI only.
-        uploadToArgos: !!process.env.CI,
-        token: process.env.ARGOS_TOKEN,
-      },
-    ],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,9 +234,6 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@argos-ci/playwright':
-        specifier: ^6.6.2
-        version: 6.6.2
       '@chromatic-com/storybook':
         specifier: ^5.1.2
         version: 5.1.2(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -451,26 +448,6 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@argos-ci/api-client@0.18.0':
-    resolution: {integrity: sha512-64vK5Bar20C4CT2MidiFQKc/bfw66VNcGKy7i6+WBSA502yRPLGw0163CWL1/+0Tb0thOxB04KoAxcOEN/CjuA==}
-    engines: {node: '>=20.0.0'}
-
-  '@argos-ci/browser@5.1.3':
-    resolution: {integrity: sha512-2acfqcb7A2VNqm43bBk90PleBV+qCwO68FNmoGn28zs3d10G3W3/ZkqtoYUY3ycWclWQ/KYxH8SdHQfz4iB3ow==}
-    engines: {node: '>=20.0.0'}
-
-  '@argos-ci/core@5.2.1':
-    resolution: {integrity: sha512-aOPB/dat46Qa6zqRyD7QS/ewxYKNTkqpAyVvA8qnfFGYM8dQ7M+MMmiQELsybMt6hRORZ+1n1r1dzVOMGvAeRQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@argos-ci/playwright@6.6.2':
-    resolution: {integrity: sha512-VFXW39A68rQIUpS54ghBeUnZrJ/LkOpHQ3tVN5STrCAv2pQ3tWYl7QJOAvK/9nZDLkt0D/QBtDMdI/uhIJ0TUw==}
-    engines: {node: '>=20.0.0'}
-
-  '@argos-ci/util@3.4.0':
-    resolution: {integrity: sha512-rPa8xu6k0TkK1V4CIapcx2x/ncB7dvGa0adXCkflQf+rZZvZaVI3jCVXR57bCZn+S5AWndj4+A/7pX5xV9krvQ==}
-    engines: {node: '>=20.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -3687,10 +3664,6 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
@@ -3834,10 +3807,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  convict@6.2.5:
-    resolution: {integrity: sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==}
-    engines: {node: '>=6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -4503,10 +4472,6 @@ packages:
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
-    engines: {node: '>=8.6.0'}
-
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
   fast-json-stable-stringify@2.1.0:
@@ -5269,9 +5234,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
-
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
@@ -5378,17 +5340,9 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -5599,14 +5553,8 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openapi-fetch@0.17.0:
-    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
-
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
-
-  openapi-typescript-helpers@0.1.0:
-    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -7110,10 +7058,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -7152,40 +7096,6 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
-
-  '@argos-ci/api-client@0.18.0':
-    dependencies:
-      debug: 4.4.3
-      openapi-fetch: 0.17.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@argos-ci/browser@5.1.3': {}
-
-  '@argos-ci/core@5.2.1':
-    dependencies:
-      '@argos-ci/api-client': 0.18.0
-      '@argos-ci/util': 3.4.0
-      convict: 6.2.5
-      debug: 4.4.3
-      fast-glob: 3.3.3
-      mime-types: 3.0.2
-      sharp: 0.34.5
-      tmp: 0.2.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@argos-ci/playwright@6.6.2':
-    dependencies:
-      '@argos-ci/browser': 5.1.3
-      '@argos-ci/core': 5.2.1
-      '@argos-ci/util': 3.4.0
-      chalk: 5.6.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@argos-ci/util@3.4.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -10486,8 +10396,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.2: {}
-
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
@@ -10614,11 +10522,6 @@ snapshots:
   consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
-
-  convict@6.2.5:
-    dependencies:
-      lodash.clonedeep: 4.5.0
-      yargs-parser: 20.2.9
 
   cookie@1.1.1: {}
 
@@ -11551,14 +11454,6 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -12296,8 +12191,6 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.clonedeep@4.5.0: {}
-
   lodash.escaperegexp@4.1.2: {}
 
   lodash.isequal@4.5.0: {}
@@ -12378,15 +12271,9 @@ snapshots:
 
   mime-db@1.52.0: {}
 
-  mime-db@1.54.0: {}
-
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -12614,13 +12501,7 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openapi-fetch@0.17.0:
-    dependencies:
-      openapi-typescript-helpers: 0.1.0
-
   openapi-types@12.1.3: {}
-
-  openapi-typescript-helpers@0.1.0: {}
 
   optionator@0.9.4:
     dependencies:
@@ -14227,8 +14108,6 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.8.3: {}
-
-  yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,8 +17,7 @@ const prisma = new PrismaClient({ adapter })
  * - Default "General" category
  * - A representative real-world TODO list — a deterministic mix of work +
  *   life tasks. This baseline lets E2E specs assume a realistic starting
- *   state in `beforeAll(resetDatabase)` without seeding individually, and
- *   gives Argos visual snapshots an authentic-looking todo list to capture.
+ *   state in `beforeAll(resetDatabase)` without seeding individually.
  */
 async function main(): Promise<void> {
   const user = await prisma.user.upsert({


### PR DESCRIPTION
## Summary

Argos visual-diff CI has been a recurring source of false-positive failures (Issue #29 documents the precedent for merging despite Argos noise). Even non-blocking, the red checkmark on every PR adds triage friction. Removing it cleanly.

## Changes

**Hard removals**
- `@argos-ci/playwright` devDependency
- `@argos-ci/playwright/reporter` block in `playwright.config.ts`
- `ARGOS_PARALLEL` / `ARGOS_PARALLEL_NONCE` / `ARGOS_PARALLEL_TOTAL` env vars in `.github/workflows/e2e.web.yml`
- README "Covered by Argos Visual Testing" badge

**Comment cleanup**
- `prisma/seed.ts` — drop Argos rationale from seed docstring
- `e2e/web/_helpers/db.ts` — drop Argos reference from `resetDatabase` docstring
- `e2e/web/skill-tree.spec.ts` — drop Issue #31 / Argos comment fragments

**`theme.spec.ts` repurposed (kept, not deleted)**

The spec now asserts theme behavior via CSS instead of pixel diffs:
- `<html>` gets `data-theme="light"` initially
- `<html>` gets `data-theme="dark"` after the menu interaction
- `document.body`'s computed `background-color` actually changes (catches regressions where the attribute swaps but CSS variables don't repaint — i.e. the `--background` token in `src/globals.css` failing to apply)

This keeps the user-flow coverage (sidebar → user menu → Change Theme → Dark) without any visual-diff dependency.

## Follow-up (out of scope)

After merge, manually disconnect the Argos GitHub App from the repo so the `argos` status check stops posting on future PRs.

## Test plan

- [x] `pnpm validate` — build, lint, test, typecheck all green
- [x] `pnpm exec playwright test --project=web --list e2e/web/theme.spec.ts` — spec parses, 1 test discovered
- [ ] CI E2E shard for `theme` runs the rewritten test against Vercel preview