### PR TITLE
test(electron): add Playwright E2E suite + Linux+xvfb CI

### DIFF
--- a/.github/workflows/e2e.electron.yml
+++ b/.github/workflows/e2e.electron.yml
@@ -36,7 +36,12 @@
 name: E2E Tests (Electron)
 
 on:
-  pull_request: ~
+  pull_request:
+    # Skip docs-only PRs — Electron build + xvfb run takes ~10 min and
+    # gains nothing from a README typo.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   push:
     branches:
       - main
@@ -46,6 +51,11 @@ jobs:
     name: E2E Electron (Linux + xvfb) 🧪
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    # Lock GITHUB_TOKEN to the minimum needed for checkout + artifact
+    # upload. Forked PRs already run with reduced permissions; explicit
+    # `read` contracts the surface for the trusted-PR case too.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository 🔄
@@ -54,26 +64,40 @@ jobs:
       - name: Use shared prepare action 🔧
         uses: ./.github/actions/prepare
 
+      # Pipe each secret through an `env:` block (rather than interpolating
+      # `${{ secrets.X }}` directly into `run:`) so values containing
+      # newlines or shell metacharacters cannot inject extra `.env` lines.
+      # `printf '%s\n' "$VAR"` keeps each value as a single literal token.
+      # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
       - name: Set environment variables
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          E2E_CLERK_USER_USERNAME: ${{ secrets.E2E_CLERK_USER_USERNAME }}
+          E2E_CLERK_USER_PASSWORD: ${{ secrets.E2E_CLERK_USER_PASSWORD }}
+          E2E_CLERK_USER_EMAIL: ${{ secrets.E2E_CLERK_USER_EMAIL }}
         run: |
-          touch .env
-          echo "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}" >> .env
-          echo "NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login" >> .env
-          echo "NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up" >> .env
-          echo "NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home" >> .env
-          echo "CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}" >> .env
-          echo "WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }}" >> .env
-          echo "POSTGRES_PRISMA_URL=postgresql://postgres:password@localhost:5432/corelive?schema=public" >> .env
-          echo "E2E_CLERK_USER_USERNAME=${{ secrets.E2E_CLERK_USER_USERNAME }}" >> .env
-          echo "E2E_CLERK_USER_PASSWORD=${{ secrets.E2E_CLERK_USER_PASSWORD }}" >> .env
-          echo "E2E_CLERK_USER_EMAIL=${{ secrets.E2E_CLERK_USER_EMAIL }}" >> .env
+          {
+            printf 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=%s\n' "$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY"
+            printf 'NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login\n'
+            printf 'NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up\n'
+            printf 'NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home\n'
+            printf 'CLERK_SECRET_KEY=%s\n' "$CLERK_SECRET_KEY"
+            printf 'WEBHOOK_SECRET=%s\n' "$WEBHOOK_SECRET"
+            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5432/corelive?schema=public'
+            printf 'E2E_CLERK_USER_USERNAME=%s\n' "$E2E_CLERK_USER_USERNAME"
+            printf 'E2E_CLERK_USER_PASSWORD=%s\n' "$E2E_CLERK_USER_PASSWORD"
+            printf 'E2E_CLERK_USER_EMAIL=%s\n' "$E2E_CLERK_USER_EMAIL"
+          } > .env
 
       - name: Start Postgres via Docker Compose 🐳
         run: |
+          # `--wait` blocks until the container's healthcheck passes, and
+          # the next "Verify database connection" step re-polls anyway, so
+          # no additional `sleep` is needed here.
           docker compose -f compose.yml -p corelive up -d postgres --wait
           docker ps -a
-          # Wait for PostgreSQL to be fully ready
-          sleep 10
 
       - name: Show Postgres logs on failure 🪵
         if: failure()

--- a/.github/workflows/e2e.electron.yml
+++ b/.github/workflows/e2e.electron.yml
@@ -1,0 +1,139 @@
+# ----------------------------------------------------------------------------
+# E2E Tests (Electron, Linux + xvfb)
+# ----------------------------------------------------------------------------
+# Runs the Playwright Electron suite (`e2e/electron/*.spec.ts`) on a
+# single ubuntu-latest runner under `xvfb-run`, the Linux virtual display.
+#
+# Why a single job (not a per-spec matrix like e2e.web.yml)?
+#   - The web workflow's matrix amortizes Postgres + Next.js bring-up
+#     across many specs (per-spec break-even ≈ 6 specs). The Electron
+#     suite is 3 specs at v0; per-spec runners would spend more time on
+#     setup than on the tests themselves.
+#   - Each runner shells out to `pnpm electron:build:ts` (electron-vite),
+#     adding ~10–20s of build time per matrix shard.
+#   - When the Electron suite grows past ~6 specs, revisit and convert
+#     to a `e2e.web.yml`-style matrix + merge-reports flow. Plan: see
+#     `~/.gstack/projects/laststance-corelive/main-electron-e2e-plan-…md`.
+#
+# Why `xvfb-run`?
+#   - Electron requires a display to create a `BrowserWindow`. CI runners
+#     are headless; `xvfb` provides a virtual one. The repo's "macOS only"
+#     constraint applies to PACKAGED DMG releases (signing/notarization),
+#     not to running Electron under a virtual display for tests.
+#
+# Coverage scope (job suffix `-linux`):
+#   - Linux + xvfb does NOT cover Cocoa-specific paths:
+#     `app.setActivationPolicy`, dock/menu bar/traffic-light buttons,
+#     `open-url` deep links, vibrancy, notarized .app/asar paths.
+#   - Manual macOS smoke before tag pushes covers those paths (see
+#     CLAUDE.md → "Electron Production Build").
+#
+# Required-check status:
+#   - Informational only at landing time. Promote to required after one
+#     stable week on main with flake rate < 2%.
+# ----------------------------------------------------------------------------
+
+name: E2E Tests (Electron)
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e-electron-linux:
+    name: E2E Electron (Linux + xvfb) 🧪
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository 🔄
+        uses: actions/checkout@v5
+
+      - name: Use shared prepare action 🔧
+        uses: ./.github/actions/prepare
+
+      - name: Set environment variables
+        run: |
+          touch .env
+          echo "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}" >> .env
+          echo "NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login" >> .env
+          echo "NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up" >> .env
+          echo "NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home" >> .env
+          echo "CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}" >> .env
+          echo "WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }}" >> .env
+          echo "POSTGRES_PRISMA_URL=postgresql://postgres:password@localhost:5432/corelive?schema=public" >> .env
+          echo "E2E_CLERK_USER_USERNAME=${{ secrets.E2E_CLERK_USER_USERNAME }}" >> .env
+          echo "E2E_CLERK_USER_PASSWORD=${{ secrets.E2E_CLERK_USER_PASSWORD }}" >> .env
+          echo "E2E_CLERK_USER_EMAIL=${{ secrets.E2E_CLERK_USER_EMAIL }}" >> .env
+
+      - name: Start Postgres via Docker Compose 🐳
+        run: |
+          docker compose -f compose.yml -p corelive up -d postgres --wait
+          docker ps -a
+          # Wait for PostgreSQL to be fully ready
+          sleep 10
+
+      - name: Show Postgres logs on failure 🪵
+        if: failure()
+        run: |
+          docker compose -f compose.yml -p corelive logs postgres | tail -n 200 || true
+
+      - name: Verify database connection 🧪
+        run: |
+          # Wait for database to be created and ready
+          timeout 60 bash -c 'until docker compose -f compose.yml -p corelive exec postgres env PGPASSWORD=password psql -U postgres -lqt | cut -d \| -f 1 | grep -qw corelive; do sleep 2; done'
+          echo "Database 'corelive' exists and is ready!"
+
+      - name: Run Prisma migrations 📦
+        run: pnpm prisma migrate deploy
+
+      - name: Generate Prisma Client 🗄️
+        run: pnpm prisma generate
+
+      - name: Build Next.js application 🏗️
+        run: pnpm build
+
+      # Always rebuild dist-electron — stale builds are a top flake source.
+      # See plan E5 ("Always rebuild `dist-electron`").
+      - name: Compile Electron main + preload 🛠️
+        run: pnpm electron:build:ts
+
+      - name: Install Playwright Browsers 🎭
+        # Chromium isn't strictly needed for `_electron`, but `--with-deps`
+        # installs the Linux libs (libnss3, libatk-bridge2.0-0, libgtk-3-0,
+        # libxss1, etc.) that Electron itself depends on under xvfb.
+        run: pnpm exec playwright install --with-deps chromium
+
+      # NOTE: Next.js is started by the `webServer` block in
+      # `playwright.config.ts` (inherited by `playwright.electron.config.ts`).
+      # That block fires for ALL projects globally — including `_electron`
+      # — so a manual `pnpm start &` here would cause port-3011 double-start.
+
+      - name: Run Electron Playwright tests 🧪
+        env:
+          # Mirrors `e2e.web.yml`'s flag — keeps the per-spec
+          # `resetDatabase` early-return consistent across both suites.
+          E2E_TEST_MODE: 'true'
+          E2E_SKIP_PER_SPEC_RESET: 'true'
+        run: xvfb-run -a pnpm exec playwright test --config=playwright.electron.config.ts
+
+      - name: Upload Playwright HTML report 📊
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report-electron
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Upload Test Results 📋
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          # `test-results/` contains Playwright traces, screenshots,
+          # videos AND the streaming Electron main-process logs that
+          # `e2e/electron/_helpers/launch.ts` writes.
+          name: test-results-electron
+          path: test-results/
+          retention-days: 30

--- a/.github/workflows/e2e.electron.yml
+++ b/.github/workflows/e2e.electron.yml
@@ -99,11 +99,6 @@ jobs:
           docker compose -f compose.yml -p corelive up -d postgres --wait
           docker ps -a
 
-      - name: Show Postgres logs on failure 🪵
-        if: failure()
-        run: |
-          docker compose -f compose.yml -p corelive logs postgres | tail -n 200 || true
-
       - name: Verify database connection 🧪
         run: |
           # Wait for database to be created and ready
@@ -161,3 +156,11 @@ jobs:
           name: test-results-electron
           path: test-results/
           retention-days: 30
+
+      # Placed at the very end so `if: failure()` covers DB verification,
+      # migrations, build, Electron compile, and the Playwright run itself —
+      # not just Docker startup. CodeRabbit caught this on PR #36.
+      - name: Show Postgres logs on failure 🪵
+        if: failure()
+        run: |
+          docker compose -f compose.yml -p corelive logs postgres | tail -n 200 || true

--- a/.github/workflows/e2e.web.yml
+++ b/.github/workflows/e2e.web.yml
@@ -1,7 +1,12 @@
 name: E2E Tests (Web)
 
 on:
-  pull_request: ~
+  pull_request:
+    # Skip docs-only PRs — full E2E matrix takes ~15 min and gains nothing
+    # from a README typo.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   push:
     branches:
       - main
@@ -60,6 +65,8 @@ jobs:
     needs: detect-specs
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -72,26 +79,38 @@ jobs:
       - name: Use shared prepare action 🔧
         uses: ./.github/actions/prepare
 
+      # Pipe each secret through an `env:` block (rather than interpolating
+      # `${{ secrets.X }}` directly into `run:`) so values containing
+      # newlines or shell metacharacters cannot inject extra `.env` lines.
+      # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
       - name: Set environment variables
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          E2E_CLERK_USER_USERNAME: ${{ secrets.E2E_CLERK_USER_USERNAME }}
+          E2E_CLERK_USER_PASSWORD: ${{ secrets.E2E_CLERK_USER_PASSWORD }}
+          E2E_CLERK_USER_EMAIL: ${{ secrets.E2E_CLERK_USER_EMAIL }}
         run: |
-          touch .env
-          echo "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}" >> .env
-          echo "NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login" >> .env
-          echo "NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up" >> .env
-          echo "NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home" >> .env
-          echo "CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}" >> .env
-          echo "WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }}" >> .env
-          echo "POSTGRES_PRISMA_URL=postgresql://postgres:password@localhost:5432/corelive?schema=public" >> .env
-          echo "E2E_CLERK_USER_USERNAME=${{ secrets.E2E_CLERK_USER_USERNAME }}" >> .env
-          echo "E2E_CLERK_USER_PASSWORD=${{ secrets.E2E_CLERK_USER_PASSWORD }}" >> .env
-          echo "E2E_CLERK_USER_EMAIL=${{ secrets.E2E_CLERK_USER_EMAIL }}" >> .env
+          {
+            printf 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=%s\n' "$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY"
+            printf 'NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login\n'
+            printf 'NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up\n'
+            printf 'NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home\n'
+            printf 'CLERK_SECRET_KEY=%s\n' "$CLERK_SECRET_KEY"
+            printf 'WEBHOOK_SECRET=%s\n' "$WEBHOOK_SECRET"
+            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5432/corelive?schema=public'
+            printf 'E2E_CLERK_USER_USERNAME=%s\n' "$E2E_CLERK_USER_USERNAME"
+            printf 'E2E_CLERK_USER_PASSWORD=%s\n' "$E2E_CLERK_USER_PASSWORD"
+            printf 'E2E_CLERK_USER_EMAIL=%s\n' "$E2E_CLERK_USER_EMAIL"
+          } > .env
 
       - name: Start Postgres via Docker Compose 🐳
         run: |
+          # `--wait` blocks until the container's healthcheck passes, and
+          # the next "Verify database connection" step re-polls anyway.
           docker compose -f compose.yml -p corelive up -d postgres --wait
           docker ps -a
-          # Wait for PostgreSQL to be fully ready
-          sleep 10
 
       - name: Show Postgres logs on failure 🪵
         if: failure()

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Test](https://github.com/laststance/unfarely/actions/workflows/test.yml/badge.svg)](https://github.com/laststance/unfarely/actions/workflows/test.yml)
 [![Typecheck](https://github.com/laststance/unfarely/actions/workflows/typecheck.yml/badge.svg)](https://github.com/laststance/unfarely/actions/workflows/typecheck.yml)
 [![E2E Tests (Web)](https://github.com/laststance/corelive/actions/workflows/e2e.web.yml/badge.svg)](https://github.com/laststance/corelive/actions/workflows/e2e.web.yml)
+[![E2E Tests (Electron)](https://github.com/laststance/corelive/actions/workflows/e2e.electron.yml/badge.svg)](https://github.com/laststance/corelive/actions/workflows/e2e.electron.yml)
 [![Storybook Testing](https://github.com/laststance/corelive/actions/workflows/storybook-test.yml/badge.svg)](https://github.com/laststance/corelive/actions/workflows/storybook-test.yml)
 
 # 🚧 It is a work in progress 🚧

--- a/e2e/electron/_helpers/launch.ts
+++ b/e2e/electron/_helpers/launch.ts
@@ -1,60 +1,16 @@
-/**
- * @fileoverview Shared Electron launcher for the Playwright E2E suite.
- *
- * Why a shared launcher?
- * - Every spec needs the same environment contract (NODE_ENV=test,
- *   ELECTRON_RENDERER_URL, PLAYWRIGHT_REMOTE_DEBUGGING_PORT,
- *   ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION). Centralizing prevents drift.
- * - Main-process stdout/stderr must be captured at launch time (NOT in
- *   `afterAll`) because `deferredInit()` can crash before any test body
- *   runs. Streaming `data` events to disk catches early failures that
- *   would otherwise surface only as Playwright timeouts.
- *
- * @module e2e/electron/_helpers/launch
- */
-
 import fs from 'node:fs'
 import path from 'node:path'
 
 import { _electron as electron } from 'playwright'
 import type { ElectronApplication } from 'playwright'
 
-/**
- * URL the renderer will load during E2E. Hardcoded to localhost so a
- * misconfigured `.env` cannot point E2E at production.
- */
 const RENDERER_URL = 'http://localhost:3011'
-
-/**
- * Compiled Electron entry point produced by `electron-vite build`. The
- * `pnpm electron:build:ts` step runs unconditionally before the spec to
- * keep this file in sync with the source.
- */
 const ELECTRON_MAIN_ENTRY = 'dist-electron/main/index.cjs'
-
-/**
- * Directory where Playwright already writes traces / screenshots /
- * videos. Putting our main-process logs here lets the existing CI
- * `actions/upload-artifact` step pick them up with no extra config.
- */
 const LOG_DIR = 'test-results'
 
-/**
- * Launch the compiled Electron app for an E2E spec.
- *
- * @param specName - Short identifier (e.g. `'startup'`, `'preload'`) used
- *   to namespace the main-process log file. Whitespace is replaced with
- *   `-` so the value lands cleanly in a filename.
- * @returns The Playwright `ElectronApplication` handle. The caller is
- *   responsible for closing it in `afterAll`.
- *
- * @example
- * ```ts
- * let app: ElectronApplication
- * test.beforeAll(async () => { app = await launchElectronForTest('startup') })
- * test.afterAll(async () => { await app?.close() })
- * ```
- */
+/** Default timeout (ms) for waiting on renderer URL transitions in specs. */
+export const LOAD_TIMEOUT_MS = 30_000
+
 export async function launchElectronForTest(
   specName: string,
 ): Promise<ElectronApplication> {
@@ -62,7 +18,6 @@ export async function launchElectronForTest(
   const safeSpecName = specName.replace(/\s+/g, '-')
   const logPath = path.join(LOG_DIR, `electron-main-${safeSpecName}.log`)
 
-  // Truncate any prior run's log so we don't conflate runs.
   fs.writeFileSync(
     logPath,
     `=== launch env ===\n` +
@@ -83,10 +38,10 @@ export async function launchElectronForTest(
     },
   })
 
-  // Attach streaming listeners IMMEDIATELY after launch — main-process
-  // output can flow during `deferredInit`, before the first window is
-  // ready. `appendFileSync` (sync I/O per chunk) is intentional: it
-  // survives a hard process exit better than buffered async writes.
+  // Attach listeners immediately — main-process output can flow during
+  // `deferredInit` before the first window is ready, and a deferredInit
+  // crash would otherwise surface only as a Playwright timeout. Sync I/O
+  // per chunk survives a hard process exit better than buffered writes.
   const proc = electronApp.process()
   proc.stdout?.on('data', (chunk) => {
     fs.appendFileSync(logPath, chunk)

--- a/e2e/electron/_helpers/launch.ts
+++ b/e2e/electron/_helpers/launch.ts
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Shared Electron launcher for the Playwright E2E suite.
+ *
+ * Why a shared launcher?
+ * - Every spec needs the same environment contract (NODE_ENV=test,
+ *   ELECTRON_RENDERER_URL, PLAYWRIGHT_REMOTE_DEBUGGING_PORT,
+ *   ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION). Centralizing prevents drift.
+ * - Main-process stdout/stderr must be captured at launch time (NOT in
+ *   `afterAll`) because `deferredInit()` can crash before any test body
+ *   runs. Streaming `data` events to disk catches early failures that
+ *   would otherwise surface only as Playwright timeouts.
+ *
+ * @module e2e/electron/_helpers/launch
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { _electron as electron } from 'playwright'
+import type { ElectronApplication } from 'playwright'
+
+/**
+ * URL the renderer will load during E2E. Hardcoded to localhost so a
+ * misconfigured `.env` cannot point E2E at production.
+ */
+const RENDERER_URL = 'http://localhost:3011'
+
+/**
+ * Compiled Electron entry point produced by `electron-vite build`. The
+ * `pnpm electron:build:ts` step runs unconditionally before the spec to
+ * keep this file in sync with the source.
+ */
+const ELECTRON_MAIN_ENTRY = 'dist-electron/main/index.cjs'
+
+/**
+ * Directory where Playwright already writes traces / screenshots /
+ * videos. Putting our main-process logs here lets the existing CI
+ * `actions/upload-artifact` step pick them up with no extra config.
+ */
+const LOG_DIR = 'test-results'
+
+/**
+ * Launch the compiled Electron app for an E2E spec.
+ *
+ * @param specName - Short identifier (e.g. `'startup'`, `'preload'`) used
+ *   to namespace the main-process log file. Whitespace is replaced with
+ *   `-` so the value lands cleanly in a filename.
+ * @returns The Playwright `ElectronApplication` handle. The caller is
+ *   responsible for closing it in `afterAll`.
+ *
+ * @example
+ * ```ts
+ * let app: ElectronApplication
+ * test.beforeAll(async () => { app = await launchElectronForTest('startup') })
+ * test.afterAll(async () => { await app?.close() })
+ * ```
+ */
+export async function launchElectronForTest(
+  specName: string,
+): Promise<ElectronApplication> {
+  fs.mkdirSync(LOG_DIR, { recursive: true })
+  const safeSpecName = specName.replace(/\s+/g, '-')
+  const logPath = path.join(LOG_DIR, `electron-main-${safeSpecName}.log`)
+
+  // Truncate any prior run's log so we don't conflate runs.
+  fs.writeFileSync(
+    logPath,
+    `=== launch env ===\n` +
+      `NODE_ENV=test\n` +
+      `ELECTRON_RENDERER_URL=${RENDERER_URL}\n` +
+      `ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION=true\n` +
+      `=== main-process output (stdout + stderr interleaved) ===\n`,
+  )
+
+  const electronApp = await electron.launch({
+    args: [ELECTRON_MAIN_ENTRY],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      ELECTRON_RENDERER_URL: RENDERER_URL,
+      PLAYWRIGHT_REMOTE_DEBUGGING_PORT: '9222',
+      ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION: 'true',
+    },
+  })
+
+  // Attach streaming listeners IMMEDIATELY after launch — main-process
+  // output can flow during `deferredInit`, before the first window is
+  // ready. `appendFileSync` (sync I/O per chunk) is intentional: it
+  // survives a hard process exit better than buffered async writes.
+  const proc = electronApp.process()
+  proc.stdout?.on('data', (chunk) => {
+    fs.appendFileSync(logPath, chunk)
+  })
+  proc.stderr?.on('data', (chunk) => {
+    fs.appendFileSync(logPath, chunk)
+  })
+
+  return electronApp
+}

--- a/e2e/electron/_helpers/launch.ts
+++ b/e2e/electron/_helpers/launch.ts
@@ -2,11 +2,12 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { _electron as electron } from 'playwright'
-import type { ElectronApplication } from 'playwright'
+import type { ElectronApplication, Page } from 'playwright'
 
 const RENDERER_URL = 'http://localhost:3011'
 const ELECTRON_MAIN_ENTRY = 'dist-electron/main/index.cjs'
 const LOG_DIR = 'test-results'
+const REMOTE_DEBUG_PORT = '9222'
 
 /** Default timeout (ms) for waiting on renderer URL transitions in specs. */
 export const LOAD_TIMEOUT_MS = 30_000
@@ -15,7 +16,10 @@ export async function launchElectronForTest(
   specName: string,
 ): Promise<ElectronApplication> {
   fs.mkdirSync(LOG_DIR, { recursive: true })
-  const safeSpecName = specName.replace(/\s+/g, '-')
+  // `path.basename` strips any directory traversal — current callers all
+  // pass hardcoded literals, but a future caller deriving `specName` from
+  // dynamic test metadata could otherwise write outside `LOG_DIR`.
+  const safeSpecName = path.basename(specName.replace(/\s+/g, '-'))
   const logPath = path.join(LOG_DIR, `electron-main-${safeSpecName}.log`)
 
   fs.writeFileSync(
@@ -33,7 +37,7 @@ export async function launchElectronForTest(
       ...process.env,
       NODE_ENV: 'test',
       ELECTRON_RENDERER_URL: RENDERER_URL,
-      PLAYWRIGHT_REMOTE_DEBUGGING_PORT: '9222',
+      PLAYWRIGHT_REMOTE_DEBUGGING_PORT: REMOTE_DEBUG_PORT,
       ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION: 'true',
     },
   })
@@ -51,4 +55,21 @@ export async function launchElectronForTest(
   })
 
   return electronApp
+}
+
+/**
+ * Launch Electron AND wait for the renderer's first window to load — the
+ * setup that `preload.spec.ts` and `window-controls.spec.ts` both need.
+ * `startup.spec.ts` does NOT use this helper because it tests the load
+ * path itself (the `domcontentloaded` wait belongs in the test body, not
+ * `beforeAll`).
+ */
+export async function setupElectronTest(specName: string): Promise<{
+  electronApp: ElectronApplication
+  mainWindow: Page
+}> {
+  const electronApp = await launchElectronForTest(specName)
+  const mainWindow = await electronApp.firstWindow()
+  await mainWindow.waitForLoadState('domcontentloaded')
+  return { electronApp, mainWindow }
 }

--- a/e2e/electron/preload.spec.ts
+++ b/e2e/electron/preload.spec.ts
@@ -1,29 +1,22 @@
 /**
- * @fileoverview Electron preload contract E2E spec.
- *
- * Verifies the `contextBridge` surface exposed in `electron/preload.ts`:
- * 1. `window.electronAPI` exists and contains the expected top-level
- *    namespaces (catches regressions like PR #34's missing `on()`).
- * 2. `window.electronEnv` reports `isElectron: true` and a platform
- *    string — proves the preload actually executed inside the renderer.
- * 3. A read-only IPC round-trip (`window.electronAPI.app.getVersion()`)
- *    successfully reaches the main process and returns a string.
- *
- * Why `app.getVersion()`? It's a documented part of the public API,
- * has no side effects, and matches the package-level `app.getVersion()`
- * we assert in the startup spec — a successful round-trip proves the
- * full preload → IPC → main → preload path is wired.
+ * Verifies the `contextBridge` surface in `electron/preload.ts`: the
+ * documented namespaces are exposed, `electronEnv.isElectron` is true,
+ * and a read-only IPC round-trip (`app.getVersion()`) reaches the main
+ * process and returns a string.
  */
 
 import { expect, test } from '@playwright/test'
-import type { ElectronApplication } from 'playwright'
+import type { ElectronApplication, Page } from 'playwright'
 
 import { launchElectronForTest } from './_helpers/launch'
 
 let electronApp: ElectronApplication
+let mainWindow: Page
 
 test.beforeAll(async () => {
   electronApp = await launchElectronForTest('preload')
+  mainWindow = await electronApp.firstWindow()
+  await mainWindow.waitForLoadState('domcontentloaded')
 })
 
 test.afterAll(async () => {
@@ -31,41 +24,19 @@ test.afterAll(async () => {
 })
 
 test('window.electronAPI exposes the documented namespaces', async () => {
-  const mainWindow = await electronApp.firstWindow()
-  await mainWindow.waitForLoadState('domcontentloaded')
-
   const exposedKeys = await mainWindow.evaluate(() => {
-    const api = (
-      globalThis as unknown as {
-        electronAPI?: Record<string, unknown>
-      }
-    ).electronAPI
-    return api ? Object.keys(api).sort() : []
+    return window.electronAPI ? Object.keys(window.electronAPI).sort() : []
   })
 
-  // Spot-check a handful of the namespaces declared in
-  // `electron/preload.ts:contextBridge.exposeInMainWorld('electronAPI', …)`.
-  // Asserting all of them would couple the test to ordering changes; the
-  // subset is enough to catch a regression like PR #34 (missing `on`).
+  // Spot-check a subset; asserting the full key set would couple this
+  // test to namespace ordering changes. The subset still catches the
+  // PR #34-style regression where `on` was missing.
   expect(exposedKeys).toEqual(expect.arrayContaining(['app', 'auth', 'on']))
   expect(exposedKeys.length).toBeGreaterThan(0)
 })
 
 test('window.electronEnv reports running inside Electron', async () => {
-  const mainWindow = await electronApp.firstWindow()
-  await mainWindow.waitForLoadState('domcontentloaded')
-
-  const env = await mainWindow.evaluate(() => {
-    return (
-      globalThis as unknown as {
-        electronEnv?: {
-          isElectron?: boolean
-          platform?: string
-          versions?: { electron?: string }
-        }
-      }
-    ).electronEnv
-  })
+  const env = await mainWindow.evaluate(() => window.electronEnv)
 
   expect(env?.isElectron).toBe(true)
   expect(typeof env?.platform).toBe('string')
@@ -73,24 +44,14 @@ test('window.electronEnv reports running inside Electron', async () => {
 })
 
 test('preload IPC round-trip reaches the main process', async () => {
-  const mainWindow = await electronApp.firstWindow()
-  await mainWindow.waitForLoadState('domcontentloaded')
-
   const version = await mainWindow.evaluate(async () => {
-    const api = (
-      globalThis as unknown as {
-        electronAPI?: { app?: { getVersion?: () => Promise<string> } }
-      }
-    ).electronAPI
-    if (!api?.app?.getVersion) {
+    const getVersion = window.electronAPI?.app?.getVersion
+    if (!getVersion) {
       throw new Error('window.electronAPI.app.getVersion is not exposed')
     }
-    return api.app.getVersion()
+    return getVersion()
   })
 
-  // The version is whatever `app.getVersion()` returns; we don't assert
-  // a specific value to avoid coupling to package.json bumps. A non-empty
-  // string proves the IPC call resolved successfully.
   expect(typeof version).toBe('string')
   expect(version.length).toBeGreaterThan(0)
 })

--- a/e2e/electron/preload.spec.ts
+++ b/e2e/electron/preload.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Electron preload contract E2E spec.
+ *
+ * Verifies the `contextBridge` surface exposed in `electron/preload.ts`:
+ * 1. `window.electronAPI` exists and contains the expected top-level
+ *    namespaces (catches regressions like PR #34's missing `on()`).
+ * 2. `window.electronEnv` reports `isElectron: true` and a platform
+ *    string — proves the preload actually executed inside the renderer.
+ * 3. A read-only IPC round-trip (`window.electronAPI.app.getVersion()`)
+ *    successfully reaches the main process and returns a string.
+ *
+ * Why `app.getVersion()`? It's a documented part of the public API,
+ * has no side effects, and matches the package-level `app.getVersion()`
+ * we assert in the startup spec — a successful round-trip proves the
+ * full preload → IPC → main → preload path is wired.
+ */
+
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication } from 'playwright'
+
+import { launchElectronForTest } from './_helpers/launch'
+
+let electronApp: ElectronApplication
+
+test.beforeAll(async () => {
+  electronApp = await launchElectronForTest('preload')
+})
+
+test.afterAll(async () => {
+  await electronApp?.close()
+})
+
+test('window.electronAPI exposes the documented namespaces', async () => {
+  const mainWindow = await electronApp.firstWindow()
+  await mainWindow.waitForLoadState('domcontentloaded')
+
+  const exposedKeys = await mainWindow.evaluate(() => {
+    const api = (
+      globalThis as unknown as {
+        electronAPI?: Record<string, unknown>
+      }
+    ).electronAPI
+    return api ? Object.keys(api).sort() : []
+  })
+
+  // Spot-check a handful of the namespaces declared in
+  // `electron/preload.ts:contextBridge.exposeInMainWorld('electronAPI', …)`.
+  // Asserting all of them would couple the test to ordering changes; the
+  // subset is enough to catch a regression like PR #34 (missing `on`).
+  expect(exposedKeys).toEqual(expect.arrayContaining(['app', 'auth', 'on']))
+  expect(exposedKeys.length).toBeGreaterThan(0)
+})
+
+test('window.electronEnv reports running inside Electron', async () => {
+  const mainWindow = await electronApp.firstWindow()
+  await mainWindow.waitForLoadState('domcontentloaded')
+
+  const env = await mainWindow.evaluate(() => {
+    return (
+      globalThis as unknown as {
+        electronEnv?: {
+          isElectron?: boolean
+          platform?: string
+          versions?: { electron?: string }
+        }
+      }
+    ).electronEnv
+  })
+
+  expect(env?.isElectron).toBe(true)
+  expect(typeof env?.platform).toBe('string')
+  expect(typeof env?.versions?.electron).toBe('string')
+})
+
+test('preload IPC round-trip reaches the main process', async () => {
+  const mainWindow = await electronApp.firstWindow()
+  await mainWindow.waitForLoadState('domcontentloaded')
+
+  const version = await mainWindow.evaluate(async () => {
+    const api = (
+      globalThis as unknown as {
+        electronAPI?: { app?: { getVersion?: () => Promise<string> } }
+      }
+    ).electronAPI
+    if (!api?.app?.getVersion) {
+      throw new Error('window.electronAPI.app.getVersion is not exposed')
+    }
+    return api.app.getVersion()
+  })
+
+  // The version is whatever `app.getVersion()` returns; we don't assert
+  // a specific value to avoid coupling to package.json bumps. A non-empty
+  // string proves the IPC call resolved successfully.
+  expect(typeof version).toBe('string')
+  expect(version.length).toBeGreaterThan(0)
+})

--- a/e2e/electron/preload.spec.ts
+++ b/e2e/electron/preload.spec.ts
@@ -8,15 +8,13 @@
 import { expect, test } from '@playwright/test'
 import type { ElectronApplication, Page } from 'playwright'
 
-import { launchElectronForTest } from './_helpers/launch'
+import { setupElectronTest } from './_helpers/launch'
 
 let electronApp: ElectronApplication
 let mainWindow: Page
 
 test.beforeAll(async () => {
-  electronApp = await launchElectronForTest('preload')
-  mainWindow = await electronApp.firstWindow()
-  await mainWindow.waitForLoadState('domcontentloaded')
+  ;({ electronApp, mainWindow } = await setupElectronTest('preload'))
 })
 
 test.afterAll(async () => {

--- a/e2e/electron/startup.spec.ts
+++ b/e2e/electron/startup.spec.ts
@@ -1,22 +1,14 @@
 /**
- * @fileoverview Electron startup E2E spec.
- *
- * Asserts the integrated startup path that no unit test covers:
- * 1. The compiled main process boots without crashing.
- * 2. `WindowManager.createMainWindow` opens a real `BrowserWindow`.
- * 3. The renderer loads from the local Next.js server (the
- *    `ELECTRON_RENDERER_URL` patch in `electron/main.ts` works).
- * 4. The renderer eventually lands on `/login` (auth-skip v0).
- *
- * Catches the regression class of PR #28 (window creation flow) and
- * the would-have-shipped CEO-caught bug where `NODE_ENV=test` left the
- * renderer pointed at `https://corelive.app`.
+ * Asserts the integrated startup path: the main process boots, opens a
+ * `BrowserWindow`, and loads the local Next.js renderer (proving the
+ * `ELECTRON_RENDERER_URL` patch in `electron/main.ts` and the test-env
+ * URL guard both work end-to-end).
  */
 
 import { expect, test } from '@playwright/test'
 import type { ElectronApplication } from 'playwright'
 
-import { launchElectronForTest } from './_helpers/launch'
+import { LOAD_TIMEOUT_MS, launchElectronForTest } from './_helpers/launch'
 
 let electronApp: ElectronApplication
 
@@ -37,7 +29,9 @@ test('main window opens and loads the local Next.js renderer', async () => {
 
   // The Clerk redirect chain may briefly show `/` before settling on
   // `/login`. Assert with `waitForURL` so we tolerate the intermediate.
-  await mainWindow.waitForURL(/(login|home|sign-in)/, { timeout: 30_000 })
+  await mainWindow.waitForURL(/(login|home|sign-in)/, {
+    timeout: LOAD_TIMEOUT_MS,
+  })
 
   const url = mainWindow.url()
   expect(url).toContain('localhost:3011')

--- a/e2e/electron/startup.spec.ts
+++ b/e2e/electron/startup.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Electron startup E2E spec.
+ *
+ * Asserts the integrated startup path that no unit test covers:
+ * 1. The compiled main process boots without crashing.
+ * 2. `WindowManager.createMainWindow` opens a real `BrowserWindow`.
+ * 3. The renderer loads from the local Next.js server (the
+ *    `ELECTRON_RENDERER_URL` patch in `electron/main.ts` works).
+ * 4. The renderer eventually lands on `/login` (auth-skip v0).
+ *
+ * Catches the regression class of PR #28 (window creation flow) and
+ * the would-have-shipped CEO-caught bug where `NODE_ENV=test` left the
+ * renderer pointed at `https://corelive.app`.
+ */
+
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication } from 'playwright'
+
+import { launchElectronForTest } from './_helpers/launch'
+
+let electronApp: ElectronApplication
+
+test.beforeAll(async () => {
+  electronApp = await launchElectronForTest('startup')
+})
+
+test.afterAll(async () => {
+  await electronApp?.close()
+})
+
+test('main window opens and loads the local Next.js renderer', async () => {
+  const mainWindow = await electronApp.firstWindow()
+
+  // Wait for the renderer to actually load — `firstWindow()` resolves
+  // before navigation completes, so URL/title checks would race.
+  await mainWindow.waitForLoadState('domcontentloaded')
+
+  // The Clerk redirect chain may briefly show `/` before settling on
+  // `/login`. Assert with `waitForURL` so we tolerate the intermediate.
+  await mainWindow.waitForURL(/(login|home|sign-in)/, { timeout: 30_000 })
+
+  const url = mainWindow.url()
+  expect(url).toContain('localhost:3011')
+  expect(url).toMatch(/(login|home|sign-in)/)
+})
+
+test('app reports the expected name from the main process', async () => {
+  // `electronApp.evaluate` runs the function in the MAIN process — proves
+  // we are talking to the real `electron` runtime, not just a renderer
+  // page. `app.getName()` is read-only and side-effect free.
+  const appName = await electronApp.evaluate(({ app }) => app.getName())
+  expect(appName).toBeTruthy()
+  expect(typeof appName).toBe('string')
+})

--- a/e2e/electron/window-controls.spec.ts
+++ b/e2e/electron/window-controls.spec.ts
@@ -1,16 +1,8 @@
 /**
- * @fileoverview Window controls E2E spec.
- *
- * Smoke-tests window-level operations from the main process:
- * 1. `BrowserWindow.getBounds()` returns sensible numbers (proves the
- *    window was created and is not zero-sized).
- * 2. `setBounds` round-trips through the IPC layer with a ±1px
- *    tolerance for xvfb DPI rounding (Failure Mode F7 in the plan).
- * 3. `setSize` is idempotent — calling it twice with the same value
- *    doesn't crash the main process.
- *
- * Asserts on `mainWindow.getBounds()` directly via `electronApp.evaluate`
- * (NOT via the `window.electronAPI.window` IPC) so that a preload
+ * Smoke-tests window-level operations from the main process: bounds are
+ * non-zero after creation, `setBounds` round-trips with a ±1px DPI
+ * tolerance, and `setSize` is idempotent. Asserts on `getBounds()` via
+ * `electronApp.evaluate` (not `window.electronAPI.window`) so a preload
  * regression cannot silently mask a window-control failure.
  */
 

--- a/e2e/electron/window-controls.spec.ts
+++ b/e2e/electron/window-controls.spec.ts
@@ -9,32 +9,27 @@
 import { expect, test } from '@playwright/test'
 import type { ElectronApplication } from 'playwright'
 
-import { launchElectronForTest } from './_helpers/launch'
+import { setupElectronTest } from './_helpers/launch'
+
+/** Tolerance (px) for window bounds/size round-trips under xvfb DPI scaling. */
+const DPI_TOLERANCE_PX = 1
 
 let electronApp: ElectronApplication
 
 test.beforeAll(async () => {
-  electronApp = await launchElectronForTest('window-controls')
-
-  // Wait for the renderer to load before any `electronApp.evaluate` call.
-  // Without this wait, the main-process inspector context can be torn down
-  // mid-evaluate while Electron is still creating the BrowserWindow and
-  // loading the URL — Playwright surfaces that as
+  // `setupElectronTest` includes the `domcontentloaded` wait — necessary
+  // because the main-process inspector context can be torn down mid-evaluate
+  // while Electron is still creating the BrowserWindow and loading the URL.
+  // Playwright surfaces that as
   // `Execution context was destroyed, most likely because of a navigation`
   // (the "navigation" wording is misleading; the destruction happens in
-  // the Node-side execution context, not the renderer). Waiting for
-  // `domcontentloaded` lets the main process reach a quiescent state where
-  // CDP main-process evaluates are stable.
-  const mainWindow = await electronApp.firstWindow()
-  await mainWindow.waitForLoadState('domcontentloaded')
+  // the Node-side execution context, not the renderer).
+  ;({ electronApp } = await setupElectronTest('window-controls'))
 })
 
 test.afterAll(async () => {
   await electronApp?.close()
 })
-
-/** Tolerance (px) for `setBounds` round-trips under xvfb DPI scaling. */
-const DPI_TOLERANCE_PX = 1
 
 test('main window has non-zero bounds after creation', async () => {
   const bounds = await electronApp.evaluate(({ BrowserWindow }) => {
@@ -82,17 +77,28 @@ test('setBounds round-trips with DPI tolerance', async () => {
 test('setSize is idempotent', async () => {
   const targetSize = { width: 900, height: 700 }
 
+  // Read via `getBounds()` (Rectangle object) instead of `getSize()`
+  // (number[] tuple) so strict-index typing doesn't surface noise here.
   const sizes = await electronApp.evaluate(({ BrowserWindow }, target) => {
     const window = BrowserWindow.getAllWindows()[0]
     if (!window) {
       throw new Error('No BrowserWindow available')
     }
     window.setSize(target.width, target.height)
-    const first = window.getSize()
+    const first = window.getBounds()
     window.setSize(target.width, target.height)
-    const second = window.getSize()
+    const second = window.getBounds()
     return { first, second }
   }, targetSize)
 
-  expect(sizes.first).toEqual(sizes.second)
+  // Two consecutive `setSize` calls with the same target should converge
+  // to the same size. WM ack is async on Linux + xvfb, so allow ±1px to
+  // absorb rounding between the two reads (same tolerance used by the
+  // `setBounds` round-trip test above).
+  expect(Math.abs(sizes.first.width - sizes.second.width)).toBeLessThanOrEqual(
+    DPI_TOLERANCE_PX,
+  )
+  expect(
+    Math.abs(sizes.first.height - sizes.second.height),
+  ).toBeLessThanOrEqual(DPI_TOLERANCE_PX)
 })

--- a/e2e/electron/window-controls.spec.ts
+++ b/e2e/electron/window-controls.spec.ts
@@ -23,6 +23,18 @@ let electronApp: ElectronApplication
 
 test.beforeAll(async () => {
   electronApp = await launchElectronForTest('window-controls')
+
+  // Wait for the renderer to load before any `electronApp.evaluate` call.
+  // Without this wait, the main-process inspector context can be torn down
+  // mid-evaluate while Electron is still creating the BrowserWindow and
+  // loading the URL — Playwright surfaces that as
+  // `Execution context was destroyed, most likely because of a navigation`
+  // (the "navigation" wording is misleading; the destruction happens in
+  // the Node-side execution context, not the renderer). Waiting for
+  // `domcontentloaded` lets the main process reach a quiescent state where
+  // CDP main-process evaluates are stable.
+  const mainWindow = await electronApp.firstWindow()
+  await mainWindow.waitForLoadState('domcontentloaded')
 })
 
 test.afterAll(async () => {

--- a/e2e/electron/window-controls.spec.ts
+++ b/e2e/electron/window-controls.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Window controls E2E spec.
+ *
+ * Smoke-tests window-level operations from the main process:
+ * 1. `BrowserWindow.getBounds()` returns sensible numbers (proves the
+ *    window was created and is not zero-sized).
+ * 2. `setBounds` round-trips through the IPC layer with a ±1px
+ *    tolerance for xvfb DPI rounding (Failure Mode F7 in the plan).
+ * 3. `setSize` is idempotent — calling it twice with the same value
+ *    doesn't crash the main process.
+ *
+ * Asserts on `mainWindow.getBounds()` directly via `electronApp.evaluate`
+ * (NOT via the `window.electronAPI.window` IPC) so that a preload
+ * regression cannot silently mask a window-control failure.
+ */
+
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication } from 'playwright'
+
+import { launchElectronForTest } from './_helpers/launch'
+
+let electronApp: ElectronApplication
+
+test.beforeAll(async () => {
+  electronApp = await launchElectronForTest('window-controls')
+})
+
+test.afterAll(async () => {
+  await electronApp?.close()
+})
+
+/** Tolerance (px) for `setBounds` round-trips under xvfb DPI scaling. */
+const DPI_TOLERANCE_PX = 1
+
+test('main window has non-zero bounds after creation', async () => {
+  const bounds = await electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0]
+    return window?.getBounds() ?? null
+  })
+
+  expect(bounds).not.toBeNull()
+  expect(bounds!.width).toBeGreaterThan(0)
+  expect(bounds!.height).toBeGreaterThan(0)
+})
+
+test('setBounds round-trips with DPI tolerance', async () => {
+  const targetBounds = { x: 50, y: 50, width: 1024, height: 768 }
+
+  const actualBounds = await electronApp.evaluate(
+    ({ BrowserWindow }, target) => {
+      const window = BrowserWindow.getAllWindows()[0]
+      if (!window) {
+        throw new Error('No BrowserWindow available')
+      }
+      window.setBounds(target)
+      return window.getBounds()
+    },
+    targetBounds,
+  )
+
+  // ±1px tolerance: xvfb at non-1.0 DPI scales rounds the size — see
+  // the plan's Failure Mode F7. The tolerance is asymmetric in practice
+  // (Linux often drops 1px), so check absolute difference.
+  expect(Math.abs(actualBounds.x - targetBounds.x)).toBeLessThanOrEqual(
+    DPI_TOLERANCE_PX,
+  )
+  expect(Math.abs(actualBounds.y - targetBounds.y)).toBeLessThanOrEqual(
+    DPI_TOLERANCE_PX,
+  )
+  expect(Math.abs(actualBounds.width - targetBounds.width)).toBeLessThanOrEqual(
+    DPI_TOLERANCE_PX,
+  )
+  expect(
+    Math.abs(actualBounds.height - targetBounds.height),
+  ).toBeLessThanOrEqual(DPI_TOLERANCE_PX)
+})
+
+test('setSize is idempotent', async () => {
+  const targetSize = { width: 900, height: 700 }
+
+  const sizes = await electronApp.evaluate(({ BrowserWindow }, target) => {
+    const window = BrowserWindow.getAllWindows()[0]
+    if (!window) {
+      throw new Error('No BrowserWindow available')
+    }
+    window.setSize(target.width, target.height)
+    const first = window.getSize()
+    window.setSize(target.width, target.height)
+    const second = window.getSize()
+    return { first, second }
+  }, targetSize)
+
+  expect(sizes.first).toEqual(sizes.second)
+})

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -95,6 +95,33 @@ if (process.env.PLAYWRIGHT_REMOTE_DEBUGGING_PORT) {
   )
 }
 
+/**
+ * E2E renderer URL override.
+ *
+ * The Playwright Electron E2E suite (`e2e/electron/*.spec.ts`) loads the
+ * renderer from a local Next.js server (`http://localhost:3011`) so tests
+ * never hit production. To swap the URL without flipping the rest of the
+ * dev/prod surface (CSP `'unsafe-eval'`, optimization level), we accept a
+ * dedicated `ELECTRON_RENDERER_URL` env var. Production runs leave this
+ * unset and continue to use `https://corelive.app`.
+ *
+ * Validation: only `http://localhost*` / `http://127.0.0.1*` are accepted.
+ * This guard prevents an operator from accidentally pointing E2E at
+ * production by typo and is a defense-in-depth check before the value
+ * reaches `WindowManager.createMainWindow`.
+ */
+if (
+  process.env.ELECTRON_RENDERER_URL &&
+  !process.env.ELECTRON_RENDERER_URL.startsWith('http://localhost') &&
+  !process.env.ELECTRON_RENDERER_URL.startsWith('http://127.0.0.1')
+) {
+  throw new Error(
+    `ELECTRON_RENDERER_URL must start with "http://localhost" or "http://127.0.0.1" — ` +
+      `got "${process.env.ELECTRON_RENDERER_URL}". This guard prevents accidental ` +
+      `production renderer load during E2E. Unset the var to use defaults.`,
+  )
+}
+
 // ============================================================================
 // Environment Flags
 // ============================================================================
@@ -105,6 +132,26 @@ if (process.env.PLAYWRIGHT_REMOTE_DEBUGGING_PORT) {
  */
 const isDev = process.env.NODE_ENV === 'development'
 const isTestEnvironment = process.env.NODE_ENV === 'test'
+
+/**
+ * E2E system-integration kill switch.
+ *
+ * Linux CI runs Electron under `xvfb` (virtual display). Several lazy-loaded
+ * managers are unsuitable in that environment:
+ * - `SystemTrayManager` — no system tray on a headless display
+ * - `NotificationManager` — DBus / libnotify is flaky/absent
+ * - `ShortcutManager` — `globalShortcut` races on Linux WMs
+ * - `DeepLinkManager` — protocol handlers can't register without a desktop
+ *
+ * When this flag is `'true'`, `deferredInit` skips all four. The renderer
+ * still loads, IPC for window controls still works, and tests can exercise
+ * the integrated startup path without flake from the system surface.
+ *
+ * Defaults to `false` (production behavior). Spec env sets this; humans
+ * can override locally to repro a tray/notification bug.
+ */
+const disableSystemIntegration =
+  process.env.ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION === 'true'
 
 /**
  * Performance optimization level selection.
@@ -704,8 +751,14 @@ async function createWindow(): Promise<BrowserWindow> {
     // Initialize window state manager
     windowStateManager = new WindowStateManager(configManager)
 
-    // Development uses local Next.js server, production uses web app
-    const serverUrl = isDev ? 'http://localhost:3011' : 'https://corelive.app'
+    // Development uses local Next.js server, production uses web app.
+    // The `ELECTRON_RENDERER_URL` env var (validated near the top of this
+    // file) lets the Playwright E2E suite point the renderer at the local
+    // Next.js server WITHOUT also flipping `isDev` — keeping CSP and
+    // optimization level identical to production for high-fidelity tests.
+    const serverUrl =
+      process.env.ELECTRON_RENDERER_URL ??
+      (isDev ? 'http://localhost:3011' : 'https://corelive.app')
 
     // Note: APIBridge no longer needed - Floating Navigator uses oRPC via web
 
@@ -758,58 +811,71 @@ async function createWindow(): Promise<BrowserWindow> {
       }
       log.info('✅ [DEFERRED] MenuManager loaded')
 
-      log.info('🔧 [DEFERRED] Loading SystemTrayManager...')
-      // Load system tray manager
-      const SystemTrayManagerCls = (await lazyLoadManager.loadComponent(
-        'SystemTrayManager',
-      )) as new (...args: unknown[]) => SystemTrayManagerType
-      systemTrayManager = new SystemTrayManagerCls(windowManager)
-      windowManager.setTrayBoundsProvider(
-        () => systemTrayManager?.getTrayBounds() ?? null,
-      )
-      log.info('✅ [DEFERRED] SystemTrayManager loaded')
-
-      log.info('🔧 [DEFERRED] Loading NotificationManager...')
-      // Load notification manager
-      const NotificationManagerCls = (await lazyLoadManager.loadComponent(
-        'NotificationManager',
-      )) as new (...args: unknown[]) => NotificationManagerType
-      notificationManager = new NotificationManagerCls(
-        windowManager,
-        systemTrayManager,
-        configManager,
-      )
-      log.info('✅ [DEFERRED] NotificationManager loaded')
-
-      log.info('🔧 [DEFERRED] Loading ShortcutManager...')
-      // Load shortcut manager
-      const ShortcutManagerCls = (await lazyLoadManager.loadComponent(
-        'ShortcutManager',
-      )) as new (...args: unknown[]) => ShortcutManagerType
-      shortcutManager = new ShortcutManagerCls(
-        windowManager,
-        notificationManager,
-        configManager,
-      )
-      log.info('✅ [DEFERRED] ShortcutManager loaded')
-
-      log.info('🔧 [DEFERRED] Setting managers in error handler...')
-      // Set managers in error handler
-      if (systemIntegrationErrorHandler) {
-        systemIntegrationErrorHandler.setManagers(
-          systemTrayManager,
-          notificationManager,
-          shortcutManager,
+      // The tray / notification / shortcut managers (and the system
+      // integration handler that orchestrates them) are skipped under the
+      // E2E kill switch — see `disableSystemIntegration` near the top of
+      // this file. They are unreliable on a Linux xvfb display and are
+      // out of scope for the v0 Electron E2E suite.
+      if (disableSystemIntegration) {
+        log.info(
+          '🧪 [DEFERRED] ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION=true — ' +
+            'skipping SystemTrayManager, NotificationManager, ShortcutManager, ' +
+            'and SystemIntegration init.',
         )
-      }
-      log.info('✅ [DEFERRED] Managers set')
+      } else {
+        log.info('🔧 [DEFERRED] Loading SystemTrayManager...')
+        // Load system tray manager
+        const SystemTrayManagerCls = (await lazyLoadManager.loadComponent(
+          'SystemTrayManager',
+        )) as new (...args: unknown[]) => SystemTrayManagerType
+        systemTrayManager = new SystemTrayManagerCls(windowManager)
+        windowManager.setTrayBoundsProvider(
+          () => systemTrayManager?.getTrayBounds() ?? null,
+        )
+        log.info('✅ [DEFERRED] SystemTrayManager loaded')
 
-      log.info('🔧 [DEFERRED] Initializing system integration...')
-      // Initialize system integration with comprehensive error handling
-      if (systemIntegrationErrorHandler) {
-        await systemIntegrationErrorHandler.initializeSystemIntegration()
+        log.info('🔧 [DEFERRED] Loading NotificationManager...')
+        // Load notification manager
+        const NotificationManagerCls = (await lazyLoadManager.loadComponent(
+          'NotificationManager',
+        )) as new (...args: unknown[]) => NotificationManagerType
+        notificationManager = new NotificationManagerCls(
+          windowManager,
+          systemTrayManager,
+          configManager,
+        )
+        log.info('✅ [DEFERRED] NotificationManager loaded')
+
+        log.info('🔧 [DEFERRED] Loading ShortcutManager...')
+        // Load shortcut manager
+        const ShortcutManagerCls = (await lazyLoadManager.loadComponent(
+          'ShortcutManager',
+        )) as new (...args: unknown[]) => ShortcutManagerType
+        shortcutManager = new ShortcutManagerCls(
+          windowManager,
+          notificationManager,
+          configManager,
+        )
+        log.info('✅ [DEFERRED] ShortcutManager loaded')
+
+        log.info('🔧 [DEFERRED] Setting managers in error handler...')
+        // Set managers in error handler
+        if (systemIntegrationErrorHandler) {
+          systemIntegrationErrorHandler.setManagers(
+            systemTrayManager,
+            notificationManager,
+            shortcutManager,
+          )
+        }
+        log.info('✅ [DEFERRED] Managers set')
+
+        log.info('🔧 [DEFERRED] Initializing system integration...')
+        // Initialize system integration with comprehensive error handling
+        if (systemIntegrationErrorHandler) {
+          await systemIntegrationErrorHandler.initializeSystemIntegration()
+        }
+        log.info('✅ [DEFERRED] System integration initialized')
       }
-      log.info('✅ [DEFERRED] System integration initialized')
 
       // Load auto-updater in background (skip during automated tests)
       // Wrapped in own try-catch so failure doesn't block other initializations
@@ -831,25 +897,35 @@ async function createWindow(): Promise<BrowserWindow> {
         log.info('AutoUpdater initialization skipped in test environment')
       }
 
-      // Ensure deep link manager is ready once supporting managers exist
-      log.info('🔧 [DEFERRED] Initializing DeepLinkManager...')
-      const manager = ensureDeepLinkManager()
-      if (manager) {
-        log.info('✅ [DEFERRED] DeepLinkManager initialized')
-        manager.setNotificationManager(notificationManager)
+      // DeepLinkManager registers a `corelive://` protocol handler with the
+      // OS — that requires a real desktop session, so it is skipped under
+      // the same E2E kill switch as the tray/notification/shortcut block.
+      if (disableSystemIntegration) {
+        log.info(
+          '🧪 [DEFERRED] DeepLinkManager skipped under ' +
+            'ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION=true.',
+        )
+      } else {
+        // Ensure deep link manager is ready once supporting managers exist
+        log.info('🔧 [DEFERRED] Initializing DeepLinkManager...')
+        const manager = ensureDeepLinkManager()
+        if (manager) {
+          log.info('✅ [DEFERRED] DeepLinkManager initialized')
+          manager.setNotificationManager(notificationManager)
 
-        // Process any pending deep link URLs after initialization
-        // This handles both:
-        // 1. URLs from early 'open-url' events (before app ready)
-        // 2. URLs from command line args (Windows/Linux)
-        setTimeout(() => {
-          try {
-            manager.processPendingUrl() // Command line URLs
-            processPendingDeepLinkUrl() // Early open-url URLs
-          } catch (error) {
-            log.warn('⚠️ Failed to process pending deep link URL', error)
-          }
-        }, 1000)
+          // Process any pending deep link URLs after initialization
+          // This handles both:
+          // 1. URLs from early 'open-url' events (before app ready)
+          // 2. URLs from command line args (Windows/Linux)
+          setTimeout(() => {
+            try {
+              manager.processPendingUrl() // Command line URLs
+              processPendingDeepLinkUrl() // Early open-url URLs
+            } catch (error) {
+              log.warn('⚠️ Failed to process pending deep link URL', error)
+            }
+          }, 1000)
+        }
       }
 
       // Set up window close behavior after tray manager is loaded

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -105,21 +105,33 @@ if (process.env.PLAYWRIGHT_REMOTE_DEBUGGING_PORT) {
  * dedicated `ELECTRON_RENDERER_URL` env var. Production runs leave this
  * unset and continue to use `https://corelive.app`.
  *
- * Validation: only `http://localhost*` / `http://127.0.0.1*` are accepted.
- * This guard prevents an operator from accidentally pointing E2E at
- * production by typo and is a defense-in-depth check before the value
- * reaches `WindowManager.createMainWindow`.
+ * Validation: hostname must be exactly `localhost` or `127.0.0.1` and the
+ * protocol must be `http:`. We parse with `URL` (instead of `startsWith`)
+ * so that subdomain tricks like `http://localhost.attacker.com` cannot
+ * slip past the guard. This is defense-in-depth before the value reaches
+ * `WindowManager.createMainWindow`.
  */
-if (
-  process.env.ELECTRON_RENDERER_URL &&
-  !process.env.ELECTRON_RENDERER_URL.startsWith('http://localhost') &&
-  !process.env.ELECTRON_RENDERER_URL.startsWith('http://127.0.0.1')
-) {
-  throw new Error(
-    `ELECTRON_RENDERER_URL must start with "http://localhost" or "http://127.0.0.1" — ` +
-      `got "${process.env.ELECTRON_RENDERER_URL}". This guard prevents accidental ` +
-      `production renderer load during E2E. Unset the var to use defaults.`,
-  )
+if (process.env.ELECTRON_RENDERER_URL) {
+  let parsedRendererUrl: URL
+  try {
+    parsedRendererUrl = new URL(process.env.ELECTRON_RENDERER_URL)
+  } catch {
+    throw new Error(
+      `ELECTRON_RENDERER_URL must be a valid URL — got ` +
+        `"${process.env.ELECTRON_RENDERER_URL}".`,
+    )
+  }
+  if (
+    parsedRendererUrl.protocol !== 'http:' ||
+    (parsedRendererUrl.hostname !== 'localhost' &&
+      parsedRendererUrl.hostname !== '127.0.0.1')
+  ) {
+    throw new Error(
+      `ELECTRON_RENDERER_URL must use http: with hostname "localhost" or ` +
+        `"127.0.0.1" — got "${parsedRendererUrl.protocol}//${parsedRendererUrl.hostname}". ` +
+        `This guard prevents accidental production renderer load during E2E.`,
+    )
+  }
 }
 
 // ============================================================================
@@ -147,11 +159,19 @@ const isTestEnvironment = process.env.NODE_ENV === 'test'
  * still loads, IPC for window controls still works, and tests can exercise
  * the integrated startup path without flake from the system surface.
  *
- * Defaults to `false` (production behavior). Spec env sets this; humans
- * can override locally to repro a tray/notification bug.
+ * Auto-coupling: setting `ELECTRON_RENDERER_URL` (E2E renderer override)
+ * implies the kill switch. Pointing the renderer at a local URL while
+ * still registering the tray icon and `corelive://` protocol handler
+ * against the host OS would leak real OS state from a test run — so the
+ * two flags are coupled by default. Setting both explicitly is also fine.
+ *
+ * Defaults to `false` (production behavior). Humans can override locally
+ * via `ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION=true` to repro a tray bug
+ * without the URL flag.
  */
 const disableSystemIntegration =
-  process.env.ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION === 'true'
+  process.env.ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION === 'true' ||
+  Boolean(process.env.ELECTRON_RENDERER_URL)
 
 /**
  * Performance optimization level selection.
@@ -724,6 +744,98 @@ function setupSecurity(): void {
  *
  * @returns The main application window
  */
+/**
+ * Load the system-integration manager stack (tray, notifications, shortcuts,
+ * and the error handler that orchestrates them).
+ *
+ * Skipped entirely under `disableSystemIntegration` (E2E kill switch). The
+ * `systemIntegrationErrorHandler` is also constructed inside this helper so
+ * that the kill-switch path leaves NO partially-initialized handler — every
+ * `if (systemIntegrationErrorHandler)` call site downstream becomes a clean
+ * no-op rather than a half-wired surface.
+ */
+async function loadSystemIntegrationStack(): Promise<void> {
+  log.info('🔧 [DEFERRED] Loading SystemIntegrationErrorHandler...')
+  const SystemIntegrationErrorHandlerCls = (await lazyLoadManager.loadComponent(
+    'SystemIntegrationErrorHandler',
+  )) as new (...args: unknown[]) => SystemIntegrationErrorHandlerType
+  systemIntegrationErrorHandler = new SystemIntegrationErrorHandlerCls(
+    windowManager,
+    configManager,
+  )
+  log.info('✅ [DEFERRED] SystemIntegrationErrorHandler loaded')
+
+  log.info('🔧 [DEFERRED] Loading SystemTrayManager...')
+  const SystemTrayManagerCls = (await lazyLoadManager.loadComponent(
+    'SystemTrayManager',
+  )) as new (...args: unknown[]) => SystemTrayManagerType
+  systemTrayManager = new SystemTrayManagerCls(windowManager)
+  windowManager.setTrayBoundsProvider(
+    () => systemTrayManager?.getTrayBounds() ?? null,
+  )
+  log.info('✅ [DEFERRED] SystemTrayManager loaded')
+
+  log.info('🔧 [DEFERRED] Loading NotificationManager...')
+  const NotificationManagerCls = (await lazyLoadManager.loadComponent(
+    'NotificationManager',
+  )) as new (...args: unknown[]) => NotificationManagerType
+  notificationManager = new NotificationManagerCls(
+    windowManager,
+    systemTrayManager,
+    configManager,
+  )
+  log.info('✅ [DEFERRED] NotificationManager loaded')
+
+  log.info('🔧 [DEFERRED] Loading ShortcutManager...')
+  const ShortcutManagerCls = (await lazyLoadManager.loadComponent(
+    'ShortcutManager',
+  )) as new (...args: unknown[]) => ShortcutManagerType
+  shortcutManager = new ShortcutManagerCls(
+    windowManager,
+    notificationManager,
+    configManager,
+  )
+  log.info('✅ [DEFERRED] ShortcutManager loaded')
+
+  log.info('🔧 [DEFERRED] Wiring managers + initializing system integration...')
+  systemIntegrationErrorHandler.setManagers(
+    systemTrayManager,
+    notificationManager,
+    shortcutManager,
+  )
+  await systemIntegrationErrorHandler.initializeSystemIntegration()
+  log.info('✅ [DEFERRED] System integration initialized')
+}
+
+/**
+ * Load the deep-link stack: registers `corelive://` protocol handler with
+ * the OS and drains any URLs that arrived before the handler was ready.
+ *
+ * Skipped under `disableSystemIntegration` since protocol registration
+ * requires a real desktop session.
+ */
+async function loadDeepLinkStack(): Promise<void> {
+  log.info('🔧 [DEFERRED] Initializing DeepLinkManager...')
+  const manager = ensureDeepLinkManager()
+  if (!manager) {
+    return
+  }
+  log.info('✅ [DEFERRED] DeepLinkManager initialized')
+  manager.setNotificationManager(notificationManager)
+
+  // Drain any deep-link URLs received before the manager was ready:
+  // 1. URLs from early `open-url` events (before app ready)
+  // 2. URLs from command line args (Windows/Linux)
+  setTimeout(() => {
+    try {
+      manager.processPendingUrl()
+      processPendingDeepLinkUrl()
+    } catch (error) {
+      log.warn('⚠️ Failed to process pending deep link URL', error)
+    }
+  }, 1000)
+}
+
 async function createWindow(): Promise<BrowserWindow> {
   // Start performance monitoring early to track startup metrics
   if (config.enableMemoryMonitoring) {
@@ -780,26 +892,13 @@ async function createWindow(): Promise<BrowserWindow> {
   // Deferred initialization - happens after main window is shown
   const deferredInit = async (): Promise<void> => {
     try {
-      // Load system integration components lazily
-      log.info('🔧 [DEFERRED] Loading SystemIntegrationErrorHandler...')
-      const SystemIntegrationErrorHandlerCls =
-        (await lazyLoadManager.loadComponent(
-          'SystemIntegrationErrorHandler',
-        )) as new (...args: unknown[]) => SystemIntegrationErrorHandlerType
-      systemIntegrationErrorHandler = new SystemIntegrationErrorHandlerCls(
-        windowManager,
-        configManager,
-      )
-      log.info('✅ [DEFERRED] SystemIntegrationErrorHandler loaded')
-
+      // MenuManager always loads (works under xvfb)
       log.info('🔧 [DEFERRED] Loading MenuManager...')
-      // Load menu manager
       const MenuManagerCls = (await lazyLoadManager.loadComponent(
         'MenuManager',
       )) as new (...args: unknown[]) => MenuManagerType
       menuManager = new MenuManagerCls()
 
-      // Get mainWindow from windowManager (mainWindow is local to criticalInit)
       const mainWindowRef = windowManager.getMainWindow()
       log.debug(
         '🔧 [DEFERRED] Retrieved mainWindow from windowManager:',
@@ -811,74 +910,22 @@ async function createWindow(): Promise<BrowserWindow> {
       }
       log.info('✅ [DEFERRED] MenuManager loaded')
 
-      // The tray / notification / shortcut managers (and the system
-      // integration handler that orchestrates them) are skipped under the
-      // E2E kill switch — see `disableSystemIntegration` near the top of
-      // this file. They are unreliable on a Linux xvfb display and are
-      // out of scope for the v0 Electron E2E suite.
+      // System-integration stack (tray, notifications, shortcuts, error
+      // handler) and deep-link stack are gated by the E2E kill switch.
+      // Both are unreliable on a Linux xvfb display.
       if (disableSystemIntegration) {
         log.info(
-          '🧪 [DEFERRED] ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION=true — ' +
-            'skipping SystemTrayManager, NotificationManager, ShortcutManager, ' +
-            'and SystemIntegration init.',
+          '🧪 [DEFERRED] disableSystemIntegration=true — skipping ' +
+            'SystemIntegrationErrorHandler, tray, notifications, shortcuts, ' +
+            'and deep link.',
         )
       } else {
-        log.info('🔧 [DEFERRED] Loading SystemTrayManager...')
-        // Load system tray manager
-        const SystemTrayManagerCls = (await lazyLoadManager.loadComponent(
-          'SystemTrayManager',
-        )) as new (...args: unknown[]) => SystemTrayManagerType
-        systemTrayManager = new SystemTrayManagerCls(windowManager)
-        windowManager.setTrayBoundsProvider(
-          () => systemTrayManager?.getTrayBounds() ?? null,
-        )
-        log.info('✅ [DEFERRED] SystemTrayManager loaded')
-
-        log.info('🔧 [DEFERRED] Loading NotificationManager...')
-        // Load notification manager
-        const NotificationManagerCls = (await lazyLoadManager.loadComponent(
-          'NotificationManager',
-        )) as new (...args: unknown[]) => NotificationManagerType
-        notificationManager = new NotificationManagerCls(
-          windowManager,
-          systemTrayManager,
-          configManager,
-        )
-        log.info('✅ [DEFERRED] NotificationManager loaded')
-
-        log.info('🔧 [DEFERRED] Loading ShortcutManager...')
-        // Load shortcut manager
-        const ShortcutManagerCls = (await lazyLoadManager.loadComponent(
-          'ShortcutManager',
-        )) as new (...args: unknown[]) => ShortcutManagerType
-        shortcutManager = new ShortcutManagerCls(
-          windowManager,
-          notificationManager,
-          configManager,
-        )
-        log.info('✅ [DEFERRED] ShortcutManager loaded')
-
-        log.info('🔧 [DEFERRED] Setting managers in error handler...')
-        // Set managers in error handler
-        if (systemIntegrationErrorHandler) {
-          systemIntegrationErrorHandler.setManagers(
-            systemTrayManager,
-            notificationManager,
-            shortcutManager,
-          )
-        }
-        log.info('✅ [DEFERRED] Managers set')
-
-        log.info('🔧 [DEFERRED] Initializing system integration...')
-        // Initialize system integration with comprehensive error handling
-        if (systemIntegrationErrorHandler) {
-          await systemIntegrationErrorHandler.initializeSystemIntegration()
-        }
-        log.info('✅ [DEFERRED] System integration initialized')
+        await loadSystemIntegrationStack()
       }
 
-      // Load auto-updater in background (skip during automated tests)
-      // Wrapped in own try-catch so failure doesn't block other initializations
+      // AutoUpdater is gated by NODE_ENV=test (NOT the kill switch) so the
+      // production-build smoke run can still exercise the updater path.
+      // Wrapped in its own try/catch so failure doesn't block startup.
       if (!isTestEnvironment) {
         try {
           const AutoUpdaterCls = (await lazyLoadManager.loadComponent(
@@ -891,41 +938,13 @@ async function createWindow(): Promise<BrowserWindow> {
           }
         } catch (autoUpdaterError) {
           log.error('❌ Failed to initialize AutoUpdater:', autoUpdaterError)
-          // Non-critical - continue without auto-updater
         }
       } else {
         log.info('AutoUpdater initialization skipped in test environment')
       }
 
-      // DeepLinkManager registers a `corelive://` protocol handler with the
-      // OS — that requires a real desktop session, so it is skipped under
-      // the same E2E kill switch as the tray/notification/shortcut block.
-      if (disableSystemIntegration) {
-        log.info(
-          '🧪 [DEFERRED] DeepLinkManager skipped under ' +
-            'ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION=true.',
-        )
-      } else {
-        // Ensure deep link manager is ready once supporting managers exist
-        log.info('🔧 [DEFERRED] Initializing DeepLinkManager...')
-        const manager = ensureDeepLinkManager()
-        if (manager) {
-          log.info('✅ [DEFERRED] DeepLinkManager initialized')
-          manager.setNotificationManager(notificationManager)
-
-          // Process any pending deep link URLs after initialization
-          // This handles both:
-          // 1. URLs from early 'open-url' events (before app ready)
-          // 2. URLs from command line args (Windows/Linux)
-          setTimeout(() => {
-            try {
-              manager.processPendingUrl() // Command line URLs
-              processPendingDeepLinkUrl() // Early open-url URLs
-            } catch (error) {
-              log.warn('⚠️ Failed to process pending deep link URL', error)
-            }
-          }, 1000)
-        }
+      if (!disableSystemIntegration) {
+        await loadDeepLinkStack()
       }
 
       // Set up window close behavior after tray manager is loaded

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "e2e:web": "playwright test --project=web",
+    "e2e:electron": "pnpm electron:build:ts && playwright test --config=playwright.electron.config.ts",
     "electron": "electron .",
     "electron:dev": "node scripts/dev.js",
     "electron:build:ts": "electron-vite build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,6 +74,25 @@ export default defineConfig({
       testMatch: /^(?!.*electron).*\.spec\.ts$/,
       dependencies: ['setup'], // Run setup project first
     },
+
+    /**
+     * Electron E2E project — runs `e2e/electron/*.spec.ts`. Each spec
+     * launches the compiled Electron main process via Playwright's
+     * `_electron.launch` API; there is no Chromium device profile because
+     * Electron supplies its own renderer.
+     *
+     * Auth: v0 specs hit pre-login screens only (no `dependencies: ['setup']`)
+     * — Clerk storage-state reuse is a TODO when authenticated specs land.
+     *
+     * Reporter / runner: `pnpm e2e:electron` invokes
+     * `playwright.electron.config.ts` (separate config) so CI can emit a
+     * single HTML report without the per-spec blob → merge fan-in that the
+     * web suite uses.
+     */
+    {
+      name: 'electron',
+      testMatch: /e2e\/electron\/.*\.spec\.ts$/,
+    },
   ],
 
   // One-time hooks

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@playwright/test'
+
+import baseConfig from './playwright.config'
+
+/**
+ * Playwright config for the Electron E2E suite.
+ *
+ * Why a separate config file?
+ * - The base `playwright.config.ts` uses the `blob` reporter on CI so its
+ *   per-spec matrix runners can fan into a `merge-reports` job. The
+ *   Electron job is single-job (3 specs at v0, breakeven at ~6) and does
+ *   not need that fan-in — emitting HTML directly avoids the merge step.
+ * - Trying to switch reporters by `--project` flag inside the base config
+ *   does not work: Playwright evaluates `reporter` at config load time,
+ *   before the CLI's `--project=electron` is parsed.
+ * - This config narrows `projects` to the `electron` project only; the
+ *   `setup` and `web` projects are excluded so they don't run during a
+ *   `pnpm e2e:electron` invocation.
+ *
+ * The `webServer`, `use`, `globalSetup`, and other top-level options are
+ * inherited unchanged from the base config — `_electron.launch()` still
+ * needs Next.js running on `localhost:3011`, and the `webServer` block
+ * fires globally for every project including this one.
+ */
+export default defineConfig({
+  ...baseConfig,
+  projects: baseConfig.projects?.filter(
+    (project) => project.name === 'electron',
+  ),
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+  ],
+})


### PR DESCRIPTION
## Summary

Adds Electron E2E coverage for CoreLive's desktop wrapper using Playwright's `_electron` API. Runs on `ubuntu-latest` under `xvfb-run` as a single job (3 specs at v0; breakeven for matrix sharding is ~6).

- **3 specs** in `e2e/electron/`: startup (renderer load + `app.getName()`), preload (contextBridge surface + IPC round-trip), window-controls (bounds round-trip with DPI tolerance).
- **Streaming main-process logs**: `e2e/electron/_helpers/launch.ts` attaches stdout/stderr listeners at launch — Playwright traces capture renderer only.
- **E2E env contract** in `electron/main.ts`:
  - `ELECTRON_RENDERER_URL` overrides production URL (validated to start with `http://localhost` / `http://127.0.0.1`).
  - `ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION=true` skips tray, notifications, shortcuts, deep-links — keeps xvfb runs deterministic.
- **Separate config** `playwright.electron.config.ts` so the Electron job emits HTML directly (web suite still uses `blob` → `merge-reports`).

> **macOS-only constraint clarified**: the constraint applies to packaged DMG releases (signing/notarization). Electron itself runs fine under a virtual display for tests.

## Coverage gaps (intentional, to revisit)

Linux + xvfb does **not** cover Cocoa-specific paths: `app.setActivationPolicy`, dock/menu bar/traffic-light buttons, `open-url` deep links, vibrancy, notarized .app/asar paths. Manual macOS smoke before tag pushes covers those.

## Required-check status

`E2E Tests (Electron)` is **informational only** at landing time. Promote to required after one stable week on `main` with flake rate < 2%.

## Test plan

- [ ] CI: `E2E Tests (Electron)` green on this PR
- [ ] CI: existing checks (Build, Lint, Test, Typecheck, E2E Tests Web, Storybook Testing) still green
- [ ] Local: `pnpm validate` passes (test + lint + build + typecheck)
- [ ] Local macOS smoke: `pnpm e2e:electron` passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added full Electron end-to-end test suite (startup, preload surface, window controls) with reporting and artifact capture.

* **Chores**
  * CI now runs Electron E2E on PRs and main, with improved env handling and artifact upload; web E2E workflow ignores docs-only changes.
  * Added an npm script to run the Electron E2E suite locally.

* **Documentation**
  * Added an “E2E Tests (Electron)” badge to the README.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/36)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->