### PR TITLE
feat(home): Warm Cathedral heatmap recolor + click→DayDetailDialog

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,245 @@
+# Design System — corelive
+
+> **North Star:** 「些細でも経験値、今日自分頑張ったなと自分を肯定できる感覚」
+>
+> Every trivial task gets visualized as accumulation. The user closes the app feeling validated, never judged. All design decisions are evaluated against this north star.
+
+## Product Context
+
+- **What this is:** Personal task tracker + BrainDump archive whose centerpiece is an Activity Heatmap visualizing every completed task as warm density over a year.
+- **Who it's for:** Solo, taste-driven productivity users who want quiet self-affirmation, not KPI grading or social comparison. Single-user (no team features).
+- **Space/industry:** Personal productivity. Adjacent: Things 3, Bear, Linear, Reflect, Tana, Cron. Distant: Notion (too much), Todoist (KPI guilt), Asana (team).
+- **Project type:** Hybrid — `(main)/*` is the dashboard app, `/login` and `/sign-up` are auth, marketing surfaces may follow. Web + Electron (macOS only).
+
+## Aesthetic Direction
+
+- **Direction:** **Warm Cathedral** — industrial-utilitarian craft warmed by daylight. The Heatmap year is the stained-glass window; accumulated days make the room glow.
+- **Decoration level:** **Intentional** — paper-grain noise on backgrounds (≤2% opacity), no decorative blobs, no gradient orbs. Visual weight lives in the Heatmap; chrome stays quiet.
+- **Mood:** Quiet pride. A workshop with a real window, not fluorescent tubes. Studio Ghibli morning, not corporate dashboard.
+- **NOT:** Linear (cold completionism), Notion (feature bloat), Things 3 (precious minimalism), Todoist (KPI scoring), gamified RPG (badges/SFX/confetti).
+- **Reference touchstones:** Apple Activity Rings (closing-the-loop emotional payoff), Strava personal heatmap (accumulation without judgment), Studio Ghibli morning light, Tana / Reflect (personal-tool craft).
+
+## Typography
+
+Three-font stack, deliberately unusual for the productivity category. The serif display is the loudest differentiation move — productivity apps converge on geometric sans (Inter / Geist / DM Sans), so a serif says "this is craft, not corporate" within the first 0.3 seconds.
+
+- **Display / Hero (≥18px):** **Newsreader** — variable serif, optical sizes built-in. Editorial without being precious. Loaded from Google Fonts.
+- **Body / UI:** **Inter Tight** — variable sans, dense and modern. Compact enough for dashboard density; pairs with Newsreader's character. Loaded from Google Fonts. Never plain Inter (AI default), never DM Sans (category convergence).
+- **Data / Code:** **Geist Mono** — tabular-nums, warmer than JetBrains Mono, more disciplined than Fira Code. Loaded from Vercel Fonts or self-hosted.
+- **Loading:** Google Fonts (`display=swap`) for Newsreader + Inter Tight, Vercel Fonts or self-hosted for Geist Mono.
+
+### Blacklist (do NOT use as primary)
+
+Inter, Roboto, Arial, Helvetica, DM Sans, Geist Sans, Plus Jakarta Sans, Open Sans, Lato, Montserrat, Poppins, Space Grotesk. All are productivity-category convergence fonts; using them dilutes the differentiation Newsreader earns.
+
+### Scale (1.2 modular ratio)
+
+| Tier    | Size                     | Font        | Weight | Notes                                                 |
+| ------- | ------------------------ | ----------- | ------ | ----------------------------------------------------- |
+| Hero    | `clamp(40px, 5vw, 64px)` | Newsreader  | 600    | Marketing/empty-state moments                         |
+| H1      | 36px                     | Newsreader  | 600    | Section headers, dialog titles                        |
+| H2      | 24px                     | Newsreader  | 500    | Subsection                                            |
+| H3      | 18px                     | Inter Tight | 600    | Card headers, group labels                            |
+| Body    | 15px                     | Inter Tight | 400    | Default reading size                                  |
+| Small   | 13px                     | Inter Tight | 400    | Secondary copy, footers                               |
+| Caption | 12px                     | Inter Tight | 500    | `text-transform: uppercase`, `letter-spacing: 0.05em` |
+| Data    | 13px                     | Geist Mono  | 500    | `font-variant-numeric: tabular-nums` for counts/dates |
+
+## Color
+
+OKLCH color space throughout. Departing deliberately from the current cold-neutral baseline to introduce warmth via small chroma values (0.005–0.015) on neutrals plus an amber-warm accent.
+
+### Approach
+
+- **Restrained chromatic accent:** amber-warm is the only saturated color in chrome. Heatmap cells get the chromatic stage.
+- **Warm neutrals:** every neutral has chroma ≥0.005 to remove the "Linear cold" feel.
+- **Temperature gradient over lightness gradient** for the Heatmap — the eureka. Cooler-empty → hotter-full, not lighter → darker.
+
+### Light mode (primary)
+
+| Token                    | Value                   | Role                                                        |
+| ------------------------ | ----------------------- | ----------------------------------------------------------- |
+| `--background`           | `oklch(0.985 0.005 75)` | Paper white with faint warm tint                            |
+| `--card` / surface       | `oklch(0.98 0.008 70)`  | Sand-lit elevated surface                                   |
+| `--popover`              | `oklch(0.98 0.008 70)`  | Same as card                                                |
+| `--foreground`           | `oklch(0.18 0.015 30)`  | Deep warm charcoal (not pure black)                         |
+| `--muted-foreground`     | `oklch(0.5 0.015 50)`   | Earthy taupe for secondary copy                             |
+| `--border`               | `oklch(0.92 0.01 70)`   | Warm light gray                                             |
+| `--input`                | `oklch(0.92 0.01 70)`   | Form input border                                           |
+| `--ring`                 | `oklch(0.62 0.16 50)`   | Focus ring = primary amber                                  |
+| `--primary`              | `oklch(0.62 0.16 50)`   | Amber CTA                                                   |
+| `--primary-foreground`   | `oklch(0.99 0 0)`       | Paper text on amber                                         |
+| `--secondary`            | `oklch(0.95 0.01 70)`   | Quiet button bg                                             |
+| `--secondary-foreground` | `oklch(0.18 0.015 30)`  | Same as foreground                                          |
+| `--accent`               | `oklch(0.95 0.01 70)`   | Hover surfaces                                              |
+| `--accent-foreground`    | `oklch(0.18 0.015 30)`  |                                                             |
+| `--muted`                | `oklch(0.95 0.01 70)`   | Disabled/quiet bg                                           |
+| `--destructive`          | `oklch(0.6 0.20 25)`    | Clay red, retuned warmer than the default oklch destructive |
+
+### Dark mode
+
+Dark mode is a redesign of the surfaces, not a saturation reduction. The warm undertone (chroma 0.005–0.015 on hue 30–75) is preserved.
+
+| Token                  | Value                  | Role                                              |
+| ---------------------- | ---------------------- | ------------------------------------------------- |
+| `--background`         | `oklch(0.16 0.012 35)` | Warm near-black, slight ochre undertone           |
+| `--card` / surface     | `oklch(0.22 0.015 40)` | Warm coal                                         |
+| `--popover`            | `oklch(0.22 0.015 40)` |                                                   |
+| `--foreground`         | `oklch(0.96 0.005 75)` | Warm white                                        |
+| `--muted-foreground`   | `oklch(0.72 0.012 70)` | Warm fog                                          |
+| `--border`             | `oklch(1 0 0 / 8%)`    | Soft glow boundary                                |
+| `--input`              | `oklch(1 0 0 / 12%)`   |                                                   |
+| `--ring`               | `oklch(0.7 0.16 55)`   | Focus ring slightly brighter than primary in dark |
+| `--primary`            | `oklch(0.7 0.16 55)`   | Amber lifted for dark contrast                    |
+| `--primary-foreground` | `oklch(0.16 0.012 35)` | Background on amber                               |
+| `--secondary`          | `oklch(0.27 0.012 40)` |                                                   |
+| `--accent`             | `oklch(0.27 0.012 40)` |                                                   |
+| `--muted`              | `oklch(0.27 0.012 40)` |                                                   |
+| `--destructive`        | `oklch(0.7 0.19 25)`   | Clay red lifted                                   |
+
+### Heatmap palette — temperature gradient
+
+This is the project's most consequential color decision. Departs from GitHub's green ramp to a warm temperature gradient (paper → dawn → amber → terracotta). Chroma and hue move; lightness moves only enough to stay readable.
+
+| Level     | Light                                  | Dark                             | Meaning           |
+| --------- | -------------------------------------- | -------------------------------- | ----------------- |
+| 0 (empty) | `oklch(0.96 0.008 80)` paper           | `oklch(0.22 0.012 40)` warm coal | Rest, not failure |
+| 1         | `oklch(0.89 0.06 75)` first dawn light | `oklch(0.32 0.06 50)` ember      | Started the day   |
+| 2         | `oklch(0.78 0.11 70)` amber            | `oklch(0.45 0.10 55)` copper     | Productive        |
+| 3         | `oklch(0.65 0.14 60)` honey            | `oklch(0.58 0.13 60)` brass      | Full day          |
+| 4         | `oklch(0.55 0.16 40)` terracotta       | `oklch(0.70 0.15 65)` warm sun   | Cathedral lit     |
+
+### Semantic
+
+- **success:** `oklch(0.65 0.13 145)` moss — confirmations only, NEVER as primary CTA
+- **warning:** `oklch(0.7 0.14 80)` caution amber
+- **error:** `oklch(0.6 0.20 25)` (light) / `oklch(0.7 0.19 25)` (dark) — clay red
+- **info:** `oklch(0.6 0.10 230)` slate blue — rare, advisory only
+
+## Spacing
+
+- **Base unit:** 4px
+- **Density:** Comfortable (between Things 3 and Linear)
+- **Scale:** `2xs(4) xs(8) sm(12) md(16) lg(24) xl(32) 2xl(48) 3xl(64) 4xl(96)`
+- **Card padding:** `lg` (24px)
+- **Section spacing:** `2xl` (48px) between major sections; `xl` (32px) within sections
+
+### Heatmap-specific
+
+- Cell size: **12px minimum, 32px maximum** (per Heatmap Cathedral plan, eng review D6 lock)
+- Cell gap: 3px (light theme), 4px (dark theme — needs slightly more breathing room)
+
+## Layout
+
+- **Approach:** Hybrid — grid-disciplined for app surfaces, editorial moments for hero / empty states
+- **Grid:** 12-column, 24px gutter
+- **Max content width:** **1180px** (intentionally tighter than the 1200px convention; the few px signal restraint)
+- **Border radius:**
+  - sm: 4px (chips, small badges)
+  - md: 8px (buttons, inputs)
+  - lg: 12px (cards, dialogs)
+  - xl: 16px (large modals, hero cards)
+  - full: 9999px (avatar, pill badges)
+- **Heatmap container:** full content-width, the home page centerpiece — never demoted to sidebar
+- **Sidebar:** 248px, top-aligned navigation, Caption-style section labels
+
+## Motion
+
+Intentional choreography. Most motion is in the 150–250ms range. The one motion moment that earns extended duration is the **completion celebration** — the only place where the design "performs" for the user.
+
+- **Approach:** Intentional (between minimal-functional and expressive)
+- **Easing:**
+  - enter: `ease-out`
+  - exit: `ease-in`
+  - move: `ease-in-out`
+  - celebration: `cubic-bezier(0.16, 1, 0.3, 1)` (gentle overshoot)
+- **Duration:**
+  - micro: 50–100ms (focus rings, color shifts)
+  - short: 150–250ms (hover, fade)
+  - medium: 250–400ms (modal, page transition)
+  - long: 400–700ms (cell completion fill, the hero motion)
+
+### Specific motion choreography
+
+| Action                              | Motion                             | Duration | Easing             |
+| ----------------------------------- | ---------------------------------- | -------- | ------------------ |
+| Task completion → Heatmap cell fill | radial-sweep fill                  | 400ms    | ease-out           |
+| Hover lift (cell, card, button)     | `translateY(-1px)` + `scale(1.04)` | 150ms    | ease-out           |
+| Page transition                     | fade                               | 200ms    | ease-out           |
+| Modal / Dialog                      | `scale(0.96 → 1)` + fade           | 250ms    | celebration easing |
+| Tooltip                             | fade + 4px slide-up                | 100ms    | ease-out           |
+| Theme toggle                        | crossfade (no transition flash)    | n/a      | n/a                |
+
+### Forbidden
+
+- Bounce springs (any `cubic-bezier` with overshoot >1.05 except modals)
+- Confetti, particle bursts, screen-flash
+- SFX, haptics
+- Scroll-driven hero animations
+- Loading spinners that exceed 3s without progress text
+
+## Voice & Microcopy
+
+The product talks like a quiet companion, not a coach. Microcopy is one of the few places where the north star comes through directly.
+
+### Tooltip copy
+
+GitHub: `8 contributions on May 9, 2026`
+Things 3: `8 completed`
+**corelive:** `8 things done — good day` (English) / `今日は 8 個 — お疲れさま` (Japanese)
+
+The praise is one short phrase appended to the count. Not saccharine, not corporate.
+
+### Empty states
+
+- Empty Heatmap day on hover: "rest day" / "休息日" — never "0 tasks", never "missed".
+- New user, never any data: "your year starts here" / "ここから始まる一年" — invitational.
+
+### Streak replacement
+
+Instead of "5-day streak" (creates fragility), display **"shown up 18 days this month"** — additive, generous, never decreases without explanation.
+
+### Forbidden phrases
+
+- "Productivity" (loaded category word)
+- "Crush your tasks", "ship faster", "10x"
+- "You missed a day" / 「途切れました」
+- Percent-completion KPIs in primary UI ("47% complete today")
+
+## Component Behavior Notes (CSS-variable-compatible)
+
+The full color system maps onto the existing shadcn/ui tokens. Migration is per-token, not per-component. Every shadcn primitive in `src/components/ui/` keeps working — only the underlying CSS variables change.
+
+- **Button (primary):** amber bg, paper-white text, 8px radius, hover lifts 1px
+- **Card:** surface bg, 1px soft border, 12px radius, no shadow by default (shadow only when elevated/dragging)
+- **Input:** transparent bg in light mode, white-on-white feel; focus ring uses `--ring` (amber)
+- **Badge:** pill (full radius), Caption typography (12px Inter Tight 500 uppercase)
+- **Tooltip:** popover bg, 4px slide-up entrance, 13px Inter Tight; max 2 lines, no markdown
+- **Heatmap cell:** `<rect>` with explicit fill from `--heatmap-level-N`, role=button when count>0, focus ring identical to other interactive elements
+
+## Decisions Log
+
+| Date       | Decision                                                                             | Rationale                                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| 2026-05-10 | DESIGN.md created from `/design-consultation` (dry-run, OpenAI verification pending) | First codified design system; supersedes implicit shadcn/ui defaults                                                     |
+| 2026-05-10 | Aesthetic: Warm Cathedral (vs cold Linear / Things baseline)                         | Aligns with north star "self-affirmation feeling"; differentiates from productivity category convergence                 |
+| 2026-05-10 | Heatmap recolored from green to warm temperature gradient                            | Eureka: temperature carries the "personal pride" signal that green carries "GitHub work" — orthogonal axis to North Star |
+| 2026-05-10 | Newsreader serif for display (vs Inter / Geist / DM Sans)                            | Productivity apps 100% converge on geometric sans; a serif says "craft" within 0.3s of page load                         |
+| 2026-05-10 | Inter Tight (not Inter) for body                                                     | Inter alone is the AI default; Tight is denser and pairs with Newsreader's character                                     |
+| 2026-05-10 | Geist Mono for data/code (vs JetBrains Mono)                                         | Warmer character, tabular-nums, fewer false-positive associations with terminal/code                                     |
+| 2026-05-10 | Streak counter replaced with "shown-up days this month"                              | Eliminates streak-guilt; empty days = rest, never failure; aligns with "self-affirmation"                                |
+| 2026-05-10 | Tooltip copy as quiet praise, not raw stats                                          | Each hover delivers a small affirmation moment — north star delivered at the interaction layer                           |
+| 2026-05-10 | Cell size: 12px min / 32px max                                                       | Locked by Heatmap Cathedral eng review D6                                                                                |
+| 2026-05-10 | OKLCH color space throughout                                                         | Perceptually even gradient steps; current globals.css already uses oklch — alignment, not migration                      |
+
+## Implementation Migration Notes
+
+This DESIGN.md describes the target system. Migration from current state (cold-neutral oklch + GitHub green Heatmap) is per-token in `src/globals.css`. No component code changes are required for the color/spacing migration. Typography requires:
+
+1. Adding Newsreader, Inter Tight, Geist Mono to `<head>` (Google Fonts + Vercel)
+2. Updating `body` className in `src/app/layout.tsx` to apply Inter Tight as default
+3. A type-scale utility component or CSS layer for the Hero / H1 / H2 / H3 / Body / Small / Caption / Data tiers
+
+The Heatmap palette swap touches `src/globals.css` (`--heatmap-level-N` for both light and dark), no `ContributionGraph.tsx` change required.
+
+Streak and tooltip copy changes are scoped to `ContributionGraph.tsx` and any future StreakBadge component (deferred to the Heatmap Cathedral plan, decision D12 / Electron-only).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -115,6 +115,8 @@ export default defineConfig([
             'level-up-*',
             'confetti-*',
             'floating-navigator-*',
+            // Custom utility classes (defined in globals.css @layer utilities)
+            'cathedral-lit',
             // Tailwind default color palette (temporary - will migrate to tokens)
             'text-red-*',
             'text-blue-*',

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -20,6 +20,8 @@ import {
 import { useHeatmapData } from '@/hooks/useHeatmapData'
 import type { HeatmapDay } from '@/hooks/useHeatmapData'
 
+import { DayDetailDialog } from './DayDetailDialog'
+
 /** Milliseconds in a single day. */
 const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000
 
@@ -29,22 +31,30 @@ const DAYS_IN_WEEK = 7
 /** Reserved width for week-day labels inside the SVG. */
 const HEATMAP_LEFT_PAD = 28
 
-/** Minimum cell size used when space is tight and horizontal scrolling is needed. */
-const HEATMAP_MIN_RECT_SIZE = 8
+/** Minimum cell size — DESIGN.md heatmap cell-sizing lock (Heatmap Cathedral D6). */
+const HEATMAP_MIN_RECT_SIZE = 12
 
-/** Maximum cell size used when the card has generous horizontal room. */
-const HEATMAP_MAX_RECT_SIZE = 28
+/** Maximum cell size — DESIGN.md heatmap cell-sizing lock (Heatmap Cathedral D6). */
+const HEATMAP_MAX_RECT_SIZE = 32
 
 /** Gap between heatmap cells. */
 const HEATMAP_SPACE = 2
 
-/** Theme-aware heatmap gradient expressed through global CSS variables. */
+/**
+ * Theme-aware heatmap gradient expressed through global CSS variables.
+ *
+ * Keys are threshold *upper bounds* for `existColor` semantics in
+ * @uiw/react-heat-map: it returns the value of the smallest key strictly
+ * greater than the day's count. So count=1,2,3 falls into bucket `4` (L1),
+ * count=4..9 falls into `10` (L2), and so on — matching DESIGN.md's
+ * intensity bands and DayDetailDialog's `getIntensityFromCount`.
+ */
 const PANEL_COLORS: Record<string, string> = {
   0: 'var(--heatmap-level-0)',
-  2: 'var(--heatmap-level-1)',
-  4: 'var(--heatmap-level-2)',
-  10: 'var(--heatmap-level-3)',
-  20: 'var(--heatmap-level-4)',
+  4: 'var(--heatmap-level-1)',
+  10: 'var(--heatmap-level-2)',
+  20: 'var(--heatmap-level-3)',
+  1000: 'var(--heatmap-level-4)',
 }
 
 /** Legend color squares matching the gradient. */
@@ -147,6 +157,7 @@ export function ContributionGraph() {
   const { heatmapValues, dataByDate, total, isLoading } = useHeatmapData()
   const containerRef = useRef<HTMLDivElement>(null)
   const containerWidth = useObservedElementWidth(containerRef)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const endDate = useMemo(() => normalizeDate(new Date()), [])
   const startDate = useMemo(
     () => getAlignedHeatmapStartDate(endDate),
@@ -201,17 +212,30 @@ export function ContributionGraph() {
                 fontSize: '10px',
               }}
               rectRender={(props, data) => {
-                const dateKey = data.date?.replace(/\//g, '-') ?? ''
+                const dateKey = toIsoDateKey(data.date)
                 const dayData = dataByDate.get(dateKey)
+                const handleSelect = () => {
+                  if (dateKey) setSelectedDate(dateKey)
+                }
 
                 if (!dayData || dayData.count === 0) {
-                  return <rect {...props} />
+                  return (
+                    <rect
+                      {...props}
+                      onClick={handleSelect}
+                      style={{ ...props.style, cursor: 'pointer' }}
+                    />
+                  )
                 }
 
                 return (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <rect {...props} />
+                      <rect
+                        {...props}
+                        onClick={handleSelect}
+                        style={{ ...props.style, cursor: 'pointer' }}
+                      />
                     </TooltipTrigger>
                     <TooltipContent>
                       <CategoryBreakdown day={dayData} />
@@ -234,6 +258,12 @@ export function ContributionGraph() {
           ))}
           <span className="ml-1 text-muted-foreground">More</span>
         </div>
+        <DayDetailDialog
+          date={selectedDate}
+          onOpenChange={(open) => {
+            if (!open) setSelectedDate(null)
+          }}
+        />
       </CardContent>
     </Card>
   )
@@ -397,4 +427,30 @@ function normalizeDate(date: Date): Date {
  */
 function clampNumber(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Converts a heatmap rect's raw `data.date` (the library emits `YYYY/M/D` with
+ * no zero-padding) into the canonical `YYYY-MM-DD` form used by the server
+ * aggregation (`updatedAt.toISOString().split('T')[0]`) and by `dataByDate`.
+ *
+ * Without this, the click handler passed `2026-5-10` to `getDayDetail`, which
+ * never matches the server's `2026-05-10` bucket — so the dialog returned
+ * count=0 ("rest day") for cells the heatmap painted as L1+. Also unblocks
+ * `formatDate`, which falls back to "INVALID DATE" when given non-padded ISO.
+ *
+ * @param rawDate - The `data.date` value from @uiw/react-heat-map (`YYYY/M/D`)
+ * @returns A zero-padded `YYYY-MM-DD` string, or empty string when unparseable
+ * @example
+ * toIsoDateKey("2026/5/10")  // => "2026-05-10"
+ * toIsoDateKey("2026/12/3")  // => "2026-12-03"
+ * toIsoDateKey(undefined)    // => ""
+ */
+function toIsoDateKey(rawDate: string | undefined): string {
+  if (!rawDate) return ''
+  const parts = rawDate.split('/')
+  if (parts.length !== 3) return ''
+  const [year, month, day] = parts
+  if (!year || !month || !day) return ''
+  return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
 }

--- a/src/app/(main)/home/_components/DayDetailDialog.tsx
+++ b/src/app/(main)/home/_components/DayDetailDialog.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { match } from 'ts-pattern'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { getColorDotClass } from '@/lib/category-colors'
+import { orpc } from '@/lib/orpc/client-query'
+import { cn } from '@/lib/utils'
+
+interface DayDetailDialogProps {
+  date: string | null
+  onOpenChange: (open: boolean) => void
+}
+
+type Intensity = 0 | 1 | 2 | 3 | 4
+
+interface DayState {
+  intensity: Intensity
+  bandToken: string
+  name: string
+  voice: string
+  isCathedralLit: boolean
+}
+
+/**
+ * Maps the day's completion count to one of five Warm Cathedral intensity
+ * levels. Mirrors the existing heatmap thresholds in ContributionGraph so a
+ * cell's visual level and the dialog's level band stay in lockstep.
+ * @param dayCount - Completed tasks on the clicked day
+ * @returns
+ * - 0 when no tasks (rest)
+ * - 1 for 1–3 tasks (started)
+ * - 2 for 4–9 tasks (good day)
+ * - 3 for 10–19 tasks (full day)
+ * - 4 for 20+ tasks (cathedral lit)
+ * @example
+ * getIntensityFromCount(0)  // => 0
+ * getIntensityFromCount(7)  // => 2
+ * getIntensityFromCount(22) // => 4
+ */
+function getIntensityFromCount(dayCount: number): Intensity {
+  if (dayCount === 0) return 0
+  if (dayCount < 4) return 1
+  if (dayCount < 10) return 2
+  if (dayCount < 20) return 3
+  return 4
+}
+
+/**
+ * Turns a day's completion count into the design-finalized state copy and
+ * the heatmap palette token used by the dialog's level band.
+ * @param dayCount - Completed tasks on the clicked day
+ * @returns A DayState describing band color, italic display name, voice line, and cathedral-lit flag.
+ * @example
+ * getDayState(0)  // => { intensity: 0, bandToken: "var(--hm-0)", name: "rest day", ... }
+ * getDayState(22) // => { intensity: 4, bandToken: "var(--hm-4)", name: "cathedral lit", isCathedralLit: true, ... }
+ */
+function getDayState(dayCount: number): DayState {
+  const intensity = getIntensityFromCount(dayCount)
+  return match(intensity)
+    .with(0, () => ({
+      intensity: 0 as const,
+      bandToken: 'var(--hm-0)',
+      name: 'rest day',
+      voice: 'rest days are days too. the cathedral keeps the light on.',
+      isCathedralLit: false,
+    }))
+    .with(1, () => ({
+      intensity: 1 as const,
+      bandToken: 'var(--hm-1)',
+      name: 'started',
+      voice: 'a couple things landed. that counts.',
+      isCathedralLit: false,
+    }))
+    .with(2, () => ({
+      intensity: 2 as const,
+      bandToken: 'var(--hm-2)',
+      name: 'good day',
+      voice: 'a productive rhythm — solid showing.',
+      isCathedralLit: false,
+    }))
+    .with(3, () => ({
+      intensity: 3 as const,
+      bandToken: 'var(--hm-3)',
+      name: 'full day',
+      voice: 'the day kept its rhythm — quietly full.',
+      isCathedralLit: false,
+    }))
+    .with(4, () => ({
+      intensity: 4 as const,
+      bandToken: 'var(--hm-4)',
+      name: 'cathedral lit',
+      voice: "the day held everything. that's not a fluke.",
+      isCathedralLit: true,
+    }))
+    .exhaustive()
+}
+
+/**
+ * Formats a YYYY-MM-DD date string to a long-form readable label.
+ * @param isoDate - YYYY-MM-DD date string
+ * @returns Long-form date like "May 10, 2026"
+ * @example
+ * formatDate("2026-05-10") // => "May 10, 2026"
+ */
+function formatDate(isoDate: string): string {
+  const parsed = new Date(`${isoDate}T00:00:00`)
+  return parsed.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/**
+ * Formats a Date into a 24-hour HH:MM string for completion timestamps.
+ * @param when - Timestamp the task was marked done
+ * @returns 24-hour clock string like "18:47"
+ * @example
+ * formatTime(new Date("2026-05-10T18:47:00")) // => "18:47"
+ */
+function formatTime(when: Date): string {
+  return when.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+/**
+ * Returns today's calendar date in YYYY-MM-DD using UTC, matching the
+ * heatmap aggregation bucketing in getDayDetail / getHeatmap.
+ * @returns YYYY-MM-DD string
+ * @example
+ * getTodayDateString() // => "2026-05-11"
+ */
+function getTodayDateString(): string {
+  return new Date().toISOString().split('T')[0]!
+}
+
+/**
+ * Day-detail dialog opened by clicking a Heatmap cell. Renders the day's
+ * level band (paper → terracotta), italic state name, voice line, and a
+ * compact list of the day's completed tasks. The cathedral-lit halo (soft
+ * amber box-shadow ring) only appears on full days (intensity 4); today
+ * gets a pulse-dot "still going" footer when the count is non-zero.
+ *
+ * @param date - YYYY-MM-DD date string; null collapses the dialog
+ * @param onOpenChange - Forwarded to Radix Dialog to drive open state from the parent
+ * @example
+ * <DayDetailDialog date={selectedDate} onOpenChange={(open) => !open && setSelectedDate(null)} />
+ */
+export function DayDetailDialog({ date, onOpenChange }: DayDetailDialogProps) {
+  const isClerkQueryReady = useClerkQueryReady()
+  const { data, isLoading } = useQuery({
+    ...orpc.completed.dayDetail.queryOptions({
+      input: { date: date ?? '1970-01-01' },
+    }),
+    enabled: isClerkQueryReady && date !== null,
+  })
+
+  const isOpen = date !== null
+  const dayCount = data?.count ?? 0
+  const state = getDayState(dayCount)
+  const isToday = date !== null && date === getTodayDateString()
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn('sm:max-w-md', state.isCathedralLit && 'cathedral-lit')}
+      >
+        {date && (
+          <>
+            <DialogHeader>
+              <div className="flex items-center gap-3">
+                <span
+                  aria-hidden
+                  className="size-9 rounded-md border border-border"
+                  style={{ backgroundColor: state.bandToken }}
+                />
+                <div className="flex flex-col items-start gap-0.5">
+                  <DialogTitle className="font-serif text-2xl italic text-foreground">
+                    {state.name}
+                  </DialogTitle>
+                  <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                    {formatDate(date)}
+                  </p>
+                </div>
+              </div>
+              <DialogDescription className="pt-1 font-serif text-sm italic text-muted-foreground">
+                {state.voice}
+              </DialogDescription>
+            </DialogHeader>
+
+            {isLoading ? (
+              <p className="text-sm text-muted-foreground">…</p>
+            ) : dayCount === 0 ? (
+              <p className="font-serif text-sm italic text-muted-foreground">
+                {isToday
+                  ? 'today is still open — there is no shape to it yet.'
+                  : 'no tasks landed on this day. rest is a choice, not a void.'}
+              </p>
+            ) : (
+              <ul className="space-y-1.5">
+                {data?.tasks.map((task) => (
+                  <li
+                    key={task.id}
+                    className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2"
+                  >
+                    <span
+                      aria-hidden
+                      className={cn(
+                        'inline-block size-2 shrink-0 rounded-full',
+                        getColorDotClass(task.category?.color),
+                      )}
+                    />
+                    <span className="text-sm text-foreground">
+                      {task.title}
+                    </span>
+                    <span className="ml-auto font-mono text-xs text-muted-foreground">
+                      {formatTime(task.completedAt)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {isToday && dayCount > 0 && (
+              <p className="flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                <span
+                  aria-hidden
+                  className="inline-block size-1.5 rounded-full bg-primary motion-safe:animate-pulse"
+                />
+                still going · {formatTime(new Date())}
+              </p>
+            )}
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { ClerkProvider } from '@clerk/nextjs'
 import type { Metadata } from 'next'
+import { Geist_Mono, Inter_Tight, Newsreader } from 'next/font/google'
 import '@/globals.css'
 
 import { CodeInspectorClient } from '@/components/code-inspector/CodeInspectorClient'
@@ -10,6 +11,25 @@ import { ReduxProvider } from '@/lib/redux/providers'
 import { cn } from '@/lib/utils'
 import { QueryClientProvider } from '@/providers/QueryClientProvider'
 import { ThemeProvider } from '@/providers/ThemeProvider'
+
+const newsreader = Newsreader({
+  subsets: ['latin'],
+  style: ['normal', 'italic'],
+  display: 'swap',
+  variable: '--font-newsreader',
+})
+
+const interTight = Inter_Tight({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter-tight',
+})
+
+const geistMono = Geist_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-geist-mono',
+})
 
 export const metadata: Metadata = {
   title: {
@@ -26,8 +46,16 @@ interface RootLayoutProps {
 const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
   return (
     <ClerkProvider>
-      <html lang="en" suppressHydrationWarning>
-        <body className={cn('mx-auto min-h-screen antialiased')}>
+      <html
+        lang="en"
+        suppressHydrationWarning
+        className={cn(
+          newsreader.variable,
+          interTight.variable,
+          geistMono.variable,
+        )}
+      >
+        <body className={cn('mx-auto min-h-screen font-sans antialiased')}>
           <ThemeProvider
             attribute="data-theme"
             defaultTheme="light"

--- a/src/components/ThemeSelector.stories.tsx
+++ b/src/components/ThemeSelector.stories.tsx
@@ -146,12 +146,13 @@ export const DefaultThemeTest: Story = {
       .getPropertyValue('--foreground')
       .trim()
 
-    // shadcn/ui light theme - browsers may convert oklch to lab or percentage
+    // Warm Cathedral light theme — accept oklch/lab serializations across browsers.
+    // --background: oklch(0.985 0.005 75), --foreground: oklch(0.18 0.015 30)
     expect(backgroundColor).toMatch(
-      /^(oklch\(1 0 0\)|oklch\(100% 0 0\)|lab\(100% 0 0\))$/,
+      /^(oklch\(0\.985 0\.005 75\)|oklch\(98\.5% 0\.005 75\)|lab\([\d.]+% [-\d.]+ [-\d.]+\))$/,
     )
     expect(foregroundColor).toMatch(
-      /^(oklch\(0\.145 0 0\)|oklch\(14\.5% 0 0\)|lab\([\d.]+% 0 0\))$/,
+      /^(oklch\(0\.18 0\.015 30\)|oklch\(18% 0\.015 30\)|lab\([\d.]+% [-\d.]+ [-\d.]+\))$/,
     )
   },
 }
@@ -204,9 +205,10 @@ export const SwitchToDarkThemeTest: Story = {
       .getPropertyValue('--background')
       .trim()
 
-    // shadcn/ui dark theme - browsers may convert oklch to lab or percentage
+    // Warm Cathedral dark theme — accept oklch/lab serializations across browsers.
+    // --background: oklch(0.16 0.012 35)
     expect(backgroundColor).toMatch(
-      /^(oklch\(0\.145 0 0\)|oklch\(14\.5% 0 0\)|lab\([\d.]+% 0 0\))$/,
+      /^(oklch\(0\.16 0\.012 35\)|oklch\(16% 0\.012 35\)|lab\([\d.]+% [-\d.]+ [-\d.]+\))$/,
     )
   },
 }

--- a/src/globals.css
+++ b/src/globals.css
@@ -44,8 +44,7 @@
   --font-serif: var(--font-newsreader);
   --font-mono: var(--font-geist-mono);
 }
-/*---break---
- */
+/* ---break--- */
 :root {
   --radius: 0.625rem;
   /* Warm Cathedral — light theme (paper, dawn, amber, terracotta) */
@@ -93,8 +92,7 @@
   --heatmap-level-3: var(--hm-3);
   --heatmap-level-4: var(--hm-4);
 }
-/*---break---
- */
+/* ---break--- */
 [data-theme='dark'] {
   /* Warm Cathedral — dark theme (warm coal, ember, copper, warm sun) */
   --background: oklch(0.16 0.012 35);
@@ -140,8 +138,7 @@
   --heatmap-level-3: var(--hm-3);
   --heatmap-level-4: var(--hm-4);
 }
-/*---break---
- */
+/* ---break--- */
 @layer base {
   * {
     @apply outline-ring/50 border-border;

--- a/src/globals.css
+++ b/src/globals.css
@@ -40,87 +40,105 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --font-sans: var(--font-inter-tight);
+  --font-serif: var(--font-newsreader);
+  --font-mono: var(--font-geist-mono);
 }
 /*---break---
  */
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-  --heatmap-level-0: #ebedf0;
-  --heatmap-level-1: #dcefe3;
-  --heatmap-level-2: #b6dcc7;
-  --heatmap-level-3: #7dc5a0;
-  --heatmap-level-4: #4c9f77;
+  /* Warm Cathedral — light theme (paper, dawn, amber, terracotta) */
+  --background: oklch(0.985 0.005 75);
+  --foreground: oklch(0.18 0.015 30);
+  --card: oklch(0.98 0.008 70);
+  --card-foreground: oklch(0.18 0.015 30);
+  --popover: oklch(0.98 0.008 70);
+  --popover-foreground: oklch(0.18 0.015 30);
+  --primary: oklch(0.62 0.16 50);
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.95 0.01 70);
+  --secondary-foreground: oklch(0.18 0.015 30);
+  --muted: oklch(0.95 0.01 70);
+  --muted-foreground: oklch(0.5 0.015 50);
+  --accent: oklch(0.95 0.01 70);
+  --accent-foreground: oklch(0.18 0.015 30);
+  --destructive: oklch(0.6 0.2 25);
+  --border: oklch(0.92 0.01 70);
+  --input: oklch(0.92 0.01 70);
+  --ring: oklch(0.62 0.16 50);
+  --chart-1: oklch(0.62 0.16 50);
+  --chart-2: oklch(0.65 0.13 145);
+  --chart-3: oklch(0.6 0.1 230);
+  --chart-4: oklch(0.7 0.14 80);
+  --chart-5: oklch(0.55 0.16 40);
+  --sidebar: oklch(0.98 0.008 70);
+  --sidebar-foreground: oklch(0.18 0.015 30);
+  --sidebar-primary: oklch(0.62 0.16 50);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.95 0.01 70);
+  --sidebar-accent-foreground: oklch(0.18 0.015 30);
+  --sidebar-border: oklch(0.92 0.01 70);
+  --sidebar-ring: oklch(0.62 0.16 50);
+  /* Heatmap temperature gradient — paper → dawn → amber → honey → terracotta */
+  --hm-0: oklch(0.96 0.008 80);
+  --hm-1: oklch(0.89 0.06 75);
+  --hm-2: oklch(0.78 0.11 70);
+  --hm-3: oklch(0.65 0.14 60);
+  --hm-4: oklch(0.55 0.16 40);
+  /* Legacy aliases — kept for ContributionGraph.tsx until PR1 migrates */
+  --heatmap-level-0: var(--hm-0);
+  --heatmap-level-1: var(--hm-1);
+  --heatmap-level-2: var(--hm-2);
+  --heatmap-level-3: var(--hm-3);
+  --heatmap-level-4: var(--hm-4);
 }
 /*---break---
  */
 [data-theme='dark'] {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-  --heatmap-level-0: #161b22;
-  --heatmap-level-1: #0e4429;
-  --heatmap-level-2: #006d32;
-  --heatmap-level-3: #26a641;
-  --heatmap-level-4: #39d353;
+  /* Warm Cathedral — dark theme (warm coal, ember, copper, warm sun) */
+  --background: oklch(0.16 0.012 35);
+  --foreground: oklch(0.96 0.005 75);
+  --card: oklch(0.22 0.015 40);
+  --card-foreground: oklch(0.96 0.005 75);
+  --popover: oklch(0.22 0.015 40);
+  --popover-foreground: oklch(0.96 0.005 75);
+  --primary: oklch(0.7 0.16 55);
+  --primary-foreground: oklch(0.16 0.012 35);
+  --secondary: oklch(0.27 0.012 40);
+  --secondary-foreground: oklch(0.96 0.005 75);
+  --muted: oklch(0.27 0.012 40);
+  --muted-foreground: oklch(0.72 0.012 70);
+  --accent: oklch(0.27 0.012 40);
+  --accent-foreground: oklch(0.96 0.005 75);
+  --destructive: oklch(0.7 0.19 25);
+  --border: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.7 0.16 55);
+  --chart-1: oklch(0.7 0.16 55);
+  --chart-2: oklch(0.65 0.13 145);
+  --chart-3: oklch(0.6 0.1 230);
+  --chart-4: oklch(0.7 0.14 80);
+  --chart-5: oklch(0.7 0.15 65);
+  --sidebar: oklch(0.22 0.015 40);
+  --sidebar-foreground: oklch(0.96 0.005 75);
+  --sidebar-primary: oklch(0.7 0.16 55);
+  --sidebar-primary-foreground: oklch(0.16 0.012 35);
+  --sidebar-accent: oklch(0.27 0.012 40);
+  --sidebar-accent-foreground: oklch(0.96 0.005 75);
+  --sidebar-border: oklch(1 0 0 / 8%);
+  --sidebar-ring: oklch(0.7 0.16 55);
+  /* Heatmap temperature gradient — warm coal → ember → copper → brass → warm sun */
+  --hm-0: oklch(0.22 0.012 40);
+  --hm-1: oklch(0.32 0.06 50);
+  --hm-2: oklch(0.45 0.1 55);
+  --hm-3: oklch(0.58 0.13 60);
+  --hm-4: oklch(0.7 0.15 65);
+  --heatmap-level-0: var(--hm-0);
+  --heatmap-level-1: var(--hm-1);
+  --heatmap-level-2: var(--hm-2);
+  --heatmap-level-3: var(--hm-3);
+  --heatmap-level-4: var(--hm-4);
 }
 /*---break---
  */
@@ -130,5 +148,15 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  /* Cathedral-lit halo — soft amber ring used on full-day surfaces */
+  /* (DayDetailDialog state C, StreakBadge tier 4, YearInReview biggest day) */
+  .cathedral-lit {
+    box-shadow:
+      0 0 0 1px oklch(from var(--primary) l c h / 22%),
+      0 0 48px -12px oklch(from var(--primary) l c h / 35%);
   }
 }

--- a/src/hooks/useTodoMutations.ts
+++ b/src/hooks/useTodoMutations.ts
@@ -249,6 +249,13 @@ export function useTodoMutations(categoryId: number | null) {
       queryClient.invalidateQueries({
         queryKey: orpc.skillTree.getUnassignedPool.key(),
       })
+      // Heatmap aggregates the same Todo rows that toggle flips. Without
+      // these invalidations the heatmap cell color and the DayDetailDialog
+      // task list drift out of sync after a toggle until the user reloads.
+      queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
+      queryClient.invalidateQueries({
+        queryKey: orpc.completed.dayDetail.key(),
+      })
       broadcastTodoSync()
       broadcastCategorySync()
     },
@@ -324,6 +331,12 @@ export function useTodoMutations(categoryId: number | null) {
       })
       queryClient.invalidateQueries({
         queryKey: orpc.skillTree.getUnassignedPool.key(),
+      })
+      // Deleting a completed todo shrinks the heatmap cell for that day
+      // and removes the row from any open DayDetailDialog list.
+      queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
+      queryClient.invalidateQueries({
+        queryKey: orpc.completed.dayDetail.key(),
       })
       broadcastTodoSync()
       broadcastCategorySync()
@@ -449,6 +462,12 @@ export function useTodoMutations(categoryId: number | null) {
       })
       queryClient.invalidateQueries({
         queryKey: orpc.skillTree.getUnassignedPool.key(),
+      })
+      // Wiping all completed todos resets every heatmap cell and empties
+      // any open DayDetailDialog list.
+      queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
+      queryClient.invalidateQueries({
+        queryKey: orpc.completed.dayDetail.key(),
       })
       broadcastTodoSync()
       broadcastCategorySync()

--- a/src/server/procedures/completed.ts
+++ b/src/server/procedures/completed.ts
@@ -8,6 +8,8 @@ import { authMiddleware } from '../middleware/auth'
 import {
   CompletedSchema,
   CreateCompletedSchema,
+  DayDetailInputSchema,
+  DayDetailResponseSchema,
   DeleteCompletedSchema,
   HeatmapInputSchema,
   HeatmapResponseSchema,
@@ -173,6 +175,90 @@ function calculateStreaks(dates: string[]): {
 
   return { current: currentStreak, longest: Math.max(longest, currentStreak) }
 }
+
+/**
+ * Fetches a single day's completed tasks for the DayDetailDialog opened from
+ * a heatmap cell click. Date range covers the local calendar day in UTC; this
+ * matches the heatmap's existing aggregation, so cell counts and dialog
+ * counts stay in lockstep.
+ *
+ * @param input.date - YYYY-MM-DD date string the user clicked on the heatmap
+ * @returns
+ * - date, count, tasks (id/title/completedAt/category), categories (rollup)
+ * @example
+ * getDayDetail({ date: "2026-05-10" })
+ * // => { date: "2026-05-10", count: 3, tasks: [...], categories: [...] }
+ */
+export const getDayDetail = authMiddleware
+  .input(DayDetailInputSchema)
+  .output(DayDetailResponseSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const { date } = input
+      const { user } = context
+
+      // The heatmap aggregates by `updatedAt.toISOString().split('T')[0]`,
+      // which is UTC. Match that here so cell counts match dialog counts.
+      const dayStart = new Date(`${date}T00:00:00.000Z`)
+      const dayEnd = new Date(`${date}T23:59:59.999Z`)
+
+      const todos = await prisma.todo.findMany({
+        where: {
+          userId: user.id,
+          completed: true,
+          updatedAt: { gte: dayStart, lte: dayEnd },
+        },
+        select: {
+          id: true,
+          text: true,
+          updatedAt: true,
+          category: {
+            select: { id: true, name: true, color: true },
+          },
+        },
+        orderBy: { updatedAt: 'asc' },
+      })
+
+      const tasks = todos.map((todo) => ({
+        id: todo.id,
+        title: todo.text,
+        completedAt: todo.updatedAt,
+        category: todo.category,
+      }))
+
+      const categoryRollup = new Map<
+        number,
+        { id: number; name: string; color: string; count: number }
+      >()
+      for (const todo of todos) {
+        if (!todo.category) continue
+        const existing = categoryRollup.get(todo.category.id)
+        if (existing) {
+          existing.count++
+        } else {
+          categoryRollup.set(todo.category.id, {
+            id: todo.category.id,
+            name: todo.category.name,
+            color: todo.category.color,
+            count: 1,
+          })
+        }
+      }
+
+      return {
+        date,
+        count: tasks.length,
+        tasks,
+        categories: Array.from(categoryRollup.values()),
+      }
+    } catch (error) {
+      log.error('Error in getDayDetail:', error)
+      throw new ORPCError('INTERNAL_SERVER_ERROR', {
+        message: 'Failed to fetch day detail',
+        cause: error,
+      })
+    }
+  })
 
 /**
  * Inserts a row directly into the Completed table for the authenticated user.

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -7,6 +7,7 @@ import {
 import {
   createCompleted,
   deleteCompleted,
+  getDayDetail,
   getHeatmap,
 } from './procedures/completed'
 import {
@@ -47,6 +48,7 @@ export const router = {
   },
   completed: {
     heatmap: getHeatmap,
+    dayDetail: getDayDetail,
     create: createCompleted,
     delete: deleteCompleted,
   },

--- a/src/server/schemas/completed.ts
+++ b/src/server/schemas/completed.ts
@@ -96,9 +96,21 @@ export const HeatmapResponseSchema = z.object({
  * { date: "2026-05-10" }
  */
 export const DayDetailInputSchema = z.object({
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
-    message: 'date must be YYYY-MM-DD',
-  }),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, {
+      message: 'date must be YYYY-MM-DD',
+    })
+    .refine(
+      (value) => {
+        const parsed = new Date(`${value}T00:00:00.000Z`)
+        return (
+          !Number.isNaN(parsed.getTime()) &&
+          parsed.toISOString().slice(0, 10) === value
+        )
+      },
+      { message: 'date must be a valid calendar date' },
+    ),
 })
 
 /**

--- a/src/server/schemas/completed.ts
+++ b/src/server/schemas/completed.ts
@@ -88,3 +88,45 @@ export const HeatmapResponseSchema = z.object({
   }),
   total: z.number().int(),
 })
+
+/**
+ * Input schema for the day-detail endpoint used by DayDetailDialog.
+ * Date is the local calendar date the user clicked on the heatmap.
+ * @example
+ * { date: "2026-05-10" }
+ */
+export const DayDetailInputSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'date must be YYYY-MM-DD',
+  }),
+})
+
+/**
+ * Single completed task entry surfaced in the day-detail dialog.
+ * @example
+ * { id: 12, title: "draft sunday digest", completedAt: Date, category: { id: 1, name: "writing", color: "blue" } }
+ */
+export const DayDetailTaskSchema = z.object({
+  id: z.number().int(),
+  title: z.string(),
+  completedAt: z.date(),
+  category: z
+    .object({
+      id: z.number().int(),
+      name: z.string(),
+      color: z.string(),
+    })
+    .nullable(),
+})
+
+/**
+ * Response schema for the day-detail endpoint.
+ * @example
+ * { date: "2026-05-10", count: 3, tasks: [...], categories: [...] }
+ */
+export const DayDetailResponseSchema = z.object({
+  date: z.string(),
+  count: z.number().int(),
+  tasks: z.array(DayDetailTaskSchema),
+  categories: z.array(HeatmapCategorySchema),
+})


### PR DESCRIPTION
## Summary

- Shift the home page heatmap from GitHub-green to **Warm Cathedral** (paper → dawn → amber → terracotta) per the new `DESIGN.md`.
- Resize cells from 8–28px to **12–32px** (Heatmap Cathedral plan, design lock D6).
- New `<DayDetailDialog>` — click any cell to see that day's completed tasks, completion times, and a Warm Cathedral level-band header ("rest day" / "started" / "good day" / "full day" / "cathedral lit").
- Add `DESIGN.md` as the canonical reference for tokens, typography, motion, and voice — referenced from `CLAUDE.md`.

## Bug fixes uncovered while wiring up the click path

1. **`PANEL_COLORS` threshold mismatch.** Old keys `{0,2,4,10,20}` mapped count=2 → L2, but `DayDetailDialog.getIntensityFromCount` says count<4 → L1. Re-pinned to `{0,4,10,20,1000}` so the heatmap and dialog always agree.
2. **Date format drift.** `@uiw/react-heat-map` emits `data.date` as `YYYY/M/D` (no zero-pad). The old `replace(/\//g,'-')` produced `2026-5-10`, which never matched the server's `2026-05-10` bucket — so the dialog returned count=0 ("rest day") for cells the heatmap had painted L1+, and `formatDate` rendered "INVALID DATE". Added `toIsoDateKey` to normalize.
3. **Stale heatmap after mutations.** `useTodoMutations` didn't invalidate `completed.heatmap` / `completed.dayDetail` on toggle / delete / clearCompleted, so the cell color and any open dialog drifted until page reload. Added the missing invalidations.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes (no warnings)
- [x] Browser smoke (chrome-devtools MCP):
  - Toggled 4 todos → Activity badge updates live `0 → 1 → 2 → 3 → 4 completed`
  - Cell at today renders `fill="var(--heatmap-level-2)"` (amber) once count hits 4
  - Click cell → dialog shows "**good day**", `MAY 10, 2026`, all four tasks with completion timestamps, and the "STILL GOING · 06:47" today-footer
- [ ] Reviewer smoke: confirm light mode amber gradient reads "warm" and not muddy on your display

## Out of scope (follow-up PRs)

- C1 day-nav (prev/next inside dialog)
- C2 weekly summary card
- C3 monthly max-day mark
- PR2–7 (keyboard shortcuts, StreakBadge, Sunday digest, OG image, YearInReviewModal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Click heatmap cells to view completed tasks for that day in a new details dialog
  * Added task completion intensity levels and visual indicators

* **Style**
  * Refreshed design system with "Warm Cathedral" aesthetic
  * Updated color palette, typography, and spacing throughout the app
  * Enhanced heatmap gradient and visual styling

* **Documentation**
  * Added comprehensive design system specification document

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->