### PR TITLE
feat(home): heatmap cathedral PR1.5+PR2 (UNION, day-nav, j/k)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ _trials/
 .gstack/
 .claude/goal.json
 .claude/goal-notes.md
+.claude/auto.json
+.claude/auto-notes.md

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,38 @@
+# TODOS
+
+Tracked deferrals flagged by `/plan-eng-review` (2026-05-11) during the Heatmap
+Cathedral PR1.5 + PR2 finalisation. Each entry links back to the forcing
+function that will pull it off the deferred list.
+
+## Heatmap / Completion semantics
+
+- [ ] **Migrate Todo heatmap bucket to a stable `completedAt` field.**
+      Today `getHeatmap` and `getDayDetail` bucket Todo rows by
+      `updatedAt`, which mutates on every edit and can shift heatmap dots
+      forward in time when a user edits a long-completed Todo. Plan:
+      (a) `Todo.completedAt: DateTime?` column,
+      (b) backfill `UPDATE Todo SET completedAt = updatedAt WHERE completed = true`,
+      (c) populate on the `complete()` mutation path,
+      (d) swap `fetchCompletedEntries` to filter/bucket by `completedAt`.
+      Forcing function: PR3 (Streak Notifications) needs immutable
+      completion timestamps to avoid streak drift on backdated edits.
+      Effort: ~half day human / ~30 min CC.
+
+- [ ] **User-TZ bucketing.** Heatmap currently uses UTC midnight buckets.
+      JST 8:00 completion lands on previous UTC day. Defer until PR3
+      requires it (streak calcs need user TZ per CEO §11.4).
+
+## URL / Deep-link
+
+- [ ] **Bidirectional `?date=` URL sync.** PR2 introduces inbound deep-link
+      handling (`/home?date=YYYY-MM-DD` opens the day dialog). Promote day-nav
+      (`←` / `→`) to call `router.replace('?date=…')` so the URL stays in
+      sync with the dialog. Pairs cleanly with PR6 share image (URL
+      pre-populated in clipboard). Forcing function: PR6 share flow.
+
+## Heatmap visual
+
+- [ ] **Per-month tie-break for max mark.** When multiple days in a month
+      tie for the max contribution, the "month max" marker currently picks
+      the earliest. Revisit if users surface complaints about "missed" tied
+      days. Forcing function: user feedback on PR1.5.

--- a/e2e/web/heatmap-day-detail.spec.ts
+++ b/e2e/web/heatmap-day-detail.spec.ts
@@ -4,12 +4,19 @@ import { test, expect, type Page } from '@playwright/test'
 import { resetDatabase } from './_helpers/db'
 
 /**
- * Fixed historical date used as the dialog "anchor" for every test that needs
- * a starting day. April 1 2026 is well within the trailing 1-year heatmap
- * range (today = 2026-05-11 per the test-environment clock) and stays the
- * same regardless of when the suite is replayed because both the URL param
- * and the label are hard-coded — there is no `new Date()` involved in the
- * E2E assertions, so the spec is replay-deterministic per plan §3.5.
+ * Fixed historical date used as the dialog "anchor" for every test that
+ * needs a starting day. The URL param and the label are both hard-coded
+ * (no `new Date()` in any assertion), so the spec is replay-deterministic
+ * per plan §3.5 *regardless of how far past* today's date drifts from
+ * when these tests were authored — `getDayDetail` accepts any valid
+ * calendar date, it does not gate on the heatmap's visible range.
+ *
+ * Caveat: cells for `DEEP_LINK_DATE` may fall outside the heatmap when
+ * replayed >365 days later, but that only affects cell *clicking* tests,
+ * and these tests open the dialog via `?date=` rather than via the cell,
+ * so they remain valid. If a future test exercises cell clicks, install
+ * `page.clock` to pin the test-environment date instead of relying on
+ * the trailing year being wide enough.
  */
 const DEEP_LINK_DATE = '2026-04-01'
 const DEEP_LINK_DATE_LABEL = 'April 1, 2026'
@@ -55,7 +62,11 @@ async function waitForAppReady(page: Page) {
  */
 async function openDialogViaDeepLink(page: Page, date: string) {
   await page.goto(`/home?date=${date}`)
-  await page.waitForLoadState('networkidle')
+  // No `waitForLoadState('networkidle')` — Clerk + TanStack Query background
+  // refetches keep the page from ever reaching network-idle on Vercel-like
+  // environments, which made earlier drafts of this spec flaky. The app
+  // readiness gate + dialog role locator are sufficient to know the deep
+  // link has resolved (Codex review MEDIUM).
   await waitForAppReady(page)
   await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10000 })
 }
@@ -87,7 +98,6 @@ test.describe('Heatmap Day Detail E2E', () => {
     }) => {
       // Arrange — non-ISO date triggers the Zod regex-fail branch.
       await page.goto('/home?date=not-a-date')
-      await page.waitForLoadState('networkidle')
       await waitForAppReady(page)
 
       // Assert — toast surfaces the invalid-URL message AND the dialog stays
@@ -108,7 +118,6 @@ test.describe('Heatmap Day Detail E2E', () => {
       // arm of the validator so a regression that drops the refine surfaces
       // here, not in production.
       await page.goto('/home?date=2026-02-31')
-      await page.waitForLoadState('networkidle')
       await waitForAppReady(page)
 
       // Assert — same toast + closed-dialog outcome as the regex-fail branch.

--- a/e2e/web/heatmap-day-detail.spec.ts
+++ b/e2e/web/heatmap-day-detail.spec.ts
@@ -1,0 +1,205 @@
+import { setupClerkTestingToken } from '@clerk/testing/playwright'
+import { test, expect, type Page } from '@playwright/test'
+
+import { resetDatabase } from './_helpers/db'
+
+/**
+ * Fixed historical date used as the dialog "anchor" for every test that needs
+ * a starting day. April 1 2026 is well within the trailing 1-year heatmap
+ * range (today = 2026-05-11 per the test-environment clock) and stays the
+ * same regardless of when the suite is replayed because both the URL param
+ * and the label are hard-coded — there is no `new Date()` involved in the
+ * E2E assertions, so the spec is replay-deterministic per plan §3.5.
+ */
+const DEEP_LINK_DATE = '2026-04-01'
+const DEEP_LINK_DATE_LABEL = 'April 1, 2026'
+const NEXT_DAY_LABEL = 'April 2, 2026'
+const PREV_DAY_LABEL = 'March 31, 2026'
+
+/**
+ * Waits for the Todo List heading to appear, handling the Loading... state.
+ * Copied from sibling specs (todo-app.spec.ts, category.spec.ts) — the home
+ * page transitions through a "Loading..." gate while `useClerkQueryReady`
+ * resolves and the persister rehydrates, so a direct `expect(Todo List)` can
+ * race with the loading skeleton on slow first-paints.
+ * @param page - Playwright page object
+ */
+async function waitForAppReady(page: Page) {
+  await expect(
+    page.getByText('Todo List').or(page.getByText('Loading...')),
+  ).toBeVisible({ timeout: 10000 })
+
+  const isLoading = await page.getByText('Loading...').isVisible()
+  if (isLoading) {
+    await expect(page.getByText('Todo List')).toBeVisible({ timeout: 10000 })
+  }
+}
+
+/**
+ * Navigates to `/home?date=<iso>` and waits for the DayDetailDialog to open.
+ * Bundles the three steps every nav-flow test needs (goto + app ready +
+ * dialog visible) so the test bodies stay focused on the *behaviour* under
+ * test instead of the boilerplate.
+ *
+ * The deep-link path is the only way to put the dialog in a known starting
+ * state without seeding a completed Todo — the home page seed only creates
+ * pending Todos (see `prisma/seed.ts`), so the heatmap cells are all empty
+ * and clicking one would still surface a "rest day" dialog. Using `?date=`
+ * gets us the same dialog without depending on which cells the heatmap
+ * library renders at the current viewport size.
+ *
+ * @param page - Playwright page object
+ * @param date - YYYY-MM-DD ISO date pushed into the URL search param
+ * @example
+ * await openDialogViaDeepLink(page, '2026-04-01')
+ */
+async function openDialogViaDeepLink(page: Page, date: string) {
+  await page.goto(`/home?date=${date}`)
+  await page.waitForLoadState('networkidle')
+  await waitForAppReady(page)
+  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10000 })
+}
+
+test.describe('Heatmap Day Detail E2E', () => {
+  test.beforeAll(resetDatabase)
+
+  test.beforeEach(async ({ page }) => {
+    // Setup Clerk testing token for each test — required for Clerk to gate
+    // the oRPC dayDetail query open. Without this, `useClerkQueryReady`
+    // returns false and the dialog never fetches.
+    await setupClerkTestingToken({ page })
+  })
+
+  test.describe('Deep-link via ?date=', () => {
+    test('opens dialog when date param is a valid calendar date', async ({
+      page,
+    }) => {
+      // Arrange — navigate with a valid ?date= param.
+      await openDialogViaDeepLink(page, DEEP_LINK_DATE)
+
+      // Assert — dialog opens with the date subtitle reflecting the URL date.
+      const dialog = page.getByRole('dialog')
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).toBeVisible()
+    })
+
+    test('shows toast + keeps dialog closed when date param is non-ISO', async ({
+      page,
+    }) => {
+      // Arrange — non-ISO date triggers the Zod regex-fail branch.
+      await page.goto('/home?date=not-a-date')
+      await page.waitForLoadState('networkidle')
+      await waitForAppReady(page)
+
+      // Assert — toast surfaces the invalid-URL message AND the dialog stays
+      // closed. Toaster region role taken from `sonner` defaults — same
+      // selector pattern used in qa-fixes.spec.ts.
+      const toaster = page.getByRole('region', { name: /Notifications/ })
+      await expect(toaster.getByText(/invalid date in url/i)).toBeVisible({
+        timeout: 5000,
+      })
+      await expect(page.getByRole('dialog')).not.toBeVisible()
+    })
+
+    test('shows toast + keeps dialog closed when date param is a non-existent calendar date', async ({
+      page,
+    }) => {
+      // Arrange — 2026-02-31 passes the YYYY-MM-DD regex but fails the
+      // calendar round-trip refine in DayDetailInputSchema. Locks the second
+      // arm of the validator so a regression that drops the refine surfaces
+      // here, not in production.
+      await page.goto('/home?date=2026-02-31')
+      await page.waitForLoadState('networkidle')
+      await waitForAppReady(page)
+
+      // Assert — same toast + closed-dialog outcome as the regex-fail branch.
+      const toaster = page.getByRole('region', { name: /Notifications/ })
+      await expect(toaster.getByText(/invalid date in url/i)).toBeVisible({
+        timeout: 5000,
+      })
+      await expect(page.getByRole('dialog')).not.toBeVisible()
+    })
+  })
+
+  test.describe('Day navigation', () => {
+    test('chevron > advances the dialog by one day', async ({ page }) => {
+      // Arrange
+      await openDialogViaDeepLink(page, DEEP_LINK_DATE)
+      const dialog = page.getByRole('dialog')
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).toBeVisible()
+
+      // Act — chevron uses aria-label="Next day" (see DayDetailDialog.tsx).
+      await dialog.getByRole('button', { name: 'Next day' }).click()
+
+      // Assert — date subtitle re-renders with April 2 2026; April 1 is gone.
+      await expect(dialog.getByText(NEXT_DAY_LABEL)).toBeVisible({
+        timeout: 5000,
+      })
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).not.toBeVisible()
+    })
+
+    test('chevron < reverses the dialog by one day', async ({ page }) => {
+      // Arrange
+      await openDialogViaDeepLink(page, DEEP_LINK_DATE)
+      const dialog = page.getByRole('dialog')
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).toBeVisible()
+
+      // Act
+      await dialog.getByRole('button', { name: 'Previous day' }).click()
+
+      // Assert — date subtitle shows March 31 2026 (cross-month boundary
+      // covered by shiftIsoDate's UTC arithmetic).
+      await expect(dialog.getByText(PREV_DAY_LABEL)).toBeVisible({
+        timeout: 5000,
+      })
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).not.toBeVisible()
+    })
+
+    test('j key advances the dialog by one day (PR2)', async ({ page }) => {
+      // Arrange
+      await openDialogViaDeepLink(page, DEEP_LINK_DATE)
+      const dialog = page.getByRole('dialog')
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).toBeVisible()
+
+      // Act — j is the "next" half of vim-style j/k nav; useKeyboardNav
+      // attaches a window listener whenever the dialog is open, so the
+      // currently-focused close X or chevron doesn't matter (the input guard
+      // only blocks INPUT/TEXTAREA/contentEditable targets).
+      await page.keyboard.press('j')
+
+      // Assert — same as chevron > result.
+      await expect(dialog.getByText(NEXT_DAY_LABEL)).toBeVisible({
+        timeout: 5000,
+      })
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).not.toBeVisible()
+    })
+
+    test('k key reverses the dialog by one day (PR2)', async ({ page }) => {
+      // Arrange
+      await openDialogViaDeepLink(page, DEEP_LINK_DATE)
+      const dialog = page.getByRole('dialog')
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).toBeVisible()
+
+      // Act
+      await page.keyboard.press('k')
+
+      // Assert — same as chevron < result.
+      await expect(dialog.getByText(PREV_DAY_LABEL)).toBeVisible({
+        timeout: 5000,
+      })
+      await expect(dialog.getByText(DEEP_LINK_DATE_LABEL)).not.toBeVisible()
+    })
+
+    test('Esc closes the dialog', async ({ page }) => {
+      // Arrange
+      await openDialogViaDeepLink(page, DEEP_LINK_DATE)
+
+      // Act — Esc handling is delegated to Radix Dialog (useKeyboardNav
+      // intentionally does NOT bind Esc to avoid double-handling, per the
+      // hook's JSDoc). Pressing Escape should still fully close the dialog.
+      await page.keyboard.press('Escape')
+
+      // Assert — dialog unmounts; the dialog role is no longer in the DOM.
+      await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 })
+    })
+  })
+})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -91,6 +91,7 @@ export default defineConfig([
             // Typography
             'antialiased',
             'subpixel-antialiased',
+            'tabular-nums',
             // Basic colors
             'text-white',
             'text-black',

--- a/src/app/(main)/home/_components/CategoryManageDialog.tsx
+++ b/src/app/(main)/home/_components/CategoryManageDialog.tsx
@@ -205,7 +205,6 @@ export function CategoryManageDialog({
                         className={`h-3 w-3 rounded-full ${getColorDotClass(category.color)}`}
                       />
                       <span className="flex-1 text-sm">{category.name}</span>
-                      {/* eslint-disable-next-line dslint/token-only -- tabular-nums is standard Tailwind utility */}
                       <span className="text-xs tabular-nums text-muted-foreground">
                         {category._count.todos} tasks
                       </span>

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -186,7 +186,13 @@ export function ContributionGraph() {
       setSelectedDate(parsed.data.date)
     } else {
       setSelectedDate(null)
-      toast.error('Invalid date in URL — showing your activity instead.')
+      // Sonner `id` dedupes the toast across React reconciliation passes so
+      // SSR→hydrate or Suspense fallback→resolution cycles can't stack two
+      // identical "invalid date" toasts on the same URL value (E2E flake on
+      // CI Linux had `..×× F` strict-mode locator violations otherwise).
+      toast.error('Invalid date in URL — showing your activity instead.', {
+        id: `invalid-date-${dateParam}`,
+      })
     }
   }, [dateParam])
 

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import HeatMap from '@uiw/react-heat-map'
+import { useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
 
 import { Badge } from '@/components/ui/badge'
 import {
@@ -21,6 +23,7 @@ import { useHeatmapData } from '@/hooks/useHeatmapData'
 import type { HeatmapDay } from '@/hooks/useHeatmapData'
 import { calcMonthlyMaxDates } from '@/lib/calcMonthlyMaxDates'
 import { shiftIsoDate } from '@/lib/shiftIsoDate'
+import { DayDetailInputSchema } from '@/server/schemas/completed'
 
 import { DayDetailDialog } from './DayDetailDialog'
 
@@ -160,6 +163,24 @@ export function ContributionGraph() {
   const containerRef = useRef<HTMLDivElement>(null)
   const containerWidth = useObservedElementWidth(containerRef)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  // `?date=YYYY-MM-DD` deep-link: validated via the same Zod schema the
+  // server uses for `getDayDetail`, so invalid input is rejected with the
+  // identical contract. The dep `[dateParam]` keeps the effect a one-shot
+  // per URL change — internal day-nav (<,>,j,k) does not write back to the
+  // URL (per plan §1.6), so this never thrashes.
+  const searchParams = useSearchParams()
+  const dateParam = searchParams.get('date')
+
+  useEffect(() => {
+    if (!dateParam) return
+    const parsed = DayDetailInputSchema.safeParse({ date: dateParam })
+    if (parsed.success) {
+      setSelectedDate(parsed.data.date)
+    } else {
+      toast.error('Invalid date in URL — showing your activity instead.')
+    }
+  }, [dateParam])
+
   const endDate = useMemo(() => normalizeDate(new Date()), [])
   const startDate = useMemo(
     () => getAlignedHeatmapStartDate(endDate),

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -272,6 +272,9 @@ export function ContributionGraph() {
                 // ◎ overlay marks each month's peak day. Painted in primary-foreground so
                 // it reads against the warmer L3/L4 bands without breaking the palette;
                 // pointer-events: none keeps the rect's click + tooltip intact.
+                // aria-hidden because the glyph is decorative — VoiceOver/NVDA would
+                // otherwise announce "circled bullet" between every neighboring cell's
+                // tooltip, which is noisy and adds no information the rect doesn't carry.
                 const monthlyPeakMark = isMonthlyPeak ? (
                   <text
                     x={Number(props.x) + Number(props.width) / 2}
@@ -280,6 +283,7 @@ export function ContributionGraph() {
                     dominantBaseline="central"
                     fontSize={Math.floor(heatmapLayout.rectSize * 0.5)}
                     fill="var(--primary-foreground)"
+                    aria-hidden
                     style={{ pointerEvents: 'none' }}
                   >
                     ◎

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -172,11 +172,20 @@ export function ContributionGraph() {
   const dateParam = searchParams.get('date')
 
   useEffect(() => {
-    if (!dateParam) return
+    // Closing the dialog when `?date=` is removed or invalidated keeps URL
+    // and dialog state coupled. Without this, navigating from `?date=valid`
+    // → `?date=` (or `?date=garbage`) would leave a stale dialog open even
+    // though the deep-link contract says invalid input keeps the dialog
+    // closed (CodeRabbit review on PR #38).
+    if (!dateParam) {
+      setSelectedDate(null)
+      return
+    }
     const parsed = DayDetailInputSchema.safeParse({ date: dateParam })
     if (parsed.success) {
       setSelectedDate(parsed.data.date)
     } else {
+      setSelectedDate(null)
       toast.error('Invalid date in URL — showing your activity instead.')
     }
   }, [dateParam])

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import HeatMap from '@uiw/react-heat-map'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Badge } from '@/components/ui/badge'
 import {
@@ -19,6 +19,8 @@ import {
 } from '@/components/ui/tooltip'
 import { useHeatmapData } from '@/hooks/useHeatmapData'
 import type { HeatmapDay } from '@/hooks/useHeatmapData'
+import { calcMonthlyMaxDates } from '@/lib/calcMonthlyMaxDates'
+import { shiftIsoDate } from '@/lib/shiftIsoDate'
 
 import { DayDetailDialog } from './DayDetailDialog'
 
@@ -171,6 +173,23 @@ export function ContributionGraph() {
     () => calculateHeatmapLayout(containerWidth, weekCount),
     [containerWidth, weekCount],
   )
+  // Set of YYYY-MM-DD strings for each month's peak day. The ◎ overlay below
+  // reads `monthlyMaxDates.has(dateKey)` on every rect render, so memoizing
+  // the Set keeps that O(1) lookup stable across re-renders triggered by
+  // hover/tooltip state.
+  const monthlyMaxDates = useMemo(
+    () => calcMonthlyMaxDates(dataByDate),
+    [dataByDate],
+  )
+  // Functional setState lets us avoid depending on `selectedDate`, so the
+  // callback identity stays stable across renders. PR2 will reuse this exact
+  // handler for j/k keyboard navigation — keeping it stable matters because
+  // `useKeyboardNav` will attach it to a window event listener.
+  const handleNavigate = useCallback((dayOffset: -1 | 1) => {
+    setSelectedDate((currentDate) =>
+      currentDate ? shiftIsoDate(currentDate, dayOffset) : currentDate,
+    )
+  }, [])
 
   if (isLoading) {
     return (
@@ -217,6 +236,7 @@ export function ContributionGraph() {
                 const handleSelect = () => {
                   if (dateKey) setSelectedDate(dateKey)
                 }
+                const isMonthlyPeak = monthlyMaxDates.has(dateKey)
 
                 if (!dayData || dayData.count === 0) {
                   return (
@@ -228,14 +248,34 @@ export function ContributionGraph() {
                   )
                 }
 
+                // ◎ overlay marks each month's peak day. Painted in primary-foreground so
+                // it reads against the warmer L3/L4 bands without breaking the palette;
+                // pointer-events: none keeps the rect's click + tooltip intact.
+                const monthlyPeakMark = isMonthlyPeak ? (
+                  <text
+                    x={Number(props.x) + Number(props.width) / 2}
+                    y={Number(props.y) + Number(props.height) / 2}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fontSize={Math.floor(heatmapLayout.rectSize * 0.5)}
+                    fill="var(--primary-foreground)"
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    ◎
+                  </text>
+                ) : null
+
                 return (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <rect
-                        {...props}
-                        onClick={handleSelect}
-                        style={{ ...props.style, cursor: 'pointer' }}
-                      />
+                      <g>
+                        <rect
+                          {...props}
+                          onClick={handleSelect}
+                          style={{ ...props.style, cursor: 'pointer' }}
+                        />
+                        {monthlyPeakMark}
+                      </g>
                     </TooltipTrigger>
                     <TooltipContent>
                       <CategoryBreakdown day={dayData} />
@@ -263,6 +303,7 @@ export function ContributionGraph() {
           onOpenChange={(open) => {
             if (!open) setSelectedDate(null)
           }}
+          onNavigate={handleNavigate}
         />
       </CardContent>
     </Card>

--- a/src/app/(main)/home/_components/DayDetailDialog.tsx
+++ b/src/app/(main)/home/_components/DayDetailDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { match } from 'ts-pattern'
 
@@ -117,17 +117,26 @@ function getDayState(dayCount: number): DayState {
 
 /**
  * Formats a YYYY-MM-DD date string to a long-form readable label.
+ *
+ * Parses + formats in UTC so the displayed date matches the bucket the
+ * server, heatmap cell, URL `?date=` param, and `shiftIsoDate` all operate
+ * on. Without `timeZone: 'UTC'` a user in (say) UTC-8 sees "March 31, 2026"
+ * for `2026-04-01` because `new Date('2026-04-01...')` is UTC midnight and
+ * `toLocaleDateString` defaults to local TZ — the subtitle drifts one day
+ * back relative to every other surface.
+ *
  * @param isoDate - YYYY-MM-DD date string
  * @returns Long-form date like "May 10, 2026"
  * @example
- * formatDate("2026-05-10") // => "May 10, 2026"
+ * formatDate("2026-05-10") // => "May 10, 2026" (in any timezone)
  */
 function formatDate(isoDate: string): string {
-  const parsed = new Date(`${isoDate}T00:00:00`)
+  const parsed = new Date(`${isoDate}T00:00:00.000Z`)
   return parsed.toLocaleDateString('en-US', {
     month: 'long',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   })
 }
 
@@ -175,11 +184,17 @@ export function DayDetailDialog({
   onNavigate,
 }: DayDetailDialogProps) {
   const isClerkQueryReady = useClerkQueryReady()
-  const { data, isLoading } = useQuery({
+  // `placeholderData: keepPreviousData` so that pressing j/k or the < >
+  // chevrons doesn't flash the header back to "rest day" while the next
+  // day's query is in flight. The previous day's count + state band hold
+  // until the new data lands — TanStack Query v5 marks the result as
+  // `isPlaceholderData` so we can still gate the task list separately.
+  const { data, isLoading, isPlaceholderData } = useQuery({
     ...orpc.completed.dayDetail.queryOptions({
       input: { date: date ?? '1970-01-01' },
     }),
     enabled: isClerkQueryReady && date !== null,
+    placeholderData: keepPreviousData,
   })
 
   const isOpen = date !== null
@@ -247,7 +262,7 @@ export function DayDetailDialog({
               </DialogDescription>
             </DialogHeader>
 
-            {isLoading ? (
+            {isLoading || isPlaceholderData ? (
               <p className="text-sm text-muted-foreground">…</p>
             ) : dayCount === 0 ? (
               <p className="font-serif text-sm italic text-muted-foreground">

--- a/src/app/(main)/home/_components/DayDetailDialog.tsx
+++ b/src/app/(main)/home/_components/DayDetailDialog.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { match } from 'ts-pattern'
 
+import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -18,6 +20,14 @@ import { cn } from '@/lib/utils'
 interface DayDetailDialogProps {
   date: string | null
   onOpenChange: (open: boolean) => void
+  /**
+   * Optional day navigation callback. When provided, `< >` icon buttons are
+   * rendered inside DialogHeader. The handler receives a signed day offset
+   * (`-1` for previous, `1` for next) and is expected to swap `date` for the
+   * shifted YYYY-MM-DD on the parent. Co-designed with PR2's keyboard nav so
+   * the same handler can be reused by `useKeyboardNav` without API churn.
+   */
+  onNavigate?: (dayOffset: -1 | 1) => void
 }
 
 type Intensity = 0 | 1 | 2 | 3 | 4
@@ -158,7 +168,11 @@ function getTodayDateString(): string {
  * @example
  * <DayDetailDialog date={selectedDate} onOpenChange={(open) => !open && setSelectedDate(null)} />
  */
-export function DayDetailDialog({ date, onOpenChange }: DayDetailDialogProps) {
+export function DayDetailDialog({
+  date,
+  onOpenChange,
+  onNavigate,
+}: DayDetailDialogProps) {
   const isClerkQueryReady = useClerkQueryReady()
   const { data, isLoading } = useQuery({
     ...orpc.completed.dayDetail.queryOptions({
@@ -194,6 +208,29 @@ export function DayDetailDialog({ date, onOpenChange }: DayDetailDialogProps) {
                     {formatDate(date)}
                   </p>
                 </div>
+                {/* `mr-8` clears the Dialog's absolute-positioned close X (right-4) so the chevrons don't visually collide with it */}
+                {onNavigate && (
+                  <div className="ml-auto mr-8 flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-8"
+                      onClick={() => onNavigate(-1)}
+                      aria-label="Previous day"
+                    >
+                      <ChevronLeft />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-8"
+                      onClick={() => onNavigate(1)}
+                      aria-label="Next day"
+                    >
+                      <ChevronRight />
+                    </Button>
+                  </div>
+                )}
               </div>
               <DialogDescription className="pt-1 font-serif text-sm italic text-muted-foreground">
                 {state.voice}

--- a/src/app/(main)/home/_components/DayDetailDialog.tsx
+++ b/src/app/(main)/home/_components/DayDetailDialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { useKeyboardNav } from '@/hooks/useKeyboardNav'
 import { getColorDotClass } from '@/lib/category-colors'
 import { orpc } from '@/lib/orpc/client-query'
 import { cn } from '@/lib/utils'
@@ -185,6 +186,15 @@ export function DayDetailDialog({
   const dayCount = data?.count ?? 0
   const state = getDayState(dayCount)
   const isToday = date !== null && date === getTodayDateString()
+
+  // j/k keyboard nav reuses the same `onNavigate` contract as the `< >`
+  // buttons, so the dialog has a single source of truth for day-stepping.
+  // Esc dismiss is delegated to Radix Dialog natively (don't double-handle).
+  useKeyboardNav({
+    isOpen,
+    onPrev: () => onNavigate?.(-1),
+    onNext: () => onNavigate?.(1),
+  })
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>

--- a/src/app/(main)/home/_components/DayDetailDialog.tsx
+++ b/src/app/(main)/home/_components/DayDetailDialog.tsx
@@ -212,7 +212,7 @@ export function DayDetailDialog({ date, onOpenChange }: DayDetailDialogProps) {
               <ul className="space-y-1.5">
                 {data?.tasks.map((task) => (
                   <li
-                    key={task.id}
+                    key={`${task.source}-${task.id}`}
                     className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2"
                   >
                     <span

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -16,7 +16,7 @@ import {
 } from '@dnd-kit/sortable'
 import { useIsRestoring, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Circle } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { Suspense, useEffect, useMemo, useState } from 'react'
 
 import { Badge } from '@/components/ui/badge'
 import {
@@ -343,7 +343,21 @@ export function TodoList() {
 
       {/* Completed Tasks Column */}
       <div className="space-y-6">
-        <ContributionGraph />
+        {/* Suspense required because ContributionGraph reads ?date= via Next.js 16's useSearchParams — fallback matches its own isLoading skeleton so the prerender phase is shape-identical. */}
+        <Suspense
+          fallback={
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  Activity
+                </CardTitle>
+                <CardDescription>Loading activity data...</CardDescription>
+              </CardHeader>
+            </Card>
+          }
+        >
+          <ContributionGraph />
+        </Suspense>
         <WeeklySummaryCard
           dataByDate={heatmapByDate}
           isLoading={heatmapLoading}

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -268,8 +268,17 @@ export function TodoList() {
   }
 
   useEffect(() => {
+    // Cross-window sync: BrainDump / Floating Navigator completions broadcast
+    // via the BroadcastChannel and also write to the Completed table, so the
+    // Home heatmap + day-detail caches need invalidation alongside the todo
+    // list. Without these two extra keys, completing a task in BrainDump
+    // leaves the main heatmap stale until reload (Codex review HIGH).
     return subscribeToTodoSync(() => {
       queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
+      queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
+      queryClient.invalidateQueries({
+        queryKey: orpc.completed.dayDetail.key(),
+      })
     })
   }, [queryClient])
 

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -27,6 +27,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { useHeatmapData } from '@/hooks/useHeatmapData'
 import { useSelectedCategory } from '@/hooks/useSelectedCategory'
 import { useTodoMutations } from '@/hooks/useTodoMutations'
 import { orpc } from '@/lib/orpc/client-query'
@@ -38,6 +39,7 @@ import { CompletedTodos } from './CompletedTodos'
 import { ContributionGraph } from './ContributionGraph'
 import { SortableTodoItem } from './SortableTodoItem'
 import type { Todo } from './TodoItem'
+import { WeeklySummaryCard } from './WeeklySummaryCard'
 
 const TODO_QUERY_LIMIT = 100
 const TODO_QUERY_OFFSET = 0
@@ -109,6 +111,12 @@ export function TodoList() {
     }),
     enabled: isClerkQueryReady,
   })
+
+  // Heatmap data shared with WeeklySummaryCard (React Query dedupes the
+  // underlying request with ContributionGraph's own useHeatmapData() call, so
+  // mounting the summary card does not add a second network round-trip).
+  const { dataByDate: heatmapByDate, isLoading: heatmapLoading } =
+    useHeatmapData()
 
   /**
    * Adds a new todo item using the create mutation.
@@ -336,6 +344,10 @@ export function TodoList() {
       {/* Completed Tasks Column */}
       <div className="space-y-6">
         <ContributionGraph />
+        <WeeklySummaryCard
+          dataByDate={heatmapByDate}
+          isLoading={heatmapLoading}
+        />
         <CompletedTodos
           onDelete={deleteTodo}
           onClearCompleted={deleteCompleted}

--- a/src/app/(main)/home/_components/WeeklySummaryCard.tsx
+++ b/src/app/(main)/home/_components/WeeklySummaryCard.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { match } from 'ts-pattern'
+
+import { Card, CardContent } from '@/components/ui/card'
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+import {
+  aggregateLastSevenDays,
+  type WeeklyTrend,
+} from '@/lib/aggregate-last-seven-days'
+import { getColorDotClass } from '@/lib/category-colors'
+import { cn } from '@/lib/utils'
+
+interface WeeklySummaryCardProps {
+  /**
+   * Map of YYYY-MM-DD → HeatmapDay returned by `useHeatmapData`. The card
+   * derives all weekly stats from it on the client; no extra fetch.
+   */
+  dataByDate: Map<string, HeatmapDay>
+  /**
+   * Loading sentinel from `useHeatmapData`. Renders a quiet placeholder so
+   * the layout doesn't jump when the heatmap query resolves.
+   */
+  isLoading?: boolean
+}
+
+/**
+ * Maps the discriminated `WeeklyTrend` to the muted phrase shown under the
+ * total count. Copy follows the DESIGN.md voice ("quiet pride", never
+ * shouty, never KPI guilt). Negative deltas read factual, not judgmental.
+ *
+ * @param trend - Trend state from {@link aggregateLastSevenDays}
+ * @returns
+ * - Italic serif phrase rendered in muted foreground
+ * @example
+ * trendLabel({ kind: 'firstWeek' })           // => "your first week"
+ * trendLabel({ kind: 'percent', value: 25 })  // => "↑ 25% from last week"
+ * trendLabel({ kind: 'percent', value: -40 }) // => "↓ 40% from last week"
+ */
+function trendLabel(trend: WeeklyTrend): string {
+  return match(trend)
+    .with(
+      { kind: 'firstWeek' },
+      () => 'your first week — the room is just waking up.',
+    )
+    .with(
+      { kind: 'flat' },
+      () => 'a quiet week. the cathedral keeps the light on.',
+    )
+    .with({ kind: 'new' }, () => '↑ new this week.')
+    .with({ kind: 'percent' }, ({ value }) => {
+      if (value === 0) return "steady — last week's pace."
+      const absolute = Math.abs(value)
+      const arrow = value > 0 ? '↑' : '↓'
+      return `${arrow} ${absolute}% from last week.`
+    })
+    .exhaustive()
+}
+
+/**
+ * Weekly summary card mounted under the ContributionGraph on the home
+ * route. Shows a 7-day rolling total, the top categories the user touched,
+ * and a week-over-week trend line — derived purely from the heatmap
+ * response the parent already fetched.
+ *
+ * Design intent (DESIGN.md "Warm Cathedral"):
+ * - Quiet pride, not KPI grading.
+ * - Newsreader (serif italic) for the trend line, Geist Mono (tabular-nums)
+ *   for the count, Inter Tight default for chips.
+ * - Negative deltas read factual ("↓ 25%"), never red, never alarming.
+ *
+ * @example
+ * <WeeklySummaryCard dataByDate={dataByDate} isLoading={isLoading} />
+ */
+export function WeeklySummaryCard({
+  dataByDate,
+  isLoading,
+}: WeeklySummaryCardProps) {
+  const stats = aggregateLastSevenDays(dataByDate, new Date())
+
+  return (
+    <Card aria-label="This week summary">
+      <CardContent className="space-y-3 p-6">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+            this week
+          </p>
+          <span
+            aria-label={`${stats.totalCompleted} completed this week`}
+            className={cn(
+              'font-mono text-2xl font-medium tabular-nums text-foreground',
+              isLoading && 'opacity-40',
+            )}
+          >
+            {stats.totalCompleted}
+          </span>
+        </div>
+
+        <p className="font-serif text-sm italic text-muted-foreground">
+          {isLoading ? '…' : trendLabel(stats.trend)}
+        </p>
+
+        {stats.topCategories.length > 0 && (
+          <ul className="flex flex-wrap gap-1.5 pt-1">
+            {stats.topCategories.map((category) => (
+              <li
+                key={category.id}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-xs"
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    'inline-block size-1.5 rounded-full',
+                    getColorDotClass(category.color),
+                  )}
+                />
+                <span className="text-foreground">{category.name}</span>
+                <span className="font-mono tabular-nums text-muted-foreground">
+                  {category.count}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(main)/home/_components/WeeklySummaryCard.tsx
+++ b/src/app/(main)/home/_components/WeeklySummaryCard.tsx
@@ -79,14 +79,23 @@ export function WeeklySummaryCard({
   const stats = aggregateLastSevenDays(dataByDate, new Date())
 
   return (
-    <Card aria-label="This week summary">
+    <Card aria-busy={isLoading} aria-label="This week summary">
       <CardContent className="space-y-3 p-6">
         <div className="flex items-baseline justify-between gap-3">
           <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
             this week
           </p>
           <span
-            aria-label={`${stats.totalCompleted} completed this week`}
+            // While `isLoading`, the numeric placeholder (a stale `0` until
+            // the heatmap query settles) must not be announced as a real
+            // weekly total to AT users — swap to a loading sentence and rely
+            // on `aria-busy` for the polite-region cue (CodeRabbit review on
+            // PR #38).
+            aria-label={
+              isLoading
+                ? 'Loading completed count for this week'
+                : `${stats.totalCompleted} completed this week`
+            }
             className={cn(
               'font-mono text-2xl font-medium tabular-nums text-foreground',
               isLoading && 'opacity-40',

--- a/src/app/(main)/skill-tree/components/XpBadge.tsx
+++ b/src/app/(main)/skill-tree/components/XpBadge.tsx
@@ -25,7 +25,6 @@ export function XpBadge({ xp }: { xp: number }) {
       <div className="flex items-center justify-between gap-2">
         <span className="font-medium text-[var(--st-gold)]">{label}</span>
         {next !== null && (
-          // eslint-disable-next-line dslint/token-only -- tabular-nums is a valid Tailwind utility class, not a design token
           <span className="tabular-nums">
             {progress} / {next}
           </span>

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -657,7 +657,6 @@ export function BrainDumpEditor({
             className="flex-1"
             aria-label="Window opacity"
           />
-          {/* eslint-disable-next-line dslint/token-only -- tabular-nums is standard Tailwind utility */}
           <span className="w-10 text-right tabular-nums">
             {Math.round(opacity * 100)}%
           </span>

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -262,7 +262,6 @@ export function BrainDumpSettings({
               <Eye className="h-4 w-4" />
               Window opacity
             </Label>
-            {/* eslint-disable-next-line dslint/token-only -- tabular-nums is standard Tailwind utility */}
             <span className="text-xs tabular-nums text-muted-foreground">
               {opacityPercent}%
             </span>

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -258,8 +258,17 @@ export function FloatingNavigatorContainer() {
   const todos = [...pendingTodos, ...completedTodos]
 
   useEffect(() => {
+    // Cross-window sync: BrainDump + Home todo completions also write to the
+    // Completed table, so the heatmap + day-detail caches must invalidate
+    // alongside the todo list. Mirrors TodoList.tsx — without these two keys,
+    // the floating navigator would silently miss completion deltas after a
+    // refresh (Codex review HIGH).
     return subscribeToTodoSync(() => {
       queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
+      queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
+      queryClient.invalidateQueries({
+        queryKey: orpc.completed.dayDetail.key(),
+      })
     })
   }, [queryClient])
 

--- a/src/hooks/useHeatmapData.ts
+++ b/src/hooks/useHeatmapData.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
 import { orpc } from '@/lib/orpc/client-query'
@@ -49,14 +50,23 @@ export function useHeatmapData(days: number = 365) {
     enabled: isClerkQueryReady,
   })
 
-  const heatmapValues =
-    data?.data.map((d) => ({
-      date: d.date.replace(/-/g, '/'),
-      count: d.count,
-    })) ?? []
-
-  const dataByDate = new Map<string, HeatmapDay>(
-    data?.data.map((d) => [d.date, d]) ?? [],
+  // Derived values are memoized on `data` identity. Without this, every call
+  // site (ContributionGraph, WeeklySummaryCard) would receive a fresh Map and
+  // Array on each render, busting downstream `useMemo` dep keys
+  // (calcMonthlyMaxDates, aggregateLastSevenDays). TanStack Query already
+  // dedups the network request — this is the in-render dedup.
+  const { heatmapValues, dataByDate } = useMemo(
+    () => ({
+      heatmapValues:
+        data?.data.map((d) => ({
+          date: d.date.replace(/-/g, '/'),
+          count: d.count,
+        })) ?? [],
+      dataByDate: new Map<string, HeatmapDay>(
+        data?.data.map((d) => [d.date, d]) ?? [],
+      ),
+    }),
+    [data],
   )
 
   return {

--- a/src/hooks/useKeyboardNav.test.ts
+++ b/src/hooks/useKeyboardNav.test.ts
@@ -1,0 +1,183 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useKeyboardNav } from './useKeyboardNav'
+
+/**
+ * Dispatches a synthetic `keydown` event so the hook's window listener fires.
+ * When `target` is provided, the event bubbles up from that element, letting
+ * us assert the typing-guard branch. Without `target`, the event is dispatched
+ * directly on `window`.
+ */
+function dispatchKeyDown(key: string, target?: HTMLElement): void {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+  })
+  if (target) {
+    target.dispatchEvent(event)
+  } else {
+    window.dispatchEvent(event)
+  }
+}
+
+describe('useKeyboardNav', () => {
+  it('calls onNext when j is pressed', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    renderHook(() => useKeyboardNav({ isOpen: true, onPrev, onNext }))
+
+    act(() => {
+      dispatchKeyDown('j')
+    })
+
+    expect(onNext).toHaveBeenCalledTimes(1)
+    expect(onPrev).not.toHaveBeenCalled()
+  })
+
+  it('calls onPrev when k is pressed', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    renderHook(() => useKeyboardNav({ isOpen: true, onPrev, onNext }))
+
+    act(() => {
+      dispatchKeyDown('k')
+    })
+
+    expect(onPrev).toHaveBeenCalledTimes(1)
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('ignores keys other than j/k', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    renderHook(() => useKeyboardNav({ isOpen: true, onPrev, onNext }))
+
+    act(() => {
+      // Escape is intentionally NOT handled here — Radix Dialog owns it.
+      dispatchKeyDown('Escape')
+      dispatchKeyDown('a')
+      dispatchKeyDown('Enter')
+    })
+
+    expect(onPrev).not.toHaveBeenCalled()
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('does not attach the listener when isOpen is false', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    renderHook(() => useKeyboardNav({ isOpen: false, onPrev, onNext }))
+
+    act(() => {
+      dispatchKeyDown('j')
+      dispatchKeyDown('k')
+    })
+
+    expect(onPrev).not.toHaveBeenCalled()
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('suppresses navigation when the target is an <input>', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    renderHook(() => useKeyboardNav({ isOpen: true, onPrev, onNext }))
+
+    act(() => {
+      dispatchKeyDown('j', input)
+      dispatchKeyDown('k', input)
+    })
+
+    expect(onPrev).not.toHaveBeenCalled()
+    expect(onNext).not.toHaveBeenCalled()
+    document.body.removeChild(input)
+  })
+
+  it('suppresses navigation when the target is a <textarea>', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    renderHook(() => useKeyboardNav({ isOpen: true, onPrev, onNext }))
+
+    act(() => {
+      dispatchKeyDown('j', textarea)
+    })
+
+    expect(onNext).not.toHaveBeenCalled()
+    document.body.removeChild(textarea)
+  })
+
+  it('suppresses navigation when the target is contentEditable', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    const editable = document.createElement('div')
+    editable.contentEditable = 'true'
+    document.body.appendChild(editable)
+    renderHook(() => useKeyboardNav({ isOpen: true, onPrev, onNext }))
+
+    act(() => {
+      dispatchKeyDown('j', editable)
+    })
+
+    expect(onNext).not.toHaveBeenCalled()
+    document.body.removeChild(editable)
+  })
+
+  it('removes the listener on unmount', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    const { unmount } = renderHook(() =>
+      useKeyboardNav({ isOpen: true, onPrev, onNext }),
+    )
+
+    unmount()
+    act(() => {
+      dispatchKeyDown('j')
+    })
+
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('removes the listener when isOpen flips to false', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    const { rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) =>
+        useKeyboardNav({ isOpen, onPrev, onNext }),
+      { initialProps: { isOpen: true } },
+    )
+
+    rerender({ isOpen: false })
+    act(() => {
+      dispatchKeyDown('j')
+    })
+
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('always invokes the latest callback (useEffectEvent stability)', () => {
+    // After re-rendering with a new onNext, pressing j must call the *new*
+    // callback even though [isOpen] is the only effect dep — proves
+    // useEffectEvent forwards to the latest props without re-attaching.
+    const firstOnNext = vi.fn()
+    const secondOnNext = vi.fn()
+    const onPrev = vi.fn()
+    const { rerender } = renderHook(
+      ({ onNext }: { onNext: () => void }) =>
+        useKeyboardNav({ isOpen: true, onPrev, onNext }),
+      { initialProps: { onNext: firstOnNext } },
+    )
+
+    rerender({ onNext: secondOnNext })
+    act(() => {
+      dispatchKeyDown('j')
+    })
+
+    expect(firstOnNext).not.toHaveBeenCalled()
+    expect(secondOnNext).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useKeyboardNav.test.ts
+++ b/src/hooks/useKeyboardNav.test.ts
@@ -127,6 +127,49 @@ describe('useKeyboardNav', () => {
     document.body.removeChild(editable)
   })
 
+  it('suppresses navigation during IME composition (isComposing)', () => {
+    // Pressing `j` while seeding `じ` (ji) in a Japanese IME fires a keydown
+    // with `isComposing=true` before the composition resolves. The hook must
+    // skip dispatch — otherwise the user would both feed the IME buffer AND
+    // step the day-detail dialog.
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    renderHook(() => useKeyboardNav({ isOpen: true, onPrev, onNext }))
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'j',
+        bubbles: true,
+        cancelable: true,
+        isComposing: true,
+      })
+      window.dispatchEvent(event)
+    })
+
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('suppresses navigation when keyCode is 229 (legacy IME signal)', () => {
+    // Older IMEs / browsers report composition via `keyCode === 229` without
+    // setting `isComposing`. The hook checks both so the JP path stays
+    // robust across input-method implementations.
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    renderHook(() => useKeyboardNav({ isOpen: true, onPrev, onNext }))
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'j',
+        bubbles: true,
+        cancelable: true,
+        keyCode: 229,
+      })
+      window.dispatchEvent(event)
+    })
+
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
   it('removes the listener on unmount', () => {
     const onPrev = vi.fn()
     const onNext = vi.fn()

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,75 @@
+import { useEffect, useEffectEvent } from 'react'
+
+/**
+ * Listens for `j` (next day) and `k` (previous day) keyboard shortcuts while
+ * `isOpen` is true, dispatching to `onPrev` / `onNext` callbacks. Powers the
+ * DayDetailDialog's day-stepping in PR2 of the Heatmap Cathedral. Esc handling
+ * is delegated to the underlying Radix Dialog so this hook does not double-
+ * handle dismiss.
+ *
+ * **Typing guard:** when the keydown target is `<input>`, `<textarea>`, or any
+ * `contentEditable` element (e.g., BrainDump's editor), the shortcut is
+ * suppressed. Without this, pressing `j` would BOTH insert a literal character
+ * AND step the dialog — confusing and destructive.
+ *
+ * **Stability:** `useEffectEvent` (React 19) wraps the callbacks so the
+ * `keydown` listener always sees the latest `onPrev` / `onNext` without
+ * forcing the effect to re-attach on every render. That keeps `[isOpen]` as
+ * the only dep — fewer listener cycles, fewer race windows.
+ *
+ * **Lifecycle:** mount this hook from the component that owns the dialog
+ * (`DayDetailDialog`) so the `keydown` listener attaches when the dialog
+ * opens and detaches when it closes. A global listener over the whole app
+ * would be wider than the shortcut's intent and could collide with other
+ * focused widgets.
+ *
+ * @param options.isOpen - When true, the listener is attached; when false, it is removed.
+ * @param options.onPrev - Called on `k`; expected to step the dialog one day back.
+ * @param options.onNext - Called on `j`; expected to step the dialog one day forward.
+ * @example
+ * useKeyboardNav({
+ *   isOpen: selectedDate !== null,
+ *   onPrev: () => onNavigate?.(-1),
+ *   onNext: () => onNavigate?.(1),
+ * })
+ */
+export function useKeyboardNav({
+  isOpen,
+  onPrev,
+  onNext,
+}: {
+  isOpen: boolean
+  onPrev: () => void
+  onNext: () => void
+}): void {
+  const handlePrev = useEffectEvent(onPrev)
+  const handleNext = useEffectEvent(onNext)
+
+  useEffect(() => {
+    if (!isOpen) return undefined
+
+    function handleKey(event: KeyboardEvent): void {
+      // Skip navigation while the user is typing — otherwise `j` / `k`
+      // would both insert a literal character and step the dialog.
+      const target = event.target as HTMLElement | null
+      if (
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.isContentEditable
+      ) {
+        return
+      }
+
+      if (event.key === 'j') {
+        event.preventDefault()
+        handleNext()
+      } else if (event.key === 'k') {
+        event.preventDefault()
+        handlePrev()
+      }
+    }
+
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [isOpen])
+}

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -49,6 +49,14 @@ export function useKeyboardNav({
     if (!isOpen) return undefined
 
     function handleKey(event: KeyboardEvent): void {
+      // IME composition guard — Japanese/Chinese/Korean input methods fire
+      // a keydown with `isComposing=true` (legacy `keyCode === 229`) before
+      // the composition resolves. Without this, pressing `j` to seed じ (ji)
+      // in romaji input would both feed the composition buffer AND step the
+      // dialog. The repo CLAUDE.md tags this as a JP-user-facing usability
+      // path, so this guard runs before the INPUT/TEXTAREA check.
+      if (event.isComposing || event.keyCode === 229) return
+
       // Skip navigation while the user is typing — otherwise `j` / `k`
       // would both insert a literal character and step the dialog.
       const target = event.target as HTMLElement | null

--- a/src/lib/aggregate-last-seven-days.test.ts
+++ b/src/lib/aggregate-last-seven-days.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+import { aggregateLastSevenDays } from './aggregate-last-seven-days'
+
+/**
+ * Anchor "today" used across cases. UTC midnight is fine — the util reads UTC
+ * parts only, so the picked moment maps cleanly onto YYYY-MM-DD buckets.
+ */
+const TODAY = new Date('2026-05-11T00:00:00.000Z')
+
+/**
+ * Builds a single HeatmapDay entry for tests. Defaults to one "writing" task
+ * so a date with non-zero count always has a matching category breakdown
+ * (the same invariant the server returns).
+ */
+function buildHeatmapDay(
+  isoDate: string,
+  count: number,
+  categories: HeatmapDay['categories'] = [
+    { id: 1, name: 'writing', color: 'blue', count },
+  ],
+): [string, HeatmapDay] {
+  return [isoDate, { date: isoDate, count, categories }]
+}
+
+describe('aggregateLastSevenDays', () => {
+  it('returns firstWeek when the heatmap response is empty', () => {
+    const stats = aggregateLastSevenDays(new Map(), TODAY)
+    expect(stats).toEqual({
+      totalCompleted: 0,
+      priorTotal: 0,
+      topCategories: [],
+      trend: { kind: 'firstWeek' },
+    })
+  })
+
+  it('returns flat when both windows are zero but older activity exists', () => {
+    // One entry outside the 14-day inspection window (30 days ago). Both the
+    // current and prior windows are empty, but `dataByDate.size > 0`, so the
+    // copy should be "quiet week" rather than "your first week".
+    const dataByDate = new Map<string, HeatmapDay>([
+      buildHeatmapDay('2026-04-11', 3),
+    ])
+    const stats = aggregateLastSevenDays(dataByDate, TODAY)
+    expect(stats.totalCompleted).toBe(0)
+    expect(stats.priorTotal).toBe(0)
+    expect(stats.trend).toEqual({ kind: 'flat' })
+  })
+
+  it('returns kind: new when prior window is empty and current window is non-zero', () => {
+    // Current window (2026-05-05 .. 2026-05-11), prior window
+    // (2026-04-28 .. 2026-05-04). Only put activity in the current window.
+    const dataByDate = new Map<string, HeatmapDay>([
+      buildHeatmapDay('2026-05-08', 5),
+    ])
+    const stats = aggregateLastSevenDays(dataByDate, TODAY)
+    expect(stats.totalCompleted).toBe(5)
+    expect(stats.priorTotal).toBe(0)
+    expect(stats.trend).toEqual({ kind: 'new' })
+  })
+
+  it('returns percent value 0 when current and prior totals match', () => {
+    const dataByDate = new Map<string, HeatmapDay>([
+      buildHeatmapDay('2026-05-08', 5), // current window
+      buildHeatmapDay('2026-05-01', 5), // prior window
+    ])
+    const stats = aggregateLastSevenDays(dataByDate, TODAY)
+    expect(stats.totalCompleted).toBe(5)
+    expect(stats.priorTotal).toBe(5)
+    expect(stats.trend).toEqual({ kind: 'percent', value: 0 })
+  })
+
+  it('returns percent value 100 when current doubles prior', () => {
+    const dataByDate = new Map<string, HeatmapDay>([
+      buildHeatmapDay('2026-05-08', 10),
+      buildHeatmapDay('2026-05-01', 5),
+    ])
+    const stats = aggregateLastSevenDays(dataByDate, TODAY)
+    expect(stats.totalCompleted).toBe(10)
+    expect(stats.priorTotal).toBe(5)
+    expect(stats.trend).toEqual({ kind: 'percent', value: 100 })
+  })
+
+  it('returns negative percent when current is below prior', () => {
+    const dataByDate = new Map<string, HeatmapDay>([
+      buildHeatmapDay('2026-05-08', 4),
+      buildHeatmapDay('2026-05-01', 8),
+    ])
+    const stats = aggregateLastSevenDays(dataByDate, TODAY)
+    expect(stats.trend).toEqual({ kind: 'percent', value: -50 })
+  })
+
+  it('rolls up top categories by count and surfaces the top 3', () => {
+    // Single day with four categories so we exercise the slice(0, 3) cutoff.
+    const dataByDate = new Map<string, HeatmapDay>([
+      [
+        '2026-05-08',
+        {
+          date: '2026-05-08',
+          count: 10,
+          categories: [
+            { id: 1, name: 'writing', color: 'blue', count: 4 },
+            { id: 2, name: 'reading', color: 'green', count: 3 },
+            { id: 3, name: 'coding', color: 'amber', count: 2 },
+            { id: 4, name: 'walking', color: 'rose', count: 1 },
+          ],
+        },
+      ],
+    ])
+    const stats = aggregateLastSevenDays(dataByDate, TODAY)
+    expect(stats.topCategories.map((category) => category.id)).toEqual([
+      1, 2, 3,
+    ])
+  })
+
+  it('breaks rank ties alphabetically by name', () => {
+    // Three categories tied at count=3; alphabetical order: amber, blue,
+    // charlie. The fourth ("delta", count 1) is below the cutoff.
+    const dataByDate = new Map<string, HeatmapDay>([
+      [
+        '2026-05-08',
+        {
+          date: '2026-05-08',
+          count: 10,
+          categories: [
+            { id: 1, name: 'charlie', color: 'amber', count: 3 },
+            { id: 2, name: 'amber', color: 'blue', count: 3 },
+            { id: 3, name: 'blue', color: 'green', count: 3 },
+            { id: 4, name: 'delta', color: 'rose', count: 1 },
+          ],
+        },
+      ],
+    ])
+    const stats = aggregateLastSevenDays(dataByDate, TODAY)
+    expect(stats.topCategories.map((category) => category.name)).toEqual([
+      'amber',
+      'blue',
+      'charlie',
+    ])
+  })
+
+  it('rounds percent to the nearest integer', () => {
+    // 7 / 3 → 133.33% increase (1.333… × 100). Math.round → 133.
+    const dataByDate = new Map<string, HeatmapDay>([
+      buildHeatmapDay('2026-05-08', 7),
+      buildHeatmapDay('2026-05-01', 3),
+    ])
+    const stats = aggregateLastSevenDays(dataByDate, TODAY)
+    expect(stats.trend).toEqual({ kind: 'percent', value: 133 })
+  })
+})

--- a/src/lib/aggregate-last-seven-days.ts
+++ b/src/lib/aggregate-last-seven-days.ts
@@ -1,0 +1,218 @@
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+/**
+ * Length of the "current" and "prior" windows used by the weekly summary.
+ * Seven calendar days each, rolling, anchored on the day passed as `today`.
+ */
+const WEEKLY_WINDOW_DAYS = 7
+
+/**
+ * Length (in days) of the prior comparison window used to compute WoW%.
+ * Held as a separate constant so a future product change (e.g. "compare to
+ * the same week last month") doesn't have to dig through aggregation code.
+ */
+const WOW_PRIOR_WINDOW_DAYS = 7
+
+/**
+ * Maximum number of categories surfaced in the WeeklySummaryCard's chip row.
+ * Three keeps the card scannable; ties beyond rank 3 are broken alphabetically.
+ */
+const TOP_CATEGORIES_COUNT = 3
+
+/**
+ * Single category surfaced in the weekly summary's top-categories chip row.
+ * Mirrors the `HeatmapCategory` shape but is re-stated here so the util
+ * can be tested without pulling in the heatmap hook's transitive types.
+ */
+export type TopCategory = {
+  id: number
+  name: string
+  color: string
+  count: number
+}
+
+/**
+ * Discriminated trend state surfaced to the WeeklySummaryCard. Renderer
+ * picks the right copy and visual treatment off the `kind` field; numeric
+ * `value` is only present in the `'percent'` arm.
+ *
+ * @example
+ * { kind: 'firstWeek' }   // user has no activity in the last 14 days at all
+ * @example
+ * { kind: 'flat' }        // both windows are zero but older activity exists
+ * @example
+ * { kind: 'new' }         // prior was zero, current is non-zero
+ * @example
+ * { kind: 'percent', value: 25 }  // current 25% above prior
+ * @example
+ * { kind: 'percent', value: -50 } // current 50% below prior
+ */
+export type WeeklyTrend =
+  | { kind: 'firstWeek' }
+  | { kind: 'flat' }
+  | { kind: 'new' }
+  | { kind: 'percent'; value: number }
+
+/**
+ * Output of {@link aggregateLastSevenDays}. `totalCompleted` and `priorTotal`
+ * use UTC day buckets so they line up with the heatmap data they were
+ * derived from.
+ *
+ * @example
+ * {
+ *   totalCompleted: 12,
+ *   priorTotal: 8,
+ *   topCategories: [
+ *     { id: 1, name: 'writing', color: 'blue', count: 5 },
+ *     { id: 2, name: 'reading', color: 'green', count: 4 },
+ *   ],
+ *   trend: { kind: 'percent', value: 50 },
+ * }
+ */
+export type WeeklyStats = {
+  totalCompleted: number
+  priorTotal: number
+  topCategories: TopCategory[]
+  trend: WeeklyTrend
+}
+
+/**
+ * Returns the YYYY-MM-DD UTC date string offset `dayOffset` days from
+ * `anchor`. Positive offsets move forward in time. Used to walk the
+ * rolling 7-day windows for the WoW calculation.
+ *
+ * Pure UTC arithmetic — DST-safe by construction since UTC has no DST.
+ *
+ * @param anchor - Reference Date the offset is measured from
+ * @param dayOffset - Integer days to shift (e.g. -7 → "one week earlier")
+ * @returns
+ * - YYYY-MM-DD string in UTC
+ * @example
+ * shiftedIsoDate(new Date('2026-05-11T00:00:00.000Z'), -1) // => "2026-05-10"
+ * @example
+ * shiftedIsoDate(new Date('2026-05-11T00:00:00.000Z'), 0)  // => "2026-05-11"
+ */
+function shiftedIsoDate(anchor: Date, dayOffset: number): string {
+  const shifted = new Date(anchor)
+  shifted.setUTCDate(shifted.getUTCDate() + dayOffset)
+  return shifted.toISOString().slice(0, 10)
+}
+
+/**
+ * Sums the per-day counts and folds the per-day category rollups in a
+ * sliding window of `WEEKLY_WINDOW_DAYS` ending at `windowEndIsoDate`. The
+ * fold is the same shape the heatmap response already returns, so the
+ * weekly summary stays consistent with what the heatmap renders.
+ *
+ * @param dataByDate - Heatmap data keyed by YYYY-MM-DD UTC date
+ * @param windowEndIsoDate - Inclusive end of the window (YYYY-MM-DD)
+ * @param windowLength - How many days the window covers (>=1)
+ * @returns
+ * - total: Sum of `count` across days in the window
+ * - categoryCounts: Map of categoryId → { name, color, count }
+ * @example
+ * sumWindow(map, '2026-05-11', 7)
+ * // => { total: 12, categoryCounts: Map { 1 => { name: 'writing', color: 'blue', count: 5 }, ... } }
+ */
+function sumWindow(
+  dataByDate: Map<string, HeatmapDay>,
+  windowEndIsoDate: string,
+  windowLength: number,
+): {
+  total: number
+  categoryCounts: Map<number, TopCategory>
+} {
+  const windowEnd = new Date(`${windowEndIsoDate}T00:00:00.000Z`)
+  const categoryCounts = new Map<number, TopCategory>()
+  let total = 0
+
+  for (let dayOffset = 0; dayOffset < windowLength; dayOffset++) {
+    const isoDate = shiftedIsoDate(windowEnd, -dayOffset)
+    const day = dataByDate.get(isoDate)
+    if (!day) continue
+    total += day.count
+
+    for (const category of day.categories) {
+      const existing = categoryCounts.get(category.id)
+      if (existing) {
+        existing.count += category.count
+      } else {
+        categoryCounts.set(category.id, {
+          id: category.id,
+          name: category.name,
+          color: category.color,
+          count: category.count,
+        })
+      }
+    }
+  }
+
+  return { total, categoryCounts }
+}
+
+/**
+ * Derives weekly summary stats (count, top categories, WoW trend) from the
+ * heatmap response that the home page already fetches. Pure client-side
+ * computation — no new procedure needed. Today is supplied by the caller so
+ * tests can pin the anchor; production callers pass `new Date()`.
+ *
+ * Trend state semantics:
+ * - `firstWeek` — heatmap is empty for the entire 14-day inspection window;
+ *   prefer a welcoming "your first week" copy over a zero-vs-zero diff.
+ * - `flat` — both windows have zero completions but older activity exists.
+ *   The user took a break; render a quiet em-dash instead of "0%".
+ * - `new` — prior window is zero, current is non-zero. Avoids `+Infinity%`.
+ * - `percent` — both windows non-zero; `value` is `(current - prior) / prior * 100`.
+ *
+ * @param dataByDate - Per-day heatmap entries from `useHeatmapData()`
+ * @param today - "Today" anchor (UTC midnight is fine; the function only reads UTC parts)
+ * @returns
+ * - `WeeklyStats` with totals, top-3 categories, and discriminated trend
+ * @example
+ * aggregateLastSevenDays(new Map(), new Date('2026-05-11Z'))
+ * // => { totalCompleted: 0, priorTotal: 0, topCategories: [], trend: { kind: 'firstWeek' } }
+ * @example
+ * // Map has 7 entries in current window, 0 in prior window
+ * aggregateLastSevenDays(dataByDate, new Date('2026-05-11Z'))
+ * // => { totalCompleted: 7, priorTotal: 0, topCategories: [...], trend: { kind: 'new' } }
+ */
+export function aggregateLastSevenDays(
+  dataByDate: Map<string, HeatmapDay>,
+  today: Date,
+): WeeklyStats {
+  const todayIsoDate = today.toISOString().slice(0, 10)
+  const priorWindowEnd = shiftedIsoDate(today, -WEEKLY_WINDOW_DAYS)
+
+  const current = sumWindow(dataByDate, todayIsoDate, WEEKLY_WINDOW_DAYS)
+  const prior = sumWindow(dataByDate, priorWindowEnd, WOW_PRIOR_WINDOW_DAYS)
+
+  const topCategories = Array.from(current.categoryCounts.values())
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count
+      // Stable alphabetical tie-break; locale-insensitive `localeCompare` keeps
+      // deterministic ordering across CI runners with different default locales.
+      return a.name.localeCompare(b.name, 'en')
+    })
+    .slice(0, TOP_CATEGORIES_COUNT)
+
+  // First-week heuristic: dataByDate has no entries anywhere in the 14-day
+  // inspection window. dataByDate could still have older entries (a 365-day
+  // response with activity 30 days ago); that case falls into `flat` because
+  // we want the "your first week" copy reserved for true new users.
+  const hasAnyActivity = dataByDate.size > 0
+  const trend = ((): WeeklyTrend => {
+    if (current.total === 0 && prior.total === 0) {
+      return hasAnyActivity ? { kind: 'flat' } : { kind: 'firstWeek' }
+    }
+    if (prior.total === 0) return { kind: 'new' }
+    const value = ((current.total - prior.total) / prior.total) * 100
+    return { kind: 'percent', value: Math.round(value) }
+  })()
+
+  return {
+    totalCompleted: current.total,
+    priorTotal: prior.total,
+    topCategories,
+    trend,
+  }
+}

--- a/src/lib/calcMonthlyMaxDates.test.ts
+++ b/src/lib/calcMonthlyMaxDates.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+import { calcMonthlyMaxDates } from './calcMonthlyMaxDates'
+
+/**
+ * Builds a HeatmapDay tuple for the Map fixture. Categories are not relevant
+ * to the monthly-max calculation, so they default to empty.
+ */
+function day(isoDate: string, count: number): [string, HeatmapDay] {
+  return [isoDate, { date: isoDate, count, categories: [] }]
+}
+
+describe('calcMonthlyMaxDates', () => {
+  it('returns an empty Set when given an empty Map', () => {
+    expect(calcMonthlyMaxDates(new Map())).toEqual(new Set())
+  })
+
+  it('picks the single highest-count day in a month', () => {
+    const dataByDate = new Map<string, HeatmapDay>([
+      day('2026-05-04', 3),
+      day('2026-05-10', 7),
+      day('2026-05-20', 5),
+    ])
+    expect(calcMonthlyMaxDates(dataByDate)).toEqual(new Set(['2026-05-10']))
+  })
+
+  it('breaks intra-month ties by picking the earliest date', () => {
+    // Map insertion order is intentionally reversed so the test fails if
+    // the implementation accidentally keys off insertion order rather than
+    // chronological order.
+    const dataByDate = new Map<string, HeatmapDay>([
+      day('2026-05-20', 5),
+      day('2026-05-04', 5),
+      day('2026-05-10', 5),
+    ])
+    expect(calcMonthlyMaxDates(dataByDate)).toEqual(new Set(['2026-05-04']))
+  })
+
+  it('omits months whose days all have count === 0', () => {
+    const dataByDate = new Map<string, HeatmapDay>([
+      day('2026-04-01', 0),
+      day('2026-04-15', 0),
+    ])
+    expect(calcMonthlyMaxDates(dataByDate)).toEqual(new Set())
+  })
+
+  it('returns one entry per month for multi-month input', () => {
+    const dataByDate = new Map<string, HeatmapDay>([
+      day('2026-03-12', 4),
+      day('2026-03-22', 6), // peak of March
+      day('2026-04-05', 8), // peak of April
+      day('2026-04-29', 2),
+      day('2026-05-01', 1), // peak of May (only day)
+    ])
+    expect(calcMonthlyMaxDates(dataByDate)).toEqual(
+      new Set(['2026-03-22', '2026-04-05', '2026-05-01']),
+    )
+  })
+
+  it('treats a month with a single non-zero day as that day being the max', () => {
+    const dataByDate = new Map<string, HeatmapDay>([day('2026-05-07', 1)])
+    expect(calcMonthlyMaxDates(dataByDate)).toEqual(new Set(['2026-05-07']))
+  })
+
+  it('ignores zero-count days when computing the month peak', () => {
+    // Zero days exist alongside non-zero days. The peak must come from the
+    // non-zero entries; zero days are never candidates even when no other
+    // day in the month beats them.
+    const dataByDate = new Map<string, HeatmapDay>([
+      day('2026-05-01', 0),
+      day('2026-05-15', 3),
+      day('2026-05-22', 0),
+    ])
+    expect(calcMonthlyMaxDates(dataByDate)).toEqual(new Set(['2026-05-15']))
+  })
+})

--- a/src/lib/calcMonthlyMaxDates.ts
+++ b/src/lib/calcMonthlyMaxDates.ts
@@ -1,0 +1,80 @@
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+/**
+ * Returns the set of YYYY-MM-DD dates that are the highest-count day inside
+ * each YYYY-MM calendar month found in `dataByDate`. The home heatmap paints
+ * a `◎` glyph on these cells so each month's "best day" reads at a glance
+ * without crowding lighter days.
+ *
+ * Decisions (locked in eng review §1.5):
+ * - **Tie policy:** earliest date wins. Visual sparsity > completeness; a
+ *   single anchor per month keeps the heatmap quiet. Tracked as a deferred
+ *   TODO ("Per-month tie-break for max mark") if user feedback wants ties
+ *   surfaced.
+ * - **Empty months:** months whose days are all `count === 0` are excluded.
+ *   A peak of zero is not a peak; rendering ◎ on a fully-rest month would
+ *   read as a false accomplishment.
+ * - **Source of truth:** `HeatmapDay.count` is the union of Todo+Completed,
+ *   so the mark already accounts for BrainDump checkbox-tick completions.
+ *
+ * @param dataByDate - Map keyed by YYYY-MM-DD returned by `useHeatmapData`
+ * @returns
+ * - `Set<string>` of YYYY-MM-DD strings, one per non-empty month
+ * - Empty `Set` when the input has no entries (or only zero-count entries)
+ * @example
+ * // Single max in 2026-05
+ * calcMonthlyMaxDates(new Map([
+ *   ['2026-05-04', { date: '2026-05-04', count: 3, categories: [] }],
+ *   ['2026-05-10', { date: '2026-05-10', count: 7, categories: [] }],
+ * ]))
+ * // => new Set(['2026-05-10'])
+ *
+ * @example
+ * // Tie within month → earliest wins
+ * calcMonthlyMaxDates(new Map([
+ *   ['2026-05-04', { date: '2026-05-04', count: 5, categories: [] }],
+ *   ['2026-05-10', { date: '2026-05-10', count: 5, categories: [] }],
+ * ]))
+ * // => new Set(['2026-05-04'])
+ *
+ * @example
+ * // All-zero month is omitted entirely
+ * calcMonthlyMaxDates(new Map([
+ *   ['2026-04-01', { date: '2026-04-01', count: 0, categories: [] }],
+ * ]))
+ * // => new Set()
+ */
+export function calcMonthlyMaxDates(
+  dataByDate: Map<string, HeatmapDay>,
+): Set<string> {
+  // Group days by YYYY-MM, then pick the single peak day per group. We can't
+  // short-circuit on the first day per month because subsequent days may
+  // dethrone the running peak. Linear pass is O(N) over the heatmap window
+  // (~365 entries) — trivially cheap.
+  const monthlyPeak = new Map<string, { date: string; count: number }>()
+
+  for (const [isoDate, day] of dataByDate) {
+    if (day.count <= 0) continue
+
+    const monthKey = isoDate.slice(0, 7)
+    const currentPeak = monthlyPeak.get(monthKey)
+
+    if (!currentPeak) {
+      monthlyPeak.set(monthKey, { date: isoDate, count: day.count })
+      continue
+    }
+
+    if (day.count > currentPeak.count) {
+      monthlyPeak.set(monthKey, { date: isoDate, count: day.count })
+      continue
+    }
+
+    // Equal-count tie: keep the earlier ISO date. ISO strings compare
+    // lexicographically the same as chronologically, so a plain `<` works.
+    if (day.count === currentPeak.count && isoDate < currentPeak.date) {
+      monthlyPeak.set(monthKey, { date: isoDate, count: day.count })
+    }
+  }
+
+  return new Set(Array.from(monthlyPeak.values()).map((peak) => peak.date))
+}

--- a/src/lib/shiftIsoDate.test.ts
+++ b/src/lib/shiftIsoDate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { shiftIsoDate } from './shiftIsoDate'
+
+describe('shiftIsoDate', () => {
+  it('adds one day inside the same month', () => {
+    expect(shiftIsoDate('2026-05-10', 1)).toBe('2026-05-11')
+  })
+
+  it('subtracts one day inside the same month', () => {
+    expect(shiftIsoDate('2026-05-10', -1)).toBe('2026-05-09')
+  })
+
+  it('returns the same date when the offset is zero', () => {
+    expect(shiftIsoDate('2026-05-10', 0)).toBe('2026-05-10')
+  })
+
+  it('rolls forward across the end of a 31-day month', () => {
+    expect(shiftIsoDate('2026-05-31', 1)).toBe('2026-06-01')
+  })
+
+  it('rolls backward across the start of a month', () => {
+    expect(shiftIsoDate('2026-06-01', -1)).toBe('2026-05-31')
+  })
+
+  it('rolls forward across a year boundary', () => {
+    expect(shiftIsoDate('2025-12-31', 1)).toBe('2026-01-01')
+  })
+
+  it('rolls backward across a year boundary', () => {
+    expect(shiftIsoDate('2026-01-01', -1)).toBe('2025-12-31')
+  })
+
+  it('lands on Feb 29 in a leap year', () => {
+    expect(shiftIsoDate('2024-02-28', 1)).toBe('2024-02-29')
+  })
+
+  it('skips to March 1 in a non-leap year', () => {
+    expect(shiftIsoDate('2026-02-28', 1)).toBe('2026-03-01')
+  })
+
+  it('crosses the US DST spring-forward date without an off-by-one', () => {
+    // 2026-03-08 → 2026-03-09 is the day the US "loses" an hour. UTC math
+    // makes this identical to any other day; the off-by-one bug that bites
+    // local-Date implementations does not apply here.
+    expect(shiftIsoDate('2026-03-08', 1)).toBe('2026-03-09')
+  })
+
+  it('handles large offsets symmetrically', () => {
+    expect(shiftIsoDate('2026-05-10', 30)).toBe('2026-06-09')
+    expect(shiftIsoDate('2026-05-10', -30)).toBe('2026-04-10')
+  })
+})

--- a/src/lib/shiftIsoDate.ts
+++ b/src/lib/shiftIsoDate.ts
@@ -1,0 +1,28 @@
+/**
+ * Adds (or subtracts) calendar days to a YYYY-MM-DD date string and returns
+ * the new YYYY-MM-DD string. Pure UTC arithmetic — DST-safe by construction
+ * because UTC has no DST. Matches the heatmap's bucketing scheme
+ * (`completedAt.toISOString().split('T')[0]`) so the output is always a valid
+ * lookup key for `dataByDate` and `getDayDetail`.
+ *
+ * Used by:
+ * - `ContributionGraph.handleNavigate` (←/→ buttons inside DayDetailDialog)
+ * - `useKeyboardNav` in PR2 (same callback, j/k key bindings)
+ *
+ * @param isoDate - YYYY-MM-DD string (zero-padded; validated upstream by `DayDetailInputSchema`)
+ * @param dayOffset - Integer days to shift. Positive moves forward; negative moves backward.
+ * @returns
+ * - The shifted YYYY-MM-DD string
+ * @example
+ * shiftIsoDate('2026-05-10', 1)   // => '2026-05-11'
+ * shiftIsoDate('2026-05-10', -1)  // => '2026-05-09'
+ * shiftIsoDate('2026-05-31', 1)   // => '2026-06-01'
+ * shiftIsoDate('2025-12-31', 1)   // => '2026-01-01'
+ * shiftIsoDate('2024-02-28', 1)   // => '2024-02-29' (leap year)
+ * shiftIsoDate('2026-02-28', 1)   // => '2026-03-01' (non-leap)
+ */
+export function shiftIsoDate(isoDate: string, dayOffset: number): string {
+  const utcAnchor = new Date(`${isoDate}T00:00:00.000Z`)
+  utcAnchor.setUTCDate(utcAnchor.getUTCDate() + dayOffset)
+  return utcAnchor.toISOString().slice(0, 10)
+}

--- a/src/server/procedures/completed.ts
+++ b/src/server/procedures/completed.ts
@@ -40,9 +40,17 @@ export const getHeatmap = authMiddleware
       const { days } = input
       const { user } = context
 
-      const startDate = new Date()
-      startDate.setDate(startDate.getDate() - days)
-      startDate.setHours(0, 0, 0, 0)
+      // UTC-anchored bounds — `fetchCompletedEntries` buckets via
+      // `entry.completedAt.toISOString().split('T')[0]` (UTC date string).
+      // If we anchored `startDate` to *local* midnight (the previous
+      // implementation), rows in the first/last UTC hours that straddle
+      // the local-vs-UTC boundary would mis-bucket on any non-UTC host
+      // (e.g., a regional deployment). Vercel happens to run UTC by
+      // default, which masked the bug — but the contract should be
+      // explicit. `getDayDetail` already uses this discipline.
+      const todayIso = new Date().toISOString().split('T')[0]!
+      const startDate = new Date(`${todayIso}T00:00:00.000Z`)
+      startDate.setUTCDate(startDate.getUTCDate() - days)
       // Upper bound = "now" so future-dated rows (clock skew, test seeds)
       // never accidentally surface on the heatmap. fetchCompletedEntries
       // requires an explicit endDate.

--- a/src/server/procedures/completed.ts
+++ b/src/server/procedures/completed.ts
@@ -50,7 +50,11 @@ export const getHeatmap = authMiddleware
       // explicit. `getDayDetail` already uses this discipline.
       const todayIso = new Date().toISOString().split('T')[0]!
       const startDate = new Date(`${todayIso}T00:00:00.000Z`)
-      startDate.setUTCDate(startDate.getUTCDate() - days)
+      // Inclusive bounds: `fetchCompletedEntries` uses `gte`/`lte`, so the
+      // window covers `(days - 1)` past calendar dates + today = exactly
+      // `days` dates. Subtracting the full `days` would include one extra
+      // day at the lower edge (CodeRabbit review on PR #38).
+      startDate.setUTCDate(startDate.getUTCDate() - (days - 1))
       // Upper bound = "now" so future-dated rows (clock skew, test seeds)
       // never accidentally surface on the heatmap. fetchCompletedEntries
       // requires an explicit endDate.

--- a/src/server/procedures/completed.ts
+++ b/src/server/procedures/completed.ts
@@ -14,14 +14,20 @@ import {
   HeatmapInputSchema,
   HeatmapResponseSchema,
 } from '../schemas/completed'
+import { fetchCompletedEntries } from '../utils/completedAggregation'
 
 /**
- * Fetches heatmap data for completed tasks, aggregated by date with category breakdown.
- * @param input.days - Number of days to look back (default: 365)
+ * Fetches heatmap data for completed tasks, aggregated by UTC date with a
+ * category breakdown. Reads the Todo+Completed UNION via
+ * {@link fetchCompletedEntries} so BrainDump checkbox-tick completions
+ * (which write directly to the `Completed` table) appear on the heatmap
+ * alongside Todos completed through the TodoList lifecycle.
+ *
+ * @param input.days - Number of days to look back (default: 365, max 365)
  * @returns
  * - data: Array of daily entries with count and category breakdown
  * - streaks: Current and longest consecutive-day streaks
- * - total: Total completed tasks in the period
+ * - total: Total completed tasks in the period (Todo + Completed union)
  * @example
  * getHeatmap({ days: 365 })
  * // => { data: [{ date: "2026-03-24", count: 5, categories: [...] }], streaks: { current: 3, longest: 12 }, total: 89 }
@@ -37,29 +43,17 @@ export const getHeatmap = authMiddleware
       const startDate = new Date()
       startDate.setDate(startDate.getDate() - days)
       startDate.setHours(0, 0, 0, 0)
+      // Upper bound = "now" so future-dated rows (clock skew, test seeds)
+      // never accidentally surface on the heatmap. fetchCompletedEntries
+      // requires an explicit endDate.
+      const endDate = new Date()
 
-      // Fetch all completed todos in the date range with their categories
-      const completedTodos = await prisma.todo.findMany({
-        where: {
-          userId: user.id,
-          completed: true,
-          updatedAt: { gte: startDate },
-        },
-        select: {
-          updatedAt: true,
-          categoryId: true,
-          category: {
-            select: {
-              id: true,
-              name: true,
-              color: true,
-            },
-          },
-        },
-        orderBy: { updatedAt: 'asc' },
-      })
+      const entries = await fetchCompletedEntries(user.id, startDate, endDate)
 
-      // Aggregate by date and category
+      // Bucket entries by UTC date string. Per-day category rollup mirrors
+      // the previous shape so the API contract (HeatmapResponseSchema) is
+      // unchanged — the only difference vs. pre-UNION is that `Completed`
+      // rows now contribute counts too.
       const dayMap = new Map<
         string,
         {
@@ -71,42 +65,40 @@ export const getHeatmap = authMiddleware
         }
       >()
 
-      for (const todo of completedTodos) {
-        const dateKey = todo.updatedAt.toISOString().split('T')[0]!
+      for (const entry of entries) {
+        const dateKey = entry.completedAt.toISOString().split('T')[0]!
         if (!dayMap.has(dateKey)) {
           dayMap.set(dateKey, { count: 0, categories: new Map() })
         }
         const day = dayMap.get(dateKey)!
         day.count++
 
-        if (todo.category) {
-          const catId = todo.category.id
-          if (!day.categories.has(catId)) {
-            day.categories.set(catId, {
-              id: catId,
-              name: todo.category.name,
-              color: todo.category.color,
+        if (entry.category) {
+          const categoryId = entry.category.id
+          if (!day.categories.has(categoryId)) {
+            day.categories.set(categoryId, {
+              id: categoryId,
+              name: entry.category.name,
+              color: entry.category.color,
               count: 0,
             })
           }
-          day.categories.get(catId)!.count++
+          day.categories.get(categoryId)!.count++
         }
       }
 
-      // Convert to array
       const data = Array.from(dayMap.entries()).map(([date, entry]) => ({
         date,
         count: entry.count,
         categories: Array.from(entry.categories.values()),
       }))
 
-      // Calculate streaks
       const streaks = calculateStreaks(data.map((d) => d.date))
 
       return {
         data,
         streaks,
-        total: completedTodos.length,
+        total: entries.length,
       }
     } catch (error) {
       log.error('Error in getHeatmap:', error)
@@ -178,9 +170,13 @@ function calculateStreaks(dates: string[]): {
 
 /**
  * Fetches a single day's completed tasks for the DayDetailDialog opened from
- * a heatmap cell click. Date range covers the local calendar day in UTC; this
+ * a heatmap cell click. Date range covers the calendar day in UTC; this
  * matches the heatmap's existing aggregation, so cell counts and dialog
  * counts stay in lockstep.
+ *
+ * Reads the Todo+Completed UNION via {@link fetchCompletedEntries} so both
+ * lifecycle paths (TodoList complete() and BrainDump checkbox-tick) surface
+ * inside the dialog's task list.
  *
  * @param input.date - YYYY-MM-DD date string the user clicked on the heatmap
  * @returns
@@ -197,49 +193,35 @@ export const getDayDetail = authMiddleware
       const { date } = input
       const { user } = context
 
-      // The heatmap aggregates by `updatedAt.toISOString().split('T')[0]`,
-      // which is UTC. Match that here so cell counts match dialog counts.
+      // Use UTC day bounds so a dialog opened from a heatmap cell matches the
+      // cell's bucket exactly (`completedAt.toISOString().split('T')[0]`).
       const dayStart = new Date(`${date}T00:00:00.000Z`)
       const dayEnd = new Date(`${date}T23:59:59.999Z`)
 
-      const todos = await prisma.todo.findMany({
-        where: {
-          userId: user.id,
-          completed: true,
-          updatedAt: { gte: dayStart, lte: dayEnd },
-        },
-        select: {
-          id: true,
-          text: true,
-          updatedAt: true,
-          category: {
-            select: { id: true, name: true, color: true },
-          },
-        },
-        orderBy: { updatedAt: 'asc' },
-      })
+      const entries = await fetchCompletedEntries(user.id, dayStart, dayEnd)
 
-      const tasks = todos.map((todo) => ({
-        id: todo.id,
-        title: todo.text,
-        completedAt: todo.updatedAt,
-        category: todo.category,
+      const tasks = entries.map((entry) => ({
+        source: entry.source,
+        id: entry.id,
+        title: entry.title,
+        completedAt: entry.completedAt,
+        category: entry.category,
       }))
 
       const categoryRollup = new Map<
         number,
         { id: number; name: string; color: string; count: number }
       >()
-      for (const todo of todos) {
-        if (!todo.category) continue
-        const existing = categoryRollup.get(todo.category.id)
+      for (const entry of entries) {
+        if (!entry.category) continue
+        const existing = categoryRollup.get(entry.category.id)
         if (existing) {
           existing.count++
         } else {
-          categoryRollup.set(todo.category.id, {
-            id: todo.category.id,
-            name: todo.category.name,
-            color: todo.category.color,
+          categoryRollup.set(entry.category.id, {
+            id: entry.category.id,
+            name: entry.category.name,
+            color: entry.category.color,
             count: 1,
           })
         }

--- a/src/server/schemas/completed.ts
+++ b/src/server/schemas/completed.ts
@@ -115,10 +115,19 @@ export const DayDetailInputSchema = z.object({
 
 /**
  * Single completed task entry surfaced in the day-detail dialog.
+ *
+ * `source` discriminates which Prisma table the entry came from. The pair
+ * `(source, id)` is globally unique; the dialog uses it as the React key
+ * because `Todo.id` and `Completed.id` are independent autoincrement
+ * sequences and can collide on the same day.
+ *
  * @example
- * { id: 12, title: "draft sunday digest", completedAt: Date, category: { id: 1, name: "writing", color: "blue" } }
+ * { source: 'todo', id: 12, title: "draft sunday digest", completedAt: Date, category: { id: 1, name: "writing", color: "blue" } }
+ * @example
+ * { source: 'completed', id: 7, title: "buy milk", completedAt: Date, category: null }
  */
 export const DayDetailTaskSchema = z.object({
+  source: z.enum(['todo', 'completed']),
   id: z.number().int(),
   title: z.string(),
   completedAt: z.date(),

--- a/src/server/utils/completedAggregation.test.ts
+++ b/src/server/utils/completedAggregation.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { prisma } from '@/lib/prisma'
+
+import { fetchCompletedEntries } from './completedAggregation'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    todo: { findMany: vi.fn() },
+    completed: { findMany: vi.fn() },
+  },
+}))
+
+const mockedTodoFindMany = vi.mocked(prisma.todo.findMany)
+const mockedCompletedFindMany = vi.mocked(prisma.completed.findMany)
+
+const RANGE_START = new Date('2026-05-04T00:00:00.000Z')
+const RANGE_END = new Date('2026-05-10T23:59:59.999Z')
+
+beforeEach(() => {
+  mockedTodoFindMany.mockReset()
+  mockedCompletedFindMany.mockReset()
+})
+
+describe('fetchCompletedEntries', () => {
+  it('returns an empty array when neither table has rows in the range', async () => {
+    mockedTodoFindMany.mockResolvedValue([])
+    mockedCompletedFindMany.mockResolvedValue([])
+
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+    expect(entries).toEqual([])
+  })
+
+  it('maps Todo rows with source="todo" using updatedAt as completedAt', async () => {
+    mockedTodoFindMany.mockResolvedValue([
+      {
+        id: 12,
+        text: 'draft digest',
+        updatedAt: new Date('2026-05-07T10:00:00.000Z'),
+        category: { id: 3, name: 'writing', color: 'blue' },
+      },
+    ] as never)
+    mockedCompletedFindMany.mockResolvedValue([])
+
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+    expect(entries).toEqual([
+      {
+        source: 'todo',
+        id: 12,
+        title: 'draft digest',
+        completedAt: new Date('2026-05-07T10:00:00.000Z'),
+        category: { id: 3, name: 'writing', color: 'blue' },
+      },
+    ])
+  })
+
+  it('maps Completed rows with source="completed" using createdAt as completedAt', async () => {
+    mockedTodoFindMany.mockResolvedValue([])
+    mockedCompletedFindMany.mockResolvedValue([
+      {
+        id: 42,
+        title: 'buy milk',
+        createdAt: new Date('2026-05-09T18:30:00.000Z'),
+        category: null,
+      },
+    ] as never)
+
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+    expect(entries).toEqual([
+      {
+        source: 'completed',
+        id: 42,
+        title: 'buy milk',
+        completedAt: new Date('2026-05-09T18:30:00.000Z'),
+        category: null,
+      },
+    ])
+  })
+
+  it('UNIONs rows from both tables sorted ascending by completedAt', async () => {
+    // Todo updated later than the Completed row, so the sort needs to flip
+    // them relative to insertion order.
+    mockedTodoFindMany.mockResolvedValue([
+      {
+        id: 1,
+        text: 'todo-later',
+        updatedAt: new Date('2026-05-09T08:00:00.000Z'),
+        category: null,
+      },
+    ] as never)
+    mockedCompletedFindMany.mockResolvedValue([
+      {
+        id: 1,
+        title: 'completed-earlier',
+        createdAt: new Date('2026-05-06T08:00:00.000Z'),
+        category: null,
+      },
+    ] as never)
+
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+    expect(entries.map((entry) => entry.source)).toEqual(['completed', 'todo'])
+  })
+
+  it('breaks identical-timestamp ties with todo first, then by id', async () => {
+    // Both rows on the same instant: todo should win the tie, then ascending
+    // id. Locks the deterministic ordering documented inline in the sort.
+    const sameInstant = new Date('2026-05-08T12:00:00.000Z')
+    mockedTodoFindMany.mockResolvedValue([
+      { id: 5, text: 'todo-5', updatedAt: sameInstant, category: null },
+      { id: 2, text: 'todo-2', updatedAt: sameInstant, category: null },
+    ] as never)
+    mockedCompletedFindMany.mockResolvedValue([
+      { id: 9, title: 'completed-9', createdAt: sameInstant, category: null },
+    ] as never)
+
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+    expect(
+      entries.map((entry) => ({ source: entry.source, id: entry.id })),
+    ).toEqual([
+      { source: 'todo', id: 2 },
+      { source: 'todo', id: 5 },
+      { source: 'completed', id: 9 },
+    ])
+  })
+
+  it('passes userId, completed=true, and the date range to the Todo query', async () => {
+    mockedTodoFindMany.mockResolvedValue([])
+    mockedCompletedFindMany.mockResolvedValue([])
+
+    await fetchCompletedEntries(7, RANGE_START, RANGE_END)
+
+    expect(mockedTodoFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: 7,
+          completed: true,
+          updatedAt: { gte: RANGE_START, lte: RANGE_END },
+        }),
+      }),
+    )
+  })
+
+  it('filters archived=false on the Completed query (defensive)', async () => {
+    mockedTodoFindMany.mockResolvedValue([])
+    mockedCompletedFindMany.mockResolvedValue([])
+
+    await fetchCompletedEntries(7, RANGE_START, RANGE_END)
+
+    expect(mockedCompletedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: 7,
+          archived: false,
+          createdAt: { gte: RANGE_START, lte: RANGE_END },
+        }),
+      }),
+    )
+  })
+
+  it('forwards null categories through the mapper untouched', async () => {
+    mockedTodoFindMany.mockResolvedValue([
+      {
+        id: 1,
+        text: 'orphan todo',
+        updatedAt: new Date('2026-05-06T00:00:00.000Z'),
+        category: null,
+      },
+    ] as never)
+    mockedCompletedFindMany.mockResolvedValue([])
+
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+    expect(entries[0]?.category).toBeNull()
+  })
+
+  it('uses Todo.updatedAt verbatim as completedAt (drift assertion, see TODOS.md)', async () => {
+    // Locks the documented drift: editing a long-completed Todo bumps the
+    // heatmap bucket to the edit day. The migration to a stable
+    // Todo.completedAt column is tracked in TODOS.md.
+    const recentEdit = new Date('2026-05-10T15:00:00.000Z')
+    mockedTodoFindMany.mockResolvedValue([
+      {
+        id: 1,
+        text: 'long-completed todo, edited today',
+        updatedAt: recentEdit,
+        category: null,
+      },
+    ] as never)
+    mockedCompletedFindMany.mockResolvedValue([])
+
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+    expect(entries[0]?.completedAt).toEqual(recentEdit)
+  })
+})

--- a/src/server/utils/completedAggregation.ts
+++ b/src/server/utils/completedAggregation.ts
@@ -1,0 +1,122 @@
+import { prisma } from '@/lib/prisma'
+
+/**
+ * One row in the merged Todo+Completed completion stream consumed by the
+ * heatmap and day-detail procedures. The `source` discriminator stays
+ * server-side (it's not surfaced in the API response shape) and exists so
+ * unit tests can assert UNION composition without relying on title equality.
+ *
+ * @example
+ * { source: 'todo', id: 12, title: 'draft digest', completedAt: Date, category: { id: 3, name: 'writing', color: 'blue' } }
+ * @example
+ * { source: 'completed', id: 42, title: 'buy milk', completedAt: Date, category: null }
+ */
+export type CompletedEntry = {
+  source: 'todo' | 'completed'
+  id: number
+  title: string
+  completedAt: Date
+  category: { id: number; name: string; color: string } | null
+}
+
+/**
+ * Returns Todo+Completed entries (UNION) for a user within a UTC date range,
+ * with category join. Single source of truth for the heatmap and day-detail
+ * oRPC procedures.
+ *
+ * Heatmap UNION semantics (locked decision D2=A):
+ *   Todo bucket      = updatedAt.toISOString().split('T')[0]   (UTC date)
+ *   Completed bucket = createdAt.toISOString().split('T')[0]   (UTC date)
+ *
+ * Known drift: Todo.updatedAt mutates on text/notes edit, so a completed
+ * Todo edited later will move dates on the heatmap. Acceptable for now;
+ * tracked in TODOS.md → "Migrate Todo heatmap bucket to a stable
+ * completedAt column". PR3 (Streak Notifications) is the forcing function
+ * for that migration.
+ *
+ * Dedup: Todo and Completed are disjoint surfaces by construction —
+ * BrainDump's checkbox-tick bypasses the Todo lifecycle (writes Completed
+ * directly), while TodoList's complete() flow never writes Completed.
+ * Therefore no row-level dedup is needed; this invariant is asserted by a
+ * unit test.
+ *
+ * @param userId - Internal `User.id` (NOT the Clerk `userId` string).
+ * @param startDate - Inclusive lower bound (caller aligns to UTC midnight).
+ * @param endDate - Inclusive upper bound (caller aligns to UTC end-of-day).
+ * @returns
+ * - `CompletedEntry[]` sorted ascending by `completedAt`
+ * - Empty array when neither table has rows in the range
+ * @example
+ * await fetchCompletedEntries(7, new Date('2026-05-04T00:00:00.000Z'), new Date('2026-05-10T23:59:59.999Z'))
+ * // => [{ source: 'todo', id: 1, ..., completedAt: 2026-05-04 }, { source: 'completed', id: 9, ..., completedAt: 2026-05-10 }]
+ */
+export async function fetchCompletedEntries(
+  userId: number,
+  startDate: Date,
+  endDate: Date,
+): Promise<CompletedEntry[]> {
+  // Two parallel reads; merge in JS. Each query is bounded by userId so the
+  // postgres planner uses the primary userId access path. No extra index
+  // needed — see /plan-eng-review §4.
+  const [todoRows, completedRows] = await Promise.all([
+    prisma.todo.findMany({
+      where: {
+        userId,
+        completed: true,
+        // Drift caveat: this bucket field is `updatedAt`, which mutates on
+        // every edit. Migration to a stable `completedAt` column is tracked
+        // in TODOS.md.
+        updatedAt: { gte: startDate, lte: endDate },
+      },
+      select: {
+        id: true,
+        text: true,
+        updatedAt: true,
+        category: { select: { id: true, name: true, color: true } },
+      },
+      orderBy: { updatedAt: 'asc' },
+    }),
+    prisma.completed.findMany({
+      where: {
+        userId,
+        // archived rows are excluded from the heatmap surface. Today nothing
+        // sets archived=true, but filtering defensively avoids surprises
+        // when an archive flow eventually lands.
+        archived: false,
+        createdAt: { gte: startDate, lte: endDate },
+      },
+      select: {
+        id: true,
+        title: true,
+        createdAt: true,
+        category: { select: { id: true, name: true, color: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    }),
+  ])
+
+  const todoEntries: CompletedEntry[] = todoRows.map((row) => ({
+    source: 'todo',
+    id: row.id,
+    title: row.text,
+    completedAt: row.updatedAt,
+    category: row.category,
+  }))
+
+  const completedEntries: CompletedEntry[] = completedRows.map((row) => ({
+    source: 'completed',
+    id: row.id,
+    title: row.title,
+    completedAt: row.createdAt,
+    category: row.category,
+  }))
+
+  // Stable merge: sort by completedAt ascending. Tie-break by source then id
+  // so test seeds with identical timestamps produce deterministic ordering.
+  return [...todoEntries, ...completedEntries].sort((a, b) => {
+    const timeDiff = a.completedAt.getTime() - b.completedAt.getTime()
+    if (timeDiff !== 0) return timeDiff
+    if (a.source !== b.source) return a.source === 'todo' ? -1 : 1
+    return a.id - b.id
+  })
+}


### PR DESCRIPTION
## Summary

Combines the **PR1.5 (W1 + W2)** and **PR2** slices of the Heatmap Cathedral design doc into a single shippable bundle, plus the E2E spec and a pre-PR 3-way adversarial review pass. Splits the remaining cathedral work into the next two PRs (Streak+Memory Lane, then Trends+Share+YIR).

### PR1.5 — Week 1 (UNION + Weekly Summary)
- `src/server/procedures/completed.ts` now UNIONs **Todo (`completed=true`) + Completed table** so the home heatmap reflects activity from BrainDump and the Floating Navigator, not just the Home column.
- New `WeeklySummaryCard` reads from the same `useHeatmapData()` so React Query dedupes the network call.
- New utilities under `src/lib/` (`aggregate-last-seven-days`, `calcMonthlyMaxDates`, `shiftIsoDate`) all UTC-anchored to stay TZ/DST-safe.

### PR1.5 — Week 2 (Day-nav + Monthly Peak ◎)
- `ContributionGraph` adds an in-place day-nav (chevron `<` / `>`) that calls `shiftIsoDate(iso, ±1)` to move `DayDetailDialog`'s anchor without remounting.
- Monthly peak day gets a ◎ glyph overlay (one per calendar month within the visible 365 days), positioned over the heatmap cell with `aria-hidden` so AT users aren't double-announced.

### PR2 — Keyboard Nav + Deep Link + E2E
- New `useKeyboardNav` hook binds `j` (next day) / `k` (prev day) **while the dialog is open**. Esc is intentionally delegated to Radix Dialog to avoid double-handling. **IME composition is guarded** (both `event.isComposing` and legacy `keyCode === 229`) so Japanese romaji input doesn't fire navigation while seeding a kana.
- `?date=YYYY-MM-DD` query param now deep-links into the dialog. Invalid (non-ISO) or non-existent (2026-02-31) dates show a Sonner toast and keep the dialog closed.
- **9-test Playwright spec** covers: deep-link valid + 2 invalid arms, chevron > / chevron < / j / k / Esc.

### Pre-PR-A 3-way review (CodeRabbit + Codex + adversarial)
Fixes committed in `8038582`:
- **CRITICAL C1** `DayDetailDialog`: `keepPreviousData` + `isLoading || isPlaceholderData` task-list gate eliminates the "rest day" flash during day-nav.
- **CRITICAL C2** `useHeatmapData`: wraps `dataByDate` Map + `heatmapValues` array in `useMemo(..., [data])` so downstream `useMemo(() => calcMonthlyMaxDates(dataByDate), [dataByDate])` doesn't bust every render.
- **HIGH H1** `useKeyboardNav`: IME composition guard (see above).
- **HIGH H2** `getHeatmap`: replaces `setHours(0,0,0,0)` with UTC-anchored `new Date(\`${iso}T00:00:00.000Z\`)` to match `getDayDetail`.
- **HIGH** `TodoList` + `FloatingNavigatorContainer`: `subscribeToTodoSync` now invalidates `completed.heatmap` + `completed.dayDetail` cache keys alongside `todo.*`, so cross-window completions don't leave heatmap stale.
- **MEDIUM** `formatDate` (DayDetailDialog) UTC-anchored.
- **MEDIUM** ◎ glyph `aria-hidden`.
- **MEDIUM** Dropped `waitForLoadState('networkidle')` from E2E in favor of UI-state gates (Clerk + TanStack background refetches never reach network-idle on Vercel-like envs).

## Test plan

- [x] `pnpm validate` green (125 unit tests pass, +2 new IME-guard cases)
- [x] `pnpm e2e:web --grep 'Heatmap Day Detail'` → 9/9 pass (~1.5 min)
- [ ] CodeRabbit review on this PR resolved via `/coderabbit-resolver`
- [ ] Visual + behavior QA on `/home` after merge (heatmap UNION reflects BrainDump completes, chevron + j/k navigate, `?date=` deep-link opens dialog, invalid date toasts, weekly card shows correct totals)

## Out of scope (intentional defers)

- **MEDIUM M1** URL `?date=` desync when navigating via chevron/j/k — accepted per design doc §1.6 trade-off (deep-link is for inbound only).
- **MEDIUM M2** KPI-shaped % deltas in WeeklySummaryCard — copy polish, may surface in PR-D.
- Cells keyboard-focusable (a11y) — bigger refactor, out of PR-A scope.

## Follow-ups (next PRs)

- **PR-B**: Streak Notifications (PR3) + Memory Lane Sunday Digest (PR4). Additive copy only — "shown up N days" per DESIGN.md, never "streak" framing.
- **PR-C**: Category Trends (PR5) + Share Image (PR6) + Year in Review (PR7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep-link to a specific day via ?date=YYYY-MM-DD; navigate days with chevrons or j/k
  * Weekly summary card showing this-week totals, trend, and top categories
  * Heatmap highlights monthly peak days and shows unified completed entries from all sources

* **Bug Fixes**
  * Minor typography/style warning cleanups

* **Tests**
  * Added E2E and unit tests for day detail, keyboard nav, date shifting, and weekly aggregation

* **Documentation**
  * Added TODOS and updated ignore rules for local tooling files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/38)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->