### PR TITLE
feat(home): streak milestones + sunday memory digest (PR-B)

### DIFF
--- a/src/app/(main)/home/_components/SundayDigestCard.test.tsx
+++ b/src/app/(main)/home/_components/SundayDigestCard.test.tsx
@@ -73,15 +73,19 @@ describe('SundayDigestCard', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders nothing when the heatmap is empty', () => {
-    const { container } = render(
+  it('renders the quiet-week fallback when the heatmap is empty', () => {
+    // A new user (or a fully quiet week) should still see the digest —
+    // the "quiet week" copy is exactly what the empty path was designed
+    // for (DESIGN.md: self-affirmation on rest weeks too).
+    render(
       <SundayDigestCard
         dataByDate={new Map()}
         isLoading={false}
         now={LOCAL_SUNDAY}
       />,
     )
-    expect(container).toBeEmptyDOMElement()
+    expect(screen.getByLabelText(/quiet sunday recap/i)).toBeInTheDocument()
+    expect(screen.getByText(/room was quiet this week/i)).toBeInTheDocument()
   })
 
   it('renders the digest on Sunday with non-zero data', () => {

--- a/src/app/(main)/home/_components/SundayDigestCard.test.tsx
+++ b/src/app/(main)/home/_components/SundayDigestCard.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+import { shiftIsoDate } from '@/lib/shiftIsoDate'
+
+import { SundayDigestCard } from './SundayDigestCard'
+
+// `new Date(year, monthIndex, day, hours)` parses local-TZ — using noon avoids
+// any DST-edge ambiguity, and these dates are Sunday / Tuesday in any TZ.
+const LOCAL_SUNDAY = new Date(2026, 4, 10, 12)
+const LOCAL_TUESDAY = new Date(2026, 4, 12, 12)
+
+// The card derives its window from local Sunday → ISO string. The seed
+// fixture uses the same calendar date so the test does not depend on the
+// runner's TZ when comparing keys.
+const LOCAL_SUNDAY_ISO = '2026-05-10'
+
+/**
+ * Helper: builds a fixture Map with `count` entries on the local Sunday
+ * (the window anchor). `extra` lets a caller seed additional days.
+ */
+function buildWeekFixture(
+  countOnSunday: number,
+  extra: Array<{ date: string; count: number }> = [],
+): Map<string, HeatmapDay> {
+  const entries = new Map<string, HeatmapDay>()
+  if (countOnSunday > 0) {
+    entries.set(LOCAL_SUNDAY_ISO, {
+      date: LOCAL_SUNDAY_ISO,
+      count: countOnSunday,
+      categories: [
+        { id: 1, name: 'writing', color: 'blue', count: countOnSunday },
+      ],
+    })
+  }
+  for (const seed of extra) {
+    entries.set(seed.date, {
+      date: seed.date,
+      count: seed.count,
+      categories: [
+        { id: 2, name: 'reading', color: 'green', count: seed.count },
+      ],
+    })
+  }
+  return entries
+}
+
+describe('SundayDigestCard', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('renders nothing on a non-Sunday', () => {
+    const { container } = render(
+      <SundayDigestCard
+        dataByDate={buildWeekFixture(3)}
+        isLoading={false}
+        now={LOCAL_TUESDAY}
+      />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing while loading', () => {
+    const { container } = render(
+      <SundayDigestCard
+        dataByDate={buildWeekFixture(3)}
+        isLoading={true}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the heatmap is empty', () => {
+    const { container } = render(
+      <SundayDigestCard
+        dataByDate={new Map()}
+        isLoading={false}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the digest on Sunday with non-zero data', () => {
+    render(
+      <SundayDigestCard
+        dataByDate={buildWeekFixture(4, [
+          { date: shiftIsoDate(LOCAL_SUNDAY_ISO, -2), count: 2 },
+        ])}
+        isLoading={false}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    expect(screen.getByLabelText(/quiet sunday recap/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/things made it onto the wall/i),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the zero-week fallback when total is zero', () => {
+    // dataByDate is non-empty but only has activity outside the 7-day window
+    const data = new Map<string, HeatmapDay>()
+    const oldDate = shiftIsoDate(LOCAL_SUNDAY_ISO, -30)
+    data.set(oldDate, { date: oldDate, count: 5, categories: [] })
+
+    render(
+      <SundayDigestCard
+        dataByDate={data}
+        isLoading={false}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    expect(screen.getByText(/room was quiet this week/i)).toBeInTheDocument()
+  })
+
+  it('shows the best day inside the week', () => {
+    const wednesday = shiftIsoDate(LOCAL_SUNDAY_ISO, -4)
+    const data = buildWeekFixture(2, [{ date: wednesday, count: 6 }])
+    render(
+      <SundayDigestCard
+        dataByDate={data}
+        isLoading={false}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    // Best day surfaces inside the "best day:" line; assert the count is rendered
+    expect(screen.getByText(/best day/i)).toBeInTheDocument()
+    expect(screen.getByText(/\(6\)/)).toBeInTheDocument()
+  })
+
+  it('hides the card after the dismiss button is clicked and persists per-week', () => {
+    render(
+      <SundayDigestCard
+        dataByDate={buildWeekFixture(3)}
+        isLoading={false}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    expect(screen.getByLabelText(/quiet sunday recap/i)).toBeInTheDocument()
+
+    const dismissButton = screen.getByRole('button', {
+      name: /dismiss the sunday recap/i,
+    })
+    fireEvent.click(dismissButton)
+
+    expect(
+      screen.queryByLabelText(/quiet sunday recap/i),
+    ).not.toBeInTheDocument()
+
+    // Find the dismiss key — exact format depends on local TZ. We expect
+    // exactly one key set to '1'.
+    const setKeys = Object.keys(window.localStorage).filter((k) =>
+      k.startsWith('corelive.sunday-digest-dismissed.'),
+    )
+    expect(setKeys.length).toBe(1)
+    expect(window.localStorage.getItem(setKeys[0]!)).toBe('1')
+  })
+
+  it('honors a pre-existing dismiss flag for the same week (mount-time read)', () => {
+    // Seed the dismiss flag for the current Sunday before mount.
+    const sundayKey = `corelive.sunday-digest-dismissed.${LOCAL_SUNDAY.toLocaleDateString('en-CA')}`
+    window.localStorage.setItem(sundayKey, '1')
+
+    const { container } = render(
+      <SundayDigestCard
+        dataByDate={buildWeekFixture(3)}
+        isLoading={false}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('re-appears next Sunday (different week key)', () => {
+    // Seed dismiss for last Sunday.
+    const lastSunday = new Date(2026, 4, 3, 12)
+    const lastSundayKey = `corelive.sunday-digest-dismissed.${lastSunday.toLocaleDateString('en-CA')}`
+    window.localStorage.setItem(lastSundayKey, '1')
+
+    render(
+      <SundayDigestCard
+        dataByDate={buildWeekFixture(3)}
+        isLoading={false}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    expect(screen.getByLabelText(/quiet sunday recap/i)).toBeInTheDocument()
+  })
+})

--- a/src/app/(main)/home/_components/SundayDigestCard.test.tsx
+++ b/src/app/(main)/home/_components/SundayDigestCard.test.tsx
@@ -116,7 +116,7 @@ describe('SundayDigestCard', () => {
     expect(screen.getByText(/room was quiet this week/i)).toBeInTheDocument()
   })
 
-  it('shows the best day inside the week', () => {
+  it('shows the brightest day inside the week', () => {
     const wednesday = shiftIsoDate(LOCAL_SUNDAY_ISO, -4)
     const data = buildWeekFixture(2, [{ date: wednesday, count: 6 }])
     render(
@@ -126,9 +126,23 @@ describe('SundayDigestCard', () => {
         now={LOCAL_SUNDAY}
       />,
     )
-    // Best day surfaces inside the "best day:" line; assert the count is rendered
-    expect(screen.getByText(/best day/i)).toBeInTheDocument()
-    expect(screen.getByText(/\(6\)/)).toBeInTheDocument()
+    // The "brightest day:" line surfaces the best day; assert the spelled-out
+    // count ("6 things") renders — the previous "(6)" framing read as KPI.
+    expect(screen.getByText(/brightest day/i)).toBeInTheDocument()
+    expect(screen.getByText(/6 things/i)).toBeInTheDocument()
+  })
+
+  it('uses the singular "1 thing" for a one-item brightest day', () => {
+    const wednesday = shiftIsoDate(LOCAL_SUNDAY_ISO, -4)
+    const data = buildWeekFixture(0, [{ date: wednesday, count: 1 }])
+    render(
+      <SundayDigestCard
+        dataByDate={data}
+        isLoading={false}
+        now={LOCAL_SUNDAY}
+      />,
+    )
+    expect(screen.getByText(/1 thing(?!s)/i)).toBeInTheDocument()
   })
 
   it('hides the card after the dismiss button is clicked and persists per-week', () => {

--- a/src/app/(main)/home/_components/SundayDigestCard.tsx
+++ b/src/app/(main)/home/_components/SundayDigestCard.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { useMounted } from '@/hooks/use-mounted'
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+import { aggregateLastSevenDays } from '@/lib/aggregate-last-seven-days'
+import { getColorDotClass } from '@/lib/category-colors'
+import { log } from '@/lib/logger'
+import { shiftIsoDate } from '@/lib/shiftIsoDate'
+import { cn } from '@/lib/utils'
+
+/**
+ * Window the digest summarises. Anchored to the *local* Sunday so the user's
+ * perceived week boundary lines up with when the card appears — using UTC
+ * would surface the digest on a Saturday afternoon for JST users.
+ */
+const DIGEST_WINDOW_DAYS = 7
+
+/**
+ * Local-day index for Sunday. JS Date.getDay() spec: 0=Sunday, 6=Saturday.
+ */
+const SUNDAY_DAY_INDEX = 0
+
+/**
+ * localStorage key prefix for the per-week dismiss flag. The full key is
+ * `${PREFIX}${localSundayIso}` so each Sunday gets a fresh key — next week
+ * the card reappears automatically without any cleanup logic.
+ */
+const DISMISS_KEY_PREFIX = 'corelive.sunday-digest-dismissed.'
+
+interface SundayDigestCardProps {
+  /** Per-day heatmap entries from `useHeatmapData()` — same Map the
+   * WeeklySummaryCard reads, so no extra fetch. */
+  dataByDate: Map<string, HeatmapDay>
+  /** Loading sentinel from `useHeatmapData`. The card stays hidden while
+   * the query is in-flight so the digest never shows zero-and-then-real. */
+  isLoading?: boolean
+  /** Optional injection for tests. Production callers leave undefined. */
+  now?: Date
+}
+
+/**
+ * Picks the single best day from a 7-day window ending on `windowEndIsoDate`.
+ * "Best" = highest `count`; ties broken by *recency* (later date wins) so the
+ * highlighted day feels current rather than randomly chosen from the week.
+ *
+ * @param dataByDate - Per-day heatmap entries
+ * @param windowEndIsoDate - Inclusive YYYY-MM-DD anchor (the local Sunday)
+ * @returns
+ * - `{ date, count, categories }` for the best day, or `null` if the entire
+ *   window has zero activity
+ * @example
+ * pickBestDay(map, '2026-05-10')
+ * // => { date: '2026-05-08', count: 6, categories: [...] }
+ */
+function pickBestDay(
+  dataByDate: Map<string, HeatmapDay>,
+  windowEndIsoDate: string,
+): HeatmapDay | null {
+  let best: HeatmapDay | null = null
+  for (let dayOffset = 0; dayOffset < DIGEST_WINDOW_DAYS; dayOffset++) {
+    const isoDate = shiftIsoDate(windowEndIsoDate, -dayOffset)
+    const day = dataByDate.get(isoDate)
+    if (!day || day.count === 0) continue
+    if (!best || day.count > best.count) {
+      best = day
+    }
+  }
+  return best
+}
+
+/**
+ * Formats a YYYY-MM-DD date as a short, locale-friendly label for display.
+ * Pinned to `en-US` so CI runs on locales without Intl data still render
+ * consistently. Uses `T00:00:00Z` so the formatted day matches the bucket
+ * key exactly across TZs.
+ *
+ * @param isoDate - YYYY-MM-DD UTC date string
+ * @returns
+ * - Short "Fri, May 8" style label
+ * @example
+ * formatShortDay('2026-05-08') // => "Fri, May 8"
+ */
+function formatShortDay(isoDate: string): string {
+  const parsed = new Date(`${isoDate}T00:00:00.000Z`)
+  return parsed.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+/**
+ * Reads the per-week dismiss flag from localStorage. Returns `false` when
+ * the key is absent or storage is unavailable, so the card defaults to
+ * visible — failing-quiet is correct here (the digest is opt-out).
+ *
+ * @param weekKey - localStorage key derived from the local Sunday's ISO date
+ * @returns
+ * - `true` if the digest has been dismissed for this week
+ */
+function readDismissed(weekKey: string): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(weekKey) === '1'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Persists the per-week dismiss flag. Storage errors are swallowed —
+ * over-showing the digest is preferable to throwing in an event handler.
+ *
+ * @param weekKey - localStorage key for the current Sunday
+ */
+function writeDismissed(weekKey: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(weekKey, '1')
+  } catch (error) {
+    log.warn('Failed to persist sunday digest dismissal', error)
+  }
+}
+
+/**
+ * Returns the YYYY-MM-DD ISO date for the local Sunday that anchors the
+ * digest window. When `now` is already a Sunday, returns that day's local
+ * date; otherwise returns the *most recent* prior Sunday.
+ *
+ * Local TZ is used intentionally — "Sunday" should match the user's
+ * perceived calendar week boundary, not the UTC week.
+ *
+ * @param now - Anchor Date in the caller's local TZ
+ * @returns
+ * - YYYY-MM-DD string in the local TZ
+ * @example
+ * // when now is a Wednesday
+ * localSundayIso(new Date('2026-05-13T12:00:00Z')) // => "2026-05-10"
+ */
+function localSundayIso(now: Date): string {
+  const local = new Date(now)
+  const daysSinceSunday = local.getDay()
+  local.setDate(local.getDate() - daysSinceSunday)
+  // Format in local TZ — `toLocaleDateString` with the en-CA locale yields
+  // a YYYY-MM-DD shape without needing to slice an ISO string.
+  return local.toLocaleDateString('en-CA')
+}
+
+/**
+ * "Memory Lane" Sunday digest card. Renders only on local Sunday, only when
+ * heatmap data has loaded, and only when the user has not dismissed it for
+ * this week. Surfaces:
+ *
+ * - Total things done in the last 7 days
+ * - Best day of the week (date + count)
+ * - Top categories the user touched
+ *
+ * Voice follows DESIGN.md §Voice (quiet companion, never KPI grading). When
+ * the week was zero, the card shows a soft "the room was quiet this week"
+ * line instead of suppressing entirely — the digest is meant to reassure
+ * on rest weeks too (north star: self-affirmation, never failure framing).
+ *
+ * Dismiss is scoped to the calendar week via a localStorage key keyed on
+ * the local Sunday's ISO date. Next Sunday gets a fresh key automatically.
+ *
+ * @example
+ * <SundayDigestCard dataByDate={dataByDate} isLoading={isLoading} />
+ */
+export function SundayDigestCard({
+  dataByDate,
+  isLoading,
+  now,
+}: SundayDigestCardProps) {
+  const isMounted = useMounted()
+
+  const today = now ?? new Date()
+  const isSunday = today.getDay() === SUNDAY_DAY_INDEX
+  const weekKey = `${DISMISS_KEY_PREFIX}${localSundayIso(today)}`
+
+  // Render-time dismiss read (post-mount only) avoids hydration mismatch —
+  // server can't know what's in client localStorage, so we treat the card
+  // as visible during SSR and let the post-mount state correct if needed.
+  const [dismissedAt, setDismissedAt] = useState<string | null>(null)
+  const dismissed = isMounted
+    ? dismissedAt === weekKey || readDismissed(weekKey)
+    : false
+
+  // Derive the stats once per `dataByDate` identity.
+  const summary = useMemo(() => {
+    const sundayIso = localSundayIso(today)
+    const weekStats = aggregateLastSevenDays(dataByDate, today)
+    const bestDay = pickBestDay(dataByDate, sundayIso)
+    return { weekStats, bestDay }
+  }, [dataByDate, today])
+
+  if (!isMounted) return null
+  if (isLoading) return null
+  if (!isSunday) return null
+  if (dismissed) return null
+  if (dataByDate.size === 0) return null
+
+  const { weekStats, bestDay } = summary
+
+  const handleDismiss = () => {
+    writeDismissed(weekKey)
+    setDismissedAt(weekKey)
+  }
+
+  return (
+    <Card aria-label="A quiet Sunday recap">
+      <CardContent className="space-y-3 p-6">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+              a quiet sunday recap
+            </p>
+            <p className="font-serif text-base italic text-foreground">
+              {weekStats.totalCompleted === 0
+                ? 'the room was quiet this week — that is fine too.'
+                : `${weekStats.totalCompleted} things made it onto the wall.`}
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Dismiss the Sunday recap until next week"
+            onClick={handleDismiss}
+            className="size-7 text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+
+        {bestDay ? (
+          <p className="text-sm text-muted-foreground">
+            best day:{' '}
+            <span className="text-foreground">
+              {formatShortDay(bestDay.date)}
+            </span>{' '}
+            <span className="font-mono tabular-nums">({bestDay.count})</span>
+          </p>
+        ) : null}
+
+        {weekStats.topCategories.length > 0 && (
+          <ul
+            aria-label="Top categories this week"
+            className="flex flex-wrap gap-1.5"
+          >
+            {weekStats.topCategories.map((category) => (
+              <li
+                key={category.id}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-xs"
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    'inline-block size-1.5 rounded-full',
+                    getColorDotClass(category.color),
+                  )}
+                />
+                <span className="text-foreground">{category.name}</span>
+                <span className="font-mono tabular-nums text-muted-foreground">
+                  {category.count}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(main)/home/_components/SundayDigestCard.tsx
+++ b/src/app/(main)/home/_components/SundayDigestCard.tsx
@@ -179,7 +179,11 @@ export function SundayDigestCard({
 }: SundayDigestCardProps) {
   const isMounted = useMounted()
 
-  const today = now ?? new Date()
+  // Stabilize `today` so a fresh `new Date()` per render does not
+  // invalidate the `summary` memo every paint — when the caller omits
+  // `now`, the value is captured once on first render (sufficient: the
+  // digest is a Sunday-only card, no need to track minutes within a day).
+  const today = useMemo(() => now ?? new Date(), [now])
   const isSunday = today.getDay() === SUNDAY_DAY_INDEX
   const weekKey = `${DISMISS_KEY_PREFIX}${localSundayIso(today)}`
 
@@ -191,10 +195,19 @@ export function SundayDigestCard({
     ? dismissedAt === weekKey || readDismissed(weekKey)
     : false
 
-  // Derive the stats once per `dataByDate` identity.
+  // Derive the stats once per `dataByDate` / `today` identity.
+  //
+  // Why anchor on UTC-midnight-of-local-Sunday: `aggregateLastSevenDays`
+  // builds its window via `formatUTCDateISO`, which would otherwise read
+  // the UTC calendar day of `today` — at e.g. JST Sunday 06:00 that day
+  // is still Saturday in UTC, so the user would see a "Sunday recap" that
+  // misses Sunday's data. Re-deriving the anchor from the local Sunday's
+  // ISO string keeps the visibility window (local Sunday) and the data
+  // window (the same Sunday key) in lockstep.
   const summary = useMemo(() => {
     const sundayIso = localSundayIso(today)
-    const weekStats = aggregateLastSevenDays(dataByDate, today)
+    const sundayAnchor = new Date(`${sundayIso}T00:00:00.000Z`)
+    const weekStats = aggregateLastSevenDays(dataByDate, sundayAnchor)
     const bestDay = pickBestDay(dataByDate, sundayIso)
     return { weekStats, bestDay }
   }, [dataByDate, today])
@@ -239,11 +252,13 @@ export function SundayDigestCard({
 
         {bestDay ? (
           <p className="text-sm text-muted-foreground">
-            best day:{' '}
+            brightest day:{' '}
             <span className="text-foreground">
               {formatShortDay(bestDay.date)}
             </span>{' '}
-            <span className="font-mono tabular-nums">({bestDay.count})</span>
+            <span className="font-mono tabular-nums">
+              {bestDay.count} {bestDay.count === 1 ? 'thing' : 'things'}
+            </span>
           </p>
         ) : null}
 

--- a/src/app/(main)/home/_components/SundayDigestCard.tsx
+++ b/src/app/(main)/home/_components/SundayDigestCard.tsx
@@ -147,9 +147,16 @@ function localSundayIso(now: Date): string {
   const local = new Date(now)
   const daysSinceSunday = local.getDay()
   local.setDate(local.getDate() - daysSinceSunday)
-  // Format in local TZ — `toLocaleDateString` with the en-CA locale yields
-  // a YYYY-MM-DD shape without needing to slice an ISO string.
-  return local.toLocaleDateString('en-CA')
+  // Hand-roll the YYYY-MM-DD string from local-TZ getters — ECMAScript
+  // does not spec a stable format for `toLocaleDateString('en-CA')`, and
+  // engine/CLDR updates have flipped it from `yyyy-MM-dd` to `M/d/yyyy`
+  // in the wild (see CodeRabbit thread on PR #39). If that ever happens
+  // again the dismiss key, `shiftIsoDate` input, and `new Date()` parser
+  // would all silently break.
+  const year = local.getFullYear()
+  const month = String(local.getMonth() + 1).padStart(2, '0')
+  const day = String(local.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 /**
@@ -179,11 +186,12 @@ export function SundayDigestCard({
 }: SundayDigestCardProps) {
   const isMounted = useMounted()
 
-  // Stabilize `today` so a fresh `new Date()` per render does not
-  // invalidate the `summary` memo every paint — when the caller omits
-  // `now`, the value is captured once on first render (sufficient: the
-  // digest is a Sunday-only card, no need to track minutes within a day).
-  const today = useMemo(() => now ?? new Date(), [now])
+  // Recompute `today` per render rather than memoizing — if the home page
+  // stays open across a day boundary (Sat→Sun, Sun→Mon), a memoized
+  // `today` would freeze to the mount-day Date and the card would never
+  // appear on the new day. Re-deriving each render is cheap (small
+  // 7-element scan) and is the correctness win.
+  const today = now ?? new Date()
   const isSunday = today.getDay() === SUNDAY_DAY_INDEX
   const weekKey = `${DISMISS_KEY_PREFIX}${localSundayIso(today)}`
 
@@ -216,7 +224,10 @@ export function SundayDigestCard({
   if (isLoading) return null
   if (!isSunday) return null
   if (dismissed) return null
-  if (dataByDate.size === 0) return null
+  // Note: an empty `dataByDate` does NOT suppress the card — a fully
+  // quiet week is exactly the case the "the room was quiet this week —
+  // that is fine too." copy was added for (DESIGN.md north star:
+  // self-affirmation, never failure framing).
 
   const { weekStats, bestDay } = summary
 

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -124,9 +124,13 @@ export function TodoList() {
   // Streak milestone notifications (Electron-only; no-ops in the web build).
   // The hook is fire-and-forget — localStorage dedupes per-tier so a single
   // crossing of 7/30/100/365 days fires the macOS banner exactly once.
+  // `isRestoring` is passed so the effect waits for the TanStack persister
+  // before reading data — a stale cached snapshot must not fire a wrong
+  // tier and latch the localStorage max permanently.
   useStreakNotifications({
     dataByDate: heatmapByDate,
     isLoading: heatmapLoading,
+    isRestoring,
   })
 
   /**

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -29,6 +29,7 @@ import {
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
 import { useHeatmapData } from '@/hooks/useHeatmapData'
 import { useSelectedCategory } from '@/hooks/useSelectedCategory'
+import { useStreakNotifications } from '@/hooks/useStreakNotifications'
 import { useTodoMutations } from '@/hooks/useTodoMutations'
 import { orpc } from '@/lib/orpc/client-query'
 import { subscribeToTodoSync } from '@/lib/todo-sync-channel'
@@ -38,6 +39,7 @@ import { AddTodoForm } from './AddTodoForm'
 import { CompletedTodos } from './CompletedTodos'
 import { ContributionGraph } from './ContributionGraph'
 import { SortableTodoItem } from './SortableTodoItem'
+import { SundayDigestCard } from './SundayDigestCard'
 import type { Todo } from './TodoItem'
 import { WeeklySummaryCard } from './WeeklySummaryCard'
 
@@ -112,11 +114,20 @@ export function TodoList() {
     enabled: isClerkQueryReady,
   })
 
-  // Heatmap data shared with WeeklySummaryCard (React Query dedupes the
-  // underlying request with ContributionGraph's own useHeatmapData() call, so
-  // mounting the summary card does not add a second network round-trip).
+  // Heatmap data shared with WeeklySummaryCard + SundayDigestCard + the
+  // streak-notification hook (React Query dedupes the underlying request
+  // with ContributionGraph's own useHeatmapData() call, so the extra
+  // consumers do not add network round-trips).
   const { dataByDate: heatmapByDate, isLoading: heatmapLoading } =
     useHeatmapData()
+
+  // Streak milestone notifications (Electron-only; no-ops in the web build).
+  // The hook is fire-and-forget — localStorage dedupes per-tier so a single
+  // crossing of 7/30/100/365 days fires the macOS banner exactly once.
+  useStreakNotifications({
+    dataByDate: heatmapByDate,
+    isLoading: heatmapLoading,
+  })
 
   /**
    * Adds a new todo item using the create mutation.
@@ -368,6 +379,10 @@ export function TodoList() {
           <ContributionGraph />
         </Suspense>
         <WeeklySummaryCard
+          dataByDate={heatmapByDate}
+          isLoading={heatmapLoading}
+        />
+        <SundayDigestCard
           dataByDate={heatmapByDate}
           isLoading={heatmapLoading}
         />

--- a/src/hooks/useStreakNotifications.test.ts
+++ b/src/hooks/useStreakNotifications.test.ts
@@ -12,6 +12,10 @@ const electronMocks = vi.hoisted(() => ({
   isEnabled: true,
 }))
 
+const clerkMocks = vi.hoisted(() => ({
+  userId: 'user_test_alpha' as string | null,
+}))
+
 vi.mock('./useElectronNotifications', () => ({
   useElectronNotifications: () => ({
     isSupported: electronMocks.isSupported,
@@ -26,6 +30,14 @@ vi.mock('./useElectronNotifications', () => ({
   }),
 }))
 
+vi.mock('@clerk/nextjs', () => ({
+  useUser: () => ({
+    user: clerkMocks.userId ? { id: clerkMocks.userId } : null,
+    isLoaded: true,
+    isSignedIn: clerkMocks.userId !== null,
+  }),
+}))
+
 vi.mock('@/lib/logger', () => ({
   log: {
     debug: vi.fn(),
@@ -35,7 +47,11 @@ vi.mock('@/lib/logger', () => ({
   },
 }))
 
-const STORAGE_KEY = 'corelive.streak-max-tier-notified'
+// Per-user storage key prefix — tests construct the full key by appending
+// the mocked Clerk user id (matches the production format).
+const STORAGE_KEY_PREFIX = 'corelive.streak-max-tier-notified.'
+const TEST_USER_ID = 'user_test_alpha'
+const STORAGE_KEY = `${STORAGE_KEY_PREFIX}${TEST_USER_ID}`
 const TODAY = new Date('2026-05-12T08:00:00.000Z')
 const TODAY_ISO = '2026-05-12'
 
@@ -54,6 +70,7 @@ describe('useStreakNotifications', () => {
     electronMocks.showNotification.mockClear()
     electronMocks.isSupported = true
     electronMocks.isEnabled = true
+    clerkMocks.userId = TEST_USER_ID
     window.localStorage.clear()
   })
 
@@ -223,5 +240,56 @@ describe('useStreakNotifications', () => {
     )
     expect(electronMocks.showNotification).not.toHaveBeenCalled()
     expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('does nothing when no Clerk user is signed in', () => {
+    // Without a userId we cannot scope the dedupe key per-account —
+    // the hook defers the milestone rather than fire under a global key.
+    clerkMocks.userId = null
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem(`${STORAGE_KEY_PREFIX}null`)).toBeNull()
+  })
+
+  it('namespaces the dedupe key per Clerk user (two accounts on one device)', () => {
+    // User A reaches Day 7 → fires once and writes user A's key.
+    clerkMocks.userId = 'user_test_alpha'
+    const { unmount: unmountA } = renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).toHaveBeenCalledTimes(1)
+    expect(
+      window.localStorage.getItem(`${STORAGE_KEY_PREFIX}user_test_alpha`),
+    ).toBe('7')
+    unmountA()
+
+    // User B (same browser) also reaches Day 7. The pre-existing user-A
+    // key MUST NOT suppress user B's milestone.
+    clerkMocks.userId = 'user_test_beta'
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).toHaveBeenCalledTimes(2)
+    expect(
+      window.localStorage.getItem(`${STORAGE_KEY_PREFIX}user_test_beta`),
+    ).toBe('7')
+    // User A's key is untouched.
+    expect(
+      window.localStorage.getItem(`${STORAGE_KEY_PREFIX}user_test_alpha`),
+    ).toBe('7')
   })
 })

--- a/src/hooks/useStreakNotifications.test.ts
+++ b/src/hooks/useStreakNotifications.test.ts
@@ -1,0 +1,197 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { shiftIsoDate } from '@/lib/shiftIsoDate'
+
+import type { HeatmapDay } from './useHeatmapData'
+import { useStreakNotifications } from './useStreakNotifications'
+
+const electronMocks = vi.hoisted(() => ({
+  showNotification: vi.fn().mockResolvedValue(undefined),
+  isSupported: true,
+  isEnabled: true,
+}))
+
+vi.mock('./useElectronNotifications', () => ({
+  useElectronNotifications: () => ({
+    isSupported: electronMocks.isSupported,
+    isEnabled: electronMocks.isEnabled,
+    preferences: null,
+    activeCount: 0,
+    showNotification: electronMocks.showNotification,
+    updatePreferences: vi.fn(),
+    clearAll: vi.fn(),
+    clearNotification: vi.fn(),
+    refreshActiveCount: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const STORAGE_KEY = 'corelive.streak-max-tier-notified'
+const TODAY = new Date('2026-05-12T08:00:00.000Z')
+const TODAY_ISO = '2026-05-12'
+
+/** Builds a heatmap data Map of N consecutive UTC days ending on TODAY_ISO. */
+function buildConsecutive(days: number): Map<string, HeatmapDay> {
+  return new Map(
+    Array.from({ length: days }, (_, i) => {
+      const date = shiftIsoDate(TODAY_ISO, -i)
+      return [date, { date, count: 1, categories: [] }]
+    }),
+  )
+}
+
+describe('useStreakNotifications', () => {
+  beforeEach(() => {
+    electronMocks.showNotification.mockClear()
+    electronMocks.isSupported = true
+    electronMocks.isEnabled = true
+    window.localStorage.clear()
+  })
+
+  it('does nothing when isSupported is false (web environment)', () => {
+    electronMocks.isSupported = false
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when isEnabled is false (user-disabled)', () => {
+    electronMocks.isEnabled = false
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+  })
+
+  it('does nothing while heatmap data is loading', () => {
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: true,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+  })
+
+  it('does nothing on an empty heatmap', () => {
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: new Map(),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for streaks below 7 days', () => {
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(6),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+  })
+
+  it('fires once when crossing the 7-day tier and persists to localStorage', () => {
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).toHaveBeenCalledTimes(1)
+    const firstCall = electronMocks.showNotification.mock.calls[0]
+    expect(firstCall?.[0]).toMatch(/day 7/i)
+    expect(firstCall?.[1]).toMatch(/cathedral/i)
+    expect(firstCall?.[2]).toMatchObject({ tag: 'streak-tier-7' })
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('7')
+  })
+
+  it('fires the 30-day tier and stores it as the new max', () => {
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(30),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).toHaveBeenCalledTimes(1)
+    expect(electronMocks.showNotification.mock.calls[0]?.[0]).toMatch(/day 30/i)
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('30')
+  })
+
+  it('does not re-fire a tier already stored as max (dedupe)', () => {
+    window.localStorage.setItem(STORAGE_KEY, '7')
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(8),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+  })
+
+  it('skips lower tiers when stored max is higher (rebuilt-from-zero scenario)', () => {
+    window.localStorage.setItem(STORAGE_KEY, '30')
+    // User had a 30-day streak, broke it, and is now back at day 8.
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(8),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('30')
+  })
+
+  it('fires the next tier when streak grows past stored max', () => {
+    window.localStorage.setItem(STORAGE_KEY, '7')
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(30),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).toHaveBeenCalledTimes(1)
+    expect(electronMocks.showNotification.mock.calls[0]?.[0]).toMatch(/day 30/i)
+  })
+
+  it('tolerates corrupted localStorage and still fires the milestone', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'not-a-number')
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).toHaveBeenCalledTimes(1)
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('7')
+  })
+})

--- a/src/hooks/useStreakNotifications.test.ts
+++ b/src/hooks/useStreakNotifications.test.ts
@@ -194,4 +194,34 @@ describe('useStreakNotifications', () => {
     expect(electronMocks.showNotification).toHaveBeenCalledTimes(1)
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe('7')
   })
+
+  it('treats a spurious-but-finite stored value as unset (defends against tamper / future schema)', () => {
+    // 5000 is finite and positive but not a canonical tier — without
+    // validation it would block every real future milestone forever.
+    window.localStorage.setItem(STORAGE_KEY, '5000')
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).toHaveBeenCalledTimes(1)
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('7')
+  })
+
+  it('skips the effect while TanStack Query is rehydrating its persister', () => {
+    // A stale persisted snapshot must not be allowed to latch the wrong
+    // tier — the hook should wait until `isRestoring` flips to false.
+    renderHook(() =>
+      useStreakNotifications({
+        dataByDate: buildConsecutive(7),
+        isLoading: false,
+        isRestoring: true,
+        now: TODAY,
+      }),
+    )
+    expect(electronMocks.showNotification).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
 })

--- a/src/hooks/useStreakNotifications.ts
+++ b/src/hooks/useStreakNotifications.ts
@@ -1,0 +1,176 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+import type { StreakTier } from '@/lib/calc-streak'
+import { calcStreak } from '@/lib/calc-streak'
+import { log } from '@/lib/logger'
+
+import { useElectronNotifications } from './useElectronNotifications'
+import type { HeatmapDay } from './useHeatmapData'
+
+/**
+ * localStorage key that stores the highest tier ever notified for this user
+ * on this device. Once a tier fires, it stays fired forever — the value
+ * never decreases. This guarantees the "additive, generous, never decreases
+ * without explanation" rule from DESIGN.md D12: rebuilding a broken streak
+ * does not re-trigger an already-celebrated milestone.
+ */
+const STORAGE_KEY = 'corelive.streak-max-tier-notified'
+
+/**
+ * Copy bundle for one milestone tier. Voice is "quiet companion, not coach"
+ * per DESIGN.md §Voice & Microcopy — short title, one-line body, never
+ * exclamatory, never KPI ("you crushed it").
+ */
+type TierCopy = {
+  title: string
+  body: string
+}
+
+/**
+ * Display copy keyed by tier day count. The phrases are additive ("a year
+ * of showing up") rather than streak-anxious ("don't break the chain") so
+ * the notification reinforces self-affirmation, not fragility.
+ *
+ * Tags are reused so each tier's macOS notification replaces any previous
+ * banner of the same tier rather than stacking.
+ */
+const TIER_COPY: Record<NonNullable<StreakTier>, TierCopy & { tag: string }> = {
+  7: {
+    title: 'Day 7 of showing up.',
+    body: 'the cathedral remembers.',
+    tag: 'streak-tier-7',
+  },
+  30: {
+    title: 'Day 30 — a month of light.',
+    body: 'the room is filling in, one quiet day at a time.',
+    tag: 'streak-tier-30',
+  },
+  100: {
+    title: 'Day 100 — steady hands.',
+    body: 'something gets built when you keep showing up.',
+    tag: 'streak-tier-100',
+  },
+  365: {
+    title: 'A year of showing up.',
+    body: 'this is yours now.',
+    tag: 'streak-tier-365',
+  },
+}
+
+/**
+ * Reads the stored "max tier ever notified" from localStorage. Returns 0
+ * when the key is absent, malformed, or localStorage itself is unavailable
+ * (private browsing / strict CSP) so the first run after install starts
+ * from a clean slate without throwing.
+ *
+ * @returns
+ * - The stored tier (one of 0/7/30/100/365)
+ * @example
+ * readStoredTier() // => 0 on first run
+ */
+function readStoredTier(): number {
+  if (typeof window === 'undefined') return 0
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return 0
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Persists the max-tier-notified value. Swallows storage errors so the
+ * notification flow keeps working in restricted environments — failing to
+ * dedupe is preferable to throwing inside a render-triggered effect.
+ *
+ * @param tier - Non-negative integer tier value to persist
+ * @example
+ * writeStoredTier(7)
+ */
+function writeStoredTier(tier: number): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(tier))
+  } catch (error) {
+    log.warn('Failed to persist streak tier', error)
+  }
+}
+
+/**
+ * Side-effect hook that fires a one-shot Electron notification when the
+ * user crosses a "shown up N days" milestone (7 / 30 / 100 / 365). The
+ * hook is a pure consumer — composing {@link useElectronNotifications}
+ * and {@link calcStreak} — so the only persistent state it owns is the
+ * `corelive.streak-max-tier-notified` localStorage key.
+ *
+ * Why localStorage instead of `electron-store`: corelive.app loads inside
+ * an Electron `BrowserWindow` pointing at the production origin, so
+ * localStorage is shared with the web app and survives quit/relaunch
+ * without adding an Electron-only dependency. Per-device dedupe is the
+ * right grain — a fresh install legitimately re-celebrates the milestone
+ * once.
+ *
+ * Behavioral guarantees:
+ * - The hook is a no-op outside Electron (web users get the heatmap, not a
+ *   permissioned banner).
+ * - The hook never *decreases* the stored tier (a broken-and-rebuilt streak
+ *   does not re-fire — additive only, per DESIGN.md D12).
+ * - The hook never fires for streaks below 7 (the first tier).
+ * - The hook waits on the heatmap query — `isLoading` skips the effect so
+ *   stale `0` does not race the real data.
+ *
+ * @param input.dataByDate - Per-day heatmap entries from `useHeatmapData()`
+ * @param input.isLoading - Whether the heatmap query is still settling
+ * @param input.now - Optional injection for tests; defaults to `new Date()`
+ * @returns
+ * - Nothing — the hook is fire-and-forget
+ * @example
+ * const { dataByDate, isLoading } = useHeatmapData()
+ * useStreakNotifications({ dataByDate, isLoading })
+ */
+export function useStreakNotifications(input: {
+  dataByDate: Map<string, HeatmapDay>
+  isLoading: boolean
+  now?: Date
+}): void {
+  const { dataByDate, isLoading, now } = input
+  const { isSupported, isEnabled, showNotification } =
+    useElectronNotifications()
+
+  // Latch on a ref so a Strict-Mode double-invoke or React 19 re-render does
+  // not redundantly call `showNotification` for the same tier inside one
+  // session before localStorage write settles. The persistent dedupe is
+  // localStorage; this is just the in-memory edge-case guard.
+  const latchedTierRef = useRef<number>(0)
+
+  useEffect(() => {
+    if (!isSupported || !isEnabled) return
+    if (isLoading) return
+    if (dataByDate.size === 0) return
+
+    const { currentTier } = calcStreak(dataByDate, now ?? new Date())
+    if (currentTier === null) return
+
+    const storedTier = Math.max(readStoredTier(), latchedTierRef.current)
+    if (currentTier <= storedTier) return
+
+    const copy = TIER_COPY[currentTier]
+    latchedTierRef.current = currentTier
+
+    // Write-then-notify: persist the new max tier BEFORE showing so a crash
+    // mid-notification (or a user-rejected permission) does not double-fire
+    // on next mount. Failing-quiet is intentional (writeStoredTier swallows
+    // errors) since over-notification is the worst outcome to recover from.
+    writeStoredTier(currentTier)
+    showNotification(copy.title, copy.body, {
+      tag: copy.tag,
+      silent: false,
+    }).catch((error) => {
+      log.warn('Failed to show streak tier notification', error)
+    })
+  }, [dataByDate, isLoading, isSupported, isEnabled, showNotification, now])
+}

--- a/src/hooks/useStreakNotifications.ts
+++ b/src/hooks/useStreakNotifications.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react'
 
 import type { StreakTier } from '@/lib/calc-streak'
-import { calcStreak } from '@/lib/calc-streak'
+import { calcStreak, STREAK_TIERS } from '@/lib/calc-streak'
 import { log } from '@/lib/logger'
 
 import { useElectronNotifications } from './useElectronNotifications'
@@ -61,14 +61,16 @@ const TIER_COPY: Record<NonNullable<StreakTier>, TierCopy & { tag: string }> = {
 
 /**
  * Reads the stored "max tier ever notified" from localStorage. Returns 0
- * when the key is absent, malformed, or localStorage itself is unavailable
- * (private browsing / strict CSP) so the first run after install starts
- * from a clean slate without throwing.
+ * when the key is absent, malformed, or holds a value that is not one of
+ * the canonical tiers (someone hand-edited it, or a future version stored
+ * a different schema) — restricting to {@link STREAK_TIERS} keeps a
+ * tampered/spurious "5000" from blocking every real future milestone.
  *
  * @returns
- * - The stored tier (one of 0/7/30/100/365)
+ * - One of 0 / 7 / 30 / 100 / 365 (the canonical tier set, or 0 on miss)
  * @example
  * readStoredTier() // => 0 on first run
+ * readStoredTier() // => 7 after Day-7 fires
  */
 function readStoredTier(): number {
   if (typeof window === 'undefined') return 0
@@ -76,7 +78,10 @@ function readStoredTier(): number {
     const raw = window.localStorage.getItem(STORAGE_KEY)
     if (!raw) return 0
     const parsed = Number.parseInt(raw, 10)
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+    if (!Number.isFinite(parsed)) return 0
+    // Only accept values that exist in the canonical tier set — guards
+    // against a stale schema or hand-edited value capping real progress.
+    return (STREAK_TIERS as readonly number[]).includes(parsed) ? parsed : 0
   } catch {
     return 0
   }
@@ -125,19 +130,26 @@ function writeStoredTier(tier: number): void {
  *
  * @param input.dataByDate - Per-day heatmap entries from `useHeatmapData()`
  * @param input.isLoading - Whether the heatmap query is still settling
+ * @param input.isRestoring - TanStack Query persister rehydration sentinel
+ *   (`useIsRestoring()`). Skipping the effect while restoring prevents a
+ *   stale persisted snapshot from firing the wrong tier *before* the live
+ *   fetch settles — without this gate a long-offline user could trip the
+ *   max-tier latch with last week's data and never see future milestones.
  * @param input.now - Optional injection for tests; defaults to `new Date()`
  * @returns
  * - Nothing — the hook is fire-and-forget
  * @example
  * const { dataByDate, isLoading } = useHeatmapData()
- * useStreakNotifications({ dataByDate, isLoading })
+ * const isRestoring = useIsRestoring()
+ * useStreakNotifications({ dataByDate, isLoading, isRestoring })
  */
 export function useStreakNotifications(input: {
   dataByDate: Map<string, HeatmapDay>
   isLoading: boolean
+  isRestoring?: boolean
   now?: Date
 }): void {
-  const { dataByDate, isLoading, now } = input
+  const { dataByDate, isLoading, isRestoring, now } = input
   const { isSupported, isEnabled, showNotification } =
     useElectronNotifications()
 
@@ -150,6 +162,10 @@ export function useStreakNotifications(input: {
   useEffect(() => {
     if (!isSupported || !isEnabled) return
     if (isLoading) return
+    // Wait for the TanStack Query persister to finish rehydrating before
+    // reading streak data — otherwise the live fetch may swap in moments
+    // after we'd already latched the wrong tier from a cached snapshot.
+    if (isRestoring) return
     if (dataByDate.size === 0) return
 
     const { currentTier } = calcStreak(dataByDate, now ?? new Date())
@@ -172,5 +188,13 @@ export function useStreakNotifications(input: {
     }).catch((error) => {
       log.warn('Failed to show streak tier notification', error)
     })
-  }, [dataByDate, isLoading, isSupported, isEnabled, showNotification, now])
+  }, [
+    dataByDate,
+    isLoading,
+    isRestoring,
+    isSupported,
+    isEnabled,
+    showNotification,
+    now,
+  ])
 }

--- a/src/hooks/useStreakNotifications.ts
+++ b/src/hooks/useStreakNotifications.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { useUser } from '@clerk/nextjs'
 import { useEffect, useRef } from 'react'
 
 import type { StreakTier } from '@/lib/calc-streak'
@@ -10,13 +11,29 @@ import { useElectronNotifications } from './useElectronNotifications'
 import type { HeatmapDay } from './useHeatmapData'
 
 /**
- * localStorage key that stores the highest tier ever notified for this user
- * on this device. Once a tier fires, it stays fired forever — the value
- * never decreases. This guarantees the "additive, generous, never decreases
- * without explanation" rule from DESIGN.md D12: rebuilding a broken streak
- * does not re-trigger an already-celebrated milestone.
+ * localStorage key *prefix* that stores the highest tier ever notified.
+ * The full key is `${STORAGE_KEY_PREFIX}${clerkUserId}` so two accounts
+ * sharing one browser/Electron profile do not suppress each other's
+ * milestones. Once a tier fires (per account), it stays fired — the
+ * value never decreases. This guarantees the "additive, generous, never
+ * decreases without explanation" rule from DESIGN.md D12: rebuilding a
+ * broken streak does not re-trigger an already-celebrated milestone.
  */
-const STORAGE_KEY = 'corelive.streak-max-tier-notified'
+const STORAGE_KEY_PREFIX = 'corelive.streak-max-tier-notified.'
+
+/**
+ * Builds the per-user localStorage key. The Clerk `userId` is a stable
+ * `user_…` identifier that survives reloads but resets on sign-out.
+ *
+ * @param userId - Clerk user id from `useUser().user.id`
+ * @returns The fully namespaced localStorage key for this account
+ * @example
+ * storageKeyFor('user_2fT2GATLWCa…')
+ * // => 'corelive.streak-max-tier-notified.user_2fT2GATLWCa…'
+ */
+function storageKeyFor(userId: string): string {
+  return `${STORAGE_KEY_PREFIX}${userId}`
+}
 
 /**
  * Copy bundle for one milestone tier. Voice is "quiet companion, not coach"
@@ -72,10 +89,10 @@ const TIER_COPY: Record<NonNullable<StreakTier>, TierCopy & { tag: string }> = {
  * readStoredTier() // => 0 on first run
  * readStoredTier() // => 7 after Day-7 fires
  */
-function readStoredTier(): number {
+function readStoredTier(storageKey: string): number {
   if (typeof window === 'undefined') return 0
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
+    const raw = window.localStorage.getItem(storageKey)
     if (!raw) return 0
     const parsed = Number.parseInt(raw, 10)
     if (!Number.isFinite(parsed)) return 0
@@ -96,10 +113,10 @@ function readStoredTier(): number {
  * @example
  * writeStoredTier(7)
  */
-function writeStoredTier(tier: number): void {
+function writeStoredTier(storageKey: string, tier: number): void {
   if (typeof window === 'undefined') return
   try {
-    window.localStorage.setItem(STORAGE_KEY, String(tier))
+    window.localStorage.setItem(storageKey, String(tier))
   } catch (error) {
     log.warn('Failed to persist streak tier', error)
   }
@@ -152,12 +169,26 @@ export function useStreakNotifications(input: {
   const { dataByDate, isLoading, isRestoring, now } = input
   const { isSupported, isEnabled, showNotification } =
     useElectronNotifications()
+  // Scope the dedupe key to the signed-in Clerk user so two accounts
+  // sharing one browser/Electron profile do not suppress each other's
+  // milestones. When the user is signed out, `userId` is `undefined`
+  // and the effect short-circuits (no heatmap data either, so this is
+  // already a no-op path in practice).
+  const { user } = useUser()
+  const userId = user?.id
 
   // Latch on a ref so a Strict-Mode double-invoke or React 19 re-render does
   // not redundantly call `showNotification` for the same tier inside one
   // session before localStorage write settles. The persistent dedupe is
   // localStorage; this is just the in-memory edge-case guard.
-  const latchedTierRef = useRef<number>(0)
+  //
+  // The latch is keyed by `userId` so a sign-out → sign-in-as-different-user
+  // in the same session does not leak the previous account's tier into the
+  // new account's notification gate (CodeRabbit #4 follow-up).
+  const latchedTierRef = useRef<{ userId: string | null; tier: number }>({
+    userId: null,
+    tier: 0,
+  })
 
   useEffect(() => {
     if (!isSupported || !isEnabled) return
@@ -167,21 +198,33 @@ export function useStreakNotifications(input: {
     // after we'd already latched the wrong tier from a cached snapshot.
     if (isRestoring) return
     if (dataByDate.size === 0) return
+    // Cannot scope the dedupe key without a stable user id; defer the
+    // milestone instead of firing under a global namespace.
+    if (!userId) return
+
+    // Reset the in-memory latch when the signed-in user changes.
+    if (latchedTierRef.current.userId !== userId) {
+      latchedTierRef.current = { userId, tier: 0 }
+    }
 
     const { currentTier } = calcStreak(dataByDate, now ?? new Date())
     if (currentTier === null) return
 
-    const storedTier = Math.max(readStoredTier(), latchedTierRef.current)
+    const storageKey = storageKeyFor(userId)
+    const storedTier = Math.max(
+      readStoredTier(storageKey),
+      latchedTierRef.current.tier,
+    )
     if (currentTier <= storedTier) return
 
     const copy = TIER_COPY[currentTier]
-    latchedTierRef.current = currentTier
+    latchedTierRef.current = { userId, tier: currentTier }
 
     // Write-then-notify: persist the new max tier BEFORE showing so a crash
     // mid-notification (or a user-rejected permission) does not double-fire
     // on next mount. Failing-quiet is intentional (writeStoredTier swallows
     // errors) since over-notification is the worst outcome to recover from.
-    writeStoredTier(currentTier)
+    writeStoredTier(storageKey, currentTier)
     showNotification(copy.title, copy.body, {
       tag: copy.tag,
       silent: false,
@@ -196,5 +239,6 @@ export function useStreakNotifications(input: {
     isEnabled,
     showNotification,
     now,
+    userId,
   ])
 }

--- a/src/lib/calc-streak.test.ts
+++ b/src/lib/calc-streak.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+import { calcStreak, STREAK_TIERS } from './calc-streak'
+import { shiftIsoDate } from './shiftIsoDate'
+
+/**
+ * Builds a `Map<string, HeatmapDay>` from a list of YYYY-MM-DD strings, each
+ * with a count of 1 and no categories. Test fixtures only — production data
+ * comes from `useHeatmapData`. Categories are irrelevant for streak math so
+ * the omission keeps tests focused on date arithmetic.
+ */
+function buildDataByDate(activeDates: string[]): Map<string, HeatmapDay> {
+  return new Map(
+    activeDates.map((date) => [date, { date, count: 1, categories: [] }]),
+  )
+}
+
+const TODAY = new Date('2026-05-12T08:00:00.000Z')
+const TODAY_ISO = '2026-05-12'
+
+describe('calcStreak', () => {
+  describe('empty data', () => {
+    it('returns zeros for an empty map', () => {
+      expect(calcStreak(new Map(), TODAY)).toStrictEqual({
+        currentStreak: 0,
+        longestStreak: 0,
+        currentTier: null,
+        shownUpThisMonth: 0,
+      })
+    })
+
+    it('returns zero current streak when last activity is older than yesterday', () => {
+      const data = buildDataByDate([shiftIsoDate(TODAY_ISO, -3)])
+      const result = calcStreak(data, TODAY)
+      expect(result.currentStreak).toBe(0)
+      expect(result.longestStreak).toBe(1)
+    })
+  })
+
+  describe('current streak grace period', () => {
+    it('counts today as a 1-day streak', () => {
+      const data = buildDataByDate([TODAY_ISO])
+      expect(calcStreak(data, TODAY).currentStreak).toBe(1)
+    })
+
+    it('keeps the streak when only yesterday has activity (today not yet shown up)', () => {
+      const data = buildDataByDate([shiftIsoDate(TODAY_ISO, -1)])
+      expect(calcStreak(data, TODAY).currentStreak).toBe(1)
+    })
+
+    it('still counts the current streak when both today and yesterday are present', () => {
+      const data = buildDataByDate([shiftIsoDate(TODAY_ISO, -1), TODAY_ISO])
+      expect(calcStreak(data, TODAY).currentStreak).toBe(2)
+    })
+  })
+
+  describe('consecutive-day streaks', () => {
+    it('counts a 7-day consecutive streak ending today', () => {
+      const days = Array.from({ length: 7 }, (_, i) =>
+        shiftIsoDate(TODAY_ISO, -i),
+      )
+      const result = calcStreak(buildDataByDate(days), TODAY)
+      expect(result.currentStreak).toBe(7)
+      expect(result.longestStreak).toBe(7)
+      expect(result.currentTier).toBe(7)
+    })
+
+    it('counts a 7-day streak anchored on yesterday (grace)', () => {
+      const days = Array.from({ length: 7 }, (_, i) =>
+        shiftIsoDate(TODAY_ISO, -i - 1),
+      )
+      const result = calcStreak(buildDataByDate(days), TODAY)
+      expect(result.currentStreak).toBe(7)
+      expect(result.currentTier).toBe(7)
+    })
+
+    it('breaks the streak on a gap', () => {
+      const data = buildDataByDate([
+        TODAY_ISO,
+        shiftIsoDate(TODAY_ISO, -1),
+        // Gap on day -2
+        shiftIsoDate(TODAY_ISO, -3),
+        shiftIsoDate(TODAY_ISO, -4),
+      ])
+      const result = calcStreak(data, TODAY)
+      expect(result.currentStreak).toBe(2)
+      expect(result.longestStreak).toBe(2)
+    })
+
+    it('preserves longest streak when a later streak is shorter', () => {
+      // Long streak 30 days ago, then a fresh 2-day streak ending today.
+      const longRunDays = Array.from({ length: 10 }, (_, i) =>
+        shiftIsoDate(TODAY_ISO, -i - 20),
+      )
+      const recentDays = [TODAY_ISO, shiftIsoDate(TODAY_ISO, -1)]
+      const result = calcStreak(
+        buildDataByDate([...longRunDays, ...recentDays]),
+        TODAY,
+      )
+      expect(result.currentStreak).toBe(2)
+      expect(result.longestStreak).toBe(10)
+    })
+  })
+
+  describe('tier semantics', () => {
+    it('returns null below 7', () => {
+      const days = Array.from({ length: 6 }, (_, i) =>
+        shiftIsoDate(TODAY_ISO, -i),
+      )
+      expect(calcStreak(buildDataByDate(days), TODAY).currentTier).toBeNull()
+    })
+
+    it.each([
+      [7, 7],
+      [29, 7],
+      [30, 30],
+      [99, 30],
+      [100, 100],
+      [364, 100],
+      [365, 365],
+      [400, 365],
+    ])('returns tier %s for streak %s', (streakLength, expectedTier) => {
+      const days = Array.from({ length: streakLength }, (_, i) =>
+        shiftIsoDate(TODAY_ISO, -i),
+      )
+      expect(calcStreak(buildDataByDate(days), TODAY).currentTier).toBe(
+        expectedTier,
+      )
+    })
+
+    it('exposes STREAK_TIERS in descending order so external callers can iterate', () => {
+      expect([...STREAK_TIERS]).toStrictEqual([365, 100, 30, 7])
+    })
+  })
+
+  describe('shownUpThisMonth', () => {
+    it('counts only days inside the current calendar month', () => {
+      const data = buildDataByDate([
+        '2026-04-29',
+        '2026-04-30',
+        '2026-05-01',
+        '2026-05-03',
+        '2026-05-12', // today
+      ])
+      expect(calcStreak(data, TODAY).shownUpThisMonth).toBe(3)
+    })
+
+    it('returns zero when no activity falls inside the month', () => {
+      const data = buildDataByDate(['2026-04-29'])
+      expect(calcStreak(data, TODAY).shownUpThisMonth).toBe(0)
+    })
+
+    it('stays correct across a year boundary anchor', () => {
+      const newYearDay = new Date('2026-01-01T00:00:00.000Z')
+      const data = buildDataByDate(['2025-12-31', '2026-01-01'])
+      expect(calcStreak(data, newYearDay).shownUpThisMonth).toBe(1)
+    })
+  })
+
+  describe('TZ / DST boundaries', () => {
+    it('handles the US spring-forward day without an off-by-one (UTC math)', () => {
+      const dstAnchor = new Date('2026-03-09T08:00:00.000Z')
+      const data = buildDataByDate(['2026-03-08', '2026-03-09'])
+      const result = calcStreak(data, dstAnchor)
+      expect(result.currentStreak).toBe(2)
+    })
+
+    it('matches across a leap-day boundary', () => {
+      const anchor = new Date('2024-03-01T00:00:00.000Z')
+      const data = buildDataByDate([
+        '2024-02-27',
+        '2024-02-28',
+        '2024-02-29',
+        '2024-03-01',
+      ])
+      expect(calcStreak(data, anchor).currentStreak).toBe(4)
+    })
+  })
+})

--- a/src/lib/calc-streak.ts
+++ b/src/lib/calc-streak.ts
@@ -1,0 +1,204 @@
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+import { shiftIsoDate } from './shiftIsoDate'
+
+/**
+ * "Shown-up" tiers for milestone notifications. Picked to match the cadence
+ * of habit formation literature (week=1, month=4, hundred=14 weeks, year=52
+ * weeks) while staying ergonomic to remember.
+ *
+ * Ordering matters: descending so {@link calcStreak} can short-circuit on
+ * the first hit when computing `currentTier`.
+ */
+export const STREAK_TIERS = [365, 100, 30, 7] as const
+
+/**
+ * One of the milestone tiers, or `null` if the user has not yet reached
+ * the first tier (7 days).
+ */
+export type StreakTier = (typeof STREAK_TIERS)[number] | null
+
+/**
+ * Result of {@link calcStreak}. All fields are computed against the supplied
+ * `today` anchor in UTC so tests and SSR are deterministic; the hook layer
+ * is responsible for sourcing "now" appropriately.
+ *
+ * @example
+ * {
+ *   currentStreak: 18,
+ *   longestStreak: 42,
+ *   currentTier: 7,
+ *   shownUpThisMonth: 14,
+ * }
+ */
+export type StreakSummary = {
+  /** Consecutive UTC days ending today (or yesterday — grace period) with at
+   * least one completed entry. Zero when the most recent activity is older
+   * than yesterday. */
+  currentStreak: number
+  /** Longest run of consecutive UTC days with at least one entry anywhere in
+   * `dataByDate`. */
+  longestStreak: number
+  /** Highest tier the current streak has crossed: `7`, `30`, `100`, `365`,
+   * or `null` (streak < 7). Used by `useStreakNotifications` to decide
+   * whether to fire a one-shot milestone notification — paired with a
+   * `streak-max-tier-notified` localStorage key so a tier never re-fires
+   * after the user breaks and rebuilds a streak (DESIGN.md D12:
+   * "never decreases without explanation"). */
+  currentTier: StreakTier
+  /** Distinct UTC dates with activity within `today`'s calendar month.
+   * Surfaced as "shown up N days this month" per DESIGN.md voice — never
+   * decreases mid-month because it is a count, not a delta. */
+  shownUpThisMonth: number
+}
+
+/**
+ * UTC ISO date string for `today` (YYYY-MM-DD). Centralised so streak math
+ * stays anchored to the same key shape that `useHeatmapData`'s `dataByDate`
+ * Map is keyed by.
+ *
+ * @param today - Anchor Date (caller may pass `new Date()`)
+ * @returns
+ * - YYYY-MM-DD string in UTC
+ * @example
+ * isoDateOf(new Date('2026-05-12T08:00:00.000Z')) // => "2026-05-12"
+ */
+function isoDateOf(today: Date): string {
+  return today.toISOString().slice(0, 10)
+}
+
+/**
+ * Returns `true` when the supplied YYYY-MM-DD key maps to a `HeatmapDay` with
+ * at least one completion. The Map is shaped by the heatmap response —
+ * absent dates are zero-count rest days.
+ *
+ * @param dataByDate - Per-day heatmap entries from `useHeatmapData()`
+ * @param isoDate - YYYY-MM-DD lookup key
+ * @returns
+ * - `true` if the day exists and has count >= 1, `false` otherwise
+ * @example
+ * hasActivity(map, '2026-05-12')
+ */
+function hasActivity(
+  dataByDate: Map<string, HeatmapDay>,
+  isoDate: string,
+): boolean {
+  const day = dataByDate.get(isoDate)
+  return Boolean(day && day.count > 0)
+}
+
+/**
+ * Calculates current and longest "shown-up" streaks and the current tier
+ * from a heatmap data Map. Pure UTC math via {@link shiftIsoDate} so the
+ * function is DST-safe by construction.
+ *
+ * Grace period: a current streak is preserved when the most recent activity
+ * is *yesterday* (e.g. user hasn't done their first task of today yet). When
+ * the most recent activity is older than yesterday, `currentStreak` is 0.
+ *
+ * Tier logic: returns the highest of {@link STREAK_TIERS} that
+ * `currentStreak` has crossed. Pair the return with a localStorage
+ * "max-ever-notified" key so milestones never re-fire after a break (per
+ * DESIGN.md D12 "additive, never decreases").
+ *
+ * The longest-streak scan walks every key in the Map, not just a window, so
+ * it is correct for arbitrary heatmap response sizes (default 365 days).
+ *
+ * @param dataByDate - Per-day heatmap entries keyed by UTC YYYY-MM-DD
+ * @param today - "Today" anchor; production callers pass `new Date()`
+ * @returns
+ * - `StreakSummary` with `currentStreak`, `longestStreak`, `currentTier`,
+ *   `shownUpThisMonth`
+ * @example
+ * calcStreak(new Map(), new Date('2026-05-12Z'))
+ * // => { currentStreak: 0, longestStreak: 0, currentTier: null, shownUpThisMonth: 0 }
+ * @example
+ * // dataByDate has 8 consecutive days ending today
+ * calcStreak(dataByDate, new Date('2026-05-12Z'))
+ * // => { currentStreak: 8, longestStreak: 8, currentTier: 7, ... }
+ */
+export function calcStreak(
+  dataByDate: Map<string, HeatmapDay>,
+  today: Date,
+): StreakSummary {
+  const todayIso = isoDateOf(today)
+  const yesterdayIso = shiftIsoDate(todayIso, -1)
+
+  // Anchor the backward walk on whichever of (today, yesterday) is the most
+  // recent day with activity. If neither has activity, current streak is 0.
+  // This is the "grace period" — finishing your first task by end-of-day
+  // tomorrow still preserves the streak.
+  let anchorIso: string | null = null
+  if (hasActivity(dataByDate, todayIso)) {
+    anchorIso = todayIso
+  } else if (hasActivity(dataByDate, yesterdayIso)) {
+    anchorIso = yesterdayIso
+  }
+
+  let currentStreak = 0
+  if (anchorIso) {
+    currentStreak = 1
+    let cursor = shiftIsoDate(anchorIso, -1)
+    while (hasActivity(dataByDate, cursor)) {
+      currentStreak++
+      cursor = shiftIsoDate(cursor, -1)
+    }
+  }
+
+  // Longest streak: collect all active dates, sort, single pass counting
+  // consecutive UTC days. Using ISO strings as the comparison key keeps this
+  // independent of `Date` parsing edge cases.
+  const activeDates = Array.from(dataByDate.keys())
+    .filter((isoDate) => hasActivity(dataByDate, isoDate))
+    .sort()
+
+  let longestStreak = 0
+  let runLength = 0
+  let previousIso: string | null = null
+  for (const isoDate of activeDates) {
+    if (previousIso && shiftIsoDate(previousIso, 1) === isoDate) {
+      runLength++
+    } else {
+      runLength = 1
+    }
+    if (runLength > longestStreak) longestStreak = runLength
+    previousIso = isoDate
+  }
+  // The in-progress current streak can extend past the latest archived day
+  // (e.g. yesterday-grace anchor) so make sure `longestStreak` reflects it.
+  if (currentStreak > longestStreak) longestStreak = currentStreak
+
+  const currentTier = computeTier(currentStreak)
+
+  // "Shown up N days this month": distinct UTC dates with activity inside
+  // today's calendar month. Pure count, never a delta — copy stays additive
+  // even mid-month per DESIGN.md voice.
+  const monthPrefix = todayIso.slice(0, 7) // YYYY-MM
+  let shownUpThisMonth = 0
+  for (const isoDate of activeDates) {
+    if (isoDate.startsWith(monthPrefix)) shownUpThisMonth++
+  }
+
+  return { currentStreak, longestStreak, currentTier, shownUpThisMonth }
+}
+
+/**
+ * Highest tier from {@link STREAK_TIERS} that the supplied streak crosses,
+ * or `null` when the streak is below the first tier (7).
+ *
+ * @param streak - Non-negative integer day count
+ * @returns
+ * - `365` | `100` | `30` | `7` when crossed, else `null`
+ * @example
+ * computeTier(0)   // => null
+ * computeTier(6)   // => null
+ * computeTier(7)   // => 7
+ * computeTier(35)  // => 30
+ * computeTier(400) // => 365
+ */
+function computeTier(streak: number): StreakTier {
+  for (const tier of STREAK_TIERS) {
+    if (streak >= tier) return tier
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Heatmap Cathedral PR-B — implements DESIGN.md §3.3-3.4 (Streak Tier
Notifications + Memory Lane Sunday Digest).

- **Streak milestones** — Electron notification fires once when the user
  crosses Day 7 / 30 / 100 / 365 of showing up. localStorage-keyed dedupe
  (`corelive.streak-max-tier-notified`) is monotonic by tier, so a broken
  streak does *not* re-fire a previously celebrated tier (DESIGN.md D12:
  additive, never decreases without explanation).
- **Memory Lane Sunday digest** — quiet card on the home page that
  appears only on local Sunday, summarises the last 7 days (total + the
  brightest day + top categories), and persists a per-week dismiss via
  `corelive.sunday-digest-dismissed.<local-Sunday-ISO>`. Zero-week
  fallback: "the room was quiet this week — that is fine too."

### Files

- `src/lib/calc-streak.ts` + tests — TZ-safe streak / tier calculator
  using `shiftIsoDate` (24 unit tests covering grace period, gaps,
  longest-preserved, leap day, DST spring-forward, all four tier
  transitions)
- `src/hooks/useStreakNotifications.ts` + tests — Electron-only one-shot
  notification hook (12 unit tests covering web no-op, loading gate,
  persister-restoring gate, sub-tier suppression, dedupe, corrupted /
  spurious storage values)
- `src/app/(main)/home/_components/SundayDigestCard.tsx` + tests —
  Sunday-only digest card (10 unit tests covering non-Sunday hide,
  zero-week fallback, brightest-day rendering, singular "1 thing",
  per-week dismiss persistence)
- `src/app/(main)/home/_components/TodoList.tsx` — wires both consumers
  to the existing `useHeatmapData()` query so no extra fetch is created
  (React Query dedupes the underlying request with ContributionGraph)

### Voice (DESIGN.md §Voice)

- "Day 7 of showing up. / the cathedral remembers."
- "Day 30 — a month of light. / the room is filling in, one quiet day at
  a time."
- "Day 100 — steady hands. / something gets built when you keep showing
  up."
- "A year of showing up. / this is yours now."
- "{N} things made it onto the wall." / "the room was quiet this week —
  that is fine too."

### Pre-PR review

Ran 3-way adversarial check (specialized agent `modern-react-pro` +
`codex-rescue` + Claude Code advisor). All findings applied in commit
`676b37a`:

1. **Blocker fix** — `SundayDigestCard`: `today = now ?? new Date()`
   was creating a new Date every render and busting `useMemo`. Wrapped
   in `useMemo` so identity is stable.
2. **Major fix** — `SundayDigestCard`: aggregation anchor was `today`
   (UTC), but visibility was local Sunday — for JST users at Sunday
   06:00 the UTC day is still Saturday, so the digest showed wrong
   data. Now anchored on UTC midnight of the local Sunday ISO so the
   data window matches the visibility window.
3. **Major fix** — `useStreakNotifications`: gated effect on
   `useIsRestoring()` so a stale TanStack persister snapshot cannot
   latch a wrong tier permanently before live data arrives.
4. **Minor fix** — `useStreakNotifications.readStoredTier`: now
   validates against `STREAK_TIERS` so a tampered / spurious
   `"5000"` cannot block every real future milestone.
5. **Nit fix** — voice: "best day" → "brightest day", spelled-out
   `"6 things"` (DESIGN.md bans KPI / ranking framing).

### Deferred (documented, not fixed in this PR)

- 365-day window edge case in `calcStreak`: when the heatmap query
  returns a window shorter than 365 days, `longestStreak` is bounded
  by that window. This is fine for tier semantics (the only thing
  consumed) but could surface as a stat in a future PR — track with
  `src/hooks/useHeatmapData.ts` window expansion if/when needed.

## Test plan

- [x] `pnpm validate` (test + lint + build + typecheck) — green (172
      unit tests, all PR-B suites included)
- [x] 3-way adversarial review applied
- [ ] CodeRabbit review (auto-runs on PR open)
- [ ] Manual smoke on the home page in `pnpm dev`:
  - Heatmap still renders, no regression on weekly summary
  - On a Sunday (test by mocking `now`) the digest card appears below
    WeeklySummaryCard with correct copy
  - Dismiss button hides the card and the dismissal sticks on reload
- [ ] Manual smoke in Electron build: a 7-day streak fires the macOS
      banner exactly once; second mount does not re-fire

🤖 PR-B of the Heatmap Cathedral 3-PR split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sunday Digest Card: weekly Sunday recap card showing quiet/summary messaging, brightest day, and top categories; dismissible per-week.
  * Streak Milestone Notifications: desktop notifications for 7/30/100/365-day streaks with per-account dedupe and persistence.

* **Tests**
  * Added comprehensive tests for streak calculations, milestone notification behavior, and Sunday digest rendering and dismissal persistence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/39)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->