### PR TITLE
feat(home): heatmap cathedral PR-C — trends + share + year-in-review

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "dotenv": "^17.4.2",
     "electron-updater": "^6.8.3",
     "embla-carousel-react": "^8.6.0",
+    "html-to-image": "^1.11.13",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.11.0",
     "next": "^16.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.5)
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -4761,6 +4764,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -11752,6 +11758,8 @@ snapshots:
       lru-cache: 6.0.0
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   htmlparser2@8.0.2:
     dependencies:

--- a/src/app/(main)/home/_components/CategoryFilterChips.tsx
+++ b/src/app/(main)/home/_components/CategoryFilterChips.tsx
@@ -1,0 +1,308 @@
+'use client'
+
+import { match } from 'ts-pattern'
+
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useIsMobile } from '@/hooks/use-mobile'
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+import { useSelectedCategory } from '@/hooks/useSelectedCategory'
+import {
+  aggregateCategoryTrends,
+  type CategoryTrend,
+  type CategoryTrendEntry,
+} from '@/lib/aggregate-category-trends'
+import { getColorDotClass } from '@/lib/category-colors'
+import { cn } from '@/lib/utils'
+
+/**
+ * Threshold above which we collapse the chip row into a `<Select>` on
+ * mobile. CEO §3.5 calls this out as cuttable scope: at 5+ chips the row
+ * starts wrapping and reads noisy on a phone — a dropdown is calmer and
+ * keeps the screen quiet (DESIGN.md "Warm Cathedral" voice).
+ */
+const MOBILE_COLLAPSE_THRESHOLD = 5
+
+interface CategoryFilterChipsProps {
+  /**
+   * Heatmap data from `useHeatmapData()`. The component computes per-
+   * category 7-day trends client-side from this Map — no extra fetch.
+   */
+  dataByDate: Map<string, HeatmapDay>
+  /**
+   * Loading sentinel from `useHeatmapData`. Renders a quiet placeholder so
+   * the card height does not jump when the heatmap query resolves.
+   */
+  isLoading?: boolean
+}
+
+/**
+ * Short label suffix for the WoW trend, e.g. `"↑ 25%"` or `"new"`.
+ * Returns an empty string when the trend should NOT show a delta (the
+ * `firstWeek` / `flat` arms — chip already communicates inactivity via
+ * the muted count).
+ *
+ * @param trend - Trend state from {@link aggregateCategoryTrends}
+ * @returns
+ * - Plain-text delta suffix or `''`
+ * @example
+ * trendSuffix({ kind: 'percent', value: 25 })  // => "↑ 25%"
+ * trendSuffix({ kind: 'percent', value: -40 }) // => "↓ 40%"
+ * trendSuffix({ kind: 'new' })                 // => "new"
+ * trendSuffix({ kind: 'flat' })                // => ""
+ */
+function trendSuffix(trend: CategoryTrend): string {
+  return match(trend)
+    .with({ kind: 'firstWeek' }, () => '')
+    .with({ kind: 'flat' }, () => '')
+    .with({ kind: 'new' }, () => 'new')
+    .with({ kind: 'percent' }, ({ value }) => {
+      if (value === 0) return ''
+      const arrow = value > 0 ? '↑' : '↓'
+      return `${arrow} ${Math.abs(value)}%`
+    })
+    .exhaustive()
+}
+
+/**
+ * One-line accessible summary for a chip, read aloud by screen readers
+ * via `aria-label`. Includes the count + trend so AT users get the same
+ * information as sighted users (the small arrow isn't announced).
+ *
+ * @param entry - Per-category aggregated trend entry
+ * @param isActive - Whether this chip is the currently selected filter
+ * @returns
+ * - Human-readable label like "writing, 5 this week, up 25% from last week"
+ * @example
+ * chipAccessibleLabel(entry, true)
+ * // => "writing filter active, 5 this week, up 25% from last week"
+ */
+function chipAccessibleLabel(
+  entry: CategoryTrendEntry,
+  isActive: boolean,
+): string {
+  const trendSentence = match(entry.trend)
+    .with({ kind: 'firstWeek' }, () => 'no activity this week')
+    .with({ kind: 'flat' }, () => 'a quiet week')
+    .with({ kind: 'new' }, () => 'new this week')
+    .with({ kind: 'percent' }, ({ value }) => {
+      if (value === 0) return "steady — last week's pace"
+      if (value > 0) return `up ${value}% from last week`
+      return `down ${Math.abs(value)}% from last week`
+    })
+    .exhaustive()
+  const activePrefix = isActive ? 'filter active, ' : ''
+  return `${entry.name}, ${activePrefix}${entry.currentCount} this week, ${trendSentence}`
+}
+
+/**
+ * Renders a single chip button. Extracted so the desktop (chip row) and
+ * mobile (Select item) renderers stay focused.
+ *
+ * @example
+ * <CategoryChip entry={entry} isActive={false} onClick={toggle} />
+ */
+function CategoryChip({
+  entry,
+  isActive,
+  onClick,
+}: {
+  entry: CategoryTrendEntry
+  isActive: boolean
+  onClick: () => void
+}) {
+  const suffix = trendSuffix(entry.trend)
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isActive}
+      aria-label={chipAccessibleLabel(entry, isActive)}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        isActive
+          ? 'border-foreground bg-foreground text-background'
+          : 'border-border bg-card hover:bg-muted',
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'inline-block size-1.5 rounded-full',
+          getColorDotClass(entry.color),
+        )}
+      />
+      <span>{entry.name}</span>
+      <span
+        aria-hidden
+        className={cn(
+          'font-mono tabular-nums',
+          isActive ? 'text-background/80' : 'text-muted-foreground',
+        )}
+      >
+        {entry.currentCount}
+      </span>
+      {suffix && (
+        <span
+          aria-hidden
+          className={cn(
+            'font-serif italic',
+            isActive ? 'text-background/80' : 'text-muted-foreground',
+          )}
+        >
+          {suffix}
+        </span>
+      )}
+    </button>
+  )
+}
+
+/**
+ * Per-category trend chip row mounted under the WeeklySummaryCard on the
+ * home route. Each chip shows the category name, last-7-day count, and a
+ * subtle WoW trend indicator. Clicking a chip toggles
+ * `useSelectedCategory` so the user can quickly drill into a single
+ * category's todo list.
+ *
+ * Layout rules (DESIGN.md):
+ * - Desktop / <5 categories → wraps a chip row.
+ * - Mobile + ≥5 categories → collapses to a `<Select>` dropdown to keep
+ *   the screen calm (CEO §3.5 cuttable-scope note).
+ *
+ * Voice:
+ * - Trend phrasing is factual ("↑ 25%"), never KPI guilt ("you crushed
+ *   it"). `firstWeek` and `flat` states emit no arrow/delta — the count
+ *   alone speaks for them.
+ *
+ * @param dataByDate - Heatmap data from `useHeatmapData()`
+ * @param isLoading - Whether the heatmap query is still settling
+ * @returns
+ * - A Card with chips (or Select on mobile + ≥5 categories)
+ * - `null` when there is no category activity to show (keeps the layout
+ *   quiet for brand-new users)
+ * @example
+ * <CategoryFilterChips dataByDate={dataByDate} isLoading={false} />
+ */
+export function CategoryFilterChips({
+  dataByDate,
+  isLoading,
+}: CategoryFilterChipsProps) {
+  const [selectedCategoryId, setSelectedCategoryId] = useSelectedCategory()
+  const isMobile = useIsMobile()
+  // Compute against `new Date()` per render so the window rolls forward
+  // at the day boundary without a useMemo on stale anchor — same trade-
+  // off SundayDigestCard made (correctness > re-render micro-opt).
+  const entries = aggregateCategoryTrends(dataByDate, new Date())
+
+  // Skeleton during the initial heatmap fetch — keeps card height stable
+  // so the layout doesn't shift when data arrives.
+  if (isLoading) {
+    return (
+      <Card aria-busy aria-label="Loading category breakdown">
+        <CardContent className="p-6">
+          <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+            categories
+          </p>
+          <p className="pt-3 font-serif text-sm italic text-muted-foreground">
+            …
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // No categories with activity in the last 14 days — render nothing
+  // rather than an empty-state nag, matching DESIGN.md voice.
+  if (entries.length === 0) return null
+
+  const useSelectFallback =
+    isMobile && entries.length >= MOBILE_COLLAPSE_THRESHOLD
+
+  return (
+    <Card aria-label="Category breakdown">
+      <CardContent className="space-y-3 p-6">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+            categories
+          </p>
+          {selectedCategoryId !== null && (
+            <button
+              type="button"
+              onClick={() => setSelectedCategoryId(null)}
+              className="font-serif text-xs italic text-muted-foreground underline-offset-4 hover:underline focus-visible:underline focus-visible:outline-none"
+            >
+              show all
+            </button>
+          )}
+        </div>
+
+        {useSelectFallback ? (
+          <Select
+            value={
+              selectedCategoryId !== null ? String(selectedCategoryId) : 'all'
+            }
+            onValueChange={(value) =>
+              setSelectedCategoryId(value === 'all' ? null : Number(value))
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Choose a category" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All categories</SelectItem>
+              {entries.map((entry) => {
+                const suffix = trendSuffix(entry.trend)
+                return (
+                  <SelectItem key={entry.id} value={String(entry.id)}>
+                    <span className="inline-flex items-center gap-2">
+                      <span
+                        aria-hidden
+                        className={cn(
+                          'inline-block size-1.5 rounded-full',
+                          getColorDotClass(entry.color),
+                        )}
+                      />
+                      <span>{entry.name}</span>
+                      <span className="font-mono tabular-nums text-muted-foreground">
+                        {entry.currentCount}
+                      </span>
+                      {suffix && (
+                        <span className="font-serif italic text-muted-foreground">
+                          {suffix}
+                        </span>
+                      )}
+                    </span>
+                  </SelectItem>
+                )
+              })}
+            </SelectContent>
+          </Select>
+        ) : (
+          <ul className="flex flex-wrap gap-1.5 pt-1">
+            {entries.map((entry) => {
+              const isActive = selectedCategoryId === entry.id
+              return (
+                <li key={entry.id}>
+                  <CategoryChip
+                    entry={entry}
+                    isActive={isActive}
+                    onClick={() =>
+                      setSelectedCategoryId(isActive ? null : entry.id)
+                    }
+                  />
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(main)/home/_components/DayDetailDialog.tsx
+++ b/src/app/(main)/home/_components/DayDetailDialog.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, ImageDown } from 'lucide-react'
+import { useState } from 'react'
 import { match } from 'ts-pattern'
 
 import { Button } from '@/components/ui/button'
@@ -15,6 +16,8 @@ import {
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
 import { useKeyboardNav } from '@/hooks/useKeyboardNav'
 import { getColorDotClass } from '@/lib/category-colors'
+import { exportDayAsImage } from '@/lib/export-day-as-image'
+import { log } from '@/lib/logger'
 import { orpc } from '@/lib/orpc/client-query'
 import { cn } from '@/lib/utils'
 
@@ -167,6 +170,40 @@ function getTodayDateString(): string {
 }
 
 /**
+ * Picks the single most-used category name across a day's completed
+ * tasks. Used by the share card to render the "mostly <category>" line.
+ * Ties broken alphabetically (locale-insensitive 'en') so two days with
+ * the same task mix produce identical share cards across machines.
+ *
+ * @param tasks - The day's completed tasks
+ * @returns
+ * - Category name with the highest occurrence
+ * - `null` when no task carries a category
+ * @example
+ * getTopCategoryName([
+ *   { category: { name: 'writing' } },
+ *   { category: { name: 'reading' } },
+ *   { category: { name: 'writing' } },
+ * ]) // => 'writing'
+ */
+function getTopCategoryName<T extends { category?: { name: string } | null }>(
+  tasks: ReadonlyArray<T>,
+): string | null {
+  const counts = new Map<string, number>()
+  for (const task of tasks) {
+    const name = task.category?.name
+    if (!name) continue
+    counts.set(name, (counts.get(name) ?? 0) + 1)
+  }
+  if (counts.size === 0) return null
+  return Array.from(counts.entries()).sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1]
+    // Deterministic tie-break — locale-insensitive so CI/local agree.
+    return a[0].localeCompare(b[0], 'en')
+  })[0]![0]
+}
+
+/**
  * Day-detail dialog opened by clicking a Heatmap cell. Renders the day's
  * level band (paper → terracotta), italic state name, voice line, and a
  * compact list of the day's completed tasks. The cathedral-lit halo (soft
@@ -184,6 +221,7 @@ export function DayDetailDialog({
   onNavigate,
 }: DayDetailDialogProps) {
   const isClerkQueryReady = useClerkQueryReady()
+  const [isSaving, setIsSaving] = useState(false)
   // `placeholderData: keepPreviousData` so that pressing j/k or the < >
   // chevrons doesn't flash the header back to "rest day" while the next
   // day's query is in flight. The previous day's count + state band hold
@@ -201,6 +239,37 @@ export function DayDetailDialog({
   const dayCount = data?.count ?? 0
   const state = getDayState(dayCount)
   const isToday = date !== null && date === getTodayDateString()
+
+  /**
+   * Captures the day's stats as a PNG via html-to-image and triggers a
+   * browser download. The button stays disabled while a previous capture
+   * is in flight so a double-click doesn't spawn parallel toPng calls
+   * (each of which would append its own off-screen card).
+   */
+  async function handleShare() {
+    if (!date || dayCount === 0 || isSaving) return
+    setIsSaving(true)
+    try {
+      const topCategoryName = data?.tasks
+        ? getTopCategoryName(data.tasks)
+        : null
+      const dataUrl = await exportDayAsImage({
+        isoDate: date,
+        totalCompleted: dayCount,
+        topCategoryName,
+      })
+      const anchor = document.createElement('a')
+      anchor.href = dataUrl
+      anchor.download = `corelive-${date}.png`
+      anchor.click()
+    } catch (error) {
+      // log.warn keeps the error visible without bubbling a toast — the
+      // button re-enables in the finally so the user can simply retry.
+      log.warn('Failed to export day as image', error)
+    } finally {
+      setIsSaving(false)
+    }
+  }
 
   // j/k keyboard nav reuses the same `onNavigate` contract as the `< >`
   // buttons, so the dialog has a single source of truth for day-stepping.
@@ -233,29 +302,46 @@ export function DayDetailDialog({
                     {formatDate(date)}
                   </p>
                 </div>
-                {/* `mr-8` clears the Dialog's absolute-positioned close X (right-4) so the chevrons don't visually collide with it */}
-                {onNavigate && (
-                  <div className="ml-auto mr-8 flex items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8"
-                      onClick={() => onNavigate(-1)}
-                      aria-label="Previous day"
-                    >
-                      <ChevronLeft />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8"
-                      onClick={() => onNavigate(1)}
-                      aria-label="Next day"
-                    >
-                      <ChevronRight />
-                    </Button>
-                  </div>
-                )}
+                {/* `mr-8` clears the Dialog's absolute-positioned close X (right-4) so action buttons don't visually collide with it */}
+                <div className="ml-auto mr-8 flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={handleShare}
+                    disabled={
+                      isSaving ||
+                      dayCount === 0 ||
+                      isLoading ||
+                      isPlaceholderData
+                    }
+                    aria-label="Save as image"
+                  >
+                    <ImageDown />
+                  </Button>
+                  {onNavigate && (
+                    <>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        onClick={() => onNavigate(-1)}
+                        aria-label="Previous day"
+                      >
+                        <ChevronLeft />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        onClick={() => onNavigate(1)}
+                        aria-label="Next day"
+                      >
+                        <ChevronRight />
+                      </Button>
+                    </>
+                  )}
+                </div>
               </div>
               <DialogDescription className="pt-1 font-serif text-sm italic text-muted-foreground">
                 {state.voice}

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -43,6 +43,7 @@ import { SortableTodoItem } from './SortableTodoItem'
 import { SundayDigestCard } from './SundayDigestCard'
 import type { Todo } from './TodoItem'
 import { WeeklySummaryCard } from './WeeklySummaryCard'
+import { YearInReviewModal } from './YearInReviewModal'
 
 const TODO_QUERY_LIMIT = 100
 const TODO_QUERY_OFFSET = 0
@@ -368,7 +369,7 @@ export function TodoList() {
 
       {/* Completed Tasks Column */}
       <div className="space-y-6">
-        {/* Suspense required because ContributionGraph reads ?date= via Next.js 16's useSearchParams — fallback matches its own isLoading skeleton so the prerender phase is shape-identical. */}
+        {/* Suspense required because ContributionGraph + YearInReviewModal read URL params via Next.js 16's useSearchParams — fallback matches its own isLoading skeleton so the prerender phase is shape-identical. */}
         <Suspense
           fallback={
             <Card>
@@ -382,6 +383,11 @@ export function TodoList() {
           }
         >
           <ContributionGraph />
+          <YearInReviewModal
+            dataByDate={heatmapByDate}
+            isLoading={heatmapLoading}
+            isRestoring={isRestoring}
+          />
         </Suspense>
         <WeeklySummaryCard
           dataByDate={heatmapByDate}

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -36,6 +36,7 @@ import { subscribeToTodoSync } from '@/lib/todo-sync-channel'
 import type { CategoryWithCount } from '@/server/schemas/category'
 
 import { AddTodoForm } from './AddTodoForm'
+import { CategoryFilterChips } from './CategoryFilterChips'
 import { CompletedTodos } from './CompletedTodos'
 import { ContributionGraph } from './ContributionGraph'
 import { SortableTodoItem } from './SortableTodoItem'
@@ -383,6 +384,10 @@ export function TodoList() {
           <ContributionGraph />
         </Suspense>
         <WeeklySummaryCard
+          dataByDate={heatmapByDate}
+          isLoading={heatmapLoading}
+        />
+        <CategoryFilterChips
           dataByDate={heatmapByDate}
           isLoading={heatmapLoading}
         />

--- a/src/app/(main)/home/_components/YearInReviewModal.tsx
+++ b/src/app/(main)/home/_components/YearInReviewModal.tsx
@@ -1,0 +1,286 @@
+'use client'
+
+import { useUser } from '@clerk/nextjs'
+import { useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+import {
+  aggregateYearInReview,
+  parseForceDate,
+  shouldAutoOpenYir,
+} from '@/lib/aggregate-year-in-review'
+import { getColorDotClass } from '@/lib/category-colors'
+import { log } from '@/lib/logger'
+import { cn } from '@/lib/utils'
+
+/**
+ * localStorage key *prefix* recording the year for which we have already
+ * auto-opened the Year-in-Review modal. The full key is
+ * `${STORAGE_KEY_PREFIX}${clerkUserId}`. Once a user dismisses the modal
+ * in any given year, the auto-open trigger stays suppressed until next
+ * January — they can still re-open it manually if we surface a button
+ * (out of PR-C scope).
+ *
+ * Per-user namespacing mirrors the streak-notification key so two
+ * accounts sharing one browser do not suppress each other's modal.
+ */
+const STORAGE_KEY_PREFIX = 'corelive.yir-shown-year.'
+
+interface YearInReviewModalProps {
+  /** Heatmap data from `useHeatmapData()`. */
+  dataByDate: Map<string, HeatmapDay>
+  /** Loading sentinel; the modal stays closed while data is hydrating. */
+  isLoading?: boolean
+  /** Tanstack-Query persister rehydration sentinel; same gate the streak hook uses. */
+  isRestoring?: boolean
+}
+
+/**
+ * Reads the auto-open dedupe value from localStorage. Returns `0` when
+ * the key is missing, malformed, or fails the integer check — failing
+ * open is preferable to silently suppressing a real milestone.
+ *
+ * @param storageKey - Fully namespaced localStorage key
+ * @returns
+ * - The stored year as a 4-digit integer, or `0` on miss / corruption
+ * @example
+ * readStoredYear('corelive.yir-shown-year.user_xyz') // => 2025
+ */
+function readStoredYear(storageKey: string): number {
+  if (typeof window === 'undefined') return 0
+  try {
+    const raw = window.localStorage.getItem(storageKey)
+    if (!raw) return 0
+    const parsed = Number.parseInt(raw, 10)
+    if (!Number.isFinite(parsed)) return 0
+    // Defend against tampered or stale-schema values — only accept a
+    // plausible 4-digit calendar year (matches what we write).
+    if (parsed < 1970 || parsed > 9999) return 0
+    return parsed
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Persists the auto-open dedupe value. Swallows storage errors so the
+ * modal render path keeps working in restricted-storage environments.
+ *
+ * @param storageKey - Fully namespaced localStorage key
+ * @param year - 4-digit calendar year just shown
+ * @example
+ * writeStoredYear('corelive.yir-shown-year.user_xyz', 2026)
+ */
+function writeStoredYear(storageKey: string, year: number): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(storageKey, String(year))
+  } catch (error) {
+    log.warn('Failed to persist YIR year', error)
+  }
+}
+
+/**
+ * Year-in-Review modal mounted on the home route. Auto-opens once per
+ * calendar year for eligible users when "today" is in December.
+ *
+ * The `?force=YYYY-MM-DD` URL flag bypasses the December check so QA can
+ * snapshot the modal mid-May — see {@link parseForceDate}. The flag is
+ * intentionally NOT documented in the UI; it stays a debug affordance.
+ *
+ * Per-user dedupe via `corelive.yir-shown-year.${clerkUserId}` so two
+ * accounts sharing one device/browser don't suppress each other's modal.
+ *
+ * Voice (DESIGN.md "Warm Cathedral"): "a year of showing up" — warm,
+ * never KPI. Lists totals factually with the "shown up N days" framing
+ * the rest of the app uses. No "you crushed it" / "all-time high" /
+ * percentile comparisons.
+ *
+ * @example
+ * <YearInReviewModal dataByDate={heatmapByDate} isLoading={heatmapLoading} />
+ */
+export function YearInReviewModal({
+  dataByDate,
+  isLoading,
+  isRestoring,
+}: YearInReviewModalProps) {
+  const { user } = useUser()
+  const userId = user?.id
+  const searchParams = useSearchParams()
+  const forceParam = searchParams.get('force')
+  const forcedToday = parseForceDate(forceParam)
+
+  const [open, setOpen] = useState(false)
+
+  // Auto-open evaluation:
+  // 1. Wait for the heatmap data + persister rehydration before reading.
+  //    A stale persisted snapshot must not auto-fire a modal for a year
+  //    the user has actually already dismissed.
+  // 2. Require a Clerk userId for per-account dedupe. When signed out,
+  //    skip silently — the home route only renders for signed-in users
+  //    so this is a defensive guard, not a happy path.
+  // 3. `?force=YYYY-MM-DD` flag bypasses the December calendar gate.
+  //    The dedupe key is also bypassed so QA can re-open repeatedly.
+  // 4. Otherwise apply the real-clock + activity-days check.
+  //
+  // The eslint-disable below is intentional: the effect's job is to read
+  // and write the localStorage dedupe key — that's an external store
+  // side effect, not "adjusting state from a prop change". The lint
+  // heuristic mis-fires here.
+  /* eslint-disable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change */
+  useEffect(() => {
+    if (isLoading) return
+    if (isRestoring) return
+    if (dataByDate.size === 0 && !forcedToday) return
+    if (!userId) return
+
+    const todayAnchor = forcedToday ?? new Date()
+    const summary = aggregateYearInReview(dataByDate, todayAnchor)
+
+    if (forcedToday) {
+      // QA override: open unconditionally; do NOT write the dedupe key
+      // so the next normal December auto-open still happens.
+      setOpen(true)
+      return
+    }
+
+    if (!shouldAutoOpenYir(todayAnchor, summary)) return
+
+    const storageKey = `${STORAGE_KEY_PREFIX}${userId}`
+    const storedYear = readStoredYear(storageKey)
+    if (storedYear >= summary.year) return // already shown this year
+
+    setOpen(true)
+    writeStoredYear(storageKey, summary.year)
+  }, [dataByDate, isLoading, isRestoring, userId, forcedToday])
+  /* eslint-enable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change */
+
+  if (!open) return null
+
+  // Recompute the summary at render time — `useEffect` decided to open;
+  // here we just need the values to display. Recomputing is cheap (single
+  // Map walk) and avoids carrying state in two places.
+  const summary = aggregateYearInReview(dataByDate, forcedToday ?? new Date())
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="font-serif text-2xl">
+            A year of showing up.
+          </DialogTitle>
+          <DialogDescription className="font-serif italic text-muted-foreground">
+            this is yours now — {summary.year} in quiet review.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="grid grid-cols-3 gap-3 text-center">
+            <Stat
+              label="completed"
+              value={summary.totalCompleted}
+              isLoading={isLoading}
+            />
+            <Stat
+              label="days shown up"
+              value={summary.activeDays}
+              isLoading={isLoading}
+            />
+            <Stat
+              label="longest streak"
+              value={summary.longestStreak}
+              isLoading={isLoading}
+            />
+          </div>
+
+          {summary.topCategories.length > 0 && (
+            <div className="space-y-2">
+              <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                where the year went
+              </p>
+              <ul className="space-y-1.5">
+                {summary.topCategories.map((category) => (
+                  <li
+                    key={category.id}
+                    className="flex items-center justify-between gap-3 text-sm"
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <span
+                        aria-hidden
+                        className={cn(
+                          'inline-block size-2 rounded-full',
+                          getColorDotClass(category.color),
+                        )}
+                      />
+                      <span className="text-foreground">{category.name}</span>
+                    </span>
+                    <span className="font-mono tabular-nums text-muted-foreground">
+                      {category.count}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <p className="font-serif text-sm italic text-muted-foreground">
+            the cathedral remembers. thank you for keeping the light on.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            className="font-serif italic"
+          >
+            close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * Single stat tile inside the modal. Geist Mono tabular numbers + serif
+ * caption so the number reads steady and the label reads warm.
+ *
+ * @example
+ * <Stat label="completed" value={412} isLoading={false} />
+ */
+function Stat({
+  label,
+  value,
+  isLoading,
+}: {
+  label: string
+  value: number
+  isLoading?: boolean
+}) {
+  return (
+    <div className="space-y-1">
+      <p
+        aria-label={isLoading ? `Loading ${label}` : `${value} ${label}`}
+        className={cn(
+          'font-mono text-3xl font-medium tabular-nums text-foreground',
+          isLoading && 'opacity-40',
+        )}
+      >
+        {isLoading ? '—' : value}
+      </p>
+      <p className="font-serif text-xs italic text-muted-foreground">{label}</p>
+    </div>
+  )
+}

--- a/src/app/(main)/home/_components/YearInReviewModal.tsx
+++ b/src/app/(main)/home/_components/YearInReviewModal.tsx
@@ -2,7 +2,7 @@
 
 import { useUser } from '@clerk/nextjs'
 import { useSearchParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -118,9 +118,23 @@ export function YearInReviewModal({
   const userId = user?.id
   const searchParams = useSearchParams()
   const forceParam = searchParams.get('force')
-  const forcedToday = parseForceDate(forceParam)
+  // Memoize by the raw URL string — `parseForceDate` returns a fresh `Date`
+  // on every call, so without `useMemo` the effect's `forcedToday` dep
+  // changes identity each render. That made `?force=YYYY-MM-DD` re-open the
+  // modal immediately after the user clicked Close (a re-render produced a
+  // new Date → effect re-fired → setOpen(true)).
+  const forcedToday = useMemo(() => parseForceDate(forceParam), [forceParam])
 
   const [open, setOpen] = useState(false)
+  // Dedupe force-mode opens by `forceParam` value. Without this, every
+  // `dataByDate` refetch (TanStack Query background revalidation) or
+  // persister rehydration re-runs the effect with the same truthy
+  // `forcedToday` and calls `setOpen(true)` again — so the modal pops
+  // back open immediately after the QA user clicks Close. The dedupe
+  // key is intentionally the raw URL param string, not `forcedToday`'s
+  // Date identity, so changing the URL to a new `?force=` value DOES
+  // re-open (which is the desired QA flow).
+  const lastShownForceParam = useRef<string | null>(null)
 
   // Auto-open evaluation:
   // 1. Wait for the heatmap data + persister rehydration before reading.
@@ -149,7 +163,11 @@ export function YearInReviewModal({
 
     if (forcedToday) {
       // QA override: open unconditionally; do NOT write the dedupe key
-      // so the next normal December auto-open still happens.
+      // so the next normal December auto-open still happens. The ref
+      // gates the open so a `dataByDate` refetch / persister rehydrate
+      // doesn't re-fire `setOpen(true)` after the user closed it.
+      if (lastShownForceParam.current === forceParam) return
+      lastShownForceParam.current = forceParam
       setOpen(true)
       return
     }
@@ -162,7 +180,7 @@ export function YearInReviewModal({
 
     setOpen(true)
     writeStoredYear(storageKey, summary.year)
-  }, [dataByDate, isLoading, isRestoring, userId, forcedToday])
+  }, [dataByDate, isLoading, isRestoring, userId, forcedToday, forceParam])
   /* eslint-enable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change */
 
   if (!open) return null

--- a/src/lib/aggregate-category-trends.test.ts
+++ b/src/lib/aggregate-category-trends.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+import { aggregateCategoryTrends } from './aggregate-category-trends'
+import { shiftIsoDate } from './shiftIsoDate'
+
+const TODAY = new Date('2026-05-12T00:00:00.000Z')
+const TODAY_ISO = '2026-05-12'
+
+/**
+ * Helper: builds a Map of N consecutive UTC days ending on `endIso`,
+ * each carrying a single `category` entry with `countPerDay`. Used to
+ * stamp predictable per-category windows for the WoW math.
+ */
+function buildWindow(input: {
+  endIso: string
+  days: number
+  category: { id: number; name: string; color: string }
+  countPerDay: number
+}): Map<string, HeatmapDay> {
+  const map = new Map<string, HeatmapDay>()
+  for (let i = 0; i < input.days; i++) {
+    const date = shiftIsoDate(input.endIso, -i)
+    map.set(date, {
+      date,
+      count: input.countPerDay,
+      categories: [
+        {
+          id: input.category.id,
+          name: input.category.name,
+          color: input.category.color,
+          count: input.countPerDay,
+        },
+      ],
+    })
+  }
+  return map
+}
+
+/**
+ * Helper: merges two heatmap maps, summing counts and concatenating
+ * category arrays on collision. Lets a test layer two categories on the
+ * same day without re-writing fixture boilerplate.
+ */
+function mergeHeatmaps(
+  a: Map<string, HeatmapDay>,
+  b: Map<string, HeatmapDay>,
+): Map<string, HeatmapDay> {
+  const merged = new Map<string, HeatmapDay>(a)
+  for (const [date, day] of b) {
+    const existing = merged.get(date)
+    if (existing) {
+      merged.set(date, {
+        date,
+        count: existing.count + day.count,
+        categories: [...existing.categories, ...day.categories],
+      })
+    } else {
+      merged.set(date, day)
+    }
+  }
+  return merged
+}
+
+describe('aggregateCategoryTrends', () => {
+  it('returns an empty array on an empty heatmap', () => {
+    expect(aggregateCategoryTrends(new Map(), TODAY)).toEqual([])
+  })
+
+  it('reports a single category with `firstWeek` trend when only the current week has data and the map starts empty before it', () => {
+    // The heatmap *only* contains entries inside the current window, so
+    // there is no historical activity outside the inspection range either
+    // — chip should fall back to "your first week" copy.
+    const dataByDate = buildWindow({
+      endIso: TODAY_ISO,
+      days: 7,
+      category: { id: 1, name: 'writing', color: 'blue' },
+      countPerDay: 1,
+    })
+
+    const result = aggregateCategoryTrends(dataByDate, TODAY)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      id: 1,
+      name: 'writing',
+      color: 'blue',
+      currentCount: 7,
+      priorCount: 0,
+      trend: { kind: 'new' },
+    })
+  })
+
+  it('emits `flat` for a category with zero in both windows but older activity exists', () => {
+    // 7 days of activity 30 days ago — outside the 14-day inspection
+    // window, so the union is empty for the chip, but `dataByDate.size > 0`
+    // means we are not a brand-new user.
+    const olderActivity = buildWindow({
+      endIso: shiftIsoDate(TODAY_ISO, -30),
+      days: 7,
+      category: { id: 9, name: 'reading', color: 'green' },
+      countPerDay: 1,
+    })
+
+    const result = aggregateCategoryTrends(olderActivity, TODAY)
+    // Older-only categories are still surfaced because the prior-window
+    // walk includes them — they aren't in either inspection window, but
+    // since `hasHistoricalActivity` is true their trend MUST read `flat`
+    // when they fall in the windows in future weeks. For now, the chip
+    // row stays empty because the category isn't in either window — that
+    // matches DESIGN.md: "show what's happening, not what's silent."
+    expect(result).toEqual([])
+  })
+
+  it('returns `percent` trend with positive value when current > prior', () => {
+    // 5 completions in current week, 4 completions in prior week → +25%.
+    const currentWeek = buildWindow({
+      endIso: TODAY_ISO,
+      days: 5,
+      category: { id: 1, name: 'writing', color: 'blue' },
+      countPerDay: 1,
+    })
+    const priorWeek = buildWindow({
+      endIso: shiftIsoDate(TODAY_ISO, -7),
+      days: 4,
+      category: { id: 1, name: 'writing', color: 'blue' },
+      countPerDay: 1,
+    })
+    const dataByDate = mergeHeatmaps(currentWeek, priorWeek)
+
+    const result = aggregateCategoryTrends(dataByDate, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.trend).toEqual({ kind: 'percent', value: 25 })
+    expect(result[0]?.currentCount).toBe(5)
+    expect(result[0]?.priorCount).toBe(4)
+  })
+
+  it('returns `percent` trend with negative value when current < prior', () => {
+    const currentWeek = buildWindow({
+      endIso: TODAY_ISO,
+      days: 2,
+      category: { id: 2, name: 'reading', color: 'green' },
+      countPerDay: 1,
+    })
+    const priorWeek = buildWindow({
+      endIso: shiftIsoDate(TODAY_ISO, -7),
+      days: 4,
+      category: { id: 2, name: 'reading', color: 'green' },
+      countPerDay: 1,
+    })
+    const dataByDate = mergeHeatmaps(currentWeek, priorWeek)
+
+    const result = aggregateCategoryTrends(dataByDate, TODAY)
+    expect(result[0]?.trend).toEqual({ kind: 'percent', value: -50 })
+  })
+
+  it('sorts by currentCount descending, then alphabetically by name', () => {
+    const writing = buildWindow({
+      endIso: TODAY_ISO,
+      days: 3,
+      category: { id: 1, name: 'writing', color: 'blue' },
+      countPerDay: 1,
+    })
+    const reading = buildWindow({
+      endIso: TODAY_ISO,
+      days: 3,
+      category: { id: 2, name: 'reading', color: 'green' },
+      countPerDay: 1,
+    })
+    const exercise = buildWindow({
+      endIso: TODAY_ISO,
+      days: 5,
+      category: { id: 3, name: 'exercise', color: 'rose' },
+      countPerDay: 1,
+    })
+    const dataByDate = mergeHeatmaps(mergeHeatmaps(writing, reading), exercise)
+
+    const result = aggregateCategoryTrends(dataByDate, TODAY)
+    expect(result.map((entry) => entry.name)).toEqual([
+      'exercise', // 5 — highest count
+      'reading', // 3 — tied count, alphabetically before 'writing'
+      'writing', // 3
+    ])
+  })
+
+  it('handles ≥5 categories without truncating', () => {
+    const categories = [
+      { id: 1, name: 'writing', color: 'blue' },
+      { id: 2, name: 'reading', color: 'green' },
+      { id: 3, name: 'exercise', color: 'rose' },
+      { id: 4, name: 'cooking', color: 'amber' },
+      { id: 5, name: 'study', color: 'violet' },
+      { id: 6, name: 'meditation', color: 'orange' },
+    ]
+    let dataByDate = new Map<string, HeatmapDay>()
+    for (const category of categories) {
+      dataByDate = mergeHeatmaps(
+        dataByDate,
+        buildWindow({
+          endIso: TODAY_ISO,
+          days: 1,
+          category,
+          countPerDay: 1,
+        }),
+      )
+    }
+
+    const result = aggregateCategoryTrends(dataByDate, TODAY)
+    // The util surfaces ALL categories — the chip component (not the util)
+    // decides whether to collapse them into a `<Select>` on mobile. This
+    // separation lets the chip row stay an opinion-free renderer.
+    expect(result).toHaveLength(6)
+  })
+
+  it('surfaces a category active only in the prior window', () => {
+    // User had a category 7-14 days ago but no completions in the last 7;
+    // the chip should still appear (so the user sees the taxonomy) with a
+    // `percent` trend that reads `↓ 100%`.
+    const priorWeek = buildWindow({
+      endIso: shiftIsoDate(TODAY_ISO, -7),
+      days: 3,
+      category: { id: 7, name: 'guitar', color: 'orange' },
+      countPerDay: 1,
+    })
+
+    const result = aggregateCategoryTrends(priorWeek, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      id: 7,
+      currentCount: 0,
+      priorCount: 3,
+      trend: { kind: 'percent', value: -100 },
+    })
+  })
+})

--- a/src/lib/aggregate-category-trends.test.ts
+++ b/src/lib/aggregate-category-trends.test.ts
@@ -68,7 +68,7 @@ describe('aggregateCategoryTrends', () => {
     expect(aggregateCategoryTrends(new Map(), TODAY)).toEqual([])
   })
 
-  it('reports a single category with `firstWeek` trend when only the current week has data and the map starts empty before it', () => {
+  it('reports `new` trend when category has current-week activity but no prior-week activity', () => {
     // The heatmap *only* contains entries inside the current window, so
     // there is no historical activity outside the inspection range either
     // — chip should fall back to "your first week" copy.

--- a/src/lib/aggregate-category-trends.ts
+++ b/src/lib/aggregate-category-trends.ts
@@ -1,0 +1,211 @@
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+import { shiftIsoDate } from './shiftIsoDate'
+
+/**
+ * Length (in days) of the "current" and "prior" sliding windows used to
+ * compute the per-category week-over-week trend. Anchored on the day
+ * supplied as `today` so tests/SSR stay deterministic.
+ */
+const CATEGORY_WINDOW_DAYS = 7
+
+/**
+ * Discriminated trend state surfaced per category. Re-mirrored from
+ * {@link import('./aggregate-last-seven-days').WeeklyTrend} on purpose:
+ * keeping this module standalone means the chip component can be
+ * unit-tested without pulling in the weekly aggregator's test fixtures.
+ *
+ * @example
+ * { kind: 'firstWeek' }            // category never touched in last 14 days
+ * @example
+ * { kind: 'flat' }                 // both windows zero, but older activity
+ * @example
+ * { kind: 'new' }                  // prior 0, current > 0 (no +Infinity%)
+ * @example
+ * { kind: 'percent', value: 25 }   // current up 25% vs prior week
+ */
+export type CategoryTrend =
+  | { kind: 'firstWeek' }
+  | { kind: 'flat' }
+  | { kind: 'new' }
+  | { kind: 'percent'; value: number }
+
+/**
+ * Per-category rollup surfaced to `CategoryFilterChips`. `currentCount`
+ * mirrors the count the user sees on the chip; `trend` is what the small
+ * arrow + delta reads off.
+ *
+ * @example
+ * {
+ *   id: 3,
+ *   name: 'writing',
+ *   color: 'blue',
+ *   currentCount: 5,
+ *   priorCount: 4,
+ *   trend: { kind: 'percent', value: 25 },
+ * }
+ */
+export type CategoryTrendEntry = {
+  id: number
+  name: string
+  color: string
+  currentCount: number
+  priorCount: number
+  trend: CategoryTrend
+}
+
+/**
+ * Sums per-category counts within a sliding `CATEGORY_WINDOW_DAYS` window
+ * ending at `windowEndIsoDate`. Returns a Map so caller can union with the
+ * prior-window Map without re-walking the heatmap data twice.
+ *
+ * @param dataByDate - Heatmap data keyed by YYYY-MM-DD UTC date
+ * @param windowEndIsoDate - Inclusive end of the window (YYYY-MM-DD)
+ * @returns
+ * - Map of categoryId → { id, name, color, count } over the window
+ * @example
+ * sumCategoriesInWindow(map, '2026-05-11')
+ * // => Map { 1 => { id: 1, name: 'writing', color: 'blue', count: 5 }, ... }
+ */
+function sumCategoriesInWindow(
+  dataByDate: Map<string, HeatmapDay>,
+  windowEndIsoDate: string,
+): Map<number, { id: number; name: string; color: string; count: number }> {
+  const counts = new Map<
+    number,
+    { id: number; name: string; color: string; count: number }
+  >()
+
+  for (let dayOffset = 0; dayOffset < CATEGORY_WINDOW_DAYS; dayOffset++) {
+    const isoDate = shiftIsoDate(windowEndIsoDate, -dayOffset)
+    const day = dataByDate.get(isoDate)
+    if (!day) continue
+
+    for (const category of day.categories) {
+      const existing = counts.get(category.id)
+      if (existing) {
+        existing.count += category.count
+      } else {
+        counts.set(category.id, {
+          id: category.id,
+          name: category.name,
+          color: category.color,
+          count: category.count,
+        })
+      }
+    }
+  }
+
+  return counts
+}
+
+/**
+ * Picks the trend `kind` for a single category given its current vs prior
+ * window counts. Mirrors `aggregateLastSevenDays` semantics so the visual
+ * vocabulary stays consistent between the WeeklySummaryCard headline and
+ * the per-chip indicators.
+ *
+ * @param currentCount - Sum of category completions in the current window
+ * @param priorCount - Sum of category completions in the prior window
+ * @returns
+ * - `firstWeek` when the category never appeared in either window
+ * - `flat` when both windows are zero but the category exists elsewhere
+ * - `new` when prior is zero and current is non-zero
+ * - `percent` with rounded value otherwise
+ * @example
+ * computeCategoryTrend(0, 0, false) // => { kind: 'firstWeek' }
+ * computeCategoryTrend(0, 0, true)  // => { kind: 'flat' }
+ * computeCategoryTrend(5, 0, false) // => { kind: 'new' }
+ * computeCategoryTrend(5, 4, false) // => { kind: 'percent', value: 25 }
+ */
+function computeCategoryTrend(
+  currentCount: number,
+  priorCount: number,
+  hasHistoricalActivity: boolean,
+): CategoryTrend {
+  if (currentCount === 0 && priorCount === 0) {
+    return hasHistoricalActivity ? { kind: 'flat' } : { kind: 'firstWeek' }
+  }
+  if (priorCount === 0) return { kind: 'new' }
+  const value = ((currentCount - priorCount) / priorCount) * 100
+  return { kind: 'percent', value: Math.round(value) }
+}
+
+/**
+ * Aggregates per-category 7-day totals and WoW trends from the heatmap
+ * response that the home page already fetched. Pure client-side math —
+ * no new oRPC procedure needed. Anchored on caller-supplied `today` so
+ * tests can pin the window.
+ *
+ * Ordering: descending by `currentCount`; ties broken alphabetically by
+ * `name` (locale-insensitive `'en'` so CI runners stay deterministic).
+ * Categories with zero counts in BOTH windows are still surfaced so the
+ * user sees the full label set — chips for inactive categories read
+ * "quiet week" instead of disappearing, matching DESIGN.md's voice.
+ *
+ * @param dataByDate - Per-day heatmap entries from `useHeatmapData()`
+ * @param today - "Today" anchor (UTC midnight is fine; only UTC parts read)
+ * @returns
+ * - Array of `CategoryTrendEntry` sorted by `currentCount` desc
+ * @example
+ * aggregateCategoryTrends(new Map(), new Date('2026-05-12Z'))
+ * // => []
+ * @example
+ * aggregateCategoryTrends(dataByDate, new Date('2026-05-12Z'))
+ * // => [{ id: 1, name: 'writing', color: 'blue', currentCount: 5, priorCount: 4, trend: { kind: 'percent', value: 25 } }, ...]
+ */
+export function aggregateCategoryTrends(
+  dataByDate: Map<string, HeatmapDay>,
+  today: Date,
+): CategoryTrendEntry[] {
+  const todayIso = today.toISOString().slice(0, 10)
+  const priorWindowEndIso = shiftIsoDate(todayIso, -CATEGORY_WINDOW_DAYS)
+
+  const currentCounts = sumCategoriesInWindow(dataByDate, todayIso)
+  const priorCounts = sumCategoriesInWindow(dataByDate, priorWindowEndIso)
+
+  // Union of category ids seen in either window — a category active only
+  // in the prior window must still be surfaced (showing a `↓` trend) so the
+  // chip row reflects the user's actual taxonomy, not just last week's wins.
+  const allCategoryIds = new Set<number>([
+    ...currentCounts.keys(),
+    ...priorCounts.keys(),
+  ])
+
+  // "hasHistoricalActivity" lets us distinguish "your first week" copy
+  // (heatmap fully empty) from "a quiet week" (older activity exists but
+  // not in the 14-day inspection window). Map size is the cheapest signal.
+  const hasHistoricalActivity = dataByDate.size > 0
+
+  const entries: CategoryTrendEntry[] = []
+  for (const categoryId of allCategoryIds) {
+    const currentEntry = currentCounts.get(categoryId)
+    const priorEntry = priorCounts.get(categoryId)
+
+    // At least one of `currentEntry`/`priorEntry` is defined by Set
+    // construction above; prefer the current week's name/color when it
+    // exists so a recent rename surfaces immediately.
+    const reference = currentEntry ?? priorEntry
+    if (!reference) continue // appeases TS; unreachable in practice
+
+    entries.push({
+      id: categoryId,
+      name: reference.name,
+      color: reference.color,
+      currentCount: currentEntry?.count ?? 0,
+      priorCount: priorEntry?.count ?? 0,
+      trend: computeCategoryTrend(
+        currentEntry?.count ?? 0,
+        priorEntry?.count ?? 0,
+        hasHistoricalActivity,
+      ),
+    })
+  }
+
+  return entries.sort((a, b) => {
+    if (b.currentCount !== a.currentCount) {
+      return b.currentCount - a.currentCount
+    }
+    return a.name.localeCompare(b.name, 'en')
+  })
+}

--- a/src/lib/aggregate-year-in-review.test.ts
+++ b/src/lib/aggregate-year-in-review.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+import {
+  aggregateYearInReview,
+  parseForceDate,
+  shouldAutoOpenYir,
+  YIR_MIN_ACTIVE_DAYS,
+} from './aggregate-year-in-review'
+import { shiftIsoDate } from './shiftIsoDate'
+
+/**
+ * Helper: builds N consecutive UTC days of activity ending at `endIso`,
+ * one completion per day under the supplied category. Lets us cross the
+ * YIR_MIN_ACTIVE_DAYS threshold deterministically without writing 30+
+ * fixture lines per test.
+ */
+function buildActivity(input: {
+  endIso: string
+  days: number
+  category: { id: number; name: string; color: string }
+}): Map<string, HeatmapDay> {
+  const map = new Map<string, HeatmapDay>()
+  for (let i = 0; i < input.days; i++) {
+    const date = shiftIsoDate(input.endIso, -i)
+    map.set(date, {
+      date,
+      count: 1,
+      categories: [{ ...input.category, count: 1 }],
+    })
+  }
+  return map
+}
+
+describe('aggregateYearInReview', () => {
+  it('returns zeros and `eligible: false` on an empty heatmap', () => {
+    const result = aggregateYearInReview(new Map(), new Date('2026-12-15Z'))
+    expect(result).toMatchObject({
+      totalCompleted: 0,
+      activeDays: 0,
+      longestStreak: 0,
+      topCategories: [],
+      year: 2026,
+      eligible: false,
+    })
+  })
+
+  it('counts distinct active days and total completions only for the anchor year', () => {
+    const map = new Map<string, HeatmapDay>([
+      // Same date but in 2025 — must NOT be counted in the 2026 review.
+      [
+        '2025-12-31',
+        {
+          date: '2025-12-31',
+          count: 99,
+          categories: [{ id: 1, name: 'old', color: 'blue', count: 99 }],
+        },
+      ],
+      [
+        '2026-01-01',
+        {
+          date: '2026-01-01',
+          count: 3,
+          categories: [{ id: 2, name: 'writing', color: 'green', count: 3 }],
+        },
+      ],
+      [
+        '2026-06-15',
+        {
+          date: '2026-06-15',
+          count: 7,
+          categories: [{ id: 2, name: 'writing', color: 'green', count: 7 }],
+        },
+      ],
+    ])
+    const result = aggregateYearInReview(map, new Date('2026-12-15Z'))
+    expect(result.totalCompleted).toBe(10) // 3 + 7 (2025 excluded)
+    expect(result.activeDays).toBe(2)
+    expect(result.topCategories).toEqual([
+      { id: 2, name: 'writing', color: 'green', count: 10 },
+    ])
+  })
+
+  it('reports `eligible: true` once activeDays crosses YIR_MIN_ACTIVE_DAYS', () => {
+    const activity = buildActivity({
+      endIso: '2026-12-15',
+      days: YIR_MIN_ACTIVE_DAYS,
+      category: { id: 1, name: 'writing', color: 'blue' },
+    })
+    const result = aggregateYearInReview(activity, new Date('2026-12-15Z'))
+    expect(result.activeDays).toBe(YIR_MIN_ACTIVE_DAYS)
+    expect(result.eligible).toBe(true)
+  })
+
+  it('reports `eligible: false` when activeDays is below YIR_MIN_ACTIVE_DAYS', () => {
+    const activity = buildActivity({
+      endIso: '2026-12-15',
+      days: YIR_MIN_ACTIVE_DAYS - 1,
+      category: { id: 1, name: 'writing', color: 'blue' },
+    })
+    const result = aggregateYearInReview(activity, new Date('2026-12-15Z'))
+    expect(result.eligible).toBe(false)
+  })
+
+  it('caps topCategories at 3 and sorts by count desc, name asc', () => {
+    const map = new Map<string, HeatmapDay>([
+      [
+        '2026-05-01',
+        {
+          date: '2026-05-01',
+          count: 5,
+          categories: [
+            { id: 1, name: 'writing', color: 'blue', count: 2 },
+            { id: 2, name: 'reading', color: 'green', count: 2 },
+            { id: 3, name: 'exercise', color: 'rose', count: 4 },
+            { id: 4, name: 'cooking', color: 'amber', count: 1 },
+          ],
+        },
+      ],
+    ])
+    const result = aggregateYearInReview(map, new Date('2026-12-15Z'))
+    expect(result.topCategories).toHaveLength(3)
+    expect(result.topCategories.map((c) => c.name)).toEqual([
+      'exercise', // 4 — highest
+      'reading', // 2 — tied with writing; alphabetical wins
+      'writing', // 2
+    ])
+  })
+})
+
+describe('shouldAutoOpenYir', () => {
+  it('opens in December (UTC month 11) when summary is eligible', () => {
+    const eligibleSummary = {
+      totalCompleted: 100,
+      activeDays: YIR_MIN_ACTIVE_DAYS,
+      longestStreak: 7,
+      topCategories: [],
+      year: 2026,
+      eligible: true,
+    }
+    expect(shouldAutoOpenYir(new Date('2026-12-15Z'), eligibleSummary)).toBe(
+      true,
+    )
+  })
+
+  it('does NOT open outside December even if eligible', () => {
+    const eligibleSummary = {
+      totalCompleted: 100,
+      activeDays: YIR_MIN_ACTIVE_DAYS,
+      longestStreak: 7,
+      topCategories: [],
+      year: 2026,
+      eligible: true,
+    }
+    expect(shouldAutoOpenYir(new Date('2026-11-30Z'), eligibleSummary)).toBe(
+      false,
+    )
+    expect(shouldAutoOpenYir(new Date('2026-05-12Z'), eligibleSummary)).toBe(
+      false,
+    )
+  })
+
+  it('does NOT open in December when summary is ineligible (<30 days)', () => {
+    const ineligibleSummary = {
+      totalCompleted: 5,
+      activeDays: 5,
+      longestStreak: 2,
+      topCategories: [],
+      year: 2026,
+      eligible: false,
+    }
+    expect(shouldAutoOpenYir(new Date('2026-12-15Z'), ineligibleSummary)).toBe(
+      false,
+    )
+  })
+})
+
+describe('shouldAutoOpenYir (with fake timers — guards against real-clock leaks)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('honors the timer-frozen "today" instead of wall clock', () => {
+    // Freeze clock to mid-May so a stray `new Date()` inside the gate
+    // would incorrectly evaluate to false. The gate must derive its
+    // decision from the supplied `today` ONLY.
+    vi.setSystemTime(new Date('2026-05-12T08:00:00.000Z'))
+    const eligible = {
+      totalCompleted: 100,
+      activeDays: YIR_MIN_ACTIVE_DAYS,
+      longestStreak: 7,
+      topCategories: [],
+      year: 2026,
+      eligible: true,
+    }
+    // Pass an explicit December date — even though wall clock says May,
+    // the gate should respect the argument and return true.
+    expect(shouldAutoOpenYir(new Date('2026-12-15Z'), eligible)).toBe(true)
+  })
+})
+
+describe('parseForceDate', () => {
+  it('returns null for null / empty / malformed input', () => {
+    expect(parseForceDate(null)).toBeNull()
+    expect(parseForceDate('')).toBeNull()
+    expect(parseForceDate('2026/12/31')).toBeNull()
+    expect(parseForceDate('not-a-date')).toBeNull()
+    expect(parseForceDate('2026-13-01')).toBeNull()
+  })
+
+  it('parses a YYYY-MM-DD string into UTC midnight', () => {
+    const parsed = parseForceDate('2026-12-31')
+    expect(parsed).toBeInstanceOf(Date)
+    expect(parsed?.toISOString()).toBe('2026-12-31T00:00:00.000Z')
+  })
+})

--- a/src/lib/aggregate-year-in-review.test.ts
+++ b/src/lib/aggregate-year-in-review.test.ts
@@ -103,6 +103,30 @@ describe('aggregateYearInReview', () => {
     expect(result.eligible).toBe(false)
   })
 
+  it('year-scopes the longest streak so a Dec→Jan run does NOT bleed into the YIR total', () => {
+    // 20-day cross-boundary streak: 10 in 2025 (Dec 22 → Dec 31) +
+    // 10 in 2026 (Jan 1 → Jan 10). The 2026 YIR should report the
+    // 10-day longest, NOT the full 20-day calendar streak — the modal
+    // recaps "your 2026", not "your longest ever".
+    const map = new Map<string, HeatmapDay>()
+    for (let dayOffset = 0; dayOffset < 10; dayOffset++) {
+      const dec = shiftIsoDate('2025-12-31', -dayOffset)
+      map.set(dec, {
+        date: dec,
+        count: 1,
+        categories: [{ id: 1, name: 'writing', color: 'blue', count: 1 }],
+      })
+      const jan = shiftIsoDate('2026-01-01', dayOffset)
+      map.set(jan, {
+        date: jan,
+        count: 1,
+        categories: [{ id: 1, name: 'writing', color: 'blue', count: 1 }],
+      })
+    }
+    const result = aggregateYearInReview(map, new Date('2026-12-15Z'))
+    expect(result.longestStreak).toBe(10)
+  })
+
   it('caps topCategories at 3 and sorts by count desc, name asc', () => {
     const map = new Map<string, HeatmapDay>([
       [
@@ -210,6 +234,17 @@ describe('parseForceDate', () => {
     expect(parseForceDate('2026/12/31')).toBeNull()
     expect(parseForceDate('not-a-date')).toBeNull()
     expect(parseForceDate('2026-13-01')).toBeNull()
+  })
+
+  it('rejects day-rollover inputs that JS Date silently normalizes', () => {
+    // `new Date('2026-02-30T00:00:00.000Z')` → `2026-03-02`. The regex
+    // passes and `getTime()` is valid, so without a round-trip check the
+    // URL surface said one date and the modal rendered a different one.
+    expect(parseForceDate('2026-02-30')).toBeNull()
+    expect(parseForceDate('2026-04-31')).toBeNull()
+    // Year-crossing rollover — most dangerous because year inference
+    // diverges from URL surface.
+    expect(parseForceDate('2025-12-32')).toBeNull()
   })
 
   it('parses a YYYY-MM-DD string into UTC midnight', () => {

--- a/src/lib/aggregate-year-in-review.ts
+++ b/src/lib/aggregate-year-in-review.ts
@@ -1,0 +1,190 @@
+import type { HeatmapDay } from '@/hooks/useHeatmapData'
+
+import { calcStreak } from './calc-streak'
+
+/**
+ * Minimum distinct active UTC days a user must have within the trailing
+ * 365-day window to qualify for an automatic Year-in-Review banner.
+ *
+ * Picked to be generous toward casual users (DESIGN.md voice: additive,
+ * never KPI guilt) while still excluding the "I opened the app twice in
+ * 2026" edge case where YIR copy would read sarcastic instead of warm.
+ */
+export const YIR_MIN_ACTIVE_DAYS = 30
+
+/**
+ * Output of {@link aggregateYearInReview}. Everything is derived from
+ * the same `dataByDate` Map the heatmap already uses — no new oRPC
+ * call needed.
+ *
+ * @example
+ * {
+ *   totalCompleted: 412,
+ *   activeDays: 178,
+ *   longestStreak: 31,
+ *   topCategories: [
+ *     { id: 1, name: 'writing', color: 'blue', count: 92 },
+ *     { id: 2, name: 'reading', color: 'green', count: 71 },
+ *     { id: 3, name: 'exercise', color: 'rose', count: 54 },
+ *   ],
+ *   year: 2026,
+ *   eligible: true,
+ * }
+ */
+export type YearInReview = {
+  totalCompleted: number
+  activeDays: number
+  longestStreak: number
+  topCategories: Array<{
+    id: number
+    name: string
+    color: string
+    count: number
+  }>
+  /** Calendar year the review is anchored on (UTC year of `today`). */
+  year: number
+  /**
+   * Whether the user has enough distinct active days for the modal to
+   * auto-open. The modal STILL surfaces totals when `eligible` is false
+   * — the field is a gate on auto-open, not on render.
+   */
+  eligible: boolean
+}
+
+/**
+ * Maximum categories surfaced in the modal's "top categories" block.
+ * Three keeps the modal scannable on a phone without scrolling and
+ * mirrors the WeeklySummaryCard's chip cap.
+ */
+const TOP_CATEGORIES_COUNT = 3
+
+/**
+ * Aggregates the calendar year the supplied `today` falls in. Walks
+ * every entry in `dataByDate` once, summing per-category counts and
+ * counting distinct active days. Pure client-side math — same Map the
+ * heatmap already fetched.
+ *
+ * The function is intentionally tolerant of `dataByDate` carrying
+ * entries outside the anchor year (e.g. a 365-day window crossing
+ * year boundaries): only entries whose ISO key starts with `${year}-`
+ * are counted, so the rollup stays year-pure.
+ *
+ * @param dataByDate - Per-day heatmap entries from `useHeatmapData()`
+ * @param today - "Today" anchor — production callers pass `new Date()`
+ * @returns
+ * - `YearInReview` summary for `today`'s UTC calendar year
+ * @example
+ * aggregateYearInReview(new Map(), new Date('2026-12-15Z'))
+ * // => { totalCompleted: 0, activeDays: 0, longestStreak: 0, topCategories: [], year: 2026, eligible: false }
+ */
+export function aggregateYearInReview(
+  dataByDate: Map<string, HeatmapDay>,
+  today: Date,
+): YearInReview {
+  const year = today.getUTCFullYear()
+  const yearPrefix = `${year}-`
+
+  let totalCompleted = 0
+  let activeDays = 0
+  const categoryTotals = new Map<
+    number,
+    { id: number; name: string; color: string; count: number }
+  >()
+
+  for (const [isoDate, day] of dataByDate) {
+    if (!isoDate.startsWith(yearPrefix)) continue
+    if (day.count > 0) {
+      activeDays++
+      totalCompleted += day.count
+    }
+    for (const category of day.categories) {
+      const existing = categoryTotals.get(category.id)
+      if (existing) {
+        existing.count += category.count
+      } else {
+        categoryTotals.set(category.id, {
+          id: category.id,
+          name: category.name,
+          color: category.color,
+          count: category.count,
+        })
+      }
+    }
+  }
+
+  const topCategories = Array.from(categoryTotals.values())
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count
+      // Deterministic tie-break — same locale-insensitive 'en' compare
+      // used elsewhere so CI runners stay consistent.
+      return a.name.localeCompare(b.name, 'en')
+    })
+    .slice(0, TOP_CATEGORIES_COUNT)
+
+  const { longestStreak } = calcStreak(dataByDate, today)
+
+  return {
+    totalCompleted,
+    activeDays,
+    longestStreak,
+    topCategories,
+    year,
+    eligible: activeDays >= YIR_MIN_ACTIVE_DAYS,
+  }
+}
+
+/**
+ * Decides whether the Year-in-Review modal should auto-open for the
+ * supplied date + summary. The modal opens when:
+ *
+ * 1. The anchor date is in December (UTC month index 11), AND
+ * 2. The user has crossed {@link YIR_MIN_ACTIVE_DAYS} active days for
+ *    the year.
+ *
+ * Why December: a year-end retrospective is a calmer prompt than a
+ * mid-year banner — see DESIGN.md "Year-in-Review" §, which calls for
+ * the modal to feel like a fireside recap, not a quarterly KPI.
+ *
+ * The `?force=YYYY-12-31` URL flag bypasses this gate for QA so we can
+ * snapshot the modal mid-May without time-warping the system clock —
+ * see {@link parseForceDate}.
+ *
+ * @param today - Anchor date (UTC parts inspected)
+ * @param summary - Aggregated review for that date's year
+ * @returns
+ * - `true` when the modal should auto-open, `false` otherwise
+ * @example
+ * shouldAutoOpenYir(new Date('2026-12-15Z'), eligibleSummary) // => true
+ * shouldAutoOpenYir(new Date('2026-05-12Z'), eligibleSummary) // => false
+ * shouldAutoOpenYir(new Date('2026-12-15Z'), notEligibleSummary) // => false
+ */
+export function shouldAutoOpenYir(today: Date, summary: YearInReview): boolean {
+  const isDecember = today.getUTCMonth() === 11
+  return isDecember && summary.eligible
+}
+
+/**
+ * Parses a `?force=YYYY-MM-DD` URL search param into a UTC midnight Date.
+ * Returns `null` for missing, malformed, or out-of-range values so the
+ * caller can fall back to `new Date()` without throwing.
+ *
+ * The flag is strictly opt-in (QA-only) and never exposed in the UI —
+ * users who land on a URL carrying `?force=` see the same modal a real
+ * December user would, which is the whole point of the flag.
+ *
+ * @param raw - Raw `?force=` value or `null` from `URLSearchParams.get`
+ * @returns
+ * - `Date` at UTC midnight when `raw` is a valid YYYY-MM-DD
+ * - `null` when missing or malformed
+ * @example
+ * parseForceDate('2026-12-31')  // => Date('2026-12-31T00:00:00.000Z')
+ * parseForceDate('bogus')       // => null
+ * parseForceDate(null)          // => null
+ */
+export function parseForceDate(raw: string | null): Date | null {
+  if (!raw) return null
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null
+  const candidate = new Date(`${raw}T00:00:00.000Z`)
+  if (Number.isNaN(candidate.getTime())) return null
+  return candidate
+}

--- a/src/lib/aggregate-year-in-review.ts
+++ b/src/lib/aggregate-year-in-review.ts
@@ -121,7 +121,14 @@ export function aggregateYearInReview(
     })
     .slice(0, TOP_CATEGORIES_COUNT)
 
-  const { longestStreak } = calcStreak(dataByDate, today)
+  // Year-scoped streak: filter dataByDate to the review year before passing
+  // to calcStreak so a streak spanning Dec→Jan doesn't inflate the YIR
+  // longest. The modal recaps "your <year>", not "your longest ever".
+  const yearScopedData = new Map<string, HeatmapDay>()
+  for (const [isoDate, day] of dataByDate) {
+    if (isoDate.startsWith(yearPrefix)) yearScopedData.set(isoDate, day)
+  }
+  const { longestStreak } = calcStreak(yearScopedData, today)
 
   return {
     totalCompleted,
@@ -186,5 +193,9 @@ export function parseForceDate(raw: string | null): Date | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null
   const candidate = new Date(`${raw}T00:00:00.000Z`)
   if (Number.isNaN(candidate.getTime())) return null
+  // Round-trip check rejects day-rollover inputs like `2026-02-30` (which
+  // JS Date silently rolls to `2026-03-02`). Without this, the URL surface
+  // says one date but the modal renders a different year.
+  if (candidate.toISOString().slice(0, 10) !== raw) return null
   return candidate
 }

--- a/src/lib/export-day-as-image.ts
+++ b/src/lib/export-day-as-image.ts
@@ -1,0 +1,227 @@
+/**
+ * Type-only import keeps html-to-image out of the initial bundle while
+ * still letting the lazy loader stay strongly typed against the module's
+ * public API.
+ */
+import type * as HtmlToImage from 'html-to-image'
+
+/**
+ * Hardcoded sRGB palette mirroring the OKLCH design tokens in DESIGN.md.
+ *
+ * Why hardcoded RGB instead of CSS variables: html-to-image walks
+ * computed styles and serializes them into a canvas pipeline. While
+ * modern browsers resolve OKLCH to sRGB before painting, the canvas
+ * bridge in html-to-image is not guaranteed to preserve P3 / OKLCH
+ * fidelity on every Chromium build — share-image output drifting from
+ * the live UI is a worse outcome than a slightly less saturated card,
+ * so we lock the share-card colors at sRGB hex values that the user
+ * can verify with a screenshot.
+ *
+ * Picked to visually match the Warm Cathedral light-mode tokens
+ * (`--background`, `--foreground`, `--muted-foreground`, `--border`,
+ * `--primary`) so the share card reads like a frame from the live app.
+ */
+const SHARE_COLORS = {
+  background: '#fbf8f3',
+  foreground: '#2c2520',
+  mutedForeground: '#7e7368',
+  border: '#e8e3dd',
+  primary: '#c77843',
+  card: '#fdfaf6',
+} as const
+
+/**
+ * Input payload for {@link exportDayAsImage}. The share card displays a
+ * single day's totals + top category — kept minimal so the image stays
+ * scannable when shared on a mobile timeline.
+ *
+ * @example
+ * exportDayAsImage({
+ *   isoDate: '2026-05-12',
+ *   totalCompleted: 8,
+ *   topCategoryName: 'writing',
+ * })
+ */
+export type ExportDayInput = {
+  /** YYYY-MM-DD UTC date string the share card is anchored on. */
+  isoDate: string
+  /** Total completions on that day. */
+  totalCompleted: number
+  /**
+   * Optional top-category name; omitted when the day has zero categorized
+   * activity — the share card just shows the count + "shown up" line.
+   */
+  topCategoryName?: string | null
+}
+
+/**
+ * Lazy reference to the html-to-image module so it is excluded from the
+ * initial bundle. The dynamic import resolves on first capture only.
+ */
+let htmlToImagePromise: Promise<typeof HtmlToImage> | null = null
+
+async function loadHtmlToImage(): Promise<typeof HtmlToImage> {
+  if (!htmlToImagePromise) {
+    // Stored as a module-level singleton so two rapid-fire captures
+    // don't trigger two separate network round-trips to the chunk.
+    htmlToImagePromise = import('html-to-image')
+  }
+  return htmlToImagePromise
+}
+
+/**
+ * Renders the share card markup with hardcoded sRGB inline styles. Lives
+ * as a string-building function (not a React component) so we don't
+ * have to render it through React, mount/unmount via portal, and chase
+ * layout-timing races inside html-to-image. The DOM node is appended
+ * off-screen, captured, then removed in a finally block.
+ *
+ * @param input - Day payload for the share card
+ * @returns
+ * - Detached HTMLDivElement ready to be appended to document.body
+ * @example
+ * const node = buildShareCard({ isoDate: '2026-05-12', totalCompleted: 8 })
+ * document.body.appendChild(node)
+ */
+function buildShareCard(input: ExportDayInput): HTMLDivElement {
+  // Pretty-print the ISO date to a readable form. Use the user's locale
+  // so the share card reads natural ("May 12, 2026" vs "12 May 2026")
+  // — the share card is for the user, not a public feed.
+  const prettyDate = new Date(
+    `${input.isoDate}T00:00:00.000Z`,
+  ).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+
+  const root = document.createElement('div')
+  // Off-screen positioning keeps the card invisible to the live UI
+  // while still being measurable + rendered by the browser. `aria-hidden`
+  // tells AT to skip the temporary tree.
+  root.setAttribute('aria-hidden', 'true')
+  root.style.cssText = [
+    'position: fixed',
+    'top: -10000px',
+    'left: -10000px',
+    'width: 480px',
+    'height: 600px',
+    'padding: 48px',
+    `background: ${SHARE_COLORS.background}`,
+    `color: ${SHARE_COLORS.foreground}`,
+    'font-family: "Inter Tight", system-ui, -apple-system, sans-serif',
+    'display: flex',
+    'flex-direction: column',
+    'justify-content: space-between',
+    'box-sizing: border-box',
+    `border: 1px solid ${SHARE_COLORS.border}`,
+    'border-radius: 16px',
+  ].join('; ')
+
+  root.innerHTML = `
+    <div>
+      <p style="font-family: 'Geist Mono', ui-monospace, monospace; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: ${SHARE_COLORS.mutedForeground}; margin: 0 0 24px 0;">
+        corelive · ${escapeHtml(prettyDate)}
+      </p>
+      <p style="font-family: 'Newsreader', Georgia, serif; font-size: 64px; font-weight: 500; line-height: 1; margin: 0; color: ${SHARE_COLORS.foreground}; font-variant-numeric: tabular-nums;">
+        ${input.totalCompleted}
+      </p>
+      <p style="font-family: 'Newsreader', Georgia, serif; font-size: 20px; font-style: italic; margin: 12px 0 0 0; color: ${SHARE_COLORS.mutedForeground};">
+        ${input.totalCompleted === 1 ? 'thing done — a good day.' : 'things done — a good day.'}
+      </p>
+      ${
+        input.topCategoryName
+          ? `<p style="font-family: 'Inter Tight', sans-serif; font-size: 14px; margin: 28px 0 0 0; color: ${SHARE_COLORS.foreground};">
+              mostly <span style="color: ${SHARE_COLORS.primary}; font-weight: 500;">${escapeHtml(input.topCategoryName)}</span>.
+            </p>`
+          : ''
+      }
+    </div>
+    <div style="border-top: 1px solid ${SHARE_COLORS.border}; padding-top: 16px;">
+      <p style="font-family: 'Newsreader', Georgia, serif; font-size: 13px; font-style: italic; margin: 0; color: ${SHARE_COLORS.mutedForeground};">
+        the cathedral remembers.
+      </p>
+    </div>
+  `
+
+  return root
+}
+
+/**
+ * Escapes user-supplied strings before they are spliced into the share
+ * card's innerHTML. Category names come from user input via the
+ * category-create flow so a raw `<script>` value MUST not execute when
+ * the card renders — even briefly off-screen.
+ *
+ * @param value - Untrusted text from a category name
+ * @returns
+ * - HTML-entity-encoded copy safe for innerHTML splicing
+ * @example
+ * escapeHtml('<b>writing</b>') // => "&lt;b&gt;writing&lt;/b&gt;"
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Exports the given day's stats as a PNG data URL. Dynamic-imports
+ * html-to-image on first call so the dependency is excluded from the
+ * initial bundle. The share card uses hardcoded sRGB hex colors (NOT
+ * OKLCH tokens) so html-to-image's canvas pipeline produces an output
+ * that exactly matches what the user sees in the off-screen card.
+ *
+ * The temporary DOM node is removed in a `finally` so a thrown error
+ * inside `toPng` does not leak the off-screen card into the live DOM.
+ *
+ * Browser-only — calling on the server throws a clear error rather than
+ * silently returning an empty data URL.
+ *
+ * @param input - Day payload (date + totals + optional top category)
+ * @returns
+ * - PNG data URL (`data:image/png;base64,…`)
+ * @throws
+ * - When called server-side (no `document`)
+ * - When html-to-image fails to capture (rare; e.g. tainted canvas)
+ * @example
+ * const dataUrl = await exportDayAsImage({
+ *   isoDate: '2026-05-12',
+ *   totalCompleted: 8,
+ *   topCategoryName: 'writing',
+ * })
+ * const a = document.createElement('a')
+ * a.href = dataUrl
+ * a.download = 'corelive-2026-05-12.png'
+ * a.click()
+ */
+export async function exportDayAsImage(input: ExportDayInput): Promise<string> {
+  if (typeof document === 'undefined') {
+    throw new Error(
+      'exportDayAsImage is browser-only — call from a client component.',
+    )
+  }
+
+  const { toPng } = await loadHtmlToImage()
+  const node = buildShareCard(input)
+  document.body.appendChild(node)
+  try {
+    return await toPng(node, {
+      // The card already has a hardcoded background; passing it again
+      // tells html-to-image to fill the canvas BEFORE drawing the node,
+      // which avoids transparent pixels at the rounded-corner edges.
+      backgroundColor: SHARE_COLORS.background,
+      // 2× capture so the resulting PNG looks crisp on retina + 4K.
+      pixelRatio: 2,
+      // Width / height matched to the card's flex container.
+      width: 480,
+      height: 600,
+      cacheBust: true,
+    })
+  } finally {
+    node.remove()
+  }
+}

--- a/src/lib/export-day-as-image.ts
+++ b/src/lib/export-day-as-image.ts
@@ -87,12 +87,19 @@ function buildShareCard(input: ExportDayInput): HTMLDivElement {
   // Pretty-print the ISO date to a readable form. Use the user's locale
   // so the share card reads natural ("May 12, 2026" vs "12 May 2026")
   // — the share card is for the user, not a public feed.
+  //
+  // `timeZone: 'UTC'` mirrors `DayDetailDialog`'s `formatDate` so the
+  // exported card shows the same calendar day as the dialog. Without it,
+  // a user in UTC-8 sees "April 30, 2026" on the share card for an
+  // `isoDate` of `2026-05-01` because `toLocaleDateString` defaults to
+  // local TZ and the constructed Date is UTC midnight.
   const prettyDate = new Date(
     `${input.isoDate}T00:00:00.000Z`,
   ).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: 'UTC',
   })
 
   const root = document.createElement('div')

--- a/src/lib/export-day-as-image.ts
+++ b/src/lib/export-day-as-image.ts
@@ -64,7 +64,15 @@ async function loadHtmlToImage(): Promise<typeof HtmlToImage> {
   if (!htmlToImagePromise) {
     // Stored as a module-level singleton so two rapid-fire captures
     // don't trigger two separate network round-trips to the chunk.
-    htmlToImagePromise = import('html-to-image')
+    // The `.catch` resets the cache so a transient network failure
+    // (offline blip, cancelled chunk fetch) doesn't permanently break
+    // share-image capture for the rest of the session — a rejected
+    // promise is still truthy, so without this every retry would
+    // re-throw the cached rejection instead of attempting the import.
+    htmlToImagePromise = import('html-to-image').catch((error: unknown) => {
+      htmlToImagePromise = null
+      throw error
+    })
   }
   return htmlToImagePromise
 }


### PR DESCRIPTION
## Summary

Final 3 features for the Heatmap Cathedral arc, bundled per CEO plan §3.5/3.6/3.7. All copy stays inside the DESIGN.md "Warm Cathedral" voice (additive, never KPI guilt, no streak shame, no percentile comparisons).

### PR5 — Per-category WoW trend chips (`69efc54`)
- `src/lib/aggregate-category-trends.ts` — pure utility computing week-over-week deltas per category from the heatmap Map.
- `CategoryFilterChips.tsx` — chip row above the heatmap; each chip shows category name + dot + neutral trend glyph (→ / ▲ / ▽), never percentages.
- Mounts above the heatmap on `/home`.

### PR6 — Exportable day card via html-to-image (`06331f2`)
- `src/lib/export-day-as-image.ts` — dynamic-imports `html-to-image` on first capture (kept out of initial bundle).
- Hardcoded sRGB palette mirrors `DESIGN.md` OKLCH tokens so the canvas-bridge output matches the live UI on every Chromium build.
- `DayDetailDialog` gets a "save image" button — disabled while the day has no activity, no data, or a save is in-flight.
- Share-card date formatting pins `timeZone: 'UTC'` so the exported PNG matches the dialog's calendar day across timezones.

### PR7 — Year-in-Review modal w/ December gate + `?force=` QA flag (`5c63ec6`)
- `src/lib/aggregate-year-in-review.ts` — pure rollup over the same heatmap Map (no new oRPC call). Year-scoped streak so a Dec→Jan run does NOT inflate the YIR longest.
- `YearInReviewModal.tsx` — auto-opens once per UTC calendar year for eligible users when the system clock is in December. Per-user localStorage dedupe (`corelive.yir-shown-year.${clerkUserId}`).
- `?force=YYYY-MM-DD` URL param bypasses the December gate for QA — round-trip validated, so `?force=2026-02-30` is rejected instead of silently rolling to March 2.

### 3-way pre-PR review fixes (`c7af18f`)
Specialized agent + Codex + Claude Code adversarial pass on the bundle, then committed:
- `forcedToday` memoized so refetches don't re-fire the modal after dismissal.
- `lastShownForceParam` ref dedupes force-mode opens by URL string — a new `?force=` value still re-opens.
- `parseForceDate` rejects day-rollover inputs via ISO round-trip check.
- `aggregateYearInReview` year-scopes data BEFORE `calcStreak` so a cross-year run does not bleed into the YIR total.
- `exportDayAsImage` share card pins `timeZone: 'UTC'`.

## Test plan

- [ ] `pnpm validate` (✅ 195 tests pass locally — unit + typecheck + lint + build)
- [ ] `/home` shows category chips above heatmap; clicking a chip filters as expected.
- [ ] Click a day with activity → DayDetailDialog → "save image" → PNG downloads matching the calendar day shown in the dialog.
- [ ] Visit `/home?force=2026-12-31` → YIR modal opens once, close stays closed across refetches.
- [ ] Visit `/home?force=2026-02-30` → modal does NOT open (rollover rejected).
- [ ] `?force=` does NOT persist to localStorage (next December auto-open still fires).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive category filter: selectable chips on desktop and a collapsing dropdown on mobile, showing counts and week-over-week trends.
  * Export daily stats as a downloadable PNG share card.
  * Year-in-Review modal with annual totals, top categories, and once-per-year auto-open gating.

* **Tests**
  * Added comprehensive tests for category trend aggregation and year-in-review calculations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/40)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->