### PR TITLE
Migrate dnd-kit to latest React API

### DIFF
--- a/e2e/web/todo-app.spec.ts
+++ b/e2e/web/todo-app.spec.ts
@@ -110,9 +110,9 @@ test.describe('TODO App E2E Tests', () => {
     await expect(page.getByText(todoText)).not.toBeVisible()
   })
 
-  test('should add TODO with notes', async ({ page }) => {
+  test('should add TODO with notes', async ({ page }, testInfo) => {
     // Arrange
-    const todoText = 'Notes feature test todo'
+    const todoText = `Notes feature test todo ${testInfo.retry}-${Date.now()}`
     const todoNotes = 'These are some important notes for this task'
 
     // Act — fill text, expand notes section, fill notes, submit
@@ -125,11 +125,16 @@ test.describe('TODO App E2E Tests', () => {
     await page.getByRole('button', { name: 'Add', exact: true }).click()
 
     // Assert — todo appears and the notes UI is reachable
-    const todoCheckbox = page.getByRole('checkbox', { name: todoText })
+    const todoCheckbox = page.locator(
+      `[role="checkbox"][aria-label="${todoText}"][id^="todo-"]:not([id^="todo--"])`,
+    )
     await expect(todoCheckbox).toBeVisible()
-    const toggleNotesButton = page
-      .getByRole('button', { name: 'Toggle notes' })
-      .first()
+    const todoItem = page.locator('.rounded-lg.border').filter({
+      has: todoCheckbox,
+    })
+    const toggleNotesButton = todoItem.getByRole('button', {
+      name: 'Toggle notes',
+    })
     await expect(toggleNotesButton).toBeVisible()
     await toggleNotesButton.click()
     await page.waitForTimeout(500)

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.7",
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/dom": "^0.4.0",
+    "@dnd-kit/helpers": "^0.4.0",
+    "@dnd-kit/react": "^0.4.0",
     "@hookform/resolvers": "^5.2.2",
     "@laststance/redux-storage-middleware": "^0.3.2",
     "@orpc/client": "^1.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,15 @@ importers:
       '@clerk/nextjs':
         specifier: ^7.2.7
         version: 7.2.7(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.5)
+      '@dnd-kit/dom':
+        specifier: ^0.4.0
+        version: 0.4.0
+      '@dnd-kit/helpers':
+        specifier: ^0.4.0
+        version: 0.4.0
+      '@dnd-kit/react':
+        specifier: ^0.4.0
+        version: 0.4.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.74.0(react@19.2.5))
@@ -630,27 +630,29 @@ packages:
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
 
-  '@dnd-kit/accessibility@3.1.1':
-    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
-    peerDependencies:
-      react: '>=16.8.0'
+  '@dnd-kit/abstract@0.4.0':
+    resolution: {integrity: sha512-loEEJxKT5oLOLeRBJVTO9qpgvvW/Qq902xO20v1JMbpANuN/NLurUdpxIwNpVz+RtOSyzznnbc7lO7psmOhc9A==}
 
-  '@dnd-kit/core@6.3.1':
-    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+  '@dnd-kit/collision@0.4.0':
+    resolution: {integrity: sha512-oOHHUkH1h9Vl2m8TwLw/mPHA7Blf+s0PYcRoLNWNBVxDzugJKZo8WdpU58EMu9qkqyQGrR/YTOozGiMPhlqZ5Q==}
 
-  '@dnd-kit/sortable@10.0.0':
-    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.3.0
-      react: '>=16.8.0'
+  '@dnd-kit/dom@0.4.0':
+    resolution: {integrity: sha512-mJDKt0BtlHXetZyrvZXh6++aycleIbYWH/OVC4nlszDh8NvW7q8dfsxFllR5RtLKLcykLaI4o545Figfks/HZQ==}
 
-  '@dnd-kit/utilities@3.2.2':
-    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+  '@dnd-kit/geometry@0.4.0':
+    resolution: {integrity: sha512-d1n+CU54V/qF/g792bmJK2oR4f5jOL7Pls2IfC+j9f5UBECpjsYbcPZ/krom/z8LgieqvMh1qrUkdcBjJJ7vpg==}
+
+  '@dnd-kit/helpers@0.4.0':
+    resolution: {integrity: sha512-9YOKevD6zOwKVvV4k3fQL//NF+UaN92sfqPpJhT0/7Jq5PLtfD+CTpzmFAjTt5o1qQpFj3xqjWnQl25ooW62wQ==}
+
+  '@dnd-kit/react@0.4.0':
+    resolution: {integrity: sha512-J2/N4CpQf98zJBZhMljDNsc+QR4VtUKU9BRO1+Di4OGaB1qafMC4qZ11xKXOkjw+d7h82FRSXmXCo0c8+VWaWg==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.4.0':
+    resolution: {integrity: sha512-vVdwOY9VsYdMNa7Z0xQhTXlzHqCcCugGuoM1kzvZhnZ0tYVPRdmIhWfeO6Y2ZoN92JwYAyJRRNl4ICkEe2mneg==}
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -1535,6 +1537,9 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@preact/signals-core@1.14.2':
+    resolution: {integrity: sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==}
 
   '@prisma/adapter-pg@7.8.0':
     resolution: {integrity: sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==}
@@ -7340,29 +7345,48 @@ snapshots:
       ajv: 6.15.0
       ajv-keywords: 3.5.2(ajv@6.15.0)
 
-  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+  '@dnd-kit/abstract@0.4.0':
     dependencies:
-      react: 19.2.5
+      '@dnd-kit/geometry': 0.4.0
+      '@dnd-kit/state': 0.4.0
       tslib: 2.8.1
 
-  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@dnd-kit/collision@0.4.0':
     dependencies:
-      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      '@dnd-kit/abstract': 0.4.0
+      '@dnd-kit/geometry': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.4.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.4.0
+      '@dnd-kit/collision': 0.4.0
+      '@dnd-kit/geometry': 0.4.0
+      '@dnd-kit/state': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.4.0':
+    dependencies:
+      '@dnd-kit/state': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/helpers@0.4.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.4.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/abstract': 0.4.0
+      '@dnd-kit/dom': 0.4.0
+      '@dnd-kit/state': 0.4.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
 
-  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@dnd-kit/state@0.4.0':
     dependencies:
-      '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
-      react: 19.2.5
-      tslib: 2.8.1
-
-  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
-    dependencies:
-      react: 19.2.5
+      '@preact/signals-core': 1.14.2
       tslib: 2.8.1
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
@@ -8142,6 +8166,8 @@ snapshots:
       playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@preact/signals-core@1.14.2': {}
 
   '@prisma/adapter-pg@7.8.0':
     dependencies:

--- a/src/app/(main)/home/_components/SortableTodoItem.tsx
+++ b/src/app/(main)/home/_components/SortableTodoItem.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
+import { useSortable } from '@dnd-kit/react/sortable'
 import React from 'react'
 
 import type { Todo } from './TodoItem'
@@ -9,6 +8,7 @@ import { TodoItem } from './TodoItem'
 
 interface SortableTodoItemProps {
   todo: Todo
+  index: number
   onToggleComplete: (id: string) => void
   onDelete: (id: string) => void
   onUpdateNotes?: (id: string, notes: string) => void
@@ -17,37 +17,37 @@ interface SortableTodoItemProps {
 /**
  * Wrapper component that makes TodoItem draggable using dnd-kit.
  * Provides drag handle functionality for reordering todos.
+ * @param todo - Todo item to render and register as sortable.
+ * @param index - Current index within the pending todo list.
+ * @param onToggleComplete - Callback fired when completion changes.
+ * @param onDelete - Callback fired when the item is deleted.
+ * @param onUpdateNotes - Optional callback fired when notes change.
+ * @returns A sortable wrapper around the TodoItem row.
+ * @example
+ * <SortableTodoItem todo={todo} index={0} onToggleComplete={toggle} onDelete={remove} />
  */
 export function SortableTodoItem({
   todo,
+  index,
   onToggleComplete,
   onDelete,
   onUpdateNotes,
 }: SortableTodoItemProps) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: todo.id })
+  const { ref, handleRef, isDragging } = useSortable({ id: todo.id, index })
 
   const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
-    transition,
     opacity: isDragging ? 0.5 : 1,
     zIndex: isDragging ? 1 : 0,
   }
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={ref} style={style}>
       <TodoItem
         todo={todo}
         onToggleComplete={onToggleComplete}
         onDelete={onDelete}
         onUpdateNotes={onUpdateNotes}
-        dragHandleProps={{ ...attributes, ...listeners }}
+        dragHandleRef={handleRef}
         isDragging={isDragging}
       />
     </div>

--- a/src/app/(main)/home/_components/TodoItem.tsx
+++ b/src/app/(main)/home/_components/TodoItem.tsx
@@ -30,19 +30,17 @@ export interface Todo {
 }
 
 /**
- * Props passed from SortableTodoItem for drag handle functionality.
+ * Ref passed from SortableTodoItem for drag handle functionality.
  */
-interface DragHandleProps {
-  [key: string]: unknown
-}
+type DragHandleRef = React.Ref<HTMLButtonElement>
 
 interface TodoItemProps {
   todo: Todo
   onToggleComplete: (id: string) => void
   onDelete: (id: string) => void
   onUpdateNotes?: (id: string, notes: string) => void
-  /** Props from useSortable for drag handle */
-  dragHandleProps?: DragHandleProps
+  /** Ref from useSortable for drag handle */
+  dragHandleRef?: DragHandleRef
   /** Whether item is currently being dragged */
   isDragging?: boolean
 }
@@ -52,7 +50,7 @@ export function TodoItem({
   onToggleComplete,
   onDelete,
   onUpdateNotes,
-  dragHandleProps,
+  dragHandleRef,
   isDragging,
 }: TodoItemProps) {
   const [isNotesOpen, setIsNotesOpen] = useState(false)
@@ -72,12 +70,12 @@ export function TodoItem({
       }`}
     >
       <div className="flex items-center gap-3 p-4">
-        {dragHandleProps && (
+        {dragHandleRef && (
           <button
+            ref={dragHandleRef}
             type="button"
             className="cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
             aria-label="Drag to reorder"
-            {...dragHandleProps}
           >
             <GripVertical className="h-5 w-5" />
           </button>

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -1,19 +1,7 @@
 'use client'
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from '@dnd-kit/core'
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
+import { arrayMove } from '@dnd-kit/helpers'
+import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react'
+import { isSortable } from '@dnd-kit/react/sortable'
 import { useIsRestoring, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Circle } from 'lucide-react'
 import { Suspense, useEffect, useMemo, useState } from 'react'
@@ -31,6 +19,7 @@ import { useHeatmapData } from '@/hooks/useHeatmapData'
 import { useSelectedCategory } from '@/hooks/useSelectedCategory'
 import { useStreakNotifications } from '@/hooks/useStreakNotifications'
 import { useTodoMutations } from '@/hooks/useTodoMutations'
+import { todoSortableSensors } from '@/lib/dnd-kit-sensors'
 import { orpc } from '@/lib/orpc/client-query'
 import { subscribeToTodoSync } from '@/lib/todo-sync-channel'
 import type { CategoryWithCount } from '@/server/schemas/category'
@@ -64,18 +53,6 @@ export function TodoList() {
 
   // Category filter state (persisted to localStorage)
   const [selectedCategoryId] = useSelectedCategory()
-
-  // Configure dnd-kit sensors for pointer and keyboard interactions
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8, // Minimum drag distance before activation
-      },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  )
 
   // Mutations with optimistic updates (pass categoryId for correct cache key)
   const {
@@ -255,18 +232,32 @@ export function TodoList() {
   /**
    * Handles drag end event to reorder todos.
    * Updates local state optimistically and syncs with server.
+   * @param event - Latest dnd-kit drag-end event from DragDropProvider.
+   * @returns
+   * - No return value; invalid drops exit early and valid drops reorder tasks.
+   * @example
+   * handleDragEnd(event)
    */
   const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event
-
-    if (!over || active.id === over.id) {
+    if (event.canceled) {
       return
     }
 
-    const oldIndex = pendingTodos.findIndex((todo) => todo.id === active.id)
-    const newIndex = pendingTodos.findIndex((todo) => todo.id === over.id)
+    const { source } = event.operation
 
-    if (oldIndex === -1 || newIndex === -1) {
+    if (!isSortable(source) || source.initialIndex === source.index) {
+      return
+    }
+
+    const oldIndex = source.initialIndex
+    const newIndex = source.index
+
+    if (
+      oldIndex < 0 ||
+      newIndex < 0 ||
+      oldIndex >= pendingTodos.length ||
+      newIndex >= pendingTodos.length
+    ) {
       return
     }
 
@@ -342,28 +333,23 @@ export function TodoList() {
             </CardContent>
           </Card>
         ) : (
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
+          <DragDropProvider
+            sensors={todoSortableSensors}
             onDragEnd={handleDragEnd}
           >
-            <SortableContext
-              items={pendingTodos.map((todo) => todo.id)}
-              strategy={verticalListSortingStrategy}
-            >
-              <div className="space-y-3">
-                {pendingTodos.map((todo) => (
-                  <SortableTodoItem
-                    key={todo.id}
-                    todo={todo}
-                    onToggleComplete={toggleComplete}
-                    onDelete={deleteTodo}
-                    onUpdateNotes={updateNotes}
-                  />
-                ))}
-              </div>
-            </SortableContext>
-          </DndContext>
+            <div className="space-y-3">
+              {pendingTodos.map((todo, index) => (
+                <SortableTodoItem
+                  key={todo.id}
+                  todo={todo}
+                  index={index}
+                  onToggleComplete={toggleComplete}
+                  onDelete={deleteTodo}
+                  onUpdateNotes={updateNotes}
+                />
+              ))}
+            </div>
+          </DragDropProvider>
         )}
       </div>
 

--- a/src/app/(main)/skill-tree/SkillTreeView.tsx
+++ b/src/app/(main)/skill-tree/SkillTreeView.tsx
@@ -1,22 +1,17 @@
 'use client'
 
 import {
-  DndContext,
+  DragDropProvider,
   DragOverlay,
-  KeyboardSensor,
-  PointerSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
   type DragEndEvent,
   type DragStartEvent,
-  type UniqueIdentifier,
-} from '@dnd-kit/core'
+} from '@dnd-kit/react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo, useOptimistic, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 
 import { SidebarTrigger } from '@/components/ui/sidebar'
+import { skillTreeSensors } from '@/lib/dnd-kit-sensors'
 import { orpc } from '@/lib/orpc/client-query'
 
 import { ConstellationCanvas } from './components/ConstellationCanvas'
@@ -140,37 +135,36 @@ export function SkillTreeView() {
     },
   })
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 6 },
-    }),
-    useSensor(TouchSensor, {
-      activationConstraint: { delay: 250, tolerance: 5 },
-    }),
-    useSensor(KeyboardSensor),
-  )
-
+  /**
+   * Starts the drag overlay when a completed todo card begins dragging.
+   * @param event - Latest dnd-kit drag-start event from DragDropProvider.
+   * @returns
+   * - No return value; non-todo drags are ignored.
+   * @example
+   * handleDragStart(event)
+   */
   function handleDragStart(event: DragStartEvent) {
-    const todoId = parseTodoDragId(event.active.id)
+    const todoId = parseTodoDragId(event.operation.source?.id)
     if (todoId !== null) {
       setActiveDragId(todoId)
     }
   }
 
-  // dnd-kit fires onDragCancel (not onDragEnd) when the user presses Escape
-  // mid-drag. Without this handler, activeDragId would stay set and the drag
-  // overlay would remain rendered until the next successful drop.
-  function handleDragCancel() {
-    setActiveDragId(null)
-  }
-
+  /**
+   * Assigns a completed todo to the skill node that received the drop.
+   * @param event - Latest dnd-kit drag-end event from DragDropProvider.
+   * @returns
+   * - No return value; canceled drags and invalid targets exit early.
+   * @example
+   * handleDragEnd(event)
+   */
   function handleDragEnd(event: DragEndEvent) {
     setActiveDragId(null)
-    const { active, over } = event
-    if (!over) return
+    if (event.canceled) return
 
-    const todoId = parseTodoDragId(active.id)
-    const nodeId = parseNodeDropId(over.id)
+    const { source, target } = event.operation
+    const todoId = parseTodoDragId(source?.id)
+    const nodeId = parseNodeDropId(target?.id)
     if (todoId === null || nodeId === null) return
 
     // Async transition is required for useOptimistic to hold its optimistic
@@ -326,10 +320,9 @@ export function SkillTreeView() {
     : 0
 
   return (
-    <DndContext
-      sensors={sensors}
+    <DragDropProvider
+      sensors={skillTreeSensors}
       onDragStart={handleDragStart}
-      onDragCancel={handleDragCancel}
       onDragEnd={handleDragEnd}
     >
       <div data-skill-tree="true" className="flex h-full w-full flex-col">
@@ -394,7 +387,7 @@ export function SkillTreeView() {
           <DragOverlayCard text={activeTodoText} />
         ) : null}
       </DragOverlay>
-    </DndContext>
+    </DragDropProvider>
   )
 }
 
@@ -402,7 +395,7 @@ export function SkillTreeView() {
  * Parses a draggable DnD id of the form `todo-<number>` into its numeric todo id.
  * Rejects zero and negative ids because Prisma autoincrement ids are always
  * positive integers — guards against `Number('')` coercing `"todo-"` to `0`.
- * @param id - The raw `UniqueIdentifier` from `@dnd-kit/core`.
+ * @param id - The raw id from the latest dnd-kit drag source.
  * @returns
  * - The todo id as a positive integer when the id has the `todo-` prefix
  *   and the suffix is a positive integer.
@@ -415,7 +408,9 @@ export function SkillTreeView() {
  * parseTodoDragId('todo-0')    // => null
  * parseTodoDragId('node-3')    // => null
  */
-function parseTodoDragId(id: UniqueIdentifier): TodoId | null {
+function parseTodoDragId(
+  id: string | number | null | undefined,
+): TodoId | null {
   const s = String(id)
   if (!s.startsWith('todo-')) return null
   const n = Number(s.slice('todo-'.length))
@@ -426,7 +421,7 @@ function parseTodoDragId(id: UniqueIdentifier): TodoId | null {
  * Parses a droppable DnD id of the form `node-<number>` into its numeric node id.
  * Rejects zero and negative ids because Prisma autoincrement ids are always
  * positive integers — guards against `Number('')` coercing `"node-"` to `0`.
- * @param id - The raw `UniqueIdentifier` from `@dnd-kit/core`.
+ * @param id - The raw id from the latest dnd-kit drop target.
  * @returns
  * - The node id as a positive integer when the id has the `node-` prefix
  *   and the suffix is a positive integer.
@@ -438,7 +433,9 @@ function parseTodoDragId(id: UniqueIdentifier): TodoId | null {
  * parseNodeDropId('node-0')    // => null
  * parseNodeDropId('todo-42')   // => null
  */
-function parseNodeDropId(id: UniqueIdentifier): SkillNodeId | null {
+function parseNodeDropId(
+  id: string | number | null | undefined,
+): SkillNodeId | null {
   const s = String(id)
   if (!s.startsWith('node-')) return null
   const n = Number(s.slice('node-'.length))

--- a/src/app/(main)/skill-tree/components/ConstellationCanvas.stories.tsx
+++ b/src/app/(main)/skill-tree/components/ConstellationCanvas.stories.tsx
@@ -1,4 +1,4 @@
-import { DndContext } from '@dnd-kit/core'
+import { DragDropProvider } from '@dnd-kit/react'
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 
 import type {
@@ -19,11 +19,11 @@ const meta: Meta<typeof ConstellationCanvas> = {
   component: ConstellationCanvas,
   decorators: [
     (Story) => (
-      <DndContext>
+      <DragDropProvider>
         <div data-skill-tree="true" style={{ width: '800px', height: '800px' }}>
           <Story />
         </div>
-      </DndContext>
+      </DragDropProvider>
     ),
   ],
 }

--- a/src/app/(main)/skill-tree/components/DragOverlayCard.tsx
+++ b/src/app/(main)/skill-tree/components/DragOverlayCard.tsx
@@ -8,7 +8,7 @@
  * @returns A visually distinct, slightly rotated card with no pointer events.
  *
  * @example
- * import { DragOverlay } from '@dnd-kit/core'
+ * import { DragOverlay } from '@dnd-kit/react'
  *
  * <DragOverlay>
  *   {activeTodo ? <DragOverlayCard text={activeTodo.text} /> : null}

--- a/src/app/(main)/skill-tree/components/SkillNodeCircle.stories.tsx
+++ b/src/app/(main)/skill-tree/components/SkillNodeCircle.stories.tsx
@@ -1,4 +1,4 @@
-import { DndContext } from '@dnd-kit/core'
+import { DragDropProvider } from '@dnd-kit/react'
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 
 import { SkillNodeCircle } from './SkillNodeCircle'
@@ -9,7 +9,7 @@ const meta: Meta<typeof SkillNodeCircle> = {
   component: SkillNodeCircle,
   decorators: [
     (Story) => (
-      <DndContext>
+      <DragDropProvider>
         <div data-skill-tree="true" className="st-canvas-bg p-8">
           <svg viewBox="0 0 100 100" width="200" height="200">
             <defs>
@@ -47,7 +47,7 @@ const meta: Meta<typeof SkillNodeCircle> = {
             <Story />
           </svg>
         </div>
-      </DndContext>
+      </DragDropProvider>
     ),
   ],
 }

--- a/src/app/(main)/skill-tree/components/SkillNodeCircle.tsx
+++ b/src/app/(main)/skill-tree/components/SkillNodeCircle.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useDroppable } from '@dnd-kit/core'
+import { useDroppable } from '@dnd-kit/react'
 import React from 'react'
 import { match } from 'ts-pattern'
 
@@ -45,9 +45,9 @@ export function SkillNodeCircle({
   xp,
   onClick,
 }: SkillNodeCircleProps) {
-  // dnd-kit ID namespace: node-* for SkillNode droppables, todo-* for Todo draggables (Task 14).
-  // Prevents collision since both Prisma models use autoincrement integers.
-  const { setNodeRef, isOver } = useDroppable({ id: `node-${id}` })
+  // dnd-kit ID namespace: node-* for SkillNode droppables, todo-* for Todo draggables.
+  // Prevents collisions because both Prisma models use autoincrement integers.
+  const { ref, isDropTarget } = useDroppable({ id: `node-${id}` })
   const { level, progress, next } = xpToLevel(xp)
 
   const ariaLabel =
@@ -59,8 +59,7 @@ export function SkillNodeCircle({
 
   return (
     <g
-      // @dnd-kit/core types setNodeRef as HTMLElement; SVGGElement is safe at runtime.
-      ref={setNodeRef as unknown as React.Ref<SVGGElement>}
+      ref={ref as React.Ref<SVGGElement>}
       // eslint-disable-next-line dslint/token-only -- skill-tree scoped CSS class from styles.css Task 11
       className="st-node-group"
       role="button"
@@ -230,7 +229,7 @@ export function SkillNodeCircle({
         .exhaustive()}
 
       {/* Hover/selection halo */}
-      {isOver && (
+      {isDropTarget && (
         <circle
           cx={cx}
           cy={cy}

--- a/src/app/(main)/skill-tree/components/TaskPoolCard.test.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolCard.test.tsx
@@ -1,4 +1,4 @@
-import { DndContext } from '@dnd-kit/core'
+import { DragDropProvider } from '@dnd-kit/react'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
@@ -7,7 +7,7 @@ import type { TodoId, TodoText } from '../lib/domain-types'
 import { TaskPoolCard } from './TaskPoolCard'
 
 function wrap(ui: React.ReactNode) {
-  return <DndContext>{ui}</DndContext>
+  return <DragDropProvider>{ui}</DragDropProvider>
 }
 
 /**

--- a/src/app/(main)/skill-tree/components/TaskPoolCard.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolCard.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useDraggable } from '@dnd-kit/core'
-import { CSS } from '@dnd-kit/utilities'
+import { useDraggable } from '@dnd-kit/react'
 
 import type { TodoId, TodoText } from '../lib/domain-types'
 
@@ -10,14 +9,14 @@ import type { TodoId, TodoText } from '../lib/domain-types'
  * Uses `useDraggable` for DnD and renders as a button for a11y.
  *
  * @param props.id - The Prisma Todo ID. Prefixed with `todo-` internally to
- *   avoid collisions with SkillNode droppable IDs in the same DndContext.
+ *   avoid collisions with SkillNode droppable IDs in the same DragDropProvider.
  * @param props.text - The display text of the todo item.
  * @returns A draggable button element that can be dropped onto a SkillNodeCircle.
  *
  * @example
- * <DndContext>
+ * <DragDropProvider>
  *   <TaskPoolCard id={42} text="Fix login bug" />
- * </DndContext>
+ * </DragDropProvider>
  */
 export interface TaskPoolCardProps {
   id: TodoId
@@ -25,29 +24,23 @@ export interface TaskPoolCardProps {
 }
 
 export function TaskPoolCard({ id, text }: TaskPoolCardProps) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } =
-    // @dnd-kit/core maintains a single ID registry across the whole DndContext for both
-    // draggables and droppables. Both Todo.id (here) and SkillNode.id (SkillNodeCircle) are
-    // Prisma autoincrement ints, so without a prefix a Todo id=3 would collide with a
-    // SkillNode id=3. SkillNodeCircle uses `node-${id}` — mirror that with `todo-${id}`.
-    // Task 18 will parse these prefixes off active.id / over.id to extract Prisma IDs.
-    useDraggable({ id: `todo-${id}` })
+  // dnd-kit maintains one ID registry across draggables and droppables.
+  // Prefix Todo ids so they cannot collide with SkillNode ids.
+  const { ref, isDragging } = useDraggable({ id: `todo-${id}` })
 
   const style = {
-    transform: CSS.Translate.toString(transform),
     opacity: isDragging ? 0.4 : 1,
     cursor: isDragging ? 'grabbing' : 'grab',
   }
 
   return (
     <button
-      ref={setNodeRef}
+      ref={ref}
       type="button"
+      tabIndex={0}
       // eslint-disable-next-line dslint/token-only -- skill-tree card dimensions not in design tokens
       className="min-w-[200px] max-w-[260px] rounded-lg border border-[var(--st-border-rune)] bg-[var(--st-surface)] p-3 text-left text-sm text-[var(--st-cream)] shadow-md transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[var(--st-arcane)]"
       style={style}
-      {...listeners}
-      {...attributes}
       aria-label={`Completed task: ${text}. Press space to pick up.`}
     >
       {text}

--- a/src/app/(main)/skill-tree/components/TaskPoolDrawer.stories.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolDrawer.stories.tsx
@@ -1,4 +1,4 @@
-import { DndContext } from '@dnd-kit/core'
+import { DragDropProvider } from '@dnd-kit/react'
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { useState } from 'react'
 
@@ -10,7 +10,7 @@ const meta: Meta<typeof TaskPoolDrawer> = {
   component: TaskPoolDrawer,
   decorators: [
     (Story) => (
-      <DndContext>
+      <DragDropProvider>
         <div
           data-skill-tree="true"
           className="st-canvas-bg"
@@ -18,7 +18,7 @@ const meta: Meta<typeof TaskPoolDrawer> = {
         >
           <Story />
         </div>
-      </DndContext>
+      </DragDropProvider>
     ),
   ],
 }

--- a/src/app/(main)/skill-tree/components/TaskPoolDrawer.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolDrawer.tsx
@@ -42,13 +42,13 @@ export interface TaskPoolDrawerProps {
  * @example
  * const [open, setOpen] = useState(false)
  *
- * <DndContext>
+ * <DragDropProvider>
  *   <TaskPoolDrawer
  *     todos={[{ id: 1, text: 'Fix login bug' }]}
  *     open={open}
  *     onOpenChange={setOpen}
  *   />
- * </DndContext>
+ * </DragDropProvider>
  */
 export function TaskPoolDrawer({
   todos,

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -1,19 +1,6 @@
 'use client'
 
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from '@dnd-kit/core'
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
+import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react'
 import React, { useState, useRef, lazy, Suspense, useCallback } from 'react'
 
 import { useFloatingNavigatorMenuActions } from '@/components/floating-navigator/useFloatingNavigatorMenuActions'
@@ -22,6 +9,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { isFloatingNavigatorEnvironment } from '@/electron/utils/electron-client'
 import { COLOR_DOT_CLASSES } from '@/lib/category-colors'
+import { todoSortableSensors } from '@/lib/dnd-kit-sensors'
 import { log } from '@/lib/logger'
 import { isEnterKeyPress } from '@/lib/utils'
 import type {
@@ -154,31 +142,28 @@ export function FloatingNavigator({
     inputRef,
   })
 
-  // Configure dnd-kit sensors for pointer and keyboard interactions
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8, // Minimum drag distance before activation
-      },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  )
-
   /**
    * Handles drag end event to reorder todos.
    * Calls parent's onTaskReorder callback with active and over IDs.
+   * @param event - Latest dnd-kit drag-end event from DragDropProvider.
+   * @returns
+   * - No return value; invalid drops exit early.
+   * @example
+   * handleDragEnd(event)
    */
   const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event
+    if (event.canceled) {
+      return
+    }
 
-    if (!over || active.id === over.id) {
+    const { source, target } = event.operation
+
+    if (!source || !target || source.id === target.id) {
       return
     }
 
     if (onTaskReorder) {
-      onTaskReorder(active.id as string, over.id as string)
+      onTaskReorder(String(source.id), String(target.id))
     }
   }
 
@@ -492,85 +477,124 @@ export function FloatingNavigator({
             {/* Pending tasks with drag-and-drop reordering */}
             {pendingTodos.length > 0 && (
               <section className="p-2" aria-label="Pending tasks">
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={closestCenter}
+                <DragDropProvider
+                  sensors={todoSortableSensors}
                   onDragEnd={handleDragEnd}
                 >
-                  <SortableContext
-                    items={pendingTodos.map((todo) => todo.id)}
-                    strategy={verticalListSortingStrategy}
+                  <div
+                    className="space-y-1"
+                    role="list"
+                    aria-label={`${pendingTodos.length} pending task${pendingTodos.length !== 1 ? 's' : ''}`}
                   >
-                    <div
-                      className="space-y-1"
-                      role="list"
-                      aria-label={`${pendingTodos.length} pending task${pendingTodos.length !== 1 ? 's' : ''}`}
-                    >
-                      {pendingTodos.map((todo) => (
-                        <SortableFloatingTodoItem key={todo.id} todo={todo}>
-                          {({ dragHandleProps, isDragging }) => (
-                            <div
-                              className={`hover:bg-muted/50 group flex items-center gap-2 rounded p-2 ${isDragging ? 'ring-primary/20 shadow-lg ring-2' : ''}`}
-                              role="listitem"
-                              aria-label={`Task: ${todo.text}, ${todo.completed ? 'completed' : 'pending'}`}
-                              aria-describedby={`task-${todo.id}-actions`}
+                    {pendingTodos.map((todo, index) => (
+                      <SortableFloatingTodoItem
+                        key={todo.id}
+                        todo={todo}
+                        index={index}
+                      >
+                        {({ dragHandleRef, isDragging }) => (
+                          <div
+                            className={`hover:bg-muted/50 group flex items-center gap-2 rounded p-2 ${isDragging ? 'ring-primary/20 shadow-lg ring-2' : ''}`}
+                            role="listitem"
+                            aria-label={`Task: ${todo.text}, ${todo.completed ? 'completed' : 'pending'}`}
+                            aria-describedby={`task-${todo.id}-actions`}
+                          >
+                            {/* Drag handle */}
+                            <button
+                              ref={dragHandleRef}
+                              type="button"
+                              className="cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                              aria-label="Drag to reorder"
                             >
-                              {/* Drag handle */}
-                              <button
-                                type="button"
-                                className="cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
-                                aria-label="Drag to reorder"
-                                {...dragHandleProps}
+                              <Suspense fallback={<IconFallback />}>
+                                <GripVertical
+                                  className="h-3 w-3"
+                                  aria-hidden="true"
+                                />
+                              </Suspense>
+                            </button>
+
+                            <Checkbox
+                              checked={todo.completed}
+                              onCheckedChange={() => handleTaskToggle(todo.id)}
+                              className="h-4 w-4 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                              aria-label={`Mark task "${todo.text}" as ${todo.completed ? 'incomplete' : 'complete'}`}
+                            />
+
+                            {editingId === todo.id ? (
+                              <div
+                                className="flex flex-1 gap-1"
+                                role="group"
+                                aria-label="Edit task"
                               >
-                                <Suspense fallback={<IconFallback />}>
-                                  <GripVertical
-                                    className="h-3 w-3"
-                                    aria-hidden="true"
-                                  />
-                                </Suspense>
-                              </button>
-
-                              <Checkbox
-                                checked={todo.completed}
-                                onCheckedChange={() =>
-                                  handleTaskToggle(todo.id)
-                                }
-                                className="h-4 w-4 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                aria-label={`Mark task "${todo.text}" as ${todo.completed ? 'incomplete' : 'complete'}`}
-                              />
-
-                              {editingId === todo.id ? (
+                                <Input
+                                  ref={editInputRef}
+                                  value={editText}
+                                  onChange={(e) => setEditText(e.target.value)}
+                                  onKeyDown={handleEditKeyPress}
+                                  className="h-6 flex-1 text-xs focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                  aria-label="Edit task title"
+                                  aria-describedby={`edit-help-${todo.id}`}
+                                />
                                 <div
-                                  className="flex flex-1 gap-1"
-                                  role="group"
-                                  aria-label="Edit task"
+                                  id={`edit-help-${todo.id}`}
+                                  className="sr-only"
                                 >
-                                  <Input
-                                    ref={editInputRef}
-                                    value={editText}
-                                    onChange={(e) =>
-                                      setEditText(e.target.value)
-                                    }
-                                    onKeyDown={handleEditKeyPress}
-                                    className="h-6 flex-1 text-xs focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                    aria-label="Edit task title"
-                                    aria-describedby={`edit-help-${todo.id}`}
-                                  />
-                                  <div
-                                    id={`edit-help-${todo.id}`}
-                                    className="sr-only"
-                                  >
-                                    Press Enter to save, Escape to cancel
-                                  </div>
+                                  Press Enter to save, Escape to cancel
+                                </div>
+                                <Button
+                                  size="sm"
+                                  onClick={saveEdit}
+                                  className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                  aria-label="Save changes"
+                                  title="Save (Enter)"
+                                >
+                                  <Suspense fallback={<IconFallback />}>
+                                    <Check
+                                      className="h-3 w-3"
+                                      aria-hidden="true"
+                                    />
+                                  </Suspense>
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={cancelEdit}
+                                  className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                  aria-label="Cancel editing"
+                                  title="Cancel (Escape)"
+                                >
+                                  <Suspense fallback={<IconFallback />}>
+                                    <X className="h-3 w-3" aria-hidden="true" />
+                                  </Suspense>
+                                </Button>
+                              </div>
+                            ) : (
+                              <>
+                                <button
+                                  className="flex-1 cursor-pointer overflow-scroll rounded px-1 text-left text-base focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                  onClick={() => startEditing(todo)}
+                                  title={`${todo.text} - Click to edit`}
+                                  aria-label={`Edit task: ${todo.text}`}
+                                >
+                                  {todo.text}
+                                </button>
+                                <div
+                                  id={`task-${todo.id}-actions`}
+                                  className="flex gap-1 opacity-0 focus-within:opacity-100 group-hover:opacity-100"
+                                  role="group"
+                                  aria-label="Task actions"
+                                >
                                   <Button
                                     size="sm"
-                                    onClick={saveEdit}
+                                    variant="ghost"
+                                    onClick={() => startEditing(todo)}
                                     className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                    aria-label="Save changes"
-                                    title="Save (Enter)"
+                                    aria-label={`Edit task: ${todo.text}`}
+                                    title="Edit task (Enter)"
                                   >
                                     <Suspense fallback={<IconFallback />}>
-                                      <Check
+                                      <Edit2
                                         className="h-3 w-3"
                                         aria-hidden="true"
                                       />
@@ -579,75 +603,27 @@ export function FloatingNavigator({
                                   <Button
                                     size="sm"
                                     variant="ghost"
-                                    onClick={cancelEdit}
-                                    className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                    aria-label="Cancel editing"
-                                    title="Cancel (Escape)"
+                                    onClick={() => handleTaskDelete(todo.id)}
+                                    className="h-6 w-6 p-0 text-destructive hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                    aria-label={`Delete task: ${todo.text}`}
+                                    title="Delete task (Delete)"
                                   >
                                     <Suspense fallback={<IconFallback />}>
-                                      <X
+                                      <Trash2
                                         className="h-3 w-3"
                                         aria-hidden="true"
                                       />
                                     </Suspense>
                                   </Button>
                                 </div>
-                              ) : (
-                                <>
-                                  <button
-                                    className="flex-1 cursor-pointer overflow-scroll rounded px-1 text-left text-base focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                    onClick={() => startEditing(todo)}
-                                    title={`${todo.text} - Click to edit`}
-                                    aria-label={`Edit task: ${todo.text}`}
-                                  >
-                                    {todo.text}
-                                  </button>
-                                  <div
-                                    id={`task-${todo.id}-actions`}
-                                    className="flex gap-1 opacity-0 focus-within:opacity-100 group-hover:opacity-100"
-                                    role="group"
-                                    aria-label="Task actions"
-                                  >
-                                    <Button
-                                      size="sm"
-                                      variant="ghost"
-                                      onClick={() => startEditing(todo)}
-                                      className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                      aria-label={`Edit task: ${todo.text}`}
-                                      title="Edit task (Enter)"
-                                    >
-                                      <Suspense fallback={<IconFallback />}>
-                                        <Edit2
-                                          className="h-3 w-3"
-                                          aria-hidden="true"
-                                        />
-                                      </Suspense>
-                                    </Button>
-                                    <Button
-                                      size="sm"
-                                      variant="ghost"
-                                      onClick={() => handleTaskDelete(todo.id)}
-                                      className="h-6 w-6 p-0 text-destructive hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                      aria-label={`Delete task: ${todo.text}`}
-                                      title="Delete task (Delete)"
-                                    >
-                                      <Suspense fallback={<IconFallback />}>
-                                        <Trash2
-                                          className="h-3 w-3"
-                                          aria-hidden="true"
-                                        />
-                                      </Suspense>
-                                    </Button>
-                                  </div>
-                                </>
-                              )}
-                            </div>
-                          )}
-                        </SortableFloatingTodoItem>
-                      ))}
-                    </div>
-                  </SortableContext>
-                </DndContext>
+                              </>
+                            )}
+                          </div>
+                        )}
+                      </SortableFloatingTodoItem>
+                    ))}
+                  </div>
+                </DragDropProvider>
               </section>
             )}
 

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react'
+import { isSortable } from '@dnd-kit/react/sortable'
 import React, { useState, useRef, lazy, Suspense, useCallback } from 'react'
 
 import { useFloatingNavigatorMenuActions } from '@/components/floating-navigator/useFloatingNavigatorMenuActions'
@@ -125,6 +126,7 @@ export function FloatingNavigator({
   // Separate todos by completion status
   const pendingTodos = todos.filter((todo) => !todo.completed)
   const completedTodos = todos.filter((todo) => todo.completed)
+  const canReorderTasks = onTaskReorder !== undefined
 
   const startEditing = useCallback((todo: FloatingTodo) => {
     setEditingId(todo.id)
@@ -152,18 +154,20 @@ export function FloatingNavigator({
    * handleDragEnd(event)
    */
   const handleDragEnd = (event: DragEndEvent) => {
-    if (event.canceled) {
+    if (!canReorderTasks || event.canceled) {
       return
     }
 
-    const { source, target } = event.operation
+    const { source } = event.operation
 
-    if (!source || !target || source.id === target.id) {
+    if (!isSortable(source) || source.initialIndex === source.index) {
       return
     }
 
-    if (onTaskReorder) {
-      onTaskReorder(String(source.id), String(target.id))
+    const destinationTodo = pendingTodos[source.index]
+
+    if (destinationTodo) {
+      onTaskReorder?.(String(source.id), destinationTodo.id)
     }
   }
 
@@ -269,6 +273,151 @@ export function FloatingNavigator({
       onTaskDelete(id)
     }
   }
+
+  /**
+   * Renders one pending task row for both sortable and static list modes.
+   * @param todo - Pending task to render.
+   * @param isDragging - Whether the latest dnd-kit sortable hook marks it active.
+   * @param dragHandleRef - Optional drag handle ref when reordering is enabled.
+   * @returns A pending task row with optional drag affordance.
+   * @example
+   * renderPendingTodoRow(todo, true, dragHandleRef)
+   */
+  const renderPendingTodoRow = (
+    todo: FloatingTodo,
+    isDragging = false,
+    dragHandleRef?: React.Ref<HTMLButtonElement>,
+  ) => (
+    <div
+      key={todo.id}
+      className={`hover:bg-muted/50 group flex items-center gap-2 rounded p-2 ${isDragging ? 'ring-primary/20 shadow-lg ring-2' : ''}`}
+      role="listitem"
+      aria-label={`Task: ${todo.text}, ${todo.completed ? 'completed' : 'pending'}`}
+      aria-describedby={`task-${todo.id}-actions`}
+    >
+      {dragHandleRef && (
+        <button
+          ref={dragHandleRef}
+          type="button"
+          className="cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
+          aria-label="Drag to reorder"
+        >
+          <Suspense fallback={<IconFallback />}>
+            <GripVertical className="h-3 w-3" aria-hidden="true" />
+          </Suspense>
+        </button>
+      )}
+
+      <Checkbox
+        checked={todo.completed}
+        onCheckedChange={() => handleTaskToggle(todo.id)}
+        className="h-4 w-4 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        aria-label={`Mark task "${todo.text}" as ${todo.completed ? 'incomplete' : 'complete'}`}
+      />
+
+      {editingId === todo.id ? (
+        <div className="flex flex-1 gap-1" role="group" aria-label="Edit task">
+          <Input
+            ref={editInputRef}
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            onKeyDown={handleEditKeyPress}
+            className="h-6 flex-1 text-xs focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label="Edit task title"
+            aria-describedby={`edit-help-${todo.id}`}
+          />
+          <div id={`edit-help-${todo.id}`} className="sr-only">
+            Press Enter to save, Escape to cancel
+          </div>
+          <Button
+            size="sm"
+            onClick={saveEdit}
+            className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label="Save changes"
+            title="Save (Enter)"
+          >
+            <Suspense fallback={<IconFallback />}>
+              <Check className="h-3 w-3" aria-hidden="true" />
+            </Suspense>
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={cancelEdit}
+            className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label="Cancel editing"
+            title="Cancel (Escape)"
+          >
+            <Suspense fallback={<IconFallback />}>
+              <X className="h-3 w-3" aria-hidden="true" />
+            </Suspense>
+          </Button>
+        </div>
+      ) : (
+        <>
+          <button
+            className="flex-1 cursor-pointer overflow-scroll rounded px-1 text-left text-base focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            onClick={() => startEditing(todo)}
+            title={`${todo.text} - Click to edit`}
+            aria-label={`Edit task: ${todo.text}`}
+          >
+            {todo.text}
+          </button>
+          <div
+            id={`task-${todo.id}-actions`}
+            className="flex gap-1 opacity-0 focus-within:opacity-100 group-hover:opacity-100"
+            role="group"
+            aria-label="Task actions"
+          >
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => startEditing(todo)}
+              className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              aria-label={`Edit task: ${todo.text}`}
+              title="Edit task (Enter)"
+            >
+              <Suspense fallback={<IconFallback />}>
+                <Edit2 className="h-3 w-3" aria-hidden="true" />
+              </Suspense>
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => handleTaskDelete(todo.id)}
+              className="h-6 w-6 p-0 text-destructive hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              aria-label={`Delete task: ${todo.text}`}
+              title="Delete task (Delete)"
+            >
+              <Suspense fallback={<IconFallback />}>
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+              </Suspense>
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+
+  const pendingTaskList = (
+    <div
+      className="space-y-1"
+      role="list"
+      aria-label={`${pendingTodos.length} pending task${pendingTodos.length !== 1 ? 's' : ''}`}
+    >
+      {pendingTodos.map((todo, index) =>
+        canReorderTasks ? (
+          <SortableFloatingTodoItem key={todo.id} todo={todo} index={index}>
+            {({ dragHandleRef, isDragging }) =>
+              renderPendingTodoRow(todo, isDragging, dragHandleRef)
+            }
+          </SortableFloatingTodoItem>
+        ) : (
+          renderPendingTodoRow(todo)
+        ),
+      )}
+    </div>
+  )
 
   return (
     <div
@@ -477,153 +626,16 @@ export function FloatingNavigator({
             {/* Pending tasks with drag-and-drop reordering */}
             {pendingTodos.length > 0 && (
               <section className="p-2" aria-label="Pending tasks">
-                <DragDropProvider
-                  sensors={todoSortableSensors}
-                  onDragEnd={handleDragEnd}
-                >
-                  <div
-                    className="space-y-1"
-                    role="list"
-                    aria-label={`${pendingTodos.length} pending task${pendingTodos.length !== 1 ? 's' : ''}`}
+                {canReorderTasks ? (
+                  <DragDropProvider
+                    sensors={todoSortableSensors}
+                    onDragEnd={handleDragEnd}
                   >
-                    {pendingTodos.map((todo, index) => (
-                      <SortableFloatingTodoItem
-                        key={todo.id}
-                        todo={todo}
-                        index={index}
-                      >
-                        {({ dragHandleRef, isDragging }) => (
-                          <div
-                            className={`hover:bg-muted/50 group flex items-center gap-2 rounded p-2 ${isDragging ? 'ring-primary/20 shadow-lg ring-2' : ''}`}
-                            role="listitem"
-                            aria-label={`Task: ${todo.text}, ${todo.completed ? 'completed' : 'pending'}`}
-                            aria-describedby={`task-${todo.id}-actions`}
-                          >
-                            {/* Drag handle */}
-                            <button
-                              ref={dragHandleRef}
-                              type="button"
-                              className="cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
-                              aria-label="Drag to reorder"
-                            >
-                              <Suspense fallback={<IconFallback />}>
-                                <GripVertical
-                                  className="h-3 w-3"
-                                  aria-hidden="true"
-                                />
-                              </Suspense>
-                            </button>
-
-                            <Checkbox
-                              checked={todo.completed}
-                              onCheckedChange={() => handleTaskToggle(todo.id)}
-                              className="h-4 w-4 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                              aria-label={`Mark task "${todo.text}" as ${todo.completed ? 'incomplete' : 'complete'}`}
-                            />
-
-                            {editingId === todo.id ? (
-                              <div
-                                className="flex flex-1 gap-1"
-                                role="group"
-                                aria-label="Edit task"
-                              >
-                                <Input
-                                  ref={editInputRef}
-                                  value={editText}
-                                  onChange={(e) => setEditText(e.target.value)}
-                                  onKeyDown={handleEditKeyPress}
-                                  className="h-6 flex-1 text-xs focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                  aria-label="Edit task title"
-                                  aria-describedby={`edit-help-${todo.id}`}
-                                />
-                                <div
-                                  id={`edit-help-${todo.id}`}
-                                  className="sr-only"
-                                >
-                                  Press Enter to save, Escape to cancel
-                                </div>
-                                <Button
-                                  size="sm"
-                                  onClick={saveEdit}
-                                  className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                  aria-label="Save changes"
-                                  title="Save (Enter)"
-                                >
-                                  <Suspense fallback={<IconFallback />}>
-                                    <Check
-                                      className="h-3 w-3"
-                                      aria-hidden="true"
-                                    />
-                                  </Suspense>
-                                </Button>
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  onClick={cancelEdit}
-                                  className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                  aria-label="Cancel editing"
-                                  title="Cancel (Escape)"
-                                >
-                                  <Suspense fallback={<IconFallback />}>
-                                    <X className="h-3 w-3" aria-hidden="true" />
-                                  </Suspense>
-                                </Button>
-                              </div>
-                            ) : (
-                              <>
-                                <button
-                                  className="flex-1 cursor-pointer overflow-scroll rounded px-1 text-left text-base focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                  onClick={() => startEditing(todo)}
-                                  title={`${todo.text} - Click to edit`}
-                                  aria-label={`Edit task: ${todo.text}`}
-                                >
-                                  {todo.text}
-                                </button>
-                                <div
-                                  id={`task-${todo.id}-actions`}
-                                  className="flex gap-1 opacity-0 focus-within:opacity-100 group-hover:opacity-100"
-                                  role="group"
-                                  aria-label="Task actions"
-                                >
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    onClick={() => startEditing(todo)}
-                                    className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                    aria-label={`Edit task: ${todo.text}`}
-                                    title="Edit task (Enter)"
-                                  >
-                                    <Suspense fallback={<IconFallback />}>
-                                      <Edit2
-                                        className="h-3 w-3"
-                                        aria-hidden="true"
-                                      />
-                                    </Suspense>
-                                  </Button>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    onClick={() => handleTaskDelete(todo.id)}
-                                    className="h-6 w-6 p-0 text-destructive hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                    aria-label={`Delete task: ${todo.text}`}
-                                    title="Delete task (Delete)"
-                                  >
-                                    <Suspense fallback={<IconFallback />}>
-                                      <Trash2
-                                        className="h-3 w-3"
-                                        aria-hidden="true"
-                                      />
-                                    </Suspense>
-                                  </Button>
-                                </div>
-                              </>
-                            )}
-                          </div>
-                        )}
-                      </SortableFloatingTodoItem>
-                    ))}
-                  </div>
-                </DragDropProvider>
+                    {pendingTaskList}
+                  </DragDropProvider>
+                ) : (
+                  pendingTaskList
+                )}
               </section>
             )}
 

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { arrayMove } from '@dnd-kit/sortable'
+import { arrayMove } from '@dnd-kit/helpers'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import React, { useEffect, useState } from 'react'
 

--- a/src/components/floating-navigator/SortableFloatingTodoItem.tsx
+++ b/src/components/floating-navigator/SortableFloatingTodoItem.tsx
@@ -21,11 +21,11 @@ interface SortableFloatingTodoItemProps {
 
 /**
  * Wrapper component that makes floating navigator todo items draggable using dnd-kit.
- * Uses render props pattern to pass drag handle props to children.
+ * Uses render props pattern to pass drag handle refs to children.
  * @param todo - The todo item to make sortable.
  * @param index - Current index within the pending floating todo list.
- * @param children - Render function receiving dragHandleProps and isDragging state.
- * @returns A draggable wrapper div with transform/transition styles.
+ * @param children - Render function receiving dragHandleRef and isDragging state.
+ * @returns A draggable wrapper div with drag-state opacity and z-index styles.
  * @example
  * <SortableFloatingTodoItem todo={todo} index={0}>
  *   {({ dragHandleRef, isDragging }) => (

--- a/src/components/floating-navigator/SortableFloatingTodoItem.tsx
+++ b/src/components/floating-navigator/SortableFloatingTodoItem.tsx
@@ -1,22 +1,20 @@
 'use client'
 
-import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
+import { useSortable } from '@dnd-kit/react/sortable'
 import React from 'react'
 
 import type { FloatingTodo } from './FloatingNavigator'
 
 /**
- * Props passed to children for drag handle functionality.
+ * Ref passed to children for drag handle functionality.
  */
-interface DragHandleProps {
-  [key: string]: unknown
-}
+type DragHandleRef = React.Ref<HTMLButtonElement>
 
 interface SortableFloatingTodoItemProps {
   todo: FloatingTodo
+  index: number
   children: (props: {
-    dragHandleProps: DragHandleProps
+    dragHandleRef: DragHandleRef
     isDragging: boolean
   }) => React.ReactNode
 }
@@ -25,39 +23,32 @@ interface SortableFloatingTodoItemProps {
  * Wrapper component that makes floating navigator todo items draggable using dnd-kit.
  * Uses render props pattern to pass drag handle props to children.
  * @param todo - The todo item to make sortable.
+ * @param index - Current index within the pending floating todo list.
  * @param children - Render function receiving dragHandleProps and isDragging state.
  * @returns A draggable wrapper div with transform/transition styles.
  * @example
- * <SortableFloatingTodoItem todo={todo}>
- *   {({ dragHandleProps, isDragging }) => (
- *     <TodoRow dragHandleProps={dragHandleProps} isDragging={isDragging} />
+ * <SortableFloatingTodoItem todo={todo} index={0}>
+ *   {({ dragHandleRef, isDragging }) => (
+ *     <TodoRow dragHandleRef={dragHandleRef} isDragging={isDragging} />
  *   )}
  * </SortableFloatingTodoItem>
  */
 export function SortableFloatingTodoItem({
   todo,
+  index,
   children,
 }: SortableFloatingTodoItemProps) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: todo.id })
+  const { ref, handleRef, isDragging } = useSortable({ id: todo.id, index })
 
   const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
-    transition,
     opacity: isDragging ? 0.5 : 1,
     zIndex: isDragging ? 1 : 0,
   }
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={ref} style={style}>
       {children({
-        dragHandleProps: { ...attributes, ...listeners },
+        dragHandleRef: handleRef,
         isDragging,
       })}
     </div>

--- a/src/lib/dnd-kit-sensors.ts
+++ b/src/lib/dnd-kit-sensors.ts
@@ -1,0 +1,84 @@
+import {
+  KeyboardSensor,
+  PointerActivationConstraints,
+  PointerSensor,
+  type Sensors,
+} from '@dnd-kit/dom'
+
+const TODO_SORT_DISTANCE = 8
+const SKILL_TREE_MOUSE_DISTANCE = 6
+const SKILL_TREE_TOUCH_DELAY_MS = 250
+const SKILL_TREE_TOUCH_TOLERANCE = 5
+
+/**
+ * Creates a fresh pointer-distance activation constraint for each drag start.
+ * Reusing one constraint instance would keep internal pointer coordinates
+ * between drags, so this helper is called from the sensor callback.
+ * @param value - Minimum pointer movement before drag activation.
+ * @returns A distance constraint for the latest dnd-kit PointerSensor.
+ * @example
+ * createDistanceConstraint(8)
+ */
+function createDistanceConstraint(value: number) {
+  return new PointerActivationConstraints.Distance({ value })
+}
+
+/**
+ * Creates a fresh touch-delay activation constraint for each drag start.
+ * The skill-tree drawer uses this to preserve the old touch affordance after
+ * migrating from the legacy TouchSensor to the latest PointerSensor.
+ * @param value - Milliseconds to hold before activating the drag.
+ * @param tolerance - Movement allowed before the delayed activation aborts.
+ * @returns A delay constraint for touch pointer interactions.
+ * @example
+ * createDelayConstraint(250, 5)
+ */
+function createDelayConstraint(value: number, tolerance: number) {
+  return new PointerActivationConstraints.Delay({ value, tolerance })
+}
+
+/**
+ * Preserves the todo-list sortable drag threshold from the legacy dnd-kit API.
+ * @returns The shared sensor list consumed by DragDropProvider.
+ * @example
+ * <DragDropProvider sensors={todoSortableSensors} />
+ */
+export const todoSortableSensors: Sensors = [
+  PointerSensor.configure({
+    activationConstraints: () => [createDistanceConstraint(TODO_SORT_DISTANCE)],
+  }),
+  KeyboardSensor,
+]
+
+/**
+ * Builds skill-tree pointer constraints with mouse and touch parity.
+ * @param event - The native pointer event that may start a drag.
+ * @returns Touch delay constraints or mouse distance constraints.
+ * @example
+ * createSkillTreeActivationConstraints(new PointerEvent('pointerdown'))
+ */
+function createSkillTreeActivationConstraints(event: PointerEvent) {
+  if (event.pointerType === 'touch') {
+    return [
+      createDelayConstraint(
+        SKILL_TREE_TOUCH_DELAY_MS,
+        SKILL_TREE_TOUCH_TOLERANCE,
+      ),
+    ]
+  }
+
+  return [createDistanceConstraint(SKILL_TREE_MOUSE_DISTANCE)]
+}
+
+/**
+ * Preserves skill-tree mouse and touch activation behavior on the latest API.
+ * @returns The shared sensor list consumed by DragDropProvider.
+ * @example
+ * <DragDropProvider sensors={skillTreeSensors} />
+ */
+export const skillTreeSensors: Sensors = [
+  PointerSensor.configure({
+    activationConstraints: createSkillTreeActivationConstraints,
+  }),
+  KeyboardSensor,
+]


### PR DESCRIPTION
## Summary
- Replace legacy @dnd-kit/core/sortable/utilities usage with @dnd-kit/react, @dnd-kit/dom, and @dnd-kit/helpers
- Move sortable rows, drag overlay, skill-tree draggables/droppables, stories, and tests onto DragDropProvider/latest hooks
- Preserve previous pointer thresholds with shared latest-API sensor configuration

## Validation
- pnpm validate
- npx kill-port 3011
- pnpm exec playwright test e2e/web/todo-app.spec.ts e2e/web/skill-tree.spec.ts --project=web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved drag handles and reordering UX across lists; drag visuals now focus on opacity/z-index for smoother feedback.
  * Explicit delete button added to the floating task navigator for quicker task removal.

* **Bug Fixes**
  * Fewer accidental reorders via stricter cancel/ bounds handling and improved event parsing.

* **Chores**
  * Migrated drag-and-drop to a consolidated provider and shared sensor configuration; updated stories and tests to match.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/42)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->