### PR TITLE
Enable react-next ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,19 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
 
+import lastStanceReactNextPlugin from '@laststance/react-next-eslint-plugin'
 import { defineConfig } from 'eslint/config'
 import tsPrefixer from 'eslint-config-ts-prefixer'
 import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need-an-effect'
 
 import dslint from './packages/eslint-plugin-dslint/dist/index.js'
+
+// Keep every custom React/Next rule enabled at error level as the plugin grows.
+const lastStanceReactNextRules = Object.fromEntries(
+  Object.keys(lastStanceReactNextPlugin.rules).map((ruleName) => [
+    `@laststance/react-next/${ruleName}`,
+    'error',
+  ]),
+)
 
 export default defineConfig([
   reactYouMightNotNeedAnEffect.configs.recommended,
@@ -26,6 +35,31 @@ export default defineConfig([
     ],
   },
   ...tsPrefixer,
+  {
+    ignores: [
+      '**/*.stories.ts',
+      '**/*.stories.tsx',
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      // Next.js server route shells are not client render targets for React.memo.
+      'src/app/**/page.tsx',
+      '**/src/app/**/page.tsx',
+      // shadcn/ui wrappers are generated primitives; product components consume them.
+      'src/components/ui/**',
+      '**/src/components/ui/**',
+      // Legacy interaction-heavy surfaces need dedicated follow-up refactors.
+      'src/app/(main)/home/_components/**',
+      'src/app/(main)/skill-tree/**',
+      'src/components/auth/**',
+      'src/components/braindump/**',
+      'src/components/electron/**',
+      'src/components/floating-navigator/**',
+    ],
+    plugins: {
+      '@laststance/react-next': lastStanceReactNextPlugin,
+    },
+    rules: lastStanceReactNextRules,
+  },
   {
     rules: {
       'no-console': ['error', { allow: ['warn', 'error'] }],

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "@chromatic-com/storybook": "^5.1.2",
     "@clerk/testing": "^2.0.21",
     "@electron/notarize": "^3.1.1",
+    "@laststance/react-next-eslint-plugin": "^2.2.0",
     "@mdx-js/react": "^3.1.1",
     "@playwright/experimental-ct-react": "^1.59.1",
     "@playwright/test": "^1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       '@electron/notarize':
         specifier: ^3.1.1
         version: 3.1.1
+      '@laststance/react-next-eslint-plugin':
+        specifier: ^2.2.0
+        version: 2.2.0(eslint@10.2.1(jiti@2.6.1))
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
@@ -1347,6 +1350,12 @@ packages:
 
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
+  '@laststance/react-next-eslint-plugin@2.2.0':
+    resolution: {integrity: sha512-x/lMgiwNiS5g4yYfxAQCdih/k/Chs09SWoXXJBuRLHnfQnzb/52uH01iVLq6vZUuMvcy+tq9eDoyq2jQ3n6efw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
 
   '@laststance/redux-storage-middleware@0.3.2':
     resolution: {integrity: sha512-/2iAO3FEyBMiCw0PHmS1VQpAFwgAJXqNRmOH+mmoh2LJ6OjVcJ05fnYVwIzzrY8SGtiNcnpU8oDaHATxnVWMhQ==}
@@ -7929,6 +7938,10 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@kurkle/color@0.3.4': {}
+
+  '@laststance/react-next-eslint-plugin@2.2.0(eslint@10.2.1(jiti@2.6.1))':
+    dependencies:
+      eslint: 10.2.1(jiti@2.6.1)
 
   '@laststance/redux-storage-middleware@0.3.2(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))':
     dependencies:

--- a/src/app/(main)/home/_components/AddTodoForm.tsx
+++ b/src/app/(main)/home/_components/AddTodoForm.tsx
@@ -36,7 +36,10 @@ interface AddTodoFormProps {
   disabled?: boolean
 }
 
-export function AddTodoForm({ onAddTodo, disabled }: AddTodoFormProps) {
+export const AddTodoForm = React.memo(function AddTodoForm({
+  onAddTodo,
+  disabled,
+}: AddTodoFormProps) {
   const [isNotesOpen, setIsNotesOpen] = useState(false)
 
   const form = useForm<TodoFormValues>({
@@ -76,7 +79,10 @@ export function AddTodoForm({ onAddTodo, disabled }: AddTodoFormProps) {
                   </FormItem>
                 )}
               />
-              <Collapsible open={isNotesOpen} onOpenChange={setIsNotesOpen}>
+              <Collapsible
+                open={isNotesOpen}
+                onOpenChange={(open: boolean) => setIsNotesOpen(open)}
+              >
                 <CollapsibleTrigger asChild>
                   <Button
                     type="button"
@@ -106,7 +112,10 @@ export function AddTodoForm({ onAddTodo, disabled }: AddTodoFormProps) {
                 {form.formState.isSubmitting ? 'Adding...' : 'Add'}
               </Button>
             </div>
-            <Collapsible open={isNotesOpen} onOpenChange={setIsNotesOpen}>
+            <Collapsible
+              open={isNotesOpen}
+              onOpenChange={(open: boolean) => setIsNotesOpen(open)}
+            >
               <CollapsibleContent>
                 <FormField
                   control={form.control}
@@ -131,4 +140,4 @@ export function AddTodoForm({ onAddTodo, disabled }: AddTodoFormProps) {
       </CardContent>
     </Card>
   )
-}
+})

--- a/src/app/(main)/home/_components/AddTodoForm.tsx
+++ b/src/app/(main)/home/_components/AddTodoForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Plus, StickyNote, ChevronDown, ChevronRight } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -41,6 +41,9 @@ export const AddTodoForm = React.memo(function AddTodoForm({
   disabled,
 }: AddTodoFormProps) {
   const [isNotesOpen, setIsNotesOpen] = useState(false)
+  const handleNotesOpenChange = useCallback((open: boolean) => {
+    setIsNotesOpen(open)
+  }, [])
 
   const form = useForm<TodoFormValues>({
     resolver: zodResolver(todoFormSchema),
@@ -81,7 +84,7 @@ export const AddTodoForm = React.memo(function AddTodoForm({
               />
               <Collapsible
                 open={isNotesOpen}
-                onOpenChange={(open: boolean) => setIsNotesOpen(open)}
+                onOpenChange={handleNotesOpenChange}
               >
                 <CollapsibleTrigger asChild>
                   <Button
@@ -114,7 +117,7 @@ export const AddTodoForm = React.memo(function AddTodoForm({
             </div>
             <Collapsible
               open={isNotesOpen}
-              onOpenChange={(open: boolean) => setIsNotesOpen(open)}
+              onOpenChange={handleNotesOpenChange}
             >
               <CollapsibleContent>
                 <FormField

--- a/src/app/(main)/home/_components/Category.tsx
+++ b/src/app/(main)/home/_components/Category.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus, Settings } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { memo, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/sidebar'
 import { useCategoryMutations } from '@/hooks/useCategoryMutations'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import {
   useAutoSelectDefaultCategory,
   useSelectedCategory,
@@ -48,7 +49,7 @@ import {
  * @example
  * <Category onOpenManageAction={() => setManageOpen(true)} />
  */
-export function Category({
+export const Category = memo(function Category({
   onOpenManageAction,
 }: {
   onOpenManageAction: () => void
@@ -79,7 +80,7 @@ export function Category({
   )
 
   // Cross-tab sync for categories
-  useEffect(() => {
+  useComponentEffect(() => {
     return subscribeToCategorySync(() => {
       queryClient.invalidateQueries({
         queryKey: orpc.category.list.key(),
@@ -120,7 +121,10 @@ export function Category({
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Categories</SidebarGroupLabel>
-      <Popover open={addOpen} onOpenChange={setAddOpen}>
+      <Popover
+        open={addOpen}
+        onOpenChange={(open: boolean) => setAddOpen(open)}
+      >
         <PopoverTrigger asChild>
           <SidebarGroupAction
             className="text-sidebar-foreground/70 hover:text-sidebar-foreground"
@@ -206,4 +210,4 @@ export function Category({
       </SidebarGroupContent>
     </SidebarGroup>
   )
-}
+})

--- a/src/app/(main)/home/_components/CategoryFilterChips.tsx
+++ b/src/app/(main)/home/_components/CategoryFilterChips.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { memo } from 'react'
 import { match } from 'ts-pattern'
 
 import { Card, CardContent } from '@/components/ui/card'
@@ -108,7 +109,7 @@ function chipAccessibleLabel(
  * @example
  * <CategoryChip entry={entry} isActive={false} onClick={toggle} />
  */
-function CategoryChip({
+const CategoryChip = memo(function CategoryChip({
   entry,
   isActive,
   onClick,
@@ -162,7 +163,7 @@ function CategoryChip({
       )}
     </button>
   )
-}
+})
 
 /**
  * Per-category trend chip row mounted under the WeeklySummaryCard on the
@@ -190,7 +191,7 @@ function CategoryChip({
  * @example
  * <CategoryFilterChips dataByDate={dataByDate} isLoading={false} />
  */
-export function CategoryFilterChips({
+export const CategoryFilterChips = memo(function CategoryFilterChips({
   dataByDate,
   isLoading,
 }: CategoryFilterChipsProps) {
@@ -305,4 +306,4 @@ export function CategoryFilterChips({
       </CardContent>
     </Card>
   )
-}
+})

--- a/src/app/(main)/home/_components/CategoryManageDialog.tsx
+++ b/src/app/(main)/home/_components/CategoryManageDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { Pencil, Trash2, Check, X } from 'lucide-react'
-import { useState } from 'react'
+import { memo, useState } from 'react'
 
 import {
   AlertDialog,
@@ -45,7 +45,7 @@ interface CategoryManageDialogProps {
  * @param open - Whether the dialog is visible
  * @param onOpenChange - Callback to toggle dialog visibility
  */
-export function CategoryManageDialog({
+export const CategoryManageDialog = memo(function CategoryManageDialog({
   open,
   onOpenChange,
 }: CategoryManageDialogProps) {
@@ -275,4 +275,4 @@ export function CategoryManageDialog({
       </AlertDialog>
     </>
   )
-}
+})

--- a/src/app/(main)/home/_components/CompletedTodos.tsx
+++ b/src/app/(main)/home/_components/CompletedTodos.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { CheckCircle2, Trash2 } from 'lucide-react'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 
 import {
   AlertDialog,
@@ -22,6 +22,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { orpc } from '@/lib/orpc/client-query'
 
 import { TodoItem } from './TodoItem'
@@ -39,7 +40,7 @@ interface GroupedTodos {
 
 const ITEMS_PER_PAGE = 10
 
-export function CompletedTodos({
+export const CompletedTodos = React.memo(function CompletedTodos({
   onDelete,
   onClearCompleted,
   onToggleComplete,
@@ -106,7 +107,7 @@ export function CompletedTodos({
   })
 
   // Intersection Observer for infinite scroll
-  useEffect(() => {
+  useComponentEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
@@ -248,7 +249,10 @@ export function CompletedTodos({
         </CardContent>
       </Card>
 
-      <AlertDialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
+      <AlertDialog
+        open={clearDialogOpen}
+        onOpenChange={(open: boolean) => setClearDialogOpen(open)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Clear all completed tasks?</AlertDialogTitle>
@@ -275,4 +279,4 @@ export function CompletedTodos({
       </AlertDialog>
     </>
   )
-}
+})

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -2,7 +2,8 @@
 
 import HeatMap from '@uiw/react-heat-map'
 import { useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import * as React from 'react'
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import { Badge } from '@/components/ui/badge'
@@ -19,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { useHeatmapData } from '@/hooks/useHeatmapData'
 import type { HeatmapDay } from '@/hooks/useHeatmapData'
 import { calcMonthlyMaxDates } from '@/lib/calcMonthlyMaxDates'
@@ -125,7 +127,11 @@ function formatDate(dateStr: string): string {
 /**
  * Tooltip content showing category breakdown for a specific day.
  */
-function CategoryBreakdown({ day }: { day: HeatmapDay }) {
+const CategoryBreakdown = memo(function CategoryBreakdown({
+  day,
+}: {
+  day: HeatmapDay
+}) {
   return (
     <div className="space-y-1">
       <p className="text-xs font-medium">{formatDate(day.date)}</p>
@@ -148,7 +154,7 @@ function CategoryBreakdown({ day }: { day: HeatmapDay }) {
       </p>
     </div>
   )
-}
+})
 
 /**
  * GitHub-style contribution heatmap showing completed task activity.
@@ -158,7 +164,7 @@ function CategoryBreakdown({ day }: { day: HeatmapDay }) {
  * @example
  * <ContributionGraph />
  */
-export function ContributionGraph() {
+export const ContributionGraph = memo(function ContributionGraph() {
   const { heatmapValues, dataByDate, total, isLoading } = useHeatmapData()
   const containerRef = useRef<HTMLDivElement>(null)
   const containerWidth = useObservedElementWidth(containerRef)
@@ -171,7 +177,7 @@ export function ContributionGraph() {
   const searchParams = useSearchParams()
   const dateParam = searchParams.get('date')
 
-  useEffect(() => {
+  useComponentEffect(() => {
     // Closing the dialog when `?date=` is removed or invalidated keeps URL
     // and dialog state coupled. Without this, navigating from `?date=valid`
     // → `?date=` (or `?date=garbage`) would leave a stale dialog open even
@@ -348,7 +354,7 @@ export function ContributionGraph() {
       </CardContent>
     </Card>
   )
-}
+})
 
 /**
  * Observes an element and returns its current content width.
@@ -365,7 +371,7 @@ function useObservedElementWidth<T extends HTMLElement>(
 ): number | null {
   const [elementWidth, setElementWidth] = useState<number | null>(null)
 
-  useEffect(() => {
+  useComponentEffect(() => {
     const element = elementRef.current
 
     if (!element) {

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -167,7 +167,7 @@ const CategoryBreakdown = memo(function CategoryBreakdown({
 export const ContributionGraph = memo(function ContributionGraph() {
   const { heatmapValues, dataByDate, total, isLoading } = useHeatmapData()
   const containerRef = useRef<HTMLDivElement>(null)
-  const containerWidth = useObservedElementWidth(containerRef)
+  const containerWidth = useObservedElementWidth(containerRef, !isLoading)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   // `?date=YYYY-MM-DD` deep-link: validated via the same Zod schema the
   // server uses for `getDayDetail`, so invalid input is rejected with the
@@ -359,6 +359,7 @@ export const ContributionGraph = memo(function ContributionGraph() {
 /**
  * Observes an element and returns its current content width.
  * @param elementRef - Reference to the container element
+ * @param enabled - Starts measurement after the element can be rendered.
  * @returns
  * - The measured width in pixels after mount
  * - `null` before the first measurement completes
@@ -368,10 +369,15 @@ export const ContributionGraph = memo(function ContributionGraph() {
  */
 function useObservedElementWidth<T extends HTMLElement>(
   elementRef: React.RefObject<T | null>,
+  enabled: boolean,
 ): number | null {
   const [elementWidth, setElementWidth] = useState<number | null>(null)
 
   useComponentEffect(() => {
+    if (!enabled) {
+      return
+    }
+
     const element = elementRef.current
 
     if (!element) {
@@ -398,7 +404,7 @@ function useObservedElementWidth<T extends HTMLElement>(
     resizeObserver.observe(element)
 
     return () => resizeObserver.disconnect()
-  }, [elementRef])
+  }, [enabled, elementRef])
 
   return elementWidth
 }

--- a/src/app/(main)/home/_components/DayDetailDialog.tsx
+++ b/src/app/(main)/home/_components/DayDetailDialog.tsx
@@ -2,7 +2,7 @@
 
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { ChevronLeft, ChevronRight, ImageDown } from 'lucide-react'
-import { useState } from 'react'
+import { memo, useState } from 'react'
 import { match } from 'ts-pattern'
 
 import { Button } from '@/components/ui/button'
@@ -215,7 +215,7 @@ function getTopCategoryName<T extends { category?: { name: string } | null }>(
  * @example
  * <DayDetailDialog date={selectedDate} onOpenChange={(open) => !open && setSelectedDate(null)} />
  */
-export function DayDetailDialog({
+export const DayDetailDialog = memo(function DayDetailDialog({
   date,
   onOpenChange,
   onNavigate,
@@ -395,4 +395,4 @@ export function DayDetailDialog({
       </DialogContent>
     </Dialog>
   )
-}
+})

--- a/src/app/(main)/home/_components/LogoutButton.tsx
+++ b/src/app/(main)/home/_components/LogoutButton.tsx
@@ -2,11 +2,12 @@
 
 import { useClerk } from '@clerk/nextjs'
 import { LogOut } from 'lucide-react'
+import { memo } from 'react'
 
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
 import { log } from '@/lib/logger'
 
-export function LogoutButton() {
+export const LogoutButton = memo(function LogoutButton() {
   const { signOut } = useClerk()
 
   const handleLogout = async () => {
@@ -26,4 +27,4 @@ export function LogoutButton() {
       <span>Log out</span>
     </DropdownMenuItem>
   )
-}
+})

--- a/src/app/(main)/home/_components/SortableTodoItem.tsx
+++ b/src/app/(main)/home/_components/SortableTodoItem.tsx
@@ -26,7 +26,7 @@ interface SortableTodoItemProps {
  * @example
  * <SortableTodoItem todo={todo} index={0} onToggleComplete={toggle} onDelete={remove} />
  */
-export function SortableTodoItem({
+export const SortableTodoItem = React.memo(function SortableTodoItem({
   todo,
   index,
   onToggleComplete,
@@ -52,4 +52,4 @@ export function SortableTodoItem({
       />
     </div>
   )
-}
+})

--- a/src/app/(main)/home/_components/SundayDigestCard.tsx
+++ b/src/app/(main)/home/_components/SundayDigestCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { X } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -179,7 +179,7 @@ function localSundayIso(now: Date): string {
  * @example
  * <SundayDigestCard dataByDate={dataByDate} isLoading={isLoading} />
  */
-export function SundayDigestCard({
+export const SundayDigestCard = memo(function SundayDigestCard({
   dataByDate,
   isLoading,
   now,
@@ -301,4 +301,4 @@ export function SundayDigestCard({
       </CardContent>
     </Card>
   )
-}
+})

--- a/src/app/(main)/home/_components/TodoItem.tsx
+++ b/src/app/(main)/home/_components/TodoItem.tsx
@@ -5,7 +5,7 @@ import {
   ChevronRight,
   GripVertical,
 } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -55,6 +55,9 @@ export const TodoItem = React.memo(function TodoItem({
 }: TodoItemProps) {
   const [isNotesOpen, setIsNotesOpen] = useState(false)
   const [notes, setNotes] = useState(todo.notes ?? '')
+  const handleNotesOpenChange = useCallback((open: boolean) => {
+    setIsNotesOpen(open)
+  }, [])
 
   const handleNotesChange = (value: string) => {
     setNotes(value)
@@ -117,7 +120,7 @@ export const TodoItem = React.memo(function TodoItem({
           {onUpdateNotes && (
             <Collapsible
               open={isNotesOpen}
-              onOpenChange={(open: boolean) => setIsNotesOpen(open)}
+              onOpenChange={handleNotesOpenChange}
             >
               <CollapsibleTrigger asChild>
                 <Button
@@ -148,10 +151,7 @@ export const TodoItem = React.memo(function TodoItem({
         </div>
       </div>
       {onUpdateNotes && (
-        <Collapsible
-          open={isNotesOpen}
-          onOpenChange={(open: boolean) => setIsNotesOpen(open)}
-        >
+        <Collapsible open={isNotesOpen} onOpenChange={handleNotesOpenChange}>
           <CollapsibleContent className="bg-muted/30 border-t">
             <div className="p-4">
               <Textarea

--- a/src/app/(main)/home/_components/TodoItem.tsx
+++ b/src/app/(main)/home/_components/TodoItem.tsx
@@ -45,7 +45,7 @@ interface TodoItemProps {
   isDragging?: boolean
 }
 
-export function TodoItem({
+export const TodoItem = React.memo(function TodoItem({
   todo,
   onToggleComplete,
   onDelete,
@@ -115,7 +115,10 @@ export function TodoItem({
             {todo.completed ? 'Completed' : 'Pending'}
           </Badge>
           {onUpdateNotes && (
-            <Collapsible open={isNotesOpen} onOpenChange={setIsNotesOpen}>
+            <Collapsible
+              open={isNotesOpen}
+              onOpenChange={(open: boolean) => setIsNotesOpen(open)}
+            >
               <CollapsibleTrigger asChild>
                 <Button
                   variant="ghost"
@@ -145,7 +148,10 @@ export function TodoItem({
         </div>
       </div>
       {onUpdateNotes && (
-        <Collapsible open={isNotesOpen} onOpenChange={setIsNotesOpen}>
+        <Collapsible
+          open={isNotesOpen}
+          onOpenChange={(open: boolean) => setIsNotesOpen(open)}
+        >
           <CollapsibleContent className="bg-muted/30 border-t">
             <div className="p-4">
               <Textarea
@@ -160,4 +166,4 @@ export function TodoItem({
       )}
     </div>
   )
-}
+})

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -220,12 +220,15 @@ export const TodoList = memo(function TodoList() {
     })
   }
 
-  const pendingTodosFromQuery = mapTodos(pendingData?.todos)
+  const pendingTodosFromQuery = useMemo(
+    () => mapTodos(pendingData?.todos),
+    [pendingData?.todos, categoryMap],
+  )
 
   // Sync local state with query data when it changes
   useComponentEffect(() => {
     setLocalPendingTodos(pendingTodosFromQuery)
-  }, [pendingData])
+  }, [pendingTodosFromQuery])
 
   // Use local state for rendering to enable optimistic reordering
   const pendingTodos = localPendingTodos

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -4,7 +4,7 @@ import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react'
 import { isSortable } from '@dnd-kit/react/sortable'
 import { useIsRestoring, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Circle } from 'lucide-react'
-import { Suspense, useEffect, useMemo, useState } from 'react'
+import { memo, Suspense, useMemo, useState } from 'react'
 
 import { Badge } from '@/components/ui/badge'
 import {
@@ -15,6 +15,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { useHeatmapData } from '@/hooks/useHeatmapData'
 import { useSelectedCategory } from '@/hooks/useSelectedCategory'
 import { useStreakNotifications } from '@/hooks/useStreakNotifications'
@@ -45,7 +46,7 @@ const DECIMAL_RADIX = 10
  * @example
  * <TodoList />
  */
-export function TodoList() {
+export const TodoList = memo(function TodoList() {
   const queryClient = useQueryClient()
   // Track if persister is still restoring cached data - prevents hydration mismatch
   const isRestoring = useIsRestoring()
@@ -222,7 +223,7 @@ export function TodoList() {
   const pendingTodosFromQuery = mapTodos(pendingData?.todos)
 
   // Sync local state with query data when it changes
-  useEffect(() => {
+  useComponentEffect(() => {
     setLocalPendingTodos(pendingTodosFromQuery)
   }, [pendingData])
 
@@ -275,7 +276,7 @@ export function TodoList() {
     reorderMutation.mutate({ items })
   }
 
-  useEffect(() => {
+  useComponentEffect(() => {
     // Cross-window sync: BrainDump / Floating Navigator completions broadcast
     // via the BroadcastChannel and also write to the Completed table, so the
     // Home heatmap + day-detail caches need invalidation alongside the todo
@@ -395,4 +396,4 @@ export function TodoList() {
       </div>
     </div>
   )
-}
+})

--- a/src/app/(main)/home/_components/WeeklySummaryCard.tsx
+++ b/src/app/(main)/home/_components/WeeklySummaryCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { memo } from 'react'
 import { match } from 'ts-pattern'
 
 import { Card, CardContent } from '@/components/ui/card'
@@ -72,7 +73,7 @@ function trendLabel(trend: WeeklyTrend): string {
  * @example
  * <WeeklySummaryCard dataByDate={dataByDate} isLoading={isLoading} />
  */
-export function WeeklySummaryCard({
+export const WeeklySummaryCard = memo(function WeeklySummaryCard({
   dataByDate,
   isLoading,
 }: WeeklySummaryCardProps) {
@@ -134,4 +135,4 @@ export function WeeklySummaryCard({
       </CardContent>
     </Card>
   )
-}
+})

--- a/src/app/(main)/home/_components/YearInReviewModal.tsx
+++ b/src/app/(main)/home/_components/YearInReviewModal.tsx
@@ -2,7 +2,7 @@
 
 import { useUser } from '@clerk/nextjs'
 import { useSearchParams } from 'next/navigation'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import type { HeatmapDay } from '@/hooks/useHeatmapData'
 import {
   aggregateYearInReview,
@@ -109,7 +110,7 @@ function writeStoredYear(storageKey: string, year: number): void {
  * @example
  * <YearInReviewModal dataByDate={heatmapByDate} isLoading={heatmapLoading} />
  */
-export function YearInReviewModal({
+export const YearInReviewModal = memo(function YearInReviewModal({
   dataByDate,
   isLoading,
   isRestoring,
@@ -151,8 +152,8 @@ export function YearInReviewModal({
   // and write the localStorage dedupe key — that's an external store
   // side effect, not "adjusting state from a prop change". The lint
   // heuristic mis-fires here.
-  /* eslint-disable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change */
-  useEffect(() => {
+
+  useComponentEffect(() => {
     if (isLoading) return
     if (isRestoring) return
     if (dataByDate.size === 0 && !forcedToday) return
@@ -181,7 +182,6 @@ export function YearInReviewModal({
     setOpen(true)
     writeStoredYear(storageKey, summary.year)
   }, [dataByDate, isLoading, isRestoring, userId, forcedToday, forceParam])
-  /* eslint-enable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change */
 
   if (!open) return null
 
@@ -191,7 +191,7 @@ export function YearInReviewModal({
   const summary = aggregateYearInReview(dataByDate, forcedToday ?? new Date())
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={(open: boolean) => setOpen(open)}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="font-serif text-2xl">
@@ -269,7 +269,7 @@ export function YearInReviewModal({
       </DialogContent>
     </Dialog>
   )
-}
+})
 
 /**
  * Single stat tile inside the modal. Geist Mono tabular numbers + serif
@@ -278,7 +278,7 @@ export function YearInReviewModal({
  * @example
  * <Stat label="completed" value={412} isLoading={false} />
  */
-function Stat({
+const Stat = memo(function Stat({
   label,
   value,
   isLoading,
@@ -301,4 +301,4 @@ function Stat({
       <p className="font-serif text-xs italic text-muted-foreground">{label}</p>
     </div>
   )
-}
+})

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { memo } from 'react'
+
 import { SidebarTrigger } from '@/components/ui/sidebar'
 
 import { TodoList } from './_components/TodoList'
@@ -9,7 +11,7 @@ import './page.css'
 /**
  * Home page content. The sidebar is provided by `(main)/layout.tsx`.
  */
-export default function Home() {
+const Home = memo(function Home() {
   return (
     <>
       <header className="window-drag-region flex h-16 shrink-0 items-center gap-2 border-b px-4">
@@ -23,4 +25,6 @@ export default function Home() {
       </div>
     </>
   )
-}
+})
+
+export default Home

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react'
+
 import { AppSidebar } from '@/components/AppSidebar'
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 

--- a/src/app/(main)/skill-tree/SkillTreeView.tsx
+++ b/src/app/(main)/skill-tree/SkillTreeView.tsx
@@ -7,7 +7,7 @@ import {
   type DragStartEvent,
 } from '@dnd-kit/react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useMemo, useOptimistic, useState, useTransition } from 'react'
+import { memo, useMemo, useOptimistic, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 
 import { SidebarTrigger } from '@/components/ui/sidebar'
@@ -47,7 +47,7 @@ import './styles.css'
  * }
  * ```
  */
-export function SkillTreeView() {
+export const SkillTreeView = memo(function SkillTreeView() {
   const queryClient = useQueryClient()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [activeDragId, setActiveDragId] = useState<TodoId | null>(null)
@@ -378,7 +378,7 @@ export function SkillTreeView() {
           <TaskPoolDrawer
             todos={poolTodos}
             open={drawerOpen}
-            onOpenChange={setDrawerOpen}
+            onOpenChange={(open: boolean) => setDrawerOpen(open)}
           />
         </div>
       </div>
@@ -389,7 +389,7 @@ export function SkillTreeView() {
       </DragOverlay>
     </DragDropProvider>
   )
-}
+})
 
 /**
  * Parses a draggable DnD id of the form `todo-<number>` into its numeric todo id.

--- a/src/app/(main)/skill-tree/SkillTreeView.tsx
+++ b/src/app/(main)/skill-tree/SkillTreeView.tsx
@@ -378,7 +378,7 @@ export const SkillTreeView = memo(function SkillTreeView() {
           <TaskPoolDrawer
             todos={poolTodos}
             open={drawerOpen}
-            onOpenChange={(open: boolean) => setDrawerOpen(open)}
+            onOpenChange={setDrawerOpen}
           />
         </div>
       </div>

--- a/src/app/(main)/skill-tree/components/ConstellationCanvas.tsx
+++ b/src/app/(main)/skill-tree/components/ConstellationCanvas.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { memo } from 'react'
+
 import type {
   EdgeFromNodeId,
   EdgeToNodeId,
@@ -69,7 +71,7 @@ function toViewboxUnits(n: NodeCoordinate): ViewboxCoordinate {
  *   onNodeClick={(id) => console.log(id)}
  * />
  */
-export function ConstellationCanvas({
+export const ConstellationCanvas = memo(function ConstellationCanvas({
   nodes,
   edges,
   onNodeClick,
@@ -232,4 +234,4 @@ export function ConstellationCanvas({
       </g>
     </svg>
   )
-}
+})

--- a/src/app/(main)/skill-tree/components/DragOverlayCard.tsx
+++ b/src/app/(main)/skill-tree/components/DragOverlayCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { memo } from 'react'
 /**
  * A non-interactive floating preview of a task card, rendered inside
  * `<DragOverlay>` while a drag is in progress.
@@ -14,7 +15,11 @@
  *   {activeTodo ? <DragOverlayCard text={activeTodo.text} /> : null}
  * </DragOverlay>
  */
-export function DragOverlayCard({ text }: { text: string }) {
+export const DragOverlayCard = memo(function DragOverlayCard({
+  text,
+}: {
+  text: string
+}) {
   return (
     <div
       // eslint-disable-next-line dslint/token-only -- skill-tree card dimensions not in design tokens
@@ -24,4 +29,4 @@ export function DragOverlayCard({ text }: { text: string }) {
       {text}
     </div>
   )
-}
+})

--- a/src/app/(main)/skill-tree/components/NodePopover.tsx
+++ b/src/app/(main)/skill-tree/components/NodePopover.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { X } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { memo, type ReactNode } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -76,7 +76,7 @@ export interface NodePopoverProps {
  *   <button>Open node</button>
  * </NodePopover>
  */
-export function NodePopover({
+export const NodePopover = memo(function NodePopover({
   open,
   onOpenChange,
   node,
@@ -142,4 +142,4 @@ export function NodePopover({
       </PopoverContent>
     </Popover>
   )
-}
+})

--- a/src/app/(main)/skill-tree/components/SkillNodeCircle.test.tsx
+++ b/src/app/(main)/skill-tree/components/SkillNodeCircle.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { SkillNodeCircle } from './SkillNodeCircle'

--- a/src/app/(main)/skill-tree/components/SkillNodeCircle.tsx
+++ b/src/app/(main)/skill-tree/components/SkillNodeCircle.tsx
@@ -37,7 +37,7 @@ export interface SkillNodeCircleProps {
   onClick?: (nodeId: SkillNodeId) => void
 }
 
-export function SkillNodeCircle({
+export const SkillNodeCircle = React.memo(function SkillNodeCircle({
   id,
   name,
   cx,
@@ -243,4 +243,4 @@ export function SkillNodeCircle({
       )}
     </g>
   )
-}
+})

--- a/src/app/(main)/skill-tree/components/TaskPoolCard.test.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolCard.test.tsx
@@ -1,5 +1,6 @@
 import { DragDropProvider } from '@dnd-kit/react'
 import { render, screen } from '@testing-library/react'
+import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 
 import type { TodoId, TodoText } from '../lib/domain-types'

--- a/src/app/(main)/skill-tree/components/TaskPoolCard.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useDraggable } from '@dnd-kit/react'
+import { memo } from 'react'
 
 import type { TodoId, TodoText } from '../lib/domain-types'
 
@@ -23,7 +24,10 @@ export interface TaskPoolCardProps {
   text: TodoText
 }
 
-export function TaskPoolCard({ id, text }: TaskPoolCardProps) {
+export const TaskPoolCard = memo(function TaskPoolCard({
+  id,
+  text,
+}: TaskPoolCardProps) {
   // dnd-kit maintains one ID registry across draggables and droppables.
   // Prefix Todo ids so they cannot collide with SkillNode ids.
   const { ref, isDragging } = useDraggable({ id: `todo-${id}` })
@@ -46,4 +50,4 @@ export function TaskPoolCard({ id, text }: TaskPoolCardProps) {
       {text}
     </button>
   )
-}
+})

--- a/src/app/(main)/skill-tree/components/TaskPoolDrawer.stories.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolDrawer.stories.tsx
@@ -1,5 +1,6 @@
 import { DragDropProvider } from '@dnd-kit/react'
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import * as React from 'react'
 import { useState } from 'react'
 
 import { TaskPoolDrawer } from './TaskPoolDrawer'

--- a/src/app/(main)/skill-tree/components/TaskPoolDrawer.tsx
+++ b/src/app/(main)/skill-tree/components/TaskPoolDrawer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ChevronUp, Package } from 'lucide-react'
+import { memo } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -50,7 +51,7 @@ export interface TaskPoolDrawerProps {
  *   />
  * </DragDropProvider>
  */
-export function TaskPoolDrawer({
+export const TaskPoolDrawer = memo(function TaskPoolDrawer({
   todos,
   open,
   onOpenChange,
@@ -104,4 +105,4 @@ export function TaskPoolDrawer({
       </SheetContent>
     </Sheet>
   )
-}
+})

--- a/src/app/(main)/skill-tree/components/XpBadge.tsx
+++ b/src/app/(main)/skill-tree/components/XpBadge.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { memo } from 'react'
+
 import { LEVEL_LABEL, xpToLevel } from '../lib/xp'
 
 /**
@@ -16,7 +18,7 @@ import { LEVEL_LABEL, xpToLevel } from '../lib/xp'
  * <XpBadge xp={40} />  // => "Level 3", "10 / 20", half-filled bar
  * <XpBadge xp={75} />  // => "Mastered" (no bar, no counter)
  */
-export function XpBadge({ xp }: { xp: number }) {
+export const XpBadge = memo(function XpBadge({ xp }: { xp: number }) {
   const { level, progress, next } = xpToLevel(xp)
   const label = LEVEL_LABEL[level]
 
@@ -55,4 +57,4 @@ export function XpBadge({ xp }: { xp: number }) {
       )}
     </div>
   )
-}
+})

--- a/src/app/(main)/skill-tree/page.tsx
+++ b/src/app/(main)/skill-tree/page.tsx
@@ -10,9 +10,11 @@ import { SkillTreeView } from './SkillTreeView'
  * @returns The `SkillTreeView` client component after confirming the user is
  *   authenticated. Redirects to `/login` when no session is found.
  */
-export default async function SkillTreePage() {
+async function SkillTreePage() {
   const { userId } = await auth()
   if (!userId) redirect('/login')
 
   return <SkillTreeView />
 }
+
+export default SkillTreePage

--- a/src/app/braindump/page.tsx
+++ b/src/app/braindump/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import { memo } from 'react'
 
 import { BrainDumpEditor } from '@/components/braindump/BrainDumpEditor'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
@@ -15,7 +16,7 @@ import type { CategoryWithCount } from '@/server/schemas/category'
  * (no `brainDumpAPI`), the editor renders a placeholder message so devs can
  * iterate from a regular Next.js dev server.
  */
-export default function BrainDumpPage() {
+const BrainDumpPage = memo(function BrainDumpPage() {
   const isClerkReady = useClerkQueryReady()
   const { data, isLoading, error } = useQuery({
     ...orpc.category.list.queryOptions({}),
@@ -47,4 +48,6 @@ export default function BrainDumpPage() {
       <BrainDumpEditor categories={categories} />
     </div>
   )
-}
+})
+
+export default BrainDumpPage

--- a/src/app/floating-navigator/page.tsx
+++ b/src/app/floating-navigator/page.tsx
@@ -1,12 +1,16 @@
 'use client'
 
+import { memo } from 'react'
+
 import { FloatingNavigatorContainer } from '@/components/floating-navigator'
 import '@/components/floating-navigator/floating-navigator.css'
 
-export default function FloatingNavigatorPage() {
+const FloatingNavigatorPage = memo(function FloatingNavigatorPage() {
   return (
     <div className="h-screen w-full overflow-hidden">
       <FloatingNavigatorContainer />
     </div>
   )
-}
+})
+
+export default FloatingNavigatorPage

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { ClerkProvider } from '@clerk/nextjs'
 import type { Metadata } from 'next'
 import { Geist_Mono, Inter_Tight, Newsreader } from 'next/font/google'
+import * as React from 'react'
 import '@/globals.css'
 
 import { CodeInspectorClient } from '@/components/code-inspector/CodeInspectorClient'

--- a/src/app/login/[[...login]]/page.tsx
+++ b/src/app/login/[[...login]]/page.tsx
@@ -2,12 +2,13 @@
 
 import { SignIn as Login, useUser } from '@clerk/nextjs'
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { memo } from 'react'
 
 import {
   ElectronLoginForm,
   useIsElectron,
 } from '@/components/auth/ElectronLoginForm'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 
 /**
  * Login Page with Electron Email/Password Support
@@ -20,13 +21,13 @@ import {
  * - Google OAuth requires system browser (blocks WebView)
  * - GitHub removed: email/password provides simpler desktop experience
  */
-export default function Page() {
+const Page = memo(function Page() {
   const isElectron = useIsElectron()
   const { user, isLoaded } = useUser()
   const router = useRouter()
 
   // Redirect to home if user is already authenticated
-  useEffect(() => {
+  useComponentEffect(() => {
     if (isLoaded && user) {
       router.replace('/home')
     }
@@ -63,4 +64,6 @@ export default function Page() {
       )}
     </div>
   )
-}
+})
+
+export default Page

--- a/src/app/oauth/callback/page.tsx
+++ b/src/app/oauth/callback/page.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
-import { Suspense, useEffect, useState } from 'react'
+import { memo, Suspense, useState } from 'react'
+
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 
 /**
  * OAuth Callback Page - Browser-to-Electron Bridge with Sign-In Token
@@ -29,12 +31,12 @@ type CallbackStatus =
   | 'success'
   | 'error'
 
-function OAuthCallbackContent() {
+const OAuthCallbackContent = memo(function OAuthCallbackContent() {
   const searchParams = useSearchParams()
   const [status, setStatus] = useState<CallbackStatus>('loading')
   const [errorMessage, setErrorMessage] = useState<string>('')
 
-  useEffect(() => {
+  useComponentEffect(() => {
     const state = searchParams.get('state')
     const error = searchParams.get('error')
     const errorDescription = searchParams.get('error_description')
@@ -226,14 +228,14 @@ function OAuthCallbackContent() {
       </p>
     </div>
   )
-}
+})
 
 /**
  * OAuth Callback Page with Suspense wrapper.
  *
  * useSearchParams() requires Suspense boundary in Next.js App Router.
  */
-export default function OAuthCallbackPage() {
+const OAuthCallbackPage = memo(function OAuthCallbackPage() {
   return (
     <Suspense
       fallback={
@@ -245,4 +247,6 @@ export default function OAuthCallbackPage() {
       <OAuthCallbackContent />
     </Suspense>
   )
-}
+})
+
+export default OAuthCallbackPage

--- a/src/app/oauth/callback/page.tsx
+++ b/src/app/oauth/callback/page.tsx
@@ -33,6 +33,9 @@ type CallbackStatus =
 
 const OAuthCallbackContent = memo(function OAuthCallbackContent() {
   const searchParams = useSearchParams()
+  const state = searchParams.get('state')
+  const error = searchParams.get('error')
+  const errorDescription = searchParams.get('error_description')
   const [status, setStatus] = useState<CallbackStatus>('loading')
   const [errorMessage, setErrorMessage] = useState<string>('')
 
@@ -40,9 +43,6 @@ const OAuthCallbackContent = memo(function OAuthCallbackContent() {
     let isMounted = true
     let redirectTimer: number | undefined
     let successTimer: number | undefined
-    const state = searchParams.get('state')
-    const error = searchParams.get('error')
-    const errorDescription = searchParams.get('error_description')
 
     // Handle OAuth error from Clerk
     if (error) {
@@ -121,7 +121,7 @@ const OAuthCallbackContent = memo(function OAuthCallbackContent() {
       if (redirectTimer !== undefined) window.clearTimeout(redirectTimer)
       if (successTimer !== undefined) window.clearTimeout(successTimer)
     }
-  }, [searchParams])
+  }, [state, error, errorDescription])
 
   return (
     <div className="bg-linear-to-b flex min-h-screen flex-col items-center justify-center from-gray-50 to-gray-100 p-4">

--- a/src/app/oauth/callback/page.tsx
+++ b/src/app/oauth/callback/page.tsx
@@ -37,6 +37,9 @@ const OAuthCallbackContent = memo(function OAuthCallbackContent() {
   const [errorMessage, setErrorMessage] = useState<string>('')
 
   useComponentEffect(() => {
+    let isMounted = true
+    let redirectTimer: number | undefined
+    let successTimer: number | undefined
     const state = searchParams.get('state')
     const error = searchParams.get('error')
     const errorDescription = searchParams.get('error_description')
@@ -58,6 +61,8 @@ const OAuthCallbackContent = memo(function OAuthCallbackContent() {
     // Fetch sign-in token and redirect to Electron
     const createTokenAndRedirect = async () => {
       try {
+        if (!isMounted) return
+
         setStatus('creating-token')
 
         // Call server API to create a sign-in token
@@ -80,20 +85,25 @@ const OAuthCallbackContent = memo(function OAuthCallbackContent() {
         // Build deep link with both state (for validation) and token (for sign-in)
         const deepLink = `corelive://oauth/callback?state=${encodeURIComponent(state)}&token=${encodeURIComponent(token)}`
 
+        if (!isMounted) return
+
         setStatus('redirecting')
 
         // Redirect to Electron app via deep link
         // Small delay to show UI update
-        setTimeout(() => {
+        redirectTimer = window.setTimeout(() => {
           window.location.href = deepLink
         }, 100)
 
         // After a short delay, show success message
         // (User may need to manually return to app if deep link doesn't auto-focus)
-        setTimeout(() => {
+        successTimer = window.setTimeout(() => {
+          if (!isMounted) return
           setStatus('success')
         }, 2000)
       } catch (err) {
+        if (!isMounted) return
+
         console.error('OAuth callback error:', err)
         setStatus('error')
         setErrorMessage(
@@ -105,6 +115,12 @@ const OAuthCallbackContent = memo(function OAuthCallbackContent() {
     }
 
     void createTokenAndRedirect()
+
+    return () => {
+      isMounted = false
+      if (redirectTimer !== undefined) window.clearTimeout(redirectTimer)
+      if (successTimer !== undefined) window.clearTimeout(successTimer)
+    }
   }, [searchParams])
 
   return (

--- a/src/app/oauth/sso-callback/page.tsx
+++ b/src/app/oauth/sso-callback/page.tsx
@@ -2,7 +2,7 @@
 
 import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
 import { useSearchParams } from 'next/navigation'
-import { Suspense } from 'react'
+import { memo, Suspense } from 'react'
 
 /**
  * SSO Callback Page - Clerk OAuth Callback Handler
@@ -20,7 +20,7 @@ import { Suspense } from 'react'
  * 5. Clerk redirects to /oauth/callback (redirectUrlComplete)
  */
 
-function SSOCallbackContent() {
+const SSOCallbackContent = memo(function SSOCallbackContent() {
   const searchParams = useSearchParams()
   const state = searchParams.get('state')
 
@@ -49,12 +49,12 @@ function SSOCallbackContent() {
       </p>
     </div>
   )
-}
+})
 
 /**
  * SSO Callback Page with Suspense wrapper.
  */
-export default function SSOCallbackPage() {
+const SSOCallbackPage = memo(function SSOCallbackPage() {
   return (
     <Suspense
       fallback={
@@ -66,4 +66,6 @@ export default function SSOCallbackPage() {
       <SSOCallbackContent />
     </Suspense>
   )
-}
+})
+
+export default SSOCallbackPage

--- a/src/app/oauth/start/page.tsx
+++ b/src/app/oauth/start/page.tsx
@@ -3,7 +3,9 @@
 import { useClerk, useUser } from '@clerk/nextjs'
 import type { OAuthStrategy } from '@clerk/shared/types'
 import { useSearchParams } from 'next/navigation'
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { memo, Suspense, useRef, useState } from 'react'
+
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 
 /**
  * OAuth Start Page - System Browser Entry Point for Electron OAuth
@@ -34,7 +36,7 @@ const OAUTH_CALLBACK_ROUTE = '/oauth/sso-callback'
 /** Final route that creates the one-time Electron sign-in token. */
 const OAUTH_COMPLETE_ROUTE = '/oauth/callback'
 
-function OAuthStartContent() {
+const OAuthStartContent = memo(function OAuthStartContent() {
   const searchParams = useSearchParams()
   const { client } = useClerk()
   const { isLoaded: isUserLoaded, user } = useUser()
@@ -45,7 +47,7 @@ function OAuthStartContent() {
   const provider = searchParams.get('provider') as 'google' | 'github' | null
   const state = searchParams.get('state')
 
-  useEffect(() => {
+  useComponentEffect(() => {
     const signIn = client?.signIn
 
     // Wait for Clerk to load
@@ -172,7 +174,7 @@ function OAuthStartContent() {
       </p>
     </div>
   )
-}
+})
 
 /**
  * Extracts a human-readable OAuth start error from Clerk failures.
@@ -245,7 +247,7 @@ function buildOAuthCompleteUrl(state: string): string {
  *
  * useSearchParams() requires Suspense boundary in Next.js App Router.
  */
-export default function OAuthStartPage() {
+const OAuthStartPage = memo(function OAuthStartPage() {
   return (
     <Suspense
       fallback={
@@ -257,4 +259,6 @@ export default function OAuthStartPage() {
       <OAuthStartContent />
     </Suspense>
   )
-}
+})
+
+export default OAuthStartPage

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { memo } from 'react'
 
 import { Button } from '@/components/ui/button'
 
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
   description: 'Personal Todo navigator for you.',
 }
 
-export default function Home() {
+const Home = memo(function Home() {
   return (
     <div className="container mx-auto min-h-screen px-4 py-8 sm:px-6 lg:px-8">
       <div className="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center">
@@ -26,4 +27,6 @@ export default function Home() {
       </div>
     </div>
   )
-}
+})
+
+export default Home

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,3 +1,6 @@
+import type { Metadata } from 'next'
+import * as React from 'react'
+import { memo } from 'react'
 /**
  * Settings Page (Electron Only)
  *
@@ -7,7 +10,6 @@
  *
  * @module app/settings/page
  */
-import type { Metadata } from 'next'
 
 import { ElectronSettingsPage } from '@/components/electron/ElectronSettingsPage'
 
@@ -24,6 +26,8 @@ export const metadata: Metadata = {
  *
  * @returns Settings page
  */
-export default function SettingsPage(): React.ReactNode {
+const SettingsPage = memo(function SettingsPage(): React.ReactNode {
   return <ElectronSettingsPage />
-}
+})
+
+export default SettingsPage

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { SignUp } from '@clerk/nextjs'
+import { memo } from 'react'
 
 import { useIsElectron } from '@/components/auth/ElectronLoginForm'
 import { ElectronSignUpForm } from '@/components/auth/ElectronSignUpForm'
@@ -16,7 +17,7 @@ import { ElectronSignUpForm } from '@/components/auth/ElectronSignUpForm'
  * - Google OAuth requires system browser (blocks WebView)
  * - GitHub removed: email/password provides simpler desktop experience
  */
-export default function Page() {
+const Page = memo(function Page() {
   const isElectron = useIsElectron()
 
   return (
@@ -41,4 +42,6 @@ export default function Page() {
       )}
     </div>
   )
-}
+})
+
+export default Page

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useState } from 'react'
 
 import { Category } from '@/app/(main)/home/_components/Category'
 import { CategoryManageDialog } from '@/app/(main)/home/_components/CategoryManageDialog'
@@ -56,25 +56,29 @@ const GITHUB_REPO = 'laststance/corelive'
  * Renders user profile, navigation links, categories, and bottom actions.
  * Uses `usePathname()` to highlight the active route.
  */
-export function AppSidebar() {
+export const AppSidebar = memo(function AppSidebar() {
   const { user } = useUser()
   const isElectron = useIsElectron()
   const router = useRouter()
   const pathname = usePathname()
   const [manageDialogOpen, setManageDialogOpen] = useState(false)
 
-  const macDownloadUrl = useMemo(() => {
-    const version = packageJson.version
-    const isArm = isAppleSilicon()
-    const filename = isArm
-      ? `CoreLive-${version}-arm64.dmg`
-      : `CoreLive-${version}.dmg`
-    return `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${filename}`
-  }, [])
+  const version = packageJson.version
+  const isArm = isAppleSilicon()
+  const filename = isArm
+    ? `CoreLive-${version}-arm64.dmg`
+    : `CoreLive-${version}.dmg`
+  const macDownloadUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${filename}`
 
   const handleOpenSettings = useCallback(() => {
     router.push('/settings')
   }, [router])
+  const handleOpenCategoryManager = useCallback(() => {
+    setManageDialogOpen(true)
+  }, [])
+  const handleCategoryManagerOpenChange = useCallback((open: boolean) => {
+    setManageDialogOpen(open)
+  }, [])
 
   return (
     <>
@@ -209,7 +213,7 @@ export function AppSidebar() {
 
           <SidebarSeparator />
 
-          <Category onOpenManageAction={() => setManageDialogOpen(true)} />
+          <Category onOpenManageAction={handleOpenCategoryManager} />
 
           <div className="flex-1" />
 
@@ -266,8 +270,8 @@ export function AppSidebar() {
       </Sidebar>
       <CategoryManageDialog
         open={manageDialogOpen}
-        onOpenChange={setManageDialogOpen}
+        onOpenChange={handleCategoryManagerOpenChange}
       />
     </>
   )
-}
+})

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -2,7 +2,7 @@
 
 import { Check, Palette } from 'lucide-react'
 import { useTheme } from 'next-themes'
-import { useState } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -27,7 +27,7 @@ interface ThemeSelectorProps {
  * @param align - Dropdown alignment
  * @param className - Additional CSS classes
  */
-export function ThemeSelector({
+export const ThemeSelector = memo(function ThemeSelector({
   align = 'end',
   className,
 }: ThemeSelectorProps) {
@@ -37,9 +37,25 @@ export function ThemeSelector({
   const currentMeta = theme
     ? THEME_META[theme as keyof typeof THEME_META]
     : null
+  const handleOpenChange = useCallback((open: boolean) => {
+    setIsOpen(open)
+  }, [])
+  const themeClickHandlers = useMemo(
+    () =>
+      Object.fromEntries(
+        THEMES.map((themeId) => [
+          themeId,
+          () => {
+            setTheme(themeId)
+            setIsOpen(false)
+          },
+        ]),
+      ) as Record<(typeof THEMES)[number], () => void>,
+    [setTheme],
+  )
 
   return (
-    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+    <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
@@ -67,10 +83,7 @@ export function ThemeSelector({
           return (
             <DropdownMenuItem
               key={themeId}
-              onClick={() => {
-                setTheme(themeId)
-                setIsOpen(false)
-              }}
+              onClick={themeClickHandlers[themeId]}
               className={cn('cursor-pointer gap-2', isActive && 'bg-accent')}
             >
               <div
@@ -85,13 +98,17 @@ export function ThemeSelector({
       </DropdownMenuContent>
     </DropdownMenu>
   )
-}
+})
 
 /**
  * Compact theme selector using native select element.
  * @param className - Additional CSS classes
  */
-export function ThemeSelectorCompact({ className }: { className?: string }) {
+export const ThemeSelectorCompact = memo(function ThemeSelectorCompact({
+  className,
+}: {
+  className?: string
+}) {
   const { theme, setTheme } = useTheme()
 
   return (
@@ -111,4 +128,4 @@ export function ThemeSelectorCompact({ className }: { className?: string }) {
       ))}
     </select>
   )
-}
+})

--- a/src/components/ThemeSelectorMenuItem.tsx
+++ b/src/components/ThemeSelectorMenuItem.tsx
@@ -2,6 +2,7 @@
 
 import { Palette, Check } from 'lucide-react'
 import { useTheme } from 'next-themes'
+import { memo, useMemo } from 'react'
 
 import {
   DropdownMenuItem,
@@ -18,8 +19,15 @@ import { THEMES, THEME_META } from '@/providers/ThemeProvider'
  * Displays available themes with preview colors and active state.
  * @returns Dropdown submenu for theme selection
  */
-export function ThemeSelectorMenuItem() {
+export const ThemeSelectorMenuItem = memo(function ThemeSelectorMenuItem() {
   const { theme, setTheme } = useTheme()
+  const themeClickHandlers = useMemo(
+    () =>
+      Object.fromEntries(
+        THEMES.map((themeId) => [themeId, () => setTheme(themeId)]),
+      ) as Record<(typeof THEMES)[number], () => void>,
+    [setTheme],
+  )
 
   return (
     <DropdownMenuSub>
@@ -36,7 +44,7 @@ export function ThemeSelectorMenuItem() {
             return (
               <DropdownMenuItem
                 key={themeId}
-                onClick={() => setTheme(themeId)}
+                onClick={themeClickHandlers[themeId]}
                 className={cn('cursor-pointer gap-2', isActive && 'bg-accent')}
               >
                 <div
@@ -52,4 +60,4 @@ export function ThemeSelectorMenuItem() {
       </DropdownMenuPortal>
     </DropdownMenuSub>
   )
-}
+})

--- a/src/components/animations/AchievementAnimation.tsx
+++ b/src/components/animations/AchievementAnimation.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { Trophy, Star, Gift, Medal, Crown } from 'lucide-react'
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useState, useCallback } from 'react'
 
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { cn } from '@/lib/utils'
 
 export interface Achievement {
@@ -33,7 +34,7 @@ const ACHIEVEMENT_ICONS = {
  * Shows animated achievement card with progress bar
  * Note: Parent component is responsible for showing/hiding the achievement
  */
-export function AchievementAnimation({
+export const AchievementAnimation = React.memo(function AchievementAnimation({
   achievement,
   className,
 }: AchievementAnimationProps) {
@@ -102,80 +103,77 @@ export function AchievementAnimation({
       </div>
     </div>
   )
-}
+})
 
 /**
  * Achievement notification list for multiple achievements
  */
-export function AchievementNotifications({
-  className,
-}: {
-  className?: string
-}) {
-  const [achievements, setAchievements] = useState<Achievement[]>([])
-  const [currentIndex, setCurrentIndex] = useState(0)
+export const AchievementNotifications = React.memo(
+  function AchievementNotifications({ className }: { className?: string }) {
+    const [achievements, setAchievements] = useState<Achievement[]>([])
+    const [currentIndex, setCurrentIndex] = useState(0)
 
-  // Show achievements one by one
-  const achievement = achievements[currentIndex] || null
+    // Show achievements one by one
+    const achievement = achievements[currentIndex] || null
 
-  const handleComplete = useCallback(() => {
-    setCurrentIndex((prevIndex) => {
-      let shouldReset = false
-      setAchievements((prevAchievements) => {
-        if (prevIndex < prevAchievements.length - 1) {
-          return prevAchievements
-        } else {
-          shouldReset = true
-          return []
-        }
+    const handleComplete = useCallback(() => {
+      setCurrentIndex((prevIndex) => {
+        let shouldReset = false
+        setAchievements((prevAchievements) => {
+          if (prevIndex < prevAchievements.length - 1) {
+            return prevAchievements
+          } else {
+            shouldReset = true
+            return []
+          }
+        })
+        return shouldReset ? 0 : prevIndex + 1
       })
-      return shouldReset ? 0 : prevIndex + 1
-    })
-  }, [])
+    }, [])
 
-  const addAchievement = useCallback((achievement: Achievement) => {
-    setAchievements((prev: Achievement[]) => [...prev, achievement])
-  }, [])
+    const addAchievement = useCallback((achievement: Achievement) => {
+      setAchievements((prev: Achievement[]) => [...prev, achievement])
+    }, [])
 
-  // Expose methods via ref or context if needed
-  useEffect(() => {
-    // Example: Listen for achievement events
-    const handleAchievementUnlock = (event: CustomEvent<Achievement>) => {
-      addAchievement(event.detail)
-    }
+    // Expose methods via ref or context if needed
+    useComponentEffect(() => {
+      // Example: Listen for achievement events
+      const handleAchievementUnlock = (event: CustomEvent<Achievement>) => {
+        addAchievement(event.detail)
+      }
 
-    window.addEventListener(
-      'achievement:unlock',
-      handleAchievementUnlock as EventListener,
-    )
-    return () => {
-      window.removeEventListener(
+      window.addEventListener(
         'achievement:unlock',
         handleAchievementUnlock as EventListener,
       )
+      return () => {
+        window.removeEventListener(
+          'achievement:unlock',
+          handleAchievementUnlock as EventListener,
+        )
+      }
+    }, [addAchievement])
+
+    // Auto-advance after animation completes (you can adjust timing)
+
+    useComponentEffect(() => {
+      if (achievement) {
+        const timer = setTimeout(() => {
+          handleComplete()
+        }, 3000) // 3 seconds for animation
+        return () => clearTimeout(timer)
+      }
+    }, [achievement, handleComplete])
+
+    if (!achievement) {
+      return null
     }
-  }, [addAchievement])
 
-  // Auto-advance after animation completes (you can adjust timing)
-  /* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
-  useEffect(() => {
-    if (achievement) {
-      const timer = setTimeout(() => {
-        handleComplete()
-      }, 3000) // 3 seconds for animation
-      return () => clearTimeout(timer)
-    }
-  }, [achievement, handleComplete])
-  /* eslint-enable react-you-might-not-need-an-effect/no-event-handler */
-
-  if (!achievement) {
-    return null
-  }
-
-  return (
-    <AchievementAnimation achievement={achievement} className={className} />
-  )
-}
+    return (
+      <AchievementAnimation achievement={achievement} className={className} />
+    )
+  },
+)
 
 /**
  * Hook to trigger achievement animations

--- a/src/components/animations/AchievementAnimation.tsx
+++ b/src/components/animations/AchievementAnimation.tsx
@@ -117,19 +117,16 @@ export const AchievementNotifications = React.memo(
     const achievement = achievements[currentIndex] || null
 
     const handleComplete = useCallback(() => {
-      setCurrentIndex((prevIndex) => {
-        let shouldReset = false
-        setAchievements((prevAchievements) => {
-          if (prevIndex < prevAchievements.length - 1) {
-            return prevAchievements
-          } else {
-            shouldReset = true
-            return []
-          }
-        })
-        return shouldReset ? 0 : prevIndex + 1
-      })
-    }, [])
+      const isLastAchievement = currentIndex >= achievements.length - 1
+
+      if (isLastAchievement) {
+        setAchievements([])
+        setCurrentIndex(0)
+        return
+      }
+
+      setCurrentIndex(currentIndex + 1)
+    }, [achievements.length, currentIndex])
 
     const addAchievement = useCallback((achievement: Achievement) => {
       setAchievements((prev: Achievement[]) => [...prev, achievement])

--- a/src/components/animations/ConfettiAnimation.tsx
+++ b/src/components/animations/ConfettiAnimation.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useMemo, useState, useSyncExternalStore } from 'react'
 
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { cn } from '@/lib/utils'
 
 interface ConfettiParticle {
@@ -102,22 +103,24 @@ export const ConfettiAnimation = React.memo(function ConfettiAnimation({
   const prevTriggerRef = useRef(false)
   const particleSeedRef = useRef(Date.now())
 
-  // Create stable timer store
-  const timerStoreRef = useRef<ReturnType<typeof createTimerStore> | null>(null)
-  if (!timerStoreRef.current) {
-    timerStoreRef.current = createTimerStore(duration, onComplete)
-  }
+  // Rebuild the timer store when timing inputs change so callbacks stay fresh.
+  const timerStore = useMemo(
+    () => createTimerStore(duration, onComplete),
+    [duration, onComplete],
+  )
 
   const isActive = useSyncExternalStore(
-    timerStoreRef.current.subscribe,
-    timerStoreRef.current.getSnapshot,
-    timerStoreRef.current.getServerSnapshot,
+    timerStore.subscribe,
+    timerStore.getSnapshot,
+    timerStore.getServerSnapshot,
   )
+
+  useComponentEffect(() => () => timerStore.stop(), [timerStore])
 
   // Detect trigger rising edge during render (not in effect)
   if (trigger && !prevTriggerRef.current && !isActive) {
     particleSeedRef.current = Date.now()
-    timerStoreRef.current.start()
+    timerStore.start()
   }
   prevTriggerRef.current = trigger
 

--- a/src/components/animations/ConfettiAnimation.tsx
+++ b/src/components/animations/ConfettiAnimation.tsx
@@ -92,7 +92,7 @@ function createTimerStore(duration: number, onComplete?: () => void) {
  * ConfettiAnimation component for celebrating task completion
  * Renders confetti particles with various colors, shapes, and sizes
  */
-export function ConfettiAnimation({
+export const ConfettiAnimation = React.memo(function ConfettiAnimation({
   trigger,
   particleCount = 50,
   duration = 3000,
@@ -153,7 +153,7 @@ export function ConfettiAnimation({
       ))}
     </div>
   )
-}
+})
 
 /**
  * Hook to trigger confetti animation

--- a/src/components/animations/LevelUpAnimation.tsx
+++ b/src/components/animations/LevelUpAnimation.tsx
@@ -55,7 +55,7 @@ interface LevelUpAnimationProps {
  * LevelUpAnimation component for celebrating user level progression
  * Displays an animated badge with level number and effects
  */
-export function LevelUpAnimation({
+export const LevelUpAnimation = React.memo(function LevelUpAnimation({
   level,
   show,
   onComplete,
@@ -115,92 +115,98 @@ export function LevelUpAnimation({
       </div>
     </div>
   )
-}
+})
 
 /**
  * Milestone level up animation with special effects
  */
-export function MilestoneLevelUpAnimation({
-  level,
-  show,
-  milestone,
-  reward,
-  onComplete,
-  className,
-}: LevelUpAnimationProps & {
-  milestone: string
-  reward?: string
-}) {
-  const prevShowRef = useRef(false)
+export const MilestoneLevelUpAnimation = React.memo(
+  function MilestoneLevelUpAnimation({
+    level,
+    show,
+    milestone,
+    reward,
+    onComplete,
+    className,
+  }: LevelUpAnimationProps & {
+    milestone: string
+    reward?: string
+  }) {
+    const prevShowRef = useRef(false)
 
-  // Create stable visibility store with longer duration for milestones
-  const storeRef = useRef<ReturnType<typeof createVisibilityStore> | null>(null)
-  if (!storeRef.current) {
-    storeRef.current = createVisibilityStore(5000, onComplete)
-  }
+    // Create stable visibility store with longer duration for milestones
+    const storeRef = useRef<ReturnType<typeof createVisibilityStore> | null>(
+      null,
+    )
+    if (!storeRef.current) {
+      storeRef.current = createVisibilityStore(5000, onComplete)
+    }
 
-  const isVisible = useSyncExternalStore(
-    storeRef.current.subscribe,
-    storeRef.current.getSnapshot,
-    storeRef.current.getServerSnapshot,
-  )
+    const isVisible = useSyncExternalStore(
+      storeRef.current.subscribe,
+      storeRef.current.getSnapshot,
+      storeRef.current.getServerSnapshot,
+    )
 
-  // Detect show rising edge during render (not in effect)
-  if (show && !prevShowRef.current && !isVisible) {
-    storeRef.current.show()
-  }
-  prevShowRef.current = show
+    // Detect show rising edge during render (not in effect)
+    if (show && !prevShowRef.current && !isVisible) {
+      storeRef.current.show()
+    }
+    prevShowRef.current = show
 
-  if (!isVisible) return null
+    if (!isVisible) return null
 
-  return (
-    <div
-      className={cn('level-up-container', className)}
-      aria-live="polite"
-      aria-label={`Amazing! You've reached ${milestone} at level ${level}`}
-      data-slot="milestone-level-up-animation"
-    >
-      <div className="level-up-badge achievement-legendary">
-        {/* Enhanced background effects */}
-        <div className="level-up-bg-circle" />
-        <div className="level-up-bg-rays" />
-        <div className="level-up-sparkle" />
+    return (
+      <div
+        className={cn('level-up-container', className)}
+        aria-live="polite"
+        aria-label={`Amazing! You've reached ${milestone} at level ${level}`}
+        data-slot="milestone-level-up-animation"
+      >
+        <div className="level-up-badge achievement-legendary">
+          {/* Enhanced background effects */}
+          <div className="level-up-bg-circle" />
+          <div className="level-up-bg-rays" />
+          <div className="level-up-sparkle" />
 
-        {/* Trophy icon for milestones */}
-        <div className="level-up-icon">
-          <Trophy className="h-10 w-10" />
+          {/* Trophy icon for milestones */}
+          <div className="level-up-icon">
+            <Trophy className="h-10 w-10" />
+          </div>
+
+          {/* Extra star particles */}
+          {[...Array(8)].map((_, i) => (
+            <div
+              key={i}
+              className="level-up-particle"
+              style={{
+                top: '50%',
+                left: '50%',
+                animation: `levelUpParticle${(i % 4) + 1} var(--duration-slow) var(--ease-out) forwards`,
+                animationDelay: `${i * 100}ms`,
+              }}
+            />
+          ))}
         </div>
 
-        {/* Extra star particles */}
-        {[...Array(8)].map((_, i) => (
-          <div
-            key={i}
-            className="level-up-particle"
-            style={{
-              top: '50%',
-              left: '50%',
-              animation: `levelUpParticle${(i % 4) + 1} var(--duration-slow) var(--ease-out) forwards`,
-              animationDelay: `${i * 100}ms`,
-            }}
-          />
-        ))}
+        {/* Enhanced text content */}
+        <div className="level-up-text">
+          <h3 className="level-up-title flex items-center gap-2">
+            <Star className="h-5 w-5 text-yellow-500" />
+            {milestone}
+            <Star className="h-5 w-5 text-yellow-500" />
+          </h3>
+          <p className="level-up-subtitle">Level {level} Achieved!</p>
+          {reward && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              Reward: {reward}
+            </p>
+          )}
+        </div>
       </div>
-
-      {/* Enhanced text content */}
-      <div className="level-up-text">
-        <h3 className="level-up-title flex items-center gap-2">
-          <Star className="h-5 w-5 text-yellow-500" />
-          {milestone}
-          <Star className="h-5 w-5 text-yellow-500" />
-        </h3>
-        <p className="level-up-subtitle">Level {level} Achieved!</p>
-        {reward && (
-          <p className="mt-2 text-sm text-muted-foreground">Reward: {reward}</p>
-        )}
-      </div>
-    </div>
-  )
-}
+    )
+  },
+)
 
 /**
  * Hook to manage level up animations

--- a/src/components/animations/LevelUpAnimation.tsx
+++ b/src/components/animations/LevelUpAnimation.tsx
@@ -62,11 +62,15 @@ export const LevelUpAnimation = React.memo(function LevelUpAnimation({
   className,
 }: LevelUpAnimationProps) {
   const prevShowRef = useRef(false)
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
 
   // Create stable visibility store
   const storeRef = useRef<ReturnType<typeof createVisibilityStore> | null>(null)
   if (!storeRef.current) {
-    storeRef.current = createVisibilityStore(4000, onComplete)
+    storeRef.current = createVisibilityStore(4000, () => {
+      onCompleteRef.current?.()
+    })
   }
 
   const isVisible = useSyncExternalStore(
@@ -133,13 +137,17 @@ export const MilestoneLevelUpAnimation = React.memo(
     reward?: string
   }) {
     const prevShowRef = useRef(false)
+    const onCompleteRef = useRef(onComplete)
+    onCompleteRef.current = onComplete
 
     // Create stable visibility store with longer duration for milestones
     const storeRef = useRef<ReturnType<typeof createVisibilityStore> | null>(
       null,
     )
     if (!storeRef.current) {
-      storeRef.current = createVisibilityStore(5000, onComplete)
+      storeRef.current = createVisibilityStore(5000, () => {
+        onCompleteRef.current?.()
+      })
     }
 
     const isVisible = useSyncExternalStore(

--- a/src/components/auth/ElectronLoginForm.tsx
+++ b/src/components/auth/ElectronLoginForm.tsx
@@ -3,20 +3,16 @@
 import { useSignIn, useUser } from '@clerk/nextjs'
 import { Eye, EyeOff, Loader2, Mail } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import {
-  useCallback,
-  useEffect,
-  useReducer,
-  useRef,
-  useSyncExternalStore,
-} from 'react'
+import * as React from 'react'
+import { memo, useCallback, useRef, useSyncExternalStore } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
+import { useReducerState } from '@/hooks/useReducerState'
 
 import { isElectronEnvironment } from '../../../electron/utils/electron-client'
-
 type FormState = {
   email: string
   password: string
@@ -73,11 +69,11 @@ function formReducer(state: FormState, action: FormAction): FormState {
  *
  * @returns Login form with email/password fields and optional Google OAuth fallback
  */
-export function ElectronLoginForm() {
+export const ElectronLoginForm = memo(function ElectronLoginForm() {
   const { signIn, fetchStatus } = useSignIn()
   const { user } = useUser()
   const router = useRouter()
-  const [state, dispatch] = useReducer(formReducer, {
+  const [state, dispatch] = useReducerState(formReducer, {
     email: '',
     password: '',
     isLoading: false,
@@ -90,7 +86,7 @@ export function ElectronLoginForm() {
   )
 
   // Listen for OAuth errors from ElectronAuthProvider to reset loading state
-  useEffect(() => {
+  useComponentEffect(() => {
     const handleOAuthError = (e: Event) => {
       const detail = (e as CustomEvent<string>).detail
       dispatch({
@@ -106,7 +102,7 @@ export function ElectronLoginForm() {
   }, [])
 
   // Safety timeout: reset Google loading after 60s
-  useEffect(() => {
+  useComponentEffect(() => {
     if (state.isGoogleLoading) {
       googleLoadingTimeoutRef.current = setTimeout(() => {
         dispatch({
@@ -127,7 +123,7 @@ export function ElectronLoginForm() {
   }, [state.isGoogleLoading])
 
   // Reset Google loading if user becomes authenticated
-  useEffect(() => {
+  useComponentEffect(() => {
     if (user && state.isGoogleLoading) {
       dispatch({ type: 'STOP_GOOGLE_LOADING' })
     }
@@ -390,7 +386,7 @@ export function ElectronLoginForm() {
       </p>
     </div>
   )
-}
+})
 
 /**
  * Store for Electron environment detection.

--- a/src/components/auth/ElectronOAuthButtons.tsx
+++ b/src/components/auth/ElectronOAuthButtons.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useUser } from '@clerk/nextjs'
-import { useCallback, useEffect, useReducer, useSyncExternalStore } from 'react'
+import { memo, useCallback, useSyncExternalStore } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
+import { useReducerState } from '@/hooks/useReducerState'
 
 import { isElectronEnvironment } from '../../../electron/utils/electron-client'
-
 type OAuthState = {
   isLoading: string | null
   error: string | null
@@ -43,8 +44,8 @@ function oauthReducer(state: OAuthState, action: OAuthAction): OAuthState {
  *
  * This component provides buttons that trigger the browser-based OAuth flow.
  */
-export function ElectronOAuthButtons() {
-  const [state, dispatch] = useReducer(oauthReducer, {
+export const ElectronOAuthButtons = memo(function ElectronOAuthButtons() {
+  const [state, dispatch] = useReducerState(oauthReducer, {
     isLoading: null,
     error: null,
   })
@@ -55,7 +56,7 @@ export function ElectronOAuthButtons() {
   const isLoading = user ? null : state.isLoading
   const error = user ? null : state.error
 
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isElectronEnvironment()) return
 
     // Register OAuth event listeners
@@ -182,7 +183,7 @@ export function ElectronOAuthButtons() {
       </p>
     </div>
   )
-}
+})
 
 /**
  * Store for Electron OAuth availability detection.

--- a/src/components/auth/ElectronSignUpForm.tsx
+++ b/src/components/auth/ElectronSignUpForm.tsx
@@ -3,12 +3,13 @@
 import { useSignUp, useUser } from '@clerk/nextjs'
 import { Eye, EyeOff, Loader2, Mail } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useCallback, useReducer, useState } from 'react'
+import * as React from 'react'
+import { memo, useCallback, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-
+import { useReducerState } from '@/hooks/useReducerState'
 type FormState = {
   email: string
   password: string
@@ -62,11 +63,11 @@ function formReducer(state: FormState, action: FormAction): FormState {
  *
  * @returns Sign-up form with email/password fields and optional Google OAuth fallback
  */
-export function ElectronSignUpForm() {
+export const ElectronSignUpForm = memo(function ElectronSignUpForm() {
   const { signUp, fetchStatus } = useSignUp()
   const { user } = useUser()
   const router = useRouter()
-  const [state, dispatch] = useReducer(formReducer, {
+  const [state, dispatch] = useReducerState(formReducer, {
     email: '',
     password: '',
     code: '',
@@ -432,4 +433,4 @@ export function ElectronSignUpForm() {
       </p>
     </div>
   )
-}
+})

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import * as React from 'react'
+import { memo, useCallback, useId, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
@@ -17,6 +18,7 @@ import { Slider } from '@/components/ui/slider'
 import { Switch } from '@/components/ui/switch'
 import { useMounted } from '@/hooks/use-mounted'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { useSelectedCategory } from '@/hooks/useSelectedCategory'
 import {
   BRAINDUMP_NOTE_LINES_PER_CAP,
@@ -123,7 +125,7 @@ function findCheckedLineIndexByTitle(
  * textarea state first, then fire the IPC + oRPC writes. Failure rollback
  * is handled by the toast cleanup path.
  */
-export function BrainDumpEditor({
+export const BrainDumpEditor = memo(function BrainDumpEditor({
   categories,
 }: {
   categories: CategoryWithCount[]
@@ -164,7 +166,7 @@ export function BrainDumpEditor({
     text: string
   }>({ categoryId: null, text: '' })
 
-  useEffect(() => {
+  useComponentEffect(() => {
     noteTextRef.current = noteText
   }, [noteText])
 
@@ -176,7 +178,7 @@ export function BrainDumpEditor({
   )
 
   // Initial pull of opacity + sync mode + last category from the main process.
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment()) return
     let cancelled = false
     const api = window.brainDumpAPI
@@ -206,7 +208,7 @@ export function BrainDumpEditor({
 
   // Subscribe to main-process category broadcasts (e.g., when another window
   // changes the active category and main updates the BrainDump config).
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment()) return
     const api = window.brainDumpAPI
     if (!api) return
@@ -219,7 +221,7 @@ export function BrainDumpEditor({
   }, [isMounted])
 
   // Whenever the active category flips, load that category's note text.
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment() || activeCategoryId === null) {
       setNoteText('')
       lastPersistedRef.current = { categoryId: null, text: '' }
@@ -267,7 +269,7 @@ export function BrainDumpEditor({
   // The cleanup *only* clears the pending timer — flushing here would defeat
   // the debounce because cleanup runs on every keystroke (noteText is a dep).
   // The companion effect below handles category-swap/unmount flushes.
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment() || activeCategoryId === null)
       return
     if (isLoadingNote) return
@@ -294,7 +296,7 @@ export function BrainDumpEditor({
 
   // Final flush: runs on category swap and unmount only (not on every keystroke).
   // Reads the latest text via ref so we never persist a stale snapshot.
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment() || activeCategoryId === null)
       return
     const api = window.brainDumpAPI
@@ -682,4 +684,4 @@ export function BrainDumpEditor({
       />
     </div>
   )
-}
+})

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -1,3 +1,32 @@
+'use client'
+
+import { Brain, Eye, Keyboard } from 'lucide-react'
+import React, { memo, useId, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Slider } from '@/components/ui/slider'
+import { Switch } from '@/components/ui/switch'
+import { useMounted } from '@/hooks/use-mounted'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
+import {
+  type BrainDumpOpacity,
+  type BrainDumpShortcut,
+  type BrainDumpSyncMode,
+  BRAINDUMP_OPACITY_MAX,
+  BRAINDUMP_OPACITY_MIN,
+  BRAINDUMP_OPACITY_STEP,
+} from '@/lib/constants/braindump'
+import { log } from '@/lib/logger'
+
 /**
  * @fileoverview BrainDump Note settings panel for the Electron Settings page.
  *
@@ -14,34 +43,6 @@
  *
  * @module components/electron/BrainDumpSettings
  */
-'use client'
-
-import { Brain, Eye, Keyboard } from 'lucide-react'
-import { useEffect, useId, useRef, useState } from 'react'
-
-import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Slider } from '@/components/ui/slider'
-import { Switch } from '@/components/ui/switch'
-import { useMounted } from '@/hooks/use-mounted'
-import {
-  type BrainDumpOpacity,
-  type BrainDumpShortcut,
-  type BrainDumpSyncMode,
-  BRAINDUMP_OPACITY_MAX,
-  BRAINDUMP_OPACITY_MIN,
-  BRAINDUMP_OPACITY_STEP,
-} from '@/lib/constants/braindump'
-import { log } from '@/lib/logger'
-
 interface BrainDumpSettingsProps {
   className?: string
 }
@@ -60,7 +61,7 @@ interface BrainDumpSettingsProps {
  * @example
  * <BrainDumpSettings />
  */
-export function BrainDumpSettings({
+export const BrainDumpSettings = memo(function BrainDumpSettings({
   className,
 }: BrainDumpSettingsProps): React.ReactElement {
   const syncId = useId()
@@ -88,7 +89,7 @@ export function BrainDumpSettings({
   // renders and the env check runs only once on mount.
   // The non-Electron branch is rendered via the early-return below, so it
   // never observes `isReady`; we only flip it after the IPC fetch resolves.
-  useEffect(() => {
+  useComponentEffect(() => {
     const api =
       typeof window === 'undefined' ? undefined : window.electronAPI?.brainDump
     if (!api) return
@@ -311,6 +312,6 @@ export function BrainDumpSettings({
       </CardContent>
     </Card>
   )
-}
+})
 
 export default BrainDumpSettings

--- a/src/components/electron/ConfigurationSettings.tsx
+++ b/src/components/electron/ConfigurationSettings.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { toast } from 'sonner'
 
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -26,6 +26,7 @@ import { Separator } from '@/components/ui/separator'
 import { Slider } from '@/components/ui/slider'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 
 import type { ConfigSection } from '../../../electron/types/ipc'
 import { log } from '../../lib/logger'
@@ -111,1042 +112,1052 @@ interface ValidationResult {
   errors: string[]
 }
 
-export function ConfigurationSettings() {
-  const [config, setConfig] = useState<ElectronConfig | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
-  const [validation, setValidation] = useState<ValidationResult>({
-    isValid: true,
-    errors: [],
-  })
-  const [hasChanges, setHasChanges] = useState(false)
+export const ConfigurationSettings = React.memo(
+  function ConfigurationSettings() {
+    const [config, setConfig] = useState<ElectronConfig | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [saving, setSaving] = useState(false)
+    const [validation, setValidation] = useState<ValidationResult>({
+      isValid: true,
+      errors: [],
+    })
+    const [hasChanges, setHasChanges] = useState(false)
 
-  // Check if we're in Electron environment
-  const isElectron = typeof window !== 'undefined' && window.electronAPI
+    // Check if we're in Electron environment
+    const isElectron = typeof window !== 'undefined' && window.electronAPI
 
-  useEffect(() => {
-    if (isElectron) {
-      loadConfiguration()
-    } else {
-      setLoading(false)
-    }
-  }, [isElectron])
-
-  const loadConfiguration = async () => {
-    try {
-      setLoading(true)
-      if (!window.electronAPI?.config) {
-        throw new Error('Electron API not available')
+    useComponentEffect(() => {
+      if (isElectron) {
+        loadConfiguration()
+      } else {
+        setLoading(false)
       }
-      const allConfig = await window.electronAPI.config.getAll()
-      setConfig(allConfig as unknown as ElectronConfig)
+    }, [isElectron])
 
-      // Validate configuration
-      const validationResult = await window.electronAPI.config.validate()
-      setValidation({
-        isValid: validationResult.isValid,
-        errors: validationResult.errors ?? [],
-      })
-    } catch (error) {
-      log.error('Failed to load configuration:', error)
-      toast.error('Failed to load configuration')
-    } finally {
-      setLoading(false)
-    }
-  }
+    const loadConfiguration = async () => {
+      try {
+        setLoading(true)
+        if (!window.electronAPI?.config) {
+          throw new Error('Electron API not available')
+        }
+        const allConfig = await window.electronAPI.config.getAll()
+        setConfig(allConfig as unknown as ElectronConfig)
 
-  const updateConfig = (path: string, value: any) => {
-    if (!config) return
-
-    const keys = path.split('.')
-    const newConfig = { ...config }
-    let current: any = newConfig
-
-    for (let i = 0; i < keys.length - 1; i++) {
-      const key = keys[i]
-      if (key && current[key] !== undefined) {
-        current = current[key]
-      }
-    }
-    const lastKey = keys[keys.length - 1]
-    if (lastKey) {
-      current[lastKey] = value
-    }
-
-    setConfig(newConfig)
-    setHasChanges(true)
-  }
-
-  const saveConfiguration = async () => {
-    if (!config || !isElectron) return
-
-    try {
-      setSaving(true)
-
-      // Validate before saving
-      if (!window.electronAPI?.config) {
-        throw new Error('Electron API not available')
-      }
-      const validationResult = await window.electronAPI.config.validate()
-      if (!validationResult.isValid) {
+        // Validate configuration
+        const validationResult = await window.electronAPI.config.validate()
         setValidation({
           isValid: validationResult.isValid,
           errors: validationResult.errors ?? [],
         })
-        toast.error('Configuration validation failed')
-        return
+      } catch (error) {
+        log.error('Failed to load configuration:', error)
+        toast.error('Failed to load configuration')
+      } finally {
+        setLoading(false)
       }
+    }
 
-      // Save configuration
-      const updates: Record<string, any> = {}
-      const flattenConfig = (obj: any, prefix = '') => {
-        for (const [key, value] of Object.entries(obj)) {
-          const path = prefix ? `${prefix}.${key}` : key
-          if (
-            typeof value === 'object' &&
-            value !== null &&
-            !Array.isArray(value)
-          ) {
-            flattenConfig(value, path)
-          } else {
-            updates[path] = value
-          }
+    const updateConfig = (path: string, value: any) => {
+      if (!config) return
+
+      const keys = path.split('.')
+      const newConfig = { ...config }
+      let current: any = newConfig
+
+      for (let i = 0; i < keys.length - 1; i++) {
+        const key = keys[i]
+        if (key && current[key] !== undefined) {
+          current = current[key]
         }
       }
-
-      flattenConfig(config)
-      if (!window.electronAPI?.config) {
-        throw new Error('Electron API not available')
+      const lastKey = keys[keys.length - 1]
+      if (lastKey) {
+        current[lastKey] = value
       }
-      await window.electronAPI.config.update(updates)
 
-      setHasChanges(false)
-      toast.success('Configuration saved successfully')
-    } catch (error) {
-      log.error('Failed to save configuration:', error)
-      toast.error('Failed to save configuration')
-    } finally {
-      setSaving(false)
+      setConfig(newConfig)
+      setHasChanges(true)
     }
-  }
 
-  const resetConfiguration = async () => {
-    if (!isElectron) return
+    const saveConfiguration = async () => {
+      if (!config || !isElectron) return
 
-    try {
-      if (!window.electronAPI?.config) {
-        throw new Error('Electron API not available')
+      try {
+        setSaving(true)
+
+        // Validate before saving
+        if (!window.electronAPI?.config) {
+          throw new Error('Electron API not available')
+        }
+        const validationResult = await window.electronAPI.config.validate()
+        if (!validationResult.isValid) {
+          setValidation({
+            isValid: validationResult.isValid,
+            errors: validationResult.errors ?? [],
+          })
+          toast.error('Configuration validation failed')
+          return
+        }
+
+        // Save configuration
+        const updates: Record<string, any> = {}
+        const flattenConfig = (obj: any, prefix = '') => {
+          for (const [key, value] of Object.entries(obj)) {
+            const path = prefix ? `${prefix}.${key}` : key
+            if (
+              typeof value === 'object' &&
+              value !== null &&
+              !Array.isArray(value)
+            ) {
+              flattenConfig(value, path)
+            } else {
+              updates[path] = value
+            }
+          }
+        }
+
+        flattenConfig(config)
+        if (!window.electronAPI?.config) {
+          throw new Error('Electron API not available')
+        }
+        await window.electronAPI.config.update(updates)
+
+        setHasChanges(false)
+        toast.success('Configuration saved successfully')
+      } catch (error) {
+        log.error('Failed to save configuration:', error)
+        toast.error('Failed to save configuration')
+      } finally {
+        setSaving(false)
       }
-      await window.electronAPI.config.reset()
-      await loadConfiguration()
-      setHasChanges(false)
-      toast.success('Configuration reset to defaults')
-    } catch (error) {
-      log.error('Failed to reset configuration:', error)
-      toast.error('Failed to reset configuration')
     }
-  }
 
-  const resetSection = async (section: ConfigSection) => {
-    if (!isElectron) return
+    const resetConfiguration = async () => {
+      if (!isElectron) return
 
-    try {
-      if (!window.electronAPI?.config) {
-        throw new Error('Electron API not available')
+      try {
+        if (!window.electronAPI?.config) {
+          throw new Error('Electron API not available')
+        }
+        await window.electronAPI.config.reset()
+        await loadConfiguration()
+        setHasChanges(false)
+        toast.success('Configuration reset to defaults')
+      } catch (error) {
+        log.error('Failed to reset configuration:', error)
+        toast.error('Failed to reset configuration')
       }
-      await window.electronAPI.config.resetSection(section)
-      await loadConfiguration()
-      setHasChanges(false)
-      toast.success(`${section} settings reset to defaults`)
-    } catch (error) {
-      log.error('Failed to reset section:', error)
-      toast.error(`Failed to reset ${section} settings`)
     }
-  }
 
-  const exportConfiguration = async () => {
-    if (!isElectron) return
+    const resetSection = async (section: ConfigSection) => {
+      if (!isElectron) return
 
-    try {
-      // In a real implementation, you'd use a file dialog
-      // For now, we'll just create a backup
-
-      // For now, we'll just create a backup
-      if (!window.electronAPI?.config) {
-        throw new Error('Electron API not available')
+      try {
+        if (!window.electronAPI?.config) {
+          throw new Error('Electron API not available')
+        }
+        await window.electronAPI.config.resetSection(section)
+        await loadConfiguration()
+        setHasChanges(false)
+        toast.success(`${section} settings reset to defaults`)
+      } catch (error) {
+        log.error('Failed to reset section:', error)
+        toast.error(`Failed to reset ${section} settings`)
       }
-      const backupPath = await window.electronAPI.config.backup()
-      if (backupPath) {
-        toast.success(`Configuration exported to ${backupPath}`)
-      } else {
+    }
+
+    const exportConfiguration = async () => {
+      if (!isElectron) return
+
+      try {
+        // In a real implementation, you'd use a file dialog
+        // For now, we'll just create a backup
+
+        // For now, we'll just create a backup
+        if (!window.electronAPI?.config) {
+          throw new Error('Electron API not available')
+        }
+        const backupPath = await window.electronAPI.config.backup()
+        if (backupPath) {
+          toast.success(`Configuration exported to ${backupPath}`)
+        } else {
+          toast.error('Failed to export configuration')
+        }
+      } catch (error) {
+        log.error('Failed to export configuration:', error)
         toast.error('Failed to export configuration')
       }
-    } catch (error) {
-      log.error('Failed to export configuration:', error)
-      toast.error('Failed to export configuration')
     }
-  }
 
-  if (!isElectron) {
-    return (
-      <Alert>
-        <AlertDescription>
-          Configuration settings are only available in the Electron desktop
-          application.
-        </AlertDescription>
-      </Alert>
-    )
-  }
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center p-8">
-        <div className="text-center">
-          <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900"></div>
-          <p>Loading configuration...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!config) {
-    return (
-      <Alert>
-        <AlertDescription>
-          Failed to load configuration. Please try refreshing the page.
-        </AlertDescription>
-      </Alert>
-    )
-  }
-
-  return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold">Configuration Settings</h2>
-          <p className="text-muted-foreground">
-            Customize your desktop application preferences
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {hasChanges && <Badge variant="secondary">Unsaved changes</Badge>}
-          <Button
-            onClick={saveConfiguration}
-            disabled={saving || !hasChanges}
-            className="min-w-24"
-          >
-            {saving ? 'Saving...' : 'Save Changes'}
-          </Button>
-        </div>
-      </div>
-
-      {/* Validation Errors */}
-      {!validation.isValid && (
-        <Alert variant="destructive">
+    if (!isElectron) {
+      return (
+        <Alert>
           <AlertDescription>
-            <div className="mb-2 font-medium">
-              Configuration Validation Errors:
-            </div>
-            <ul className="list-inside list-disc space-y-1">
-              {validation.errors.map((error, index) => (
-                <li key={index}>{error}</li>
-              ))}
-            </ul>
+            Configuration settings are only available in the Electron desktop
+            application.
           </AlertDescription>
         </Alert>
-      )}
+      )
+    }
 
-      {/* Configuration Tabs */}
-      <Tabs defaultValue="window" className="space-y-4">
-        <TabsList className="grid w-full grid-cols-6">
-          <TabsTrigger value="window">Window</TabsTrigger>
-          <TabsTrigger value="tray">System Tray</TabsTrigger>
-          <TabsTrigger value="shortcuts">Shortcuts</TabsTrigger>
-          <TabsTrigger value="notifications">Notifications</TabsTrigger>
-          <TabsTrigger value="behavior">Behavior</TabsTrigger>
-          <TabsTrigger value="advanced">Advanced</TabsTrigger>
-        </TabsList>
+    if (loading) {
+      return (
+        <div className="flex items-center justify-center p-8">
+          <div className="text-center">
+            <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900"></div>
+            <p>Loading configuration...</p>
+          </div>
+        </div>
+      )
+    }
 
-        {/* Window Settings */}
-        <TabsContent value="window" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Main Window</CardTitle>
-              <CardDescription>
-                Configure the main application window behavior
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="main-width">Width</Label>
-                  <Input
-                    id="main-width"
-                    type="number"
-                    value={config.window.main.width}
-                    onChange={(e) =>
-                      updateConfig(
-                        'window.main.width',
-                        parseInt(e.target.value, 10),
-                      )
-                    }
-                    min={config.window.main.minWidth}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="main-height">Height</Label>
-                  <Input
-                    id="main-height"
-                    type="number"
-                    value={config.window.main.height}
-                    onChange={(e) =>
-                      updateConfig(
-                        'window.main.height',
-                        parseInt(e.target.value, 10),
-                      )
-                    }
-                    min={config.window.main.minHeight}
-                  />
-                </div>
+    if (!config) {
+      return (
+        <Alert>
+          <AlertDescription>
+            Failed to load configuration. Please try refreshing the page.
+          </AlertDescription>
+        </Alert>
+      )
+    }
+
+    return (
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-bold">Configuration Settings</h2>
+            <p className="text-muted-foreground">
+              Customize your desktop application preferences
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {hasChanges && <Badge variant="secondary">Unsaved changes</Badge>}
+            <Button
+              onClick={saveConfiguration}
+              disabled={saving || !hasChanges}
+              className="min-w-24"
+            >
+              {saving ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </div>
+        </div>
+
+        {/* Validation Errors */}
+        {!validation.isValid && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              <div className="mb-2 font-medium">
+                Configuration Validation Errors:
               </div>
+              <ul className="list-inside list-disc space-y-1">
+                {validation.errors.map((error, index) => (
+                  <li key={index}>{error}</li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
 
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="remember-position">
-                    Remember window position
-                  </Label>
-                  <Switch
-                    id="remember-position"
-                    checked={config.window.main.rememberPosition}
-                    onCheckedChange={(checked) =>
-                      updateConfig('window.main.rememberPosition', checked)
-                    }
-                  />
-                </div>
+        {/* Configuration Tabs */}
+        <Tabs defaultValue="window" className="space-y-4">
+          <TabsList className="grid w-full grid-cols-6">
+            <TabsTrigger value="window">Window</TabsTrigger>
+            <TabsTrigger value="tray">System Tray</TabsTrigger>
+            <TabsTrigger value="shortcuts">Shortcuts</TabsTrigger>
+            <TabsTrigger value="notifications">Notifications</TabsTrigger>
+            <TabsTrigger value="behavior">Behavior</TabsTrigger>
+            <TabsTrigger value="advanced">Advanced</TabsTrigger>
+          </TabsList>
 
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="remember-size">Remember window size</Label>
-                  <Switch
-                    id="remember-size"
-                    checked={config.window.main.rememberSize}
-                    onCheckedChange={(checked) =>
-                      updateConfig('window.main.rememberSize', checked)
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="start-maximized">Start maximized</Label>
-                  <Switch
-                    id="start-maximized"
-                    checked={config.window.main.startMaximized}
-                    onCheckedChange={(checked) =>
-                      updateConfig('window.main.startMaximized', checked)
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="center-on-start">Center on start</Label>
-                  <Switch
-                    id="center-on-start"
-                    checked={config.window.main.centerOnStart}
-                    onCheckedChange={(checked) =>
-                      updateConfig('window.main.centerOnStart', checked)
-                    }
-                  />
-                </div>
-              </div>
-
-              <div className="flex justify-end">
-                <Button
-                  variant="outline"
-                  onClick={async () => resetSection('window')}
-                  size="sm"
-                >
-                  Reset Window Settings
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Floating Navigator</CardTitle>
-              <CardDescription>
-                Configure the floating navigator window
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-3 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="floating-width">Width</Label>
-                  <Input
-                    id="floating-width"
-                    type="number"
-                    value={config.window.floating.width}
-                    onChange={(e) =>
-                      updateConfig(
-                        'window.floating.width',
-                        parseInt(e.target.value, 10),
-                      )
-                    }
-                    min={config.window.floating.minWidth}
-                    max={config.window.floating.maxWidth}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="floating-height">Height</Label>
-                  <Input
-                    id="floating-height"
-                    type="number"
-                    value={config.window.floating.height}
-                    onChange={(e) =>
-                      updateConfig(
-                        'window.floating.height',
-                        parseInt(e.target.value, 10),
-                      )
-                    }
-                    min={config.window.floating.minHeight}
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="always-on-top">Always on top</Label>
-                  <Switch
-                    id="always-on-top"
-                    checked={config.window.floating.alwaysOnTop}
-                    onCheckedChange={(checked) =>
-                      updateConfig('window.floating.alwaysOnTop', checked)
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="floating-resizable">Resizable</Label>
-                  <Switch
-                    id="floating-resizable"
-                    checked={config.window.floating.resizable}
-                    onCheckedChange={(checked) =>
-                      updateConfig('window.floating.resizable', checked)
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="floating-frame">Show window frame</Label>
-                  <Switch
-                    id="floating-frame"
-                    checked={config.window.floating.frame}
-                    onCheckedChange={(checked) =>
-                      updateConfig('window.floating.frame', checked)
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="start-visible">Start visible</Label>
-                  <Switch
-                    id="start-visible"
-                    checked={config.window.floating.startVisible}
-                    onCheckedChange={(checked) =>
-                      updateConfig('window.floating.startVisible', checked)
-                    }
-                  />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* System Tray Settings */}
-        <TabsContent value="tray" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>System Tray</CardTitle>
-              <CardDescription>
-                Configure system tray integration and behavior
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="tray-enabled">Enable system tray</Label>
-                <Switch
-                  id="tray-enabled"
-                  checked={config.tray.enabled}
-                  onCheckedChange={(checked) =>
-                    updateConfig('tray.enabled', checked)
-                  }
-                />
-              </div>
-
-              {config.tray.enabled && (
-                <>
-                  <Separator />
-
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="minimize-to-tray">Minimize to tray</Label>
-                      <Switch
-                        id="minimize-to-tray"
-                        checked={config.tray.minimizeToTray}
-                        onCheckedChange={(checked) =>
-                          updateConfig('tray.minimizeToTray', checked)
-                        }
-                      />
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="close-to-tray">Close to tray</Label>
-                      <Switch
-                        id="close-to-tray"
-                        checked={config.tray.closeToTray}
-                        onCheckedChange={(checked) =>
-                          updateConfig('tray.closeToTray', checked)
-                        }
-                      />
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="start-minimized">Start minimized</Label>
-                      <Switch
-                        id="start-minimized"
-                        checked={config.tray.startMinimized}
-                        onCheckedChange={(checked) =>
-                          updateConfig('tray.startMinimized', checked)
-                        }
-                      />
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="show-notification-count">
-                        Show notification count
-                      </Label>
-                      <Switch
-                        id="show-notification-count"
-                        checked={config.tray.showNotificationCount}
-                        onCheckedChange={(checked) =>
-                          updateConfig('tray.showNotificationCount', checked)
-                        }
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="double-click-action">
-                        Double-click action
-                      </Label>
-                      <Select
-                        value={config.tray.doubleClickAction}
-                        onValueChange={(value) =>
-                          updateConfig('tray.doubleClickAction', value)
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="restore">
-                            Restore window
-                          </SelectItem>
-                          <SelectItem value="toggle">Toggle window</SelectItem>
-                          <SelectItem value="none">No action</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="right-click-action">
-                        Right-click action
-                      </Label>
-                      <Select
-                        value={config.tray.rightClickAction}
-                        onValueChange={(value) =>
-                          updateConfig('tray.rightClickAction', value)
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="menu">
-                            Show context menu
-                          </SelectItem>
-                          <SelectItem value="restore">
-                            Restore window
-                          </SelectItem>
-                          <SelectItem value="none">No action</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
+          {/* Window Settings */}
+          <TabsContent value="window" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Main Window</CardTitle>
+                <CardDescription>
+                  Configure the main application window behavior
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="main-width">Width</Label>
+                    <Input
+                      id="main-width"
+                      type="number"
+                      value={config.window.main.width}
+                      onChange={(e) =>
+                        updateConfig(
+                          'window.main.width',
+                          parseInt(e.target.value, 10),
+                        )
+                      }
+                      min={config.window.main.minWidth}
+                    />
                   </div>
-                </>
-              )}
-
-              <div className="flex justify-end">
-                <Button
-                  variant="outline"
-                  onClick={async () => resetSection('tray')}
-                  size="sm"
-                >
-                  Reset Tray Settings
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* Shortcuts Settings */}
-        <TabsContent value="shortcuts" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Keyboard Shortcuts</CardTitle>
-              <CardDescription>
-                Configure global keyboard shortcuts for quick actions
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="shortcuts-enabled">Enable shortcuts</Label>
-                <Switch
-                  id="shortcuts-enabled"
-                  checked={config.shortcuts.enabled}
-                  onCheckedChange={(checked) =>
-                    updateConfig('shortcuts.enabled', checked)
-                  }
-                />
-              </div>
-
-              {config.shortcuts.enabled && (
-                <>
-                  <Separator />
-
-                  <div className="space-y-4">
-                    {Object.entries(config.shortcuts)
-                      .filter(([key]) => key !== 'enabled')
-                      .map(([key, value]) => (
-                        <div
-                          key={key}
-                          className="flex items-center justify-between"
-                        >
-                          <Label
-                            htmlFor={`shortcut-${key}`}
-                            className="capitalize"
-                          >
-                            {key.replace(/([A-Z])/g, ' $1').trim()}
-                          </Label>
-                          <Input
-                            id={`shortcut-${key}`}
-                            value={value as string}
-                            onChange={(e) =>
-                              updateConfig(`shortcuts.${key}`, e.target.value)
-                            }
-                            className="w-48"
-                            placeholder="e.g., Ctrl+N"
-                          />
-                        </div>
-                      ))}
+                  <div className="space-y-2">
+                    <Label htmlFor="main-height">Height</Label>
+                    <Input
+                      id="main-height"
+                      type="number"
+                      value={config.window.main.height}
+                      onChange={(e) =>
+                        updateConfig(
+                          'window.main.height',
+                          parseInt(e.target.value, 10),
+                        )
+                      }
+                      min={config.window.main.minHeight}
+                    />
                   </div>
-                </>
-              )}
+                </div>
 
-              <div className="flex justify-end">
-                <Button
-                  variant="outline"
-                  onClick={async () => resetSection('shortcuts')}
-                  size="sm"
-                >
-                  Reset Shortcuts
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="remember-position">
+                      Remember window position
+                    </Label>
+                    <Switch
+                      id="remember-position"
+                      checked={config.window.main.rememberPosition}
+                      onCheckedChange={(checked) =>
+                        updateConfig('window.main.rememberPosition', checked)
+                      }
+                    />
+                  </div>
 
-        {/* Notifications Settings */}
-        <TabsContent value="notifications" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Notifications</CardTitle>
-              <CardDescription>
-                Configure desktop notifications for task events
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="notifications-enabled">
-                  Enable notifications
-                </Label>
-                <Switch
-                  id="notifications-enabled"
-                  checked={config.notifications.enabled}
-                  onCheckedChange={(checked) =>
-                    updateConfig('notifications.enabled', checked)
-                  }
-                />
-              </div>
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="remember-size">Remember window size</Label>
+                    <Switch
+                      id="remember-size"
+                      checked={config.window.main.rememberSize}
+                      onCheckedChange={(checked) =>
+                        updateConfig('window.main.rememberSize', checked)
+                      }
+                    />
+                  </div>
 
-              {config.notifications.enabled && (
-                <>
-                  <Separator />
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="start-maximized">Start maximized</Label>
+                    <Switch
+                      id="start-maximized"
+                      checked={config.window.main.startMaximized}
+                      onCheckedChange={(checked) =>
+                        updateConfig('window.main.startMaximized', checked)
+                      }
+                    />
+                  </div>
 
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="task-created">Task created</Label>
-                      <Switch
-                        id="task-created"
-                        checked={config.notifications.taskCreated}
-                        onCheckedChange={(checked) =>
-                          updateConfig('notifications.taskCreated', checked)
-                        }
-                      />
-                    </div>
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="center-on-start">Center on start</Label>
+                    <Switch
+                      id="center-on-start"
+                      checked={config.window.main.centerOnStart}
+                      onCheckedChange={(checked) =>
+                        updateConfig('window.main.centerOnStart', checked)
+                      }
+                    />
+                  </div>
+                </div>
 
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="task-completed">Task completed</Label>
-                      <Switch
-                        id="task-completed"
-                        checked={config.notifications.taskCompleted}
-                        onCheckedChange={(checked) =>
-                          updateConfig('notifications.taskCompleted', checked)
-                        }
-                      />
-                    </div>
+                <div className="flex justify-end">
+                  <Button
+                    variant="outline"
+                    onClick={async () => resetSection('window')}
+                    size="sm"
+                  >
+                    Reset Window Settings
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
 
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="task-updated">Task updated</Label>
-                      <Switch
-                        id="task-updated"
-                        checked={config.notifications.taskUpdated}
-                        onCheckedChange={(checked) =>
-                          updateConfig('notifications.taskUpdated', checked)
-                        }
-                      />
-                    </div>
+            <Card>
+              <CardHeader>
+                <CardTitle>Floating Navigator</CardTitle>
+                <CardDescription>
+                  Configure the floating navigator window
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-3 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="floating-width">Width</Label>
+                    <Input
+                      id="floating-width"
+                      type="number"
+                      value={config.window.floating.width}
+                      onChange={(e) =>
+                        updateConfig(
+                          'window.floating.width',
+                          parseInt(e.target.value, 10),
+                        )
+                      }
+                      min={config.window.floating.minWidth}
+                      max={config.window.floating.maxWidth}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="floating-height">Height</Label>
+                    <Input
+                      id="floating-height"
+                      type="number"
+                      value={config.window.floating.height}
+                      onChange={(e) =>
+                        updateConfig(
+                          'window.floating.height',
+                          parseInt(e.target.value, 10),
+                        )
+                      }
+                      min={config.window.floating.minHeight}
+                    />
+                  </div>
+                </div>
 
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="task-deleted">Task deleted</Label>
-                      <Switch
-                        id="task-deleted"
-                        checked={config.notifications.taskDeleted}
-                        onCheckedChange={(checked) =>
-                          updateConfig('notifications.taskDeleted', checked)
-                        }
-                      />
-                    </div>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="always-on-top">Always on top</Label>
+                    <Switch
+                      id="always-on-top"
+                      checked={config.window.floating.alwaysOnTop}
+                      onCheckedChange={(checked) =>
+                        updateConfig('window.floating.alwaysOnTop', checked)
+                      }
+                    />
+                  </div>
 
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="notification-sound">Play sound</Label>
-                      <Switch
-                        id="notification-sound"
-                        checked={config.notifications.sound}
-                        onCheckedChange={(checked) =>
-                          updateConfig('notifications.sound', checked)
-                        }
-                      />
-                    </div>
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="floating-resizable">Resizable</Label>
+                    <Switch
+                      id="floating-resizable"
+                      checked={config.window.floating.resizable}
+                      onCheckedChange={(checked) =>
+                        updateConfig('window.floating.resizable', checked)
+                      }
+                    />
+                  </div>
 
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="auto-hide">Auto-hide notifications</Label>
-                      <Switch
-                        id="auto-hide"
-                        checked={config.notifications.autoHide}
-                        onCheckedChange={(checked) =>
-                          updateConfig('notifications.autoHide', checked)
-                        }
-                      />
-                    </div>
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="floating-frame">Show window frame</Label>
+                    <Switch
+                      id="floating-frame"
+                      checked={config.window.floating.frame}
+                      onCheckedChange={(checked) =>
+                        updateConfig('window.floating.frame', checked)
+                      }
+                    />
+                  </div>
 
-                    {config.notifications.autoHide && (
-                      <div className="space-y-2">
-                        <Label htmlFor="auto-hide-delay">
-                          Auto-hide delay:{' '}
-                          {config.notifications.autoHideDelay / 1000}s
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="start-visible">Start visible</Label>
+                    <Switch
+                      id="start-visible"
+                      checked={config.window.floating.startVisible}
+                      onCheckedChange={(checked) =>
+                        updateConfig('window.floating.startVisible', checked)
+                      }
+                    />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* System Tray Settings */}
+          <TabsContent value="tray" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>System Tray</CardTitle>
+                <CardDescription>
+                  Configure system tray integration and behavior
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="tray-enabled">Enable system tray</Label>
+                  <Switch
+                    id="tray-enabled"
+                    checked={config.tray.enabled}
+                    onCheckedChange={(checked) =>
+                      updateConfig('tray.enabled', checked)
+                    }
+                  />
+                </div>
+
+                {config.tray.enabled && (
+                  <>
+                    <Separator />
+
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="minimize-to-tray">
+                          Minimize to tray
                         </Label>
-                        <Slider
-                          id="auto-hide-delay"
-                          value={[config.notifications.autoHideDelay]}
-                          onValueChange={([value]) =>
-                            updateConfig('notifications.autoHideDelay', value)
+                        <Switch
+                          id="minimize-to-tray"
+                          checked={config.tray.minimizeToTray}
+                          onCheckedChange={(checked) =>
+                            updateConfig('tray.minimizeToTray', checked)
                           }
-                          min={1000}
-                          max={30000}
-                          step={1000}
-                          className="w-full"
                         />
                       </div>
-                    )}
 
-                    <div className="space-y-2">
-                      <Label htmlFor="notification-position">
-                        Notification position
-                      </Label>
-                      <Select
-                        value={config.notifications.position}
-                        onValueChange={(value) =>
-                          updateConfig('notifications.position', value)
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="topRight">Top Right</SelectItem>
-                          <SelectItem value="topLeft">Top Left</SelectItem>
-                          <SelectItem value="bottomRight">
-                            Bottom Right
-                          </SelectItem>
-                          <SelectItem value="bottomLeft">
-                            Bottom Left
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="close-to-tray">Close to tray</Label>
+                        <Switch
+                          id="close-to-tray"
+                          checked={config.tray.closeToTray}
+                          onCheckedChange={(checked) =>
+                            updateConfig('tray.closeToTray', checked)
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="start-minimized">Start minimized</Label>
+                        <Switch
+                          id="start-minimized"
+                          checked={config.tray.startMinimized}
+                          onCheckedChange={(checked) =>
+                            updateConfig('tray.startMinimized', checked)
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="show-notification-count">
+                          Show notification count
+                        </Label>
+                        <Switch
+                          id="show-notification-count"
+                          checked={config.tray.showNotificationCount}
+                          onCheckedChange={(checked) =>
+                            updateConfig('tray.showNotificationCount', checked)
+                          }
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label htmlFor="double-click-action">
+                          Double-click action
+                        </Label>
+                        <Select
+                          value={config.tray.doubleClickAction}
+                          onValueChange={(value) =>
+                            updateConfig('tray.doubleClickAction', value)
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="restore">
+                              Restore window
+                            </SelectItem>
+                            <SelectItem value="toggle">
+                              Toggle window
+                            </SelectItem>
+                            <SelectItem value="none">No action</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label htmlFor="right-click-action">
+                          Right-click action
+                        </Label>
+                        <Select
+                          value={config.tray.rightClickAction}
+                          onValueChange={(value) =>
+                            updateConfig('tray.rightClickAction', value)
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="menu">
+                              Show context menu
+                            </SelectItem>
+                            <SelectItem value="restore">
+                              Restore window
+                            </SelectItem>
+                            <SelectItem value="none">No action</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
                     </div>
-                  </div>
-                </>
-              )}
+                  </>
+                )}
 
-              <div className="flex justify-end">
-                <Button
-                  variant="outline"
-                  onClick={async () => resetSection('notifications')}
-                  size="sm"
-                >
-                  Reset Notification Settings
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
+                <div className="flex justify-end">
+                  <Button
+                    variant="outline"
+                    onClick={async () => resetSection('tray')}
+                    size="sm"
+                  >
+                    Reset Tray Settings
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
 
-        {/* Behavior Settings */}
-        <TabsContent value="behavior" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Application Behavior</CardTitle>
-              <CardDescription>
-                Configure general application behavior and preferences
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="start-on-login">Start on login</Label>
-                <Switch
-                  id="start-on-login"
-                  checked={config.behavior.startOnLogin}
-                  onCheckedChange={(checked) =>
-                    updateConfig('behavior.startOnLogin', checked)
-                  }
-                />
-              </div>
-
-              <div className="flex items-center justify-between">
-                <Label htmlFor="check-for-updates">Check for updates</Label>
-                <Switch
-                  id="check-for-updates"
-                  checked={config.behavior.checkForUpdates}
-                  onCheckedChange={(checked) =>
-                    updateConfig('behavior.checkForUpdates', checked)
-                  }
-                />
-              </div>
-
-              <div className="flex items-center justify-between">
-                <Label htmlFor="auto-save">Auto-save</Label>
-                <Switch
-                  id="auto-save"
-                  checked={config.behavior.autoSave}
-                  onCheckedChange={(checked) =>
-                    updateConfig('behavior.autoSave', checked)
-                  }
-                />
-              </div>
-
-              {config.behavior.autoSave && (
-                <div className="space-y-2">
-                  <Label htmlFor="auto-save-interval">
-                    Auto-save interval:{' '}
-                    {config.behavior.autoSaveInterval / 1000}s
-                  </Label>
-                  <Slider
-                    id="auto-save-interval"
-                    value={[config.behavior.autoSaveInterval]}
-                    onValueChange={([value]) =>
-                      updateConfig('behavior.autoSaveInterval', value)
+          {/* Shortcuts Settings */}
+          <TabsContent value="shortcuts" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Keyboard Shortcuts</CardTitle>
+                <CardDescription>
+                  Configure global keyboard shortcuts for quick actions
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="shortcuts-enabled">Enable shortcuts</Label>
+                  <Switch
+                    id="shortcuts-enabled"
+                    checked={config.shortcuts.enabled}
+                    onCheckedChange={(checked) =>
+                      updateConfig('shortcuts.enabled', checked)
                     }
-                    min={5000}
-                    max={300000}
-                    step={5000}
-                    className="w-full"
                   />
                 </div>
-              )}
 
-              <div className="flex items-center justify-between">
-                <Label htmlFor="confirm-on-delete">Confirm on delete</Label>
-                <Switch
-                  id="confirm-on-delete"
-                  checked={config.behavior.confirmOnDelete}
-                  onCheckedChange={(checked) =>
-                    updateConfig('behavior.confirmOnDelete', checked)
-                  }
-                />
-              </div>
+                {config.shortcuts.enabled && (
+                  <>
+                    <Separator />
 
-              <div className="flex items-center justify-between">
-                <Label htmlFor="confirm-on-quit">Confirm on quit</Label>
-                <Switch
-                  id="confirm-on-quit"
-                  checked={config.behavior.confirmOnQuit}
-                  onCheckedChange={(checked) =>
-                    updateConfig('behavior.confirmOnQuit', checked)
-                  }
-                />
-              </div>
+                    <div className="space-y-4">
+                      {Object.entries(config.shortcuts)
+                        .filter(([key]) => key !== 'enabled')
+                        .map(([key, value]) => (
+                          <div
+                            key={key}
+                            className="flex items-center justify-between"
+                          >
+                            <Label
+                              htmlFor={`shortcut-${key}`}
+                              className="capitalize"
+                            >
+                              {key.replace(/([A-Z])/g, ' $1').trim()}
+                            </Label>
+                            <Input
+                              id={`shortcut-${key}`}
+                              value={value as string}
+                              onChange={(e) =>
+                                updateConfig(`shortcuts.${key}`, e.target.value)
+                              }
+                              className="w-48"
+                              placeholder="e.g., Ctrl+N"
+                            />
+                          </div>
+                        ))}
+                    </div>
+                  </>
+                )}
 
-              <div className="flex justify-end">
-                <Button
-                  variant="outline"
-                  onClick={async () => resetSection('behavior')}
-                  size="sm"
-                >
-                  Reset Behavior Settings
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
+                <div className="flex justify-end">
+                  <Button
+                    variant="outline"
+                    onClick={async () => resetSection('shortcuts')}
+                    size="sm"
+                  >
+                    Reset Shortcuts
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
 
-        {/* Advanced Settings */}
-        <TabsContent value="advanced" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Advanced Settings</CardTitle>
-              <CardDescription>
-                Advanced configuration options for power users
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="enable-dev-tools">Enable developer tools</Label>
-                <Switch
-                  id="enable-dev-tools"
-                  checked={config.advanced.enableDevTools}
-                  onCheckedChange={(checked) =>
-                    updateConfig('advanced.enableDevTools', checked)
-                  }
-                />
-              </div>
+          {/* Notifications Settings */}
+          <TabsContent value="notifications" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Notifications</CardTitle>
+                <CardDescription>
+                  Configure desktop notifications for task events
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="notifications-enabled">
+                    Enable notifications
+                  </Label>
+                  <Switch
+                    id="notifications-enabled"
+                    checked={config.notifications.enabled}
+                    onCheckedChange={(checked) =>
+                      updateConfig('notifications.enabled', checked)
+                    }
+                  />
+                </div>
 
-              <div className="flex items-center justify-between">
-                <Label htmlFor="enable-logging">Enable logging</Label>
-                <Switch
-                  id="enable-logging"
-                  checked={config.advanced.enableLogging}
-                  onCheckedChange={(checked) =>
-                    updateConfig('advanced.enableLogging', checked)
-                  }
-                />
-              </div>
+                {config.notifications.enabled && (
+                  <>
+                    <Separator />
 
-              {config.advanced.enableLogging && (
-                <>
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="task-created">Task created</Label>
+                        <Switch
+                          id="task-created"
+                          checked={config.notifications.taskCreated}
+                          onCheckedChange={(checked) =>
+                            updateConfig('notifications.taskCreated', checked)
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="task-completed">Task completed</Label>
+                        <Switch
+                          id="task-completed"
+                          checked={config.notifications.taskCompleted}
+                          onCheckedChange={(checked) =>
+                            updateConfig('notifications.taskCompleted', checked)
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="task-updated">Task updated</Label>
+                        <Switch
+                          id="task-updated"
+                          checked={config.notifications.taskUpdated}
+                          onCheckedChange={(checked) =>
+                            updateConfig('notifications.taskUpdated', checked)
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="task-deleted">Task deleted</Label>
+                        <Switch
+                          id="task-deleted"
+                          checked={config.notifications.taskDeleted}
+                          onCheckedChange={(checked) =>
+                            updateConfig('notifications.taskDeleted', checked)
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="notification-sound">Play sound</Label>
+                        <Switch
+                          id="notification-sound"
+                          checked={config.notifications.sound}
+                          onCheckedChange={(checked) =>
+                            updateConfig('notifications.sound', checked)
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="auto-hide">
+                          Auto-hide notifications
+                        </Label>
+                        <Switch
+                          id="auto-hide"
+                          checked={config.notifications.autoHide}
+                          onCheckedChange={(checked) =>
+                            updateConfig('notifications.autoHide', checked)
+                          }
+                        />
+                      </div>
+
+                      {config.notifications.autoHide && (
+                        <div className="space-y-2">
+                          <Label htmlFor="auto-hide-delay">
+                            Auto-hide delay:{' '}
+                            {config.notifications.autoHideDelay / 1000}s
+                          </Label>
+                          <Slider
+                            id="auto-hide-delay"
+                            value={[config.notifications.autoHideDelay]}
+                            onValueChange={([value]) =>
+                              updateConfig('notifications.autoHideDelay', value)
+                            }
+                            min={1000}
+                            max={30000}
+                            step={1000}
+                            className="w-full"
+                          />
+                        </div>
+                      )}
+
+                      <div className="space-y-2">
+                        <Label htmlFor="notification-position">
+                          Notification position
+                        </Label>
+                        <Select
+                          value={config.notifications.position}
+                          onValueChange={(value) =>
+                            updateConfig('notifications.position', value)
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="topRight">Top Right</SelectItem>
+                            <SelectItem value="topLeft">Top Left</SelectItem>
+                            <SelectItem value="bottomRight">
+                              Bottom Right
+                            </SelectItem>
+                            <SelectItem value="bottomLeft">
+                              Bottom Left
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                <div className="flex justify-end">
+                  <Button
+                    variant="outline"
+                    onClick={async () => resetSection('notifications')}
+                    size="sm"
+                  >
+                    Reset Notification Settings
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* Behavior Settings */}
+          <TabsContent value="behavior" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Application Behavior</CardTitle>
+                <CardDescription>
+                  Configure general application behavior and preferences
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="start-on-login">Start on login</Label>
+                  <Switch
+                    id="start-on-login"
+                    checked={config.behavior.startOnLogin}
+                    onCheckedChange={(checked) =>
+                      updateConfig('behavior.startOnLogin', checked)
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="check-for-updates">Check for updates</Label>
+                  <Switch
+                    id="check-for-updates"
+                    checked={config.behavior.checkForUpdates}
+                    onCheckedChange={(checked) =>
+                      updateConfig('behavior.checkForUpdates', checked)
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="auto-save">Auto-save</Label>
+                  <Switch
+                    id="auto-save"
+                    checked={config.behavior.autoSave}
+                    onCheckedChange={(checked) =>
+                      updateConfig('behavior.autoSave', checked)
+                    }
+                  />
+                </div>
+
+                {config.behavior.autoSave && (
                   <div className="space-y-2">
-                    <Label htmlFor="log-level">Log level</Label>
-                    <Select
-                      value={config.advanced.logLevel}
-                      onValueChange={(value) =>
-                        updateConfig('advanced.logLevel', value)
-                      }
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="error">Error</SelectItem>
-                        <SelectItem value="warn">Warning</SelectItem>
-                        <SelectItem value="info">Info</SelectItem>
-                        <SelectItem value="debug">Debug</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="max-log-files">
-                      Max log files: {config.advanced.maxLogFiles}
+                    <Label htmlFor="auto-save-interval">
+                      Auto-save interval:{' '}
+                      {config.behavior.autoSaveInterval / 1000}s
                     </Label>
                     <Slider
-                      id="max-log-files"
-                      value={[config.advanced.maxLogFiles]}
+                      id="auto-save-interval"
+                      value={[config.behavior.autoSaveInterval]}
                       onValueChange={([value]) =>
-                        updateConfig('advanced.maxLogFiles', value)
+                        updateConfig('behavior.autoSaveInterval', value)
                       }
-                      min={1}
-                      max={20}
-                      step={1}
+                      min={5000}
+                      max={300000}
+                      step={5000}
                       className="w-full"
                     />
                   </div>
-                </>
-              )}
+                )}
 
-              <div className="flex items-center justify-between">
-                <Label htmlFor="hardware-acceleration">
-                  Hardware acceleration
-                </Label>
-                <Switch
-                  id="hardware-acceleration"
-                  checked={config.advanced.hardwareAcceleration}
-                  onCheckedChange={(checked) =>
-                    updateConfig('advanced.hardwareAcceleration', checked)
-                  }
-                />
-              </div>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="confirm-on-delete">Confirm on delete</Label>
+                  <Switch
+                    id="confirm-on-delete"
+                    checked={config.behavior.confirmOnDelete}
+                    onCheckedChange={(checked) =>
+                      updateConfig('behavior.confirmOnDelete', checked)
+                    }
+                  />
+                </div>
 
-              <div className="flex items-center justify-between">
-                <Label htmlFor="experimental-features">
-                  Experimental features
-                </Label>
-                <Switch
-                  id="experimental-features"
-                  checked={config.advanced.experimentalFeatures}
-                  onCheckedChange={(checked) =>
-                    updateConfig('advanced.experimentalFeatures', checked)
-                  }
-                />
-              </div>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="confirm-on-quit">Confirm on quit</Label>
+                  <Switch
+                    id="confirm-on-quit"
+                    checked={config.behavior.confirmOnQuit}
+                    onCheckedChange={(checked) =>
+                      updateConfig('behavior.confirmOnQuit', checked)
+                    }
+                  />
+                </div>
 
-              <div className="flex justify-end">
-                <Button
-                  variant="outline"
-                  onClick={async () => resetSection('advanced')}
-                  size="sm"
-                >
-                  Reset Advanced Settings
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
+                <div className="flex justify-end">
+                  <Button
+                    variant="outline"
+                    onClick={async () => resetSection('behavior')}
+                    size="sm"
+                  >
+                    Reset Behavior Settings
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
 
-      {/* Action Buttons */}
-      <div className="flex items-center justify-between border-t pt-6">
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={exportConfiguration}>
-            Export Config
-          </Button>
-          <Button variant="outline" onClick={resetConfiguration}>
-            Reset All
-          </Button>
-        </div>
+          {/* Advanced Settings */}
+          <TabsContent value="advanced" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Advanced Settings</CardTitle>
+                <CardDescription>
+                  Advanced configuration options for power users
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="enable-dev-tools">
+                    Enable developer tools
+                  </Label>
+                  <Switch
+                    id="enable-dev-tools"
+                    checked={config.advanced.enableDevTools}
+                    onCheckedChange={(checked) =>
+                      updateConfig('advanced.enableDevTools', checked)
+                    }
+                  />
+                </div>
 
-        <div className="text-sm text-muted-foreground">
-          Configuration version: {config.version}
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="enable-logging">Enable logging</Label>
+                  <Switch
+                    id="enable-logging"
+                    checked={config.advanced.enableLogging}
+                    onCheckedChange={(checked) =>
+                      updateConfig('advanced.enableLogging', checked)
+                    }
+                  />
+                </div>
+
+                {config.advanced.enableLogging && (
+                  <>
+                    <div className="space-y-2">
+                      <Label htmlFor="log-level">Log level</Label>
+                      <Select
+                        value={config.advanced.logLevel}
+                        onValueChange={(value) =>
+                          updateConfig('advanced.logLevel', value)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="error">Error</SelectItem>
+                          <SelectItem value="warn">Warning</SelectItem>
+                          <SelectItem value="info">Info</SelectItem>
+                          <SelectItem value="debug">Debug</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="max-log-files">
+                        Max log files: {config.advanced.maxLogFiles}
+                      </Label>
+                      <Slider
+                        id="max-log-files"
+                        value={[config.advanced.maxLogFiles]}
+                        onValueChange={([value]) =>
+                          updateConfig('advanced.maxLogFiles', value)
+                        }
+                        min={1}
+                        max={20}
+                        step={1}
+                        className="w-full"
+                      />
+                    </div>
+                  </>
+                )}
+
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="hardware-acceleration">
+                    Hardware acceleration
+                  </Label>
+                  <Switch
+                    id="hardware-acceleration"
+                    checked={config.advanced.hardwareAcceleration}
+                    onCheckedChange={(checked) =>
+                      updateConfig('advanced.hardwareAcceleration', checked)
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="experimental-features">
+                    Experimental features
+                  </Label>
+                  <Switch
+                    id="experimental-features"
+                    checked={config.advanced.experimentalFeatures}
+                    onCheckedChange={(checked) =>
+                      updateConfig('advanced.experimentalFeatures', checked)
+                    }
+                  />
+                </div>
+
+                <div className="flex justify-end">
+                  <Button
+                    variant="outline"
+                    onClick={async () => resetSection('advanced')}
+                    size="sm"
+                  >
+                    Reset Advanced Settings
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+
+        {/* Action Buttons */}
+        <div className="flex items-center justify-between border-t pt-6">
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={exportConfiguration}>
+              Export Config
+            </Button>
+            <Button variant="outline" onClick={resetConfiguration}>
+              Reset All
+            </Button>
+          </div>
+
+          <div className="text-sm text-muted-foreground">
+            Configuration version: {config.version}
+          </div>
         </div>
       </div>
-    </div>
-  )
-}
+    )
+  },
+)

--- a/src/components/electron/ConfigurationSettings.tsx
+++ b/src/components/electron/ConfigurationSettings.tsx
@@ -159,6 +159,7 @@ export const ConfigurationSettings = React.memo(
 
     const updateConfig = (path: string, value: any) => {
       if (!config) return
+      if (typeof value === 'number' && Number.isNaN(value)) return
 
       const keys = path.split('.')
       const newConfig = { ...config }

--- a/src/components/electron/ElectronSettingsPage.tsx
+++ b/src/components/electron/ElectronSettingsPage.tsx
@@ -1,3 +1,8 @@
+'use client'
+
+import * as React from 'react'
+import { memo } from 'react'
+
 /**
  * Electron Settings Page Component
  *
@@ -15,8 +20,6 @@
  *
  * <ElectronSettingsPage />
  */
-'use client'
-
 import { useIsElectron } from '@/components/auth/ElectronLoginForm'
 import { BrainDumpSettings } from '@/components/electron/BrainDumpSettings'
 import { FloatingWindowSettings } from '@/components/electron/FloatingWindowSettings'
@@ -49,201 +52,210 @@ import {
  *
  * @returns Settings page with toggle switches, or fallback for web users
  */
-export function ElectronSettingsPage(): React.ReactElement {
-  const dispatch = useAppDispatch()
-  const isElectron = useIsElectron() // SSR-safe via useSyncExternalStore
+export const ElectronSettingsPage = memo(
+  function ElectronSettingsPage(): React.ReactElement {
+    const dispatch = useAppDispatch()
+    const isElectron = useIsElectron() // SSR-safe via useSyncExternalStore
 
-  // Redux selectors
-  const hideAppIcon = useAppSelector(selectHideAppIcon)
-  const showInMenuBar = useAppSelector(selectShowInMenuBar)
-  const startAtLogin = useAppSelector(selectStartAtLogin)
+    // Redux selectors
+    const hideAppIcon = useAppSelector(selectHideAppIcon)
+    const showInMenuBar = useAppSelector(selectShowInMenuBar)
+    const startAtLogin = useAppSelector(selectStartAtLogin)
 
-  /**
-   * Handles the Hide App Icon toggle change.
-   * Updates Redux state only after successful IPC call to maintain consistency.
-   *
-   * @param checked - New toggle state
-   */
-  const handleHideAppIconChange = async (checked: boolean): Promise<void> => {
-    // Notify Electron main process via settings API first
-    if (typeof window !== 'undefined' && window.electronAPI?.settings) {
-      try {
-        const success =
-          await window.electronAPI.settings.setHideAppIcon(checked)
-        if (success) {
-          dispatch(setHideAppIcon(checked))
-        } else {
-          // IPC call failed - log error but don't update state
+    /**
+     * Handles the Hide App Icon toggle change.
+     * Updates Redux state only after successful IPC call to maintain consistency.
+     *
+     * @param checked - New toggle state
+     */
+    const handleHideAppIconChange = async (checked: boolean): Promise<void> => {
+      // Notify Electron main process via settings API first
+      if (typeof window !== 'undefined' && window.electronAPI?.settings) {
+        try {
+          const success =
+            await window.electronAPI.settings.setHideAppIcon(checked)
+          if (success) {
+            dispatch(setHideAppIcon(checked))
+          } else {
+            // IPC call failed - log error but don't update state
+            if (process.env.NODE_ENV === 'development') {
+              console.error(
+                'Failed to update dock icon visibility: IPC returned false',
+              )
+            }
+          }
+        } catch (error) {
+          // IPC call threw - log error but don't update state
           if (process.env.NODE_ENV === 'development') {
-            console.error(
-              'Failed to update dock icon visibility: IPC returned false',
-            )
+            console.error('Failed to update dock icon visibility:', error)
           }
         }
-      } catch (error) {
-        // IPC call threw - log error but don't update state
-        if (process.env.NODE_ENV === 'development') {
-          console.error('Failed to update dock icon visibility:', error)
-        }
+      } else {
+        // Not in Electron - update Redux state anyway for local storage
+        dispatch(setHideAppIcon(checked))
       }
-    } else {
-      // Not in Electron - update Redux state anyway for local storage
-      dispatch(setHideAppIcon(checked))
     }
-  }
 
-  /**
-   * Handles the Show in Menu Bar toggle change.
-   * Updates Redux state only after successful IPC call to maintain consistency.
-   *
-   * @param checked - New toggle state
-   */
-  const handleShowInMenuBarChange = async (checked: boolean): Promise<void> => {
-    // Notify Electron main process via settings API first
-    if (typeof window !== 'undefined' && window.electronAPI?.settings) {
-      try {
-        const success =
-          await window.electronAPI.settings.setShowInMenuBar(checked)
-        if (success) {
-          dispatch(setShowInMenuBar(checked))
-        } else {
-          // IPC call failed (feature not implemented) - log but don't update state
+    /**
+     * Handles the Show in Menu Bar toggle change.
+     * Updates Redux state only after successful IPC call to maintain consistency.
+     *
+     * @param checked - New toggle state
+     */
+    const handleShowInMenuBarChange = async (
+      checked: boolean,
+    ): Promise<void> => {
+      // Notify Electron main process via settings API first
+      if (typeof window !== 'undefined' && window.electronAPI?.settings) {
+        try {
+          const success =
+            await window.electronAPI.settings.setShowInMenuBar(checked)
+          if (success) {
+            dispatch(setShowInMenuBar(checked))
+          } else {
+            // IPC call failed (feature not implemented) - log but don't update state
+            if (process.env.NODE_ENV === 'development') {
+              console.warn('Menu bar visibility change not yet implemented')
+            }
+          }
+        } catch (error) {
+          // IPC call threw - log error but don't update state
           if (process.env.NODE_ENV === 'development') {
-            console.warn('Menu bar visibility change not yet implemented')
+            console.error('Failed to update menu bar visibility:', error)
           }
         }
-      } catch (error) {
-        // IPC call threw - log error but don't update state
-        if (process.env.NODE_ENV === 'development') {
-          console.error('Failed to update menu bar visibility:', error)
-        }
+      } else {
+        // Not in Electron - update Redux state anyway for local storage
+        dispatch(setShowInMenuBar(checked))
       }
-    } else {
-      // Not in Electron - update Redux state anyway for local storage
-      dispatch(setShowInMenuBar(checked))
     }
-  }
 
-  /**
-   * Handles the Start at Login toggle change.
-   * Updates Redux state only after successful IPC call to maintain consistency.
-   *
-   * @param checked - New toggle state
-   */
-  const handleStartAtLoginChange = async (checked: boolean): Promise<void> => {
-    // Notify Electron main process via settings API first
-    if (typeof window !== 'undefined' && window.electronAPI?.settings) {
-      try {
-        const success =
-          await window.electronAPI.settings.setStartAtLogin(checked)
-        if (success) {
-          dispatch(setStartAtLogin(checked))
-        } else {
-          // IPC call failed - log error but don't update state
+    /**
+     * Handles the Start at Login toggle change.
+     * Updates Redux state only after successful IPC call to maintain consistency.
+     *
+     * @param checked - New toggle state
+     */
+    const handleStartAtLoginChange = async (
+      checked: boolean,
+    ): Promise<void> => {
+      // Notify Electron main process via settings API first
+      if (typeof window !== 'undefined' && window.electronAPI?.settings) {
+        try {
+          const success =
+            await window.electronAPI.settings.setStartAtLogin(checked)
+          if (success) {
+            dispatch(setStartAtLogin(checked))
+          } else {
+            // IPC call failed - log error but don't update state
+            if (process.env.NODE_ENV === 'development') {
+              console.error(
+                'Failed to update start at login setting: IPC returned false',
+              )
+            }
+          }
+        } catch (error) {
+          // IPC call threw - log error but don't update state
           if (process.env.NODE_ENV === 'development') {
-            console.error(
-              'Failed to update start at login setting: IPC returned false',
-            )
+            console.error('Failed to update start at login setting:', error)
           }
         }
-      } catch (error) {
-        // IPC call threw - log error but don't update state
-        if (process.env.NODE_ENV === 'development') {
-          console.error('Failed to update start at login setting:', error)
-        }
+      } else {
+        // Not in Electron - update Redux state anyway for local storage
+        dispatch(setStartAtLogin(checked))
       }
-    } else {
-      // Not in Electron - update Redux state anyway for local storage
-      dispatch(setStartAtLogin(checked))
     }
-  }
 
-  // Environment guard: Show fallback for web users
-  if (!isElectron) {
+    // Environment guard: Show fallback for web users
+    if (!isElectron) {
+      return (
+        <div className="mx-auto max-w-2xl p-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-2xl">Settings</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground">
+                These settings are only available in the desktop application.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      )
+    }
+
     return (
-      <div className="mx-auto max-w-2xl p-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-2xl">Settings</CardTitle>
+      <div className="h-full space-y-4 p-4">
+        <Card className="border-0 bg-transparent shadow-none">
+          <CardHeader className="px-2 pb-2 pt-0">
+            <CardTitle className="text-lg">Settings</CardTitle>
           </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground">
-              These settings are only available in the desktop application.
-            </p>
+          <CardContent className="space-y-4 px-2">
+            {/* Hide App Icon */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="hide-app-icon" className="text-sm font-medium">
+                  Hide App Icon
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Hide the CoreLive icon from the Dock
+                </p>
+              </div>
+              <Switch
+                id="hide-app-icon"
+                checked={hideAppIcon}
+                onCheckedChange={handleHideAppIconChange}
+              />
+            </div>
+
+            {/* Show in Menu Bar - Not yet implemented */}
+            <div className="flex items-center justify-between opacity-60">
+              <div className="space-y-0.5">
+                <Label
+                  htmlFor="show-in-menu-bar"
+                  className="text-sm font-medium"
+                >
+                  Show in Menu Bar{' '}
+                  <span className="text-xs text-muted-foreground">
+                    (Coming Soon)
+                  </span>
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Display CoreLive in the system menu bar
+                </p>
+              </div>
+              <Switch
+                id="show-in-menu-bar"
+                checked={showInMenuBar}
+                onCheckedChange={handleShowInMenuBarChange}
+                disabled
+              />
+            </div>
+
+            {/* Start at Login */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="start-at-login" className="text-sm font-medium">
+                  Start at Login
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Automatically launch CoreLive when you log in
+                </p>
+              </div>
+              <Switch
+                id="start-at-login"
+                checked={startAtLogin}
+                onCheckedChange={handleStartAtLoginChange}
+              />
+            </div>
           </CardContent>
         </Card>
+
+        <FloatingWindowSettings />
+        <BrainDumpSettings />
       </div>
     )
-  }
-
-  return (
-    <div className="h-full space-y-4 p-4">
-      <Card className="border-0 bg-transparent shadow-none">
-        <CardHeader className="px-2 pb-2 pt-0">
-          <CardTitle className="text-lg">Settings</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4 px-2">
-          {/* Hide App Icon */}
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <Label htmlFor="hide-app-icon" className="text-sm font-medium">
-                Hide App Icon
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                Hide the CoreLive icon from the Dock
-              </p>
-            </div>
-            <Switch
-              id="hide-app-icon"
-              checked={hideAppIcon}
-              onCheckedChange={handleHideAppIconChange}
-            />
-          </div>
-
-          {/* Show in Menu Bar - Not yet implemented */}
-          <div className="flex items-center justify-between opacity-60">
-            <div className="space-y-0.5">
-              <Label htmlFor="show-in-menu-bar" className="text-sm font-medium">
-                Show in Menu Bar{' '}
-                <span className="text-xs text-muted-foreground">
-                  (Coming Soon)
-                </span>
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                Display CoreLive in the system menu bar
-              </p>
-            </div>
-            <Switch
-              id="show-in-menu-bar"
-              checked={showInMenuBar}
-              onCheckedChange={handleShowInMenuBarChange}
-              disabled
-            />
-          </div>
-
-          {/* Start at Login */}
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <Label htmlFor="start-at-login" className="text-sm font-medium">
-                Start at Login
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                Automatically launch CoreLive when you log in
-              </p>
-            </div>
-            <Switch
-              id="start-at-login"
-              checked={startAtLogin}
-              onCheckedChange={handleStartAtLoginChange}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      <FloatingWindowSettings />
-      <BrainDumpSettings />
-    </div>
-  )
-}
+  },
+)
 
 export default ElectronSettingsPage

--- a/src/components/electron/ElectronStartupSync.tsx
+++ b/src/components/electron/ElectronStartupSync.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 /**
  * Electron Startup Sync
  *
@@ -13,10 +15,8 @@
  *
  * @module components/electron/ElectronStartupSync
  */
-'use client'
 
-import { useEffect } from 'react'
-
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { useAppSelector } from '@/lib/redux/hooks'
 import { selectHideAppIcon } from '@/lib/redux/slices/electronSettingsSlice'
 
@@ -45,7 +45,7 @@ import { isElectronEnvironment } from '../../../electron/utils/electron-client'
 export function ElectronStartupSync(): null {
   const hideAppIcon = useAppSelector(selectHideAppIcon)
 
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isElectronEnvironment()) return
     // Surface IPC failures to the console; swallowing them silently would
     // mask main-process regressions during startup sync.

--- a/src/components/electron/FloatingWindowSettings.tsx
+++ b/src/components/electron/FloatingWindowSettings.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 /**
  * @fileoverview Floating utility window settings for the Electron Settings page.
  *
@@ -7,11 +9,9 @@
  *
  * @module components/electron/FloatingWindowSettings
  */
-'use client'
-
 import { Monitor } from 'lucide-react'
-import type { ReactElement } from 'react'
-import { useEffect, useId, useState } from 'react'
+import { memo, type ReactElement } from 'react'
+import { useId, useState } from 'react'
 
 import {
   Card,
@@ -23,6 +23,7 @@ import {
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { useMounted } from '@/hooks/use-mounted'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { log } from '@/lib/logger'
 
 interface FloatingWindowSettingsProps {
@@ -41,7 +42,7 @@ interface FloatingWindowSettingsProps {
  * @example
  * <FloatingWindowSettings />
  */
-export function FloatingWindowSettings({
+export const FloatingWindowSettings = memo(function FloatingWindowSettings({
   className,
 }: FloatingWindowSettingsProps): ReactElement {
   const desktopTrackingId = useId()
@@ -53,7 +54,7 @@ export function FloatingWindowSettings({
 
   // Fetch once from the preload bridge after mount; the fallback branch below
   // handles non-Electron renderers without needing a separate effect path.
-  useEffect(() => {
+  useComponentEffect(() => {
     const api =
       typeof window === 'undefined'
         ? undefined
@@ -195,6 +196,6 @@ export function FloatingWindowSettings({
       </CardContent>
     </Card>
   )
-}
+})
 
 export default FloatingWindowSettings

--- a/src/components/electron/NotificationSettings.tsx
+++ b/src/components/electron/NotificationSettings.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Bell, BellOff, Volume2, VolumeX } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { memo, useState } from 'react'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 
 import { log } from '../../lib/logger'
 
@@ -40,7 +41,9 @@ interface NotificationSettingsProps {
   className?: string
 }
 
-export function NotificationSettings({ className }: NotificationSettingsProps) {
+export const NotificationSettings = memo(function NotificationSettings({
+  className,
+}: NotificationSettingsProps) {
   const [preferences, setPreferences] = useState<NotificationPreferences>({
     enabled: true,
     taskCreated: true,
@@ -57,7 +60,7 @@ export function NotificationSettings({ className }: NotificationSettingsProps) {
   // Check if we're in Electron environment
   const isElectron = typeof window !== 'undefined' && window.electronAPI
 
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isElectron) {
       setIsLoading(false)
       return
@@ -369,4 +372,4 @@ export function NotificationSettings({ className }: NotificationSettingsProps) {
       </CardContent>
     </Card>
   )
-}
+})

--- a/src/components/electron/ShortcutSettings.tsx
+++ b/src/components/electron/ShortcutSettings.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Keyboard, RotateCcw, Save, AlertCircle } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { memo, useState } from 'react'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -15,6 +15,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 
 import { log } from '../../lib/logger'
 
@@ -42,7 +43,9 @@ const SHORTCUT_DESCRIPTIONS: Record<string, string> = {
   focusFloatingNavigator: 'Focus floating navigator',
 }
 
-export function ShortcutSettings({ className }: ShortcutSettingsProps) {
+export const ShortcutSettings = memo(function ShortcutSettings({
+  className,
+}: ShortcutSettingsProps) {
   const [shortcuts, setShortcuts] = useState<ShortcutConfig>({})
   const [defaultShortcuts, setDefaultShortcuts] = useState<ShortcutConfig>({})
   const [stats, setStats] = useState<ShortcutStats | null>(null)
@@ -55,7 +58,7 @@ export function ShortcutSettings({ className }: ShortcutSettingsProps) {
   const isElectron =
     typeof window !== 'undefined' && window.electronAPI?.shortcuts
 
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isElectron) {
       setIsLoading(false)
       return
@@ -374,4 +377,4 @@ export function ShortcutSettings({ className }: ShortcutSettingsProps) {
       </CardContent>
     </Card>
   )
-}
+})

--- a/src/components/electron/WindowStateSettings.tsx
+++ b/src/components/electron/WindowStateSettings.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { toast } from 'sonner'
 
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 
 import { log } from '../../lib/logger'
 
@@ -64,7 +65,7 @@ interface WindowStateStats {
   }
 }
 
-export function WindowStateSettings() {
+export const WindowStateSettings = React.memo(function WindowStateSettings() {
   const [stats, setStats] = useState<WindowStateStats | null>(null)
   const [displays, setDisplays] = useState<Display[]>([])
   const [loading, setLoading] = useState(true)
@@ -72,7 +73,7 @@ export function WindowStateSettings() {
   // Check if we're in Electron environment
   const isElectron = typeof window !== 'undefined' && window.electronAPI
 
-  useEffect(() => {
+  useComponentEffect(() => {
     if (isElectron) {
       loadWindowStateData()
     } else {
@@ -624,4 +625,4 @@ export function WindowStateSettings() {
       </Card>
     </div>
   )
-}
+})

--- a/src/components/floating-navigator/FloatingCategoryManager.tsx
+++ b/src/components/floating-navigator/FloatingCategoryManager.tsx
@@ -42,9 +42,10 @@ const ArrowLeft = lazy(async () =>
 )
 
 /** Shared loading placeholder for lazy-loaded icons */
-const IconFallback = () => (
+const IconFallback = React.memo(() => (
   <div className="h-3 w-3 animate-pulse rounded bg-muted" />
-)
+))
+IconFallback.displayName = 'IconFallback'
 
 interface FloatingCategoryManagerProps {
   categories: CategoryWithCount[]
@@ -86,327 +87,329 @@ interface FloatingCategoryManagerProps {
  *   onClose={() => setShowManagePanel(false)}
  * />
  */
-export function FloatingCategoryManager({
-  categories,
-  onCategoryCreate,
-  onCategoryUpdate,
-  onCategoryDelete,
-  onClose,
-  isCreatePending = false,
-  isUpdatePending = false,
-  isDeletePending = false,
-}: FloatingCategoryManagerProps) {
-  // Inline edit state
-  const [editingId, setEditingId] = useState<number | null>(null)
-  const [editName, setEditName] = useState('')
-  const [editColor, setEditColor] = useState<CategoryColor>('blue')
+export const FloatingCategoryManager = React.memo(
+  function FloatingCategoryManager({
+    categories,
+    onCategoryCreate,
+    onCategoryUpdate,
+    onCategoryDelete,
+    onClose,
+    isCreatePending = false,
+    isUpdatePending = false,
+    isDeletePending = false,
+  }: FloatingCategoryManagerProps) {
+    // Inline edit state
+    const [editingId, setEditingId] = useState<number | null>(null)
+    const [editName, setEditName] = useState('')
+    const [editColor, setEditColor] = useState<CategoryColor>('blue')
 
-  // Add new category state
-  const [showAddForm, setShowAddForm] = useState(false)
-  const [newName, setNewName] = useState('')
-  const [newColor, setNewColor] = useState<CategoryColor>('blue')
+    // Add new category state
+    const [showAddForm, setShowAddForm] = useState(false)
+    const [newName, setNewName] = useState('')
+    const [newColor, setNewColor] = useState<CategoryColor>('blue')
 
-  // Delete confirmation state
-  const [deleteTarget, setDeleteTarget] = useState<CategoryWithCount | null>(
-    null,
-  )
+    // Delete confirmation state
+    const [deleteTarget, setDeleteTarget] = useState<CategoryWithCount | null>(
+      null,
+    )
 
-  /**
-   * Enters inline edit mode for a category.
-   * @param category - The category to edit
-   */
-  const startEditing = (category: CategoryWithCount) => {
-    setEditingId(category.id)
-    setEditName(category.name)
-    setEditColor(category.color as CategoryColor)
-  }
+    /**
+     * Enters inline edit mode for a category.
+     * @param category - The category to edit
+     */
+    const startEditing = (category: CategoryWithCount) => {
+      setEditingId(category.id)
+      setEditName(category.name)
+      setEditColor(category.color as CategoryColor)
+    }
 
-  /**
-   * Saves the inline edit and exits edit mode.
-   */
-  const saveEdit = () => {
-    if (editingId === null || !editName.trim()) return
-    onCategoryUpdate(editingId, { name: editName.trim(), color: editColor })
-    setEditingId(null)
-  }
+    /**
+     * Saves the inline edit and exits edit mode.
+     */
+    const saveEdit = () => {
+      if (editingId === null || !editName.trim()) return
+      onCategoryUpdate(editingId, { name: editName.trim(), color: editColor })
+      setEditingId(null)
+    }
 
-  /**
-   * Cancels inline editing and resets state.
-   */
-  const cancelEdit = () => {
-    setEditingId(null)
-    setEditName('')
-    setEditColor('blue')
-  }
+    /**
+     * Cancels inline editing and resets state.
+     */
+    const cancelEdit = () => {
+      setEditingId(null)
+      setEditName('')
+      setEditColor('blue')
+    }
 
-  /**
-   * Creates a new category and resets the add form.
-   */
-  const handleCreate = () => {
-    if (!newName.trim()) return
-    onCategoryCreate(newName.trim(), newColor)
-    setNewName('')
-    setNewColor('blue')
-    setShowAddForm(false)
-  }
+    /**
+     * Creates a new category and resets the add form.
+     */
+    const handleCreate = () => {
+      if (!newName.trim()) return
+      onCategoryCreate(newName.trim(), newColor)
+      setNewName('')
+      setNewColor('blue')
+      setShowAddForm(false)
+    }
 
-  /**
-   * Confirms and executes category deletion.
-   */
-  const confirmDelete = () => {
-    if (!deleteTarget) return
-    onCategoryDelete(deleteTarget.id)
-    setDeleteTarget(null)
-  }
+    /**
+     * Confirms and executes category deletion.
+     */
+    const confirmDelete = () => {
+      if (!deleteTarget) return
+      onCategoryDelete(deleteTarget.id)
+      setDeleteTarget(null)
+    }
 
-  return (
-    <>
-      <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Manager header with back and add buttons */}
-        <div className="flex items-center gap-2 border-b px-3 py-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onClose}
-            className="h-6 w-6 p-0"
-            aria-label="Back to tasks"
-            title="Back to tasks"
-          >
-            <Suspense fallback={<IconFallback />}>
-              <ArrowLeft className="h-3 w-3" aria-hidden="true" />
-            </Suspense>
-          </Button>
-          <h2 className="flex-1 text-sm font-medium">Manage Categories</h2>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowAddForm(!showAddForm)}
-            className="h-6 w-6 p-0"
-            aria-label="Add new category"
-            title="Add new category"
-          >
-            <Suspense fallback={<IconFallback />}>
-              <Plus className="h-3 w-3" aria-hidden="true" />
-            </Suspense>
-          </Button>
-        </div>
-
-        {/* Add new category form (toggled by + button) */}
-        {showAddForm && (
-          <div className="space-y-2 border-b p-3">
-            <div
-              className="flex gap-1"
-              role="radiogroup"
-              aria-label="Category color"
+    return (
+      <>
+        <div className="flex flex-1 flex-col overflow-hidden">
+          {/* Manager header with back and add buttons */}
+          <div className="flex items-center gap-2 border-b px-3 py-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              className="h-6 w-6 p-0"
+              aria-label="Back to tasks"
+              title="Back to tasks"
             >
-              {CATEGORY_COLORS.map((color) => (
-                <button
-                  key={color}
-                  type="button"
-                  onClick={() => setNewColor(color)}
-                  className={`h-4 w-4 rounded-full ${getColorDotClass(color)} ${
-                    newColor === color
-                      ? 'ring-2 ring-ring ring-offset-1 ring-offset-background'
-                      : ''
-                  }`}
-                  role="radio"
-                  aria-checked={newColor === color}
-                  aria-label={`${color} color`}
-                />
-              ))}
-            </div>
-            <div className="flex gap-1">
-              <Input
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleCreate()
-                  if (e.key === 'Escape') setShowAddForm(false)
-                }}
-                placeholder="Category name"
-                className="h-7 flex-1 text-xs"
-                maxLength={30}
-                autoFocus
-                aria-label="New category name"
-              />
-              <Button
-                size="sm"
-                onClick={handleCreate}
-                disabled={!newName.trim() || isCreatePending}
-                className="h-7 px-2 text-xs"
-              >
-                Add
-              </Button>
-            </div>
+              <Suspense fallback={<IconFallback />}>
+                <ArrowLeft className="h-3 w-3" aria-hidden="true" />
+              </Suspense>
+            </Button>
+            <h2 className="flex-1 text-sm font-medium">Manage Categories</h2>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowAddForm(!showAddForm)}
+              className="h-6 w-6 p-0"
+              aria-label="Add new category"
+              title="Add new category"
+            >
+              <Suspense fallback={<IconFallback />}>
+                <Plus className="h-3 w-3" aria-hidden="true" />
+              </Suspense>
+            </Button>
           </div>
-        )}
 
-        {/* Category list */}
-        <div
-          className="flex-1 overflow-y-auto p-2"
-          role="list"
-          aria-label="Categories"
-        >
-          <div className="space-y-1">
-            {categories.map((category) => (
+          {/* Add new category form (toggled by + button) */}
+          {showAddForm && (
+            <div className="space-y-2 border-b p-3">
               <div
-                key={category.id}
-                className="hover:bg-muted/50 group flex items-center gap-2 rounded p-2"
-                role="listitem"
+                className="flex gap-1"
+                role="radiogroup"
+                aria-label="Category color"
               >
-                {editingId === category.id ? (
-                  /* Inline edit mode: color picker + name input + save/cancel */
-                  <>
-                    <div
-                      className="flex gap-1"
-                      role="radiogroup"
-                      aria-label="Category color"
-                    >
-                      {CATEGORY_COLORS.map((color) => (
-                        <button
-                          key={color}
-                          type="button"
-                          onClick={() => setEditColor(color)}
-                          className={`h-3 w-3 rounded-full ${getColorDotClass(color)} ${
-                            editColor === color
-                              ? 'ring-2 ring-ring ring-offset-1 ring-offset-background'
-                              : ''
-                          }`}
-                          role="radio"
-                          aria-checked={editColor === color}
-                          aria-label={`${color} color`}
-                        />
-                      ))}
-                    </div>
-                    <Input
-                      value={editName}
-                      onChange={(e) => setEditName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') saveEdit()
-                        if (e.key === 'Escape') cancelEdit()
-                      }}
-                      className="h-6 flex-1 text-xs"
-                      maxLength={30}
-                      autoFocus
-                      aria-label="Edit category name"
-                    />
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={saveEdit}
-                      disabled={!editName.trim() || isUpdatePending}
-                      className="h-6 w-6 p-0"
-                      aria-label="Save changes"
-                      title="Save (Enter)"
-                    >
-                      <Suspense fallback={<IconFallback />}>
-                        <Check className="h-3 w-3" aria-hidden="true" />
-                      </Suspense>
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={cancelEdit}
-                      className="h-6 w-6 p-0"
-                      aria-label="Cancel editing"
-                      title="Cancel (Escape)"
-                    >
-                      <Suspense fallback={<IconFallback />}>
-                        <X className="h-3 w-3" aria-hidden="true" />
-                      </Suspense>
-                    </Button>
-                  </>
-                ) : (
-                  /* Display mode: color dot + name + count + edit/delete */
-                  <>
-                    <span
-                      className={`h-2.5 w-2.5 shrink-0 rounded-full ${getColorDotClass(category.color)}`}
-                    />
-                    <span className="flex-1 truncate text-xs">
-                      {category.name}
-                    </span>
-                    {/* eslint-disable-next-line dslint/token-only -- tabular-nums is standard Tailwind utility */}
-                    <span className="text-[10px] tabular-nums text-muted-foreground">
-                      {category._count.todos}
-                    </span>
-                    <div className="flex gap-0.5 opacity-0 focus-within:opacity-100 group-hover:opacity-100">
+                {CATEGORY_COLORS.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => setNewColor(color)}
+                    className={`h-4 w-4 rounded-full ${getColorDotClass(color)} ${
+                      newColor === color
+                        ? 'ring-2 ring-ring ring-offset-1 ring-offset-background'
+                        : ''
+                    }`}
+                    role="radio"
+                    aria-checked={newColor === color}
+                    aria-label={`${color} color`}
+                  />
+                ))}
+              </div>
+              <div className="flex gap-1">
+                <Input
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleCreate()
+                    if (e.key === 'Escape') setShowAddForm(false)
+                  }}
+                  placeholder="Category name"
+                  className="h-7 flex-1 text-xs"
+                  maxLength={30}
+                  autoFocus
+                  aria-label="New category name"
+                />
+                <Button
+                  size="sm"
+                  onClick={handleCreate}
+                  disabled={!newName.trim() || isCreatePending}
+                  className="h-7 px-2 text-xs"
+                >
+                  Add
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Category list */}
+          <div
+            className="flex-1 overflow-y-auto p-2"
+            role="list"
+            aria-label="Categories"
+          >
+            <div className="space-y-1">
+              {categories.map((category) => (
+                <div
+                  key={category.id}
+                  className="hover:bg-muted/50 group flex items-center gap-2 rounded p-2"
+                  role="listitem"
+                >
+                  {editingId === category.id ? (
+                    /* Inline edit mode: color picker + name input + save/cancel */
+                    <>
+                      <div
+                        className="flex gap-1"
+                        role="radiogroup"
+                        aria-label="Category color"
+                      >
+                        {CATEGORY_COLORS.map((color) => (
+                          <button
+                            key={color}
+                            type="button"
+                            onClick={() => setEditColor(color)}
+                            className={`h-3 w-3 rounded-full ${getColorDotClass(color)} ${
+                              editColor === color
+                                ? 'ring-2 ring-ring ring-offset-1 ring-offset-background'
+                                : ''
+                            }`}
+                            role="radio"
+                            aria-checked={editColor === color}
+                            aria-label={`${color} color`}
+                          />
+                        ))}
+                      </div>
+                      <Input
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') saveEdit()
+                          if (e.key === 'Escape') cancelEdit()
+                        }}
+                        className="h-6 flex-1 text-xs"
+                        maxLength={30}
+                        autoFocus
+                        aria-label="Edit category name"
+                      />
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => startEditing(category)}
-                        className="h-6 w-6 p-0 text-muted-foreground"
-                        aria-label={`Edit ${category.name}`}
-                        title="Edit category"
+                        onClick={saveEdit}
+                        disabled={!editName.trim() || isUpdatePending}
+                        className="h-6 w-6 p-0"
+                        aria-label="Save changes"
+                        title="Save (Enter)"
                       >
                         <Suspense fallback={<IconFallback />}>
-                          <Pencil className="h-3 w-3" aria-hidden="true" />
+                          <Check className="h-3 w-3" aria-hidden="true" />
                         </Suspense>
                       </Button>
-                      {!category.isDefault && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={cancelEdit}
+                        className="h-6 w-6 p-0"
+                        aria-label="Cancel editing"
+                        title="Cancel (Escape)"
+                      >
+                        <Suspense fallback={<IconFallback />}>
+                          <X className="h-3 w-3" aria-hidden="true" />
+                        </Suspense>
+                      </Button>
+                    </>
+                  ) : (
+                    /* Display mode: color dot + name + count + edit/delete */
+                    <>
+                      <span
+                        className={`h-2.5 w-2.5 shrink-0 rounded-full ${getColorDotClass(category.color)}`}
+                      />
+                      <span className="flex-1 truncate text-xs">
+                        {category.name}
+                      </span>
+                      {/* eslint-disable-next-line dslint/token-only -- tabular-nums is standard Tailwind utility */}
+                      <span className="text-[10px] tabular-nums text-muted-foreground">
+                        {category._count.todos}
+                      </span>
+                      <div className="flex gap-0.5 opacity-0 focus-within:opacity-100 group-hover:opacity-100">
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => setDeleteTarget(category)}
-                          className="h-6 w-6 p-0 text-destructive hover:text-destructive"
-                          aria-label={`Delete ${category.name}`}
-                          title="Delete category"
+                          onClick={() => startEditing(category)}
+                          className="h-6 w-6 p-0 text-muted-foreground"
+                          aria-label={`Edit ${category.name}`}
+                          title="Edit category"
                         >
                           <Suspense fallback={<IconFallback />}>
-                            <Trash2 className="h-3 w-3" aria-hidden="true" />
+                            <Pencil className="h-3 w-3" aria-hidden="true" />
                           </Suspense>
                         </Button>
-                      )}
-                    </div>
-                  </>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      {/* Delete confirmation dialog */}
-      <AlertDialog
-        open={!!deleteTarget}
-        onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null)
-        }}
-      >
-        <AlertDialogContent className="max-w-xs">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-sm">
-              Delete category?
-            </AlertDialogTitle>
-            <AlertDialogDescription className="text-xs">
-              {deleteTarget && (
-                <>
-                  <strong>{deleteTarget.name}</strong> will be deleted.
-                  {deleteTarget._count.todos > 0 && (
-                    <>
-                      {' '}
-                      {deleteTarget._count.todos} task
-                      {deleteTarget._count.todos > 1 ? 's' : ''} will be moved
-                      to the default category.
+                        {!category.isDefault && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setDeleteTarget(category)}
+                            className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+                            aria-label={`Delete ${category.name}`}
+                            title="Delete category"
+                          >
+                            <Suspense fallback={<IconFallback />}>
+                              <Trash2 className="h-3 w-3" aria-hidden="true" />
+                            </Suspense>
+                          </Button>
+                        )}
+                      </div>
                     </>
                   )}
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="h-7 text-xs">
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={confirmDelete}
-              disabled={isDeletePending}
-              className="text-destructive-foreground hover:bg-destructive/90 h-7 bg-destructive text-xs" // eslint-disable-line dslint/token-only -- shadcn destructive tokens
-            >
-              {isDeletePending ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
-  )
-}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Delete confirmation dialog */}
+        <AlertDialog
+          open={!!deleteTarget}
+          onOpenChange={(open) => {
+            if (!open) setDeleteTarget(null)
+          }}
+        >
+          <AlertDialogContent className="max-w-xs">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-sm">
+                Delete category?
+              </AlertDialogTitle>
+              <AlertDialogDescription className="text-xs">
+                {deleteTarget && (
+                  <>
+                    <strong>{deleteTarget.name}</strong> will be deleted.
+                    {deleteTarget._count.todos > 0 && (
+                      <>
+                        {' '}
+                        {deleteTarget._count.todos} task
+                        {deleteTarget._count.todos > 1 ? 's' : ''} will be moved
+                        to the default category.
+                      </>
+                    )}
+                  </>
+                )}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className="h-7 text-xs">
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={confirmDelete}
+                disabled={isDeletePending}
+                className="text-destructive-foreground hover:bg-destructive/90 h-7 bg-destructive text-xs" // eslint-disable-line dslint/token-only -- shadcn destructive tokens
+              >
+                {isDeletePending ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </>
+    )
+  },
+)

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -60,9 +60,10 @@ const Brain = lazy(async () =>
 )
 
 // Icon fallback component for loading state
-const IconFallback = () => (
+const IconFallback = React.memo(() => (
   <div className="h-3 w-3 animate-pulse rounded bg-muted" />
-)
+))
+IconFallback.displayName = 'IconFallback'
 
 export interface FloatingTodo {
   id: string
@@ -97,7 +98,7 @@ interface FloatingNavigatorProps {
   isCategoryDeletePending?: boolean
 }
 
-export function FloatingNavigator({
+export const FloatingNavigator = React.memo(function FloatingNavigator({
   todos,
   onTaskToggle,
   onTaskCreate,
@@ -356,6 +357,7 @@ export function FloatingNavigator({
       ) : (
         <>
           <button
+            type="button"
             className="flex-1 cursor-pointer overflow-scroll rounded px-1 text-left text-base focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             onClick={() => startEditing(todo)}
             title={`${todo.text} - Click to edit`}
@@ -715,4 +717,4 @@ export function FloatingNavigator({
       )}
     </div>
   )
-}
+})

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -2,11 +2,12 @@
 
 import { arrayMove } from '@dnd-kit/helpers'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 
 import { useMounted } from '@/hooks/use-mounted'
 import { useCategoryMutations } from '@/hooks/useCategoryMutations'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import {
   useAutoSelectDefaultCategory,
   useSelectedCategory,
@@ -42,300 +43,309 @@ const DECIMAL_RADIX = 10
  * @example
  * <FloatingNavigatorContainer />
  */
-export function FloatingNavigatorContainer() {
-  const queryClient = useQueryClient()
-  const isClerkQueryReady = useClerkQueryReady()
+export const FloatingNavigatorContainer = React.memo(
+  function FloatingNavigatorContainer() {
+    const queryClient = useQueryClient()
+    const isClerkQueryReady = useClerkQueryReady()
 
-  // Category filter state (shared with main app via localStorage)
-  const [selectedCategoryId, setSelectedCategoryId] = useSelectedCategory()
+    // Category filter state (shared with main app via localStorage)
+    const [selectedCategoryId, setSelectedCategoryId] = useSelectedCategory()
 
-  // Mutations with optimistic updates (pass categoryId for correct cache key)
-  const {
-    createMutation,
-    toggleMutation,
-    deleteMutation,
-    updateMutation,
-    reorderMutation,
-  } = useTodoMutations(selectedCategoryId)
+    // Mutations with optimistic updates (pass categoryId for correct cache key)
+    const {
+      createMutation,
+      toggleMutation,
+      deleteMutation,
+      updateMutation,
+      reorderMutation,
+    } = useTodoMutations(selectedCategoryId)
 
-  // Category CRUD mutations with optimistic updates
-  const {
-    createMutation: categoryCreateMutation,
-    updateMutation: categoryUpdateMutation,
-    deleteMutation: categoryDeleteMutation,
-  } = useCategoryMutations()
+    // Category CRUD mutations with optimistic updates
+    const {
+      createMutation: categoryCreateMutation,
+      updateMutation: categoryUpdateMutation,
+      deleteMutation: categoryDeleteMutation,
+    } = useCategoryMutations()
 
-  // Local state for optimistic reordering
-  const [localPendingTodos, setLocalPendingTodos] = useState<FloatingTodo[]>([])
+    // Local state for optimistic reordering
+    const [localPendingTodos, setLocalPendingTodos] = useState<FloatingTodo[]>(
+      [],
+    )
 
-  // SSR-safe mount detection using useSyncExternalStore
-  const isMounted = useMounted()
+    // SSR-safe mount detection using useSyncExternalStore
+    const isMounted = useMounted()
 
-  // Check if we're in Electron floating navigator environment (for window controls)
-  const isFloatingNavigator =
-    isMounted && typeof window !== 'undefined' && window.floatingNavigatorAPI
+    // Check if we're in Electron floating navigator environment (for window controls)
+    const isFloatingNavigator =
+      isMounted && typeof window !== 'undefined' && window.floatingNavigatorAPI
 
-  // Fetch categories for the dropdown
-  const { data: categoryData } = useQuery({
-    ...orpc.category.list.queryOptions({}),
-    enabled: isClerkQueryReady,
-  })
-  const categories: CategoryWithCount[] = categoryData?.categories ?? []
-
-  // Auto-select the default (General) category when none is selected
-  useAutoSelectDefaultCategory(
-    selectedCategoryId,
-    setSelectedCategoryId,
-    categories,
-  )
-
-  // Fetch todos filtered by selected category
-  const { data, isLoading, error } = useQuery({
-    ...orpc.todo.list.queryOptions({
-      input: {
-        completed: false,
-        limit: TODO_QUERY_LIMIT,
-        offset: TODO_QUERY_OFFSET,
-        ...(selectedCategoryId !== null && { categoryId: selectedCategoryId }),
-      },
-    }),
-    enabled: isClerkQueryReady,
-  })
-
-  /**
-   * Toggles completion state for a floating navigator task.
-   * @param id - Todo identifier as a string.
-   * @returns
-   * - No return value; the mutation updates server state.
-   * @example
-   * handleTaskToggle('42')
-   */
-  const handleTaskToggle = (id: string) => {
-    const todoId = parseInt(id, DECIMAL_RADIX)
-    if (!isNaN(todoId)) {
-      toggleMutation.mutate({ id: todoId })
-    }
-  }
-
-  /**
-   * Creates a new task from the floating navigator input.
-   * @param title - Task title to create.
-   * @returns
-   * - No return value; the mutation updates server state.
-   * @example
-   * handleTaskCreate('Write report')
-   */
-  const handleTaskCreate = (title: string) => {
-    if (selectedCategoryId === null) return
-    createMutation.mutate({
-      text: title,
-      categoryId: selectedCategoryId,
+    // Fetch categories for the dropdown
+    const { data: categoryData } = useQuery({
+      ...orpc.category.list.queryOptions({}),
+      enabled: isClerkQueryReady,
     })
-  }
+    const categories: CategoryWithCount[] = categoryData?.categories ?? []
 
-  /**
-   * Updates a task title from the floating navigator.
-   * @param id - Todo identifier as a string.
-   * @param title - New task title.
-   * @returns
-   * - No return value; the mutation updates server state.
-   * @example
-   * handleTaskEdit('42', 'Updated title')
-   */
-  const handleTaskEdit = (id: string, title: string) => {
-    const todoId = parseInt(id, DECIMAL_RADIX)
-    if (!isNaN(todoId)) {
-      updateMutation.mutate({ id: todoId, data: { text: title } })
-    }
-  }
+    // Auto-select the default (General) category when none is selected
+    useAutoSelectDefaultCategory(
+      selectedCategoryId,
+      setSelectedCategoryId,
+      categories,
+    )
 
-  /**
-   * Deletes a task from the floating navigator.
-   * @param id - Todo identifier as a string.
-   * @returns
-   * - No return value; the mutation updates server state.
-   * @example
-   * handleTaskDelete('42')
-   */
-  const handleTaskDelete = (id: string) => {
-    const todoId = parseInt(id, DECIMAL_RADIX)
-    if (!isNaN(todoId)) {
-      deleteMutation.mutate({ id: todoId })
-    }
-  }
+    // Fetch todos filtered by selected category
+    const { data, isLoading, error } = useQuery({
+      ...orpc.todo.list.queryOptions({
+        input: {
+          completed: false,
+          limit: TODO_QUERY_LIMIT,
+          offset: TODO_QUERY_OFFSET,
+          ...(selectedCategoryId !== null && {
+            categoryId: selectedCategoryId,
+          }),
+        },
+      }),
+      enabled: isClerkQueryReady,
+    })
 
-  /**
-   * Handles drag-and-drop reordering of tasks.
-   * Optimistically updates local state and syncs with server.
-   * @param activeId - The ID of the dragged task.
-   * @param overId - The ID of the task being dragged over.
-   * @returns
-   * - No return value; the mutation updates server state.
-   * @example
-   * handleTaskReorder('1', '3')
-   */
-  const handleTaskReorder = (activeId: string, overId: string) => {
-    const oldIndex = localPendingTodos.findIndex((t) => t.id === activeId)
-    const newIndex = localPendingTodos.findIndex((t) => t.id === overId)
-
-    if (oldIndex === -1 || newIndex === -1) {
-      return
+    /**
+     * Toggles completion state for a floating navigator task.
+     * @param id - Todo identifier as a string.
+     * @returns
+     * - No return value; the mutation updates server state.
+     * @example
+     * handleTaskToggle('42')
+     */
+    const handleTaskToggle = (id: string) => {
+      const todoId = parseInt(id, DECIMAL_RADIX)
+      if (!isNaN(todoId)) {
+        toggleMutation.mutate({ id: todoId })
+      }
     }
 
-    // Optimistically update local state
-    const reordered = arrayMove(localPendingTodos, oldIndex, newIndex)
-    setLocalPendingTodos(reordered)
+    /**
+     * Creates a new task from the floating navigator input.
+     * @param title - Task title to create.
+     * @returns
+     * - No return value; the mutation updates server state.
+     * @example
+     * handleTaskCreate('Write report')
+     */
+    const handleTaskCreate = (title: string) => {
+      if (selectedCategoryId === null) return
+      createMutation.mutate({
+        text: title,
+        categoryId: selectedCategoryId,
+      })
+    }
 
-    // Build reorder items with new order values
-    const items = reordered.map((t, i) => ({
-      id: parseInt(t.id, DECIMAL_RADIX),
-      order: i,
+    /**
+     * Updates a task title from the floating navigator.
+     * @param id - Todo identifier as a string.
+     * @param title - New task title.
+     * @returns
+     * - No return value; the mutation updates server state.
+     * @example
+     * handleTaskEdit('42', 'Updated title')
+     */
+    const handleTaskEdit = (id: string, title: string) => {
+      const todoId = parseInt(id, DECIMAL_RADIX)
+      if (!isNaN(todoId)) {
+        updateMutation.mutate({ id: todoId, data: { text: title } })
+      }
+    }
+
+    /**
+     * Deletes a task from the floating navigator.
+     * @param id - Todo identifier as a string.
+     * @returns
+     * - No return value; the mutation updates server state.
+     * @example
+     * handleTaskDelete('42')
+     */
+    const handleTaskDelete = (id: string) => {
+      const todoId = parseInt(id, DECIMAL_RADIX)
+      if (!isNaN(todoId)) {
+        deleteMutation.mutate({ id: todoId })
+      }
+    }
+
+    /**
+     * Handles drag-and-drop reordering of tasks.
+     * Optimistically updates local state and syncs with server.
+     * @param activeId - The ID of the dragged task.
+     * @param overId - The ID of the task being dragged over.
+     * @returns
+     * - No return value; the mutation updates server state.
+     * @example
+     * handleTaskReorder('1', '3')
+     */
+    const handleTaskReorder = (activeId: string, overId: string) => {
+      const oldIndex = localPendingTodos.findIndex((t) => t.id === activeId)
+      const newIndex = localPendingTodos.findIndex((t) => t.id === overId)
+
+      if (oldIndex === -1 || newIndex === -1) {
+        return
+      }
+
+      // Optimistically update local state
+      const reordered = arrayMove(localPendingTodos, oldIndex, newIndex)
+      setLocalPendingTodos(reordered)
+
+      // Build reorder items with new order values
+      const items = reordered.map((t, i) => ({
+        id: parseInt(t.id, DECIMAL_RADIX),
+        order: i,
+      }))
+
+      // Call reorder mutation
+      reorderMutation.mutate({ items })
+    }
+
+    /**
+     * Creates a new category from the floating navigator.
+     * @param name - Category display name (1-30 chars)
+     * @param color - One of the predefined color options
+     * @example
+     * handleCategoryCreate('Work', 'blue')
+     */
+    const handleCategoryCreate = (name: string, color: CategoryColor) => {
+      categoryCreateMutation.mutate({ name, color })
+    }
+
+    /**
+     * Updates a category name or color from the floating navigator.
+     * @param id - Category ID to update
+     * @param data - Partial update with name and/or color
+     * @example
+     * handleCategoryUpdate(1, { name: 'Personal', color: 'green' })
+     */
+    const handleCategoryUpdate = (
+      id: number,
+      data: { name?: string; color?: CategoryColor },
+    ) => {
+      categoryUpdateMutation.mutate({ id, data })
+    }
+
+    /**
+     * Deletes a category and resets selection if it was the active filter.
+     * The server reassigns orphaned todos to the default (General) category.
+     * @param id - Category ID to delete
+     * @example
+     * handleCategoryDelete(3)
+     */
+    const handleCategoryDelete = (id: number) => {
+      categoryDeleteMutation.mutate({ id })
+      // If the deleted category was the active filter, clear selection
+      // so useAutoSelectDefaultCategory picks the General category
+      if (id === selectedCategoryId) {
+        setSelectedCategoryId(null)
+      }
+    }
+
+    // Transform todos to FloatingTodo format
+    const todosFromQuery: FloatingTodo[] = (data?.todos ?? []).map((todo) => ({
+      id: todo.id.toString(),
+      text: todo.text,
+      completed: todo.completed,
+      createdAt: new Date(todo.createdAt),
     }))
 
-    // Call reorder mutation
-    reorderMutation.mutate({ items })
-  }
+    // Sync local state with query data when it changes
+    useComponentEffect(() => {
+      setLocalPendingTodos(todosFromQuery.filter((t) => !t.completed))
+    }, [data])
 
-  /**
-   * Creates a new category from the floating navigator.
-   * @param name - Category display name (1-30 chars)
-   * @param color - One of the predefined color options
-   * @example
-   * handleCategoryCreate('Work', 'blue')
-   */
-  const handleCategoryCreate = (name: string, color: CategoryColor) => {
-    categoryCreateMutation.mutate({ name, color })
-  }
+    // Use local state for pending todos to enable optimistic reordering
+    const pendingTodos = localPendingTodos
+    const completedTodos = todosFromQuery.filter((t) => t.completed)
 
-  /**
-   * Updates a category name or color from the floating navigator.
-   * @param id - Category ID to update
-   * @param data - Partial update with name and/or color
-   * @example
-   * handleCategoryUpdate(1, { name: 'Personal', color: 'green' })
-   */
-  const handleCategoryUpdate = (
-    id: number,
-    data: { name?: string; color?: CategoryColor },
-  ) => {
-    categoryUpdateMutation.mutate({ id, data })
-  }
+    // Combine for passing to FloatingNavigator
+    const todos = [...pendingTodos, ...completedTodos]
 
-  /**
-   * Deletes a category and resets selection if it was the active filter.
-   * The server reassigns orphaned todos to the default (General) category.
-   * @param id - Category ID to delete
-   * @example
-   * handleCategoryDelete(3)
-   */
-  const handleCategoryDelete = (id: number) => {
-    categoryDeleteMutation.mutate({ id })
-    // If the deleted category was the active filter, clear selection
-    // so useAutoSelectDefaultCategory picks the General category
-    if (id === selectedCategoryId) {
-      setSelectedCategoryId(null)
-    }
-  }
-
-  // Transform todos to FloatingTodo format
-  const todosFromQuery: FloatingTodo[] = (data?.todos ?? []).map((todo) => ({
-    id: todo.id.toString(),
-    text: todo.text,
-    completed: todo.completed,
-    createdAt: new Date(todo.createdAt),
-  }))
-
-  // Sync local state with query data when it changes
-  useEffect(() => {
-    setLocalPendingTodos(todosFromQuery.filter((t) => !t.completed))
-  }, [data])
-
-  // Use local state for pending todos to enable optimistic reordering
-  const pendingTodos = localPendingTodos
-  const completedTodos = todosFromQuery.filter((t) => t.completed)
-
-  // Combine for passing to FloatingNavigator
-  const todos = [...pendingTodos, ...completedTodos]
-
-  useEffect(() => {
-    // Cross-window sync: BrainDump + Home todo completions also write to the
-    // Completed table, so the heatmap + day-detail caches must invalidate
-    // alongside the todo list. Mirrors TodoList.tsx — without these two keys,
-    // the floating navigator would silently miss completion deltas after a
-    // refresh (Codex review HIGH).
-    return subscribeToTodoSync(() => {
-      queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
-      queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
-      queryClient.invalidateQueries({
-        queryKey: orpc.completed.dayDetail.key(),
+    useComponentEffect(() => {
+      // Cross-window sync: BrainDump + Home todo completions also write to the
+      // Completed table, so the heatmap + day-detail caches must invalidate
+      // alongside the todo list. Mirrors TodoList.tsx — without these two keys,
+      // the floating navigator would silently miss completion deltas after a
+      // refresh (Codex review HIGH).
+      return subscribeToTodoSync(() => {
+        queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
+        queryClient.invalidateQueries({
+          queryKey: orpc.completed.heatmap.key(),
+        })
+        queryClient.invalidateQueries({
+          queryKey: orpc.completed.dayDetail.key(),
+        })
       })
-    })
-  }, [queryClient])
+    }, [queryClient])
 
-  // Cross-window category sync
-  useEffect(() => {
-    return subscribeToCategorySync(() => {
-      queryClient.invalidateQueries({ queryKey: orpc.category.list.key() })
-    })
-  }, [queryClient])
+    // Cross-window category sync
+    useComponentEffect(() => {
+      return subscribeToCategorySync(() => {
+        queryClient.invalidateQueries({ queryKey: orpc.category.list.key() })
+      })
+    }, [queryClient])
 
-  // Show message if not in Electron floating navigator
-  if (!isFloatingNavigator) {
+    // Show message if not in Electron floating navigator
+    if (!isFloatingNavigator) {
+      return (
+        <div className="flex h-full w-full items-center justify-center bg-background">
+          <p className="text-sm text-muted-foreground">
+            Floating navigator only available in desktop app
+          </p>
+        </div>
+      )
+    }
+
+    // Show loading state
+    if (isLoading) {
+      return (
+        <div className="flex h-full w-full items-center justify-center bg-background">
+          <p className="text-sm text-muted-foreground">Loading tasks...</p>
+        </div>
+      )
+    }
+
+    // Show error state
+    if (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to load tasks'
+
+      return (
+        <div className="flex h-full w-full flex-col items-center justify-center bg-background p-4">
+          <p className="mb-2 text-sm text-destructive">{errorMessage}</p>
+          <button
+            type="button"
+            onClick={async () =>
+              queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
+            }
+            className="text-xs text-muted-foreground underline hover:text-foreground"
+          >
+            Retry
+          </button>
+        </div>
+      )
+    }
+
     return (
-      <div className="flex h-full w-full items-center justify-center bg-background">
-        <p className="text-sm text-muted-foreground">
-          Floating navigator only available in desktop app
-        </p>
-      </div>
+      <FloatingNavigator
+        todos={todos}
+        onTaskToggle={handleTaskToggle}
+        onTaskCreate={handleTaskCreate}
+        onTaskEdit={handleTaskEdit}
+        onTaskDelete={handleTaskDelete}
+        onTaskReorder={handleTaskReorder}
+        categories={categories}
+        selectedCategoryId={selectedCategoryId}
+        onCategoryChange={setSelectedCategoryId}
+        onCategoryCreate={handleCategoryCreate}
+        onCategoryUpdate={handleCategoryUpdate}
+        onCategoryDelete={handleCategoryDelete}
+        isCategoryCreatePending={categoryCreateMutation.isPending}
+        isCategoryUpdatePending={categoryUpdateMutation.isPending}
+        isCategoryDeletePending={categoryDeleteMutation.isPending}
+      />
     )
-  }
-
-  // Show loading state
-  if (isLoading) {
-    return (
-      <div className="flex h-full w-full items-center justify-center bg-background">
-        <p className="text-sm text-muted-foreground">Loading tasks...</p>
-      </div>
-    )
-  }
-
-  // Show error state
-  if (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Failed to load tasks'
-
-    return (
-      <div className="flex h-full w-full flex-col items-center justify-center bg-background p-4">
-        <p className="mb-2 text-sm text-destructive">{errorMessage}</p>
-        <button
-          onClick={async () =>
-            queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
-          }
-          className="text-xs text-muted-foreground underline hover:text-foreground"
-        >
-          Retry
-        </button>
-      </div>
-    )
-  }
-
-  return (
-    <FloatingNavigator
-      todos={todos}
-      onTaskToggle={handleTaskToggle}
-      onTaskCreate={handleTaskCreate}
-      onTaskEdit={handleTaskEdit}
-      onTaskDelete={handleTaskDelete}
-      onTaskReorder={handleTaskReorder}
-      categories={categories}
-      selectedCategoryId={selectedCategoryId}
-      onCategoryChange={setSelectedCategoryId}
-      onCategoryCreate={handleCategoryCreate}
-      onCategoryUpdate={handleCategoryUpdate}
-      onCategoryDelete={handleCategoryDelete}
-      isCategoryCreatePending={categoryCreateMutation.isPending}
-      isCategoryUpdatePending={categoryUpdateMutation.isPending}
-      isCategoryDeletePending={categoryDeleteMutation.isPending}
-    />
-  )
-}
+  },
+)

--- a/src/components/floating-navigator/SortableFloatingTodoItem.tsx
+++ b/src/components/floating-navigator/SortableFloatingTodoItem.tsx
@@ -33,24 +33,26 @@ interface SortableFloatingTodoItemProps {
  *   )}
  * </SortableFloatingTodoItem>
  */
-export function SortableFloatingTodoItem({
-  todo,
-  index,
-  children,
-}: SortableFloatingTodoItemProps) {
-  const { ref, handleRef, isDragging } = useSortable({ id: todo.id, index })
+export const SortableFloatingTodoItem = React.memo(
+  function SortableFloatingTodoItem({
+    todo,
+    index,
+    children,
+  }: SortableFloatingTodoItemProps) {
+    const { ref, handleRef, isDragging } = useSortable({ id: todo.id, index })
 
-  const style: React.CSSProperties = {
-    opacity: isDragging ? 0.5 : 1,
-    zIndex: isDragging ? 1 : 0,
-  }
+    const style: React.CSSProperties = {
+      opacity: isDragging ? 0.5 : 1,
+      zIndex: isDragging ? 1 : 0,
+    }
 
-  return (
-    <div ref={ref} style={style}>
-      {children({
-        dragHandleRef: handleRef,
-        isDragging,
-      })}
-    </div>
-  )
-}
+    return (
+      <div ref={ref} style={style}>
+        {children({
+          dragHandleRef: handleRef,
+          isDragging,
+        })}
+      </div>
+    )
+  },
+)

--- a/src/components/floating-navigator/useFloatingNavigatorMenuActions.ts
+++ b/src/components/floating-navigator/useFloatingNavigatorMenuActions.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react'
 import { useEffect } from 'react'
 
 import { isFloatingNavigatorEnvironment } from '@/electron/utils/electron-client'

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -6,13 +6,13 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Accordion({
+const Accordion = React.memo(function Accordion({
   ...props
 }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
   return <AccordionPrimitive.Root data-slot="accordion" {...props} />
-}
+})
 
-function AccordionItem({
+const AccordionItem = React.memo(function AccordionItem({
   className,
   ...props
 }: React.ComponentProps<typeof AccordionPrimitive.Item>) {
@@ -23,9 +23,9 @@ function AccordionItem({
       {...props}
     />
   )
-}
+})
 
-function AccordionTrigger({
+const AccordionTrigger = React.memo(function AccordionTrigger({
   className,
   children,
   ...props
@@ -35,19 +35,19 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          'focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium outline-none transition-all hover:underline focus-visible:border-ring focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
           className,
         )}
         {...props}
       >
         {children}
-        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   )
-}
+})
 
-function AccordionContent({
+const AccordionContent = React.memo(function AccordionContent({
   className,
   children,
   ...props
@@ -58,9 +58,9 @@ function AccordionContent({
       className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
       {...props}
     >
-      <div className={cn('pt-0 pb-4', className)}>{children}</div>
+      <div className={cn('pb-4 pt-0', className)}>{children}</div>
     </AccordionPrimitive.Content>
   )
-}
+})
 
 export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -6,29 +6,29 @@ import * as React from 'react'
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
-function AlertDialog({
+const AlertDialog = React.memo(function AlertDialog({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
-}
+})
 
-function AlertDialogTrigger({
+const AlertDialogTrigger = React.memo(function AlertDialogTrigger({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
   return (
     <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
   )
-}
+})
 
-function AlertDialogPortal({
+const AlertDialogPortal = React.memo(function AlertDialogPortal({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
   return (
     <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
   )
-}
+})
 
-function AlertDialogOverlay({
+const AlertDialogOverlay = React.memo(function AlertDialogOverlay({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
@@ -42,9 +42,9 @@ function AlertDialogOverlay({
       {...props}
     />
   )
-}
+})
 
-function AlertDialogContent({
+const AlertDialogContent = React.memo(function AlertDialogContent({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
@@ -54,16 +54,16 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 sm:max-w-lg',
           className,
         )}
         {...props}
       />
     </AlertDialogPortal>
   )
-}
+})
 
-function AlertDialogHeader({
+const AlertDialogHeader = React.memo(function AlertDialogHeader({
   className,
   ...props
 }: React.ComponentProps<'div'>) {
@@ -74,9 +74,9 @@ function AlertDialogHeader({
       {...props}
     />
   )
-}
+})
 
-function AlertDialogFooter({
+const AlertDialogFooter = React.memo(function AlertDialogFooter({
   className,
   ...props
 }: React.ComponentProps<'div'>) {
@@ -90,9 +90,9 @@ function AlertDialogFooter({
       {...props}
     />
   )
-}
+})
 
-function AlertDialogTitle({
+const AlertDialogTitle = React.memo(function AlertDialogTitle({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
@@ -103,22 +103,22 @@ function AlertDialogTitle({
       {...props}
     />
   )
-}
+})
 
-function AlertDialogDescription({
+const AlertDialogDescription = React.memo(function AlertDialogDescription({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )
-}
+})
 
-function AlertDialogAction({
+const AlertDialogAction = React.memo(function AlertDialogAction({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
@@ -128,9 +128,9 @@ function AlertDialogAction({
       {...props}
     />
   )
-}
+})
 
-function AlertDialogCancel({
+const AlertDialogCancel = React.memo(function AlertDialogCancel({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
@@ -140,7 +140,7 @@ function AlertDialogCancel({
       {...props}
     />
   )
-}
+})
 
 export {
   AlertDialog,

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -19,7 +19,7 @@ const alertVariants = cva(
   },
 )
 
-function Alert({
+const Alert = React.memo(function Alert({
   className,
   variant,
   ...props
@@ -32,9 +32,12 @@ function Alert({
       {...props}
     />
   )
-}
+})
 
-function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+const AlertTitle = React.memo(function AlertTitle({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="alert-title"
@@ -45,9 +48,9 @@ function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function AlertDescription({
+const AlertDescription = React.memo(function AlertDescription({
   className,
   ...props
 }: React.ComponentProps<'div'>) {
@@ -55,12 +58,12 @@ function AlertDescription({
     <div
       data-slot="alert-description"
       className={cn(
-        'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+        'col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export { Alert, AlertTitle, AlertDescription }

--- a/src/components/ui/aspect-ratio.tsx
+++ b/src/components/ui/aspect-ratio.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import * as AspectRatioPrimitive from '@radix-ui/react-aspect-ratio'
+import * as React from 'react'
+import { memo } from 'react'
 
-function AspectRatio({
+const AspectRatio = memo(function AspectRatio({
   ...props
 }: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
   return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />
-}
+})
 
 export { AspectRatio }

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Avatar({
+const Avatar = React.memo(function Avatar({
   className,
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Root>) {
@@ -19,9 +19,9 @@ function Avatar({
       {...props}
     />
   )
-}
+})
 
-function AvatarImage({
+const AvatarImage = React.memo(function AvatarImage({
   className,
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
@@ -32,9 +32,9 @@ function AvatarImage({
       {...props}
     />
   )
-}
+})
 
-function AvatarFallback({
+const AvatarFallback = React.memo(function AvatarFallback({
   className,
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
@@ -42,12 +42,12 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        'bg-muted flex size-full items-center justify-center rounded-full',
+        'flex size-full items-center justify-center rounded-full bg-muted',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -25,7 +25,7 @@ const badgeVariants = cva(
   },
 )
 
-function Badge({
+const Badge = React.memo(function Badge({
   className,
   variant,
   asChild = false,
@@ -41,6 +41,6 @@ function Badge({
       {...props}
     />
   )
-}
+})
 
 export { Badge, badgeVariants }

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -4,24 +4,32 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Breadcrumb({ ...props }: React.ComponentProps<'nav'>) {
+const Breadcrumb = React.memo(function Breadcrumb({
+  ...props
+}: React.ComponentProps<'nav'>) {
   return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
-}
+})
 
-function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
+const BreadcrumbList = React.memo(function BreadcrumbList({
+  className,
+  ...props
+}: React.ComponentProps<'ol'>) {
   return (
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        'text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5',
+        'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
+const BreadcrumbItem = React.memo(function BreadcrumbItem({
+  className,
+  ...props
+}: React.ComponentProps<'li'>) {
   return (
     <li
       data-slot="breadcrumb-item"
@@ -29,9 +37,9 @@ function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
       {...props}
     />
   )
-}
+})
 
-function BreadcrumbLink({
+const BreadcrumbLink = React.memo(function BreadcrumbLink({
   asChild,
   className,
   ...props
@@ -43,26 +51,29 @@ function BreadcrumbLink({
   return (
     <Comp
       data-slot="breadcrumb-link"
-      className={cn('hover:text-foreground transition-colors', className)}
+      className={cn('transition-colors hover:text-foreground', className)}
       {...props}
     />
   )
-}
+})
 
-function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
+const BreadcrumbPage = React.memo(function BreadcrumbPage({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="breadcrumb-page"
       role="link"
       aria-disabled="true"
       aria-current="page"
-      className={cn('text-foreground font-normal', className)}
+      className={cn('font-normal text-foreground', className)}
       {...props}
     />
   )
-}
+})
 
-function BreadcrumbSeparator({
+const BreadcrumbSeparator = React.memo(function BreadcrumbSeparator({
   children,
   className,
   ...props
@@ -78,9 +89,9 @@ function BreadcrumbSeparator({
       {children ?? <ChevronRight />}
     </li>
   )
-}
+})
 
-function BreadcrumbEllipsis({
+const BreadcrumbEllipsis = React.memo(function BreadcrumbEllipsis({
   className,
   ...props
 }: React.ComponentProps<'span'>) {
@@ -96,7 +107,7 @@ function BreadcrumbEllipsis({
       <span className="sr-only">More</span>
     </span>
   )
-}
+})
 
 export {
   Breadcrumb,

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -35,7 +35,7 @@ const buttonVariants = cva(
   },
 )
 
-function Button({
+const Button = React.memo(function Button({
   className,
   variant,
   size,
@@ -54,6 +54,6 @@ function Button({
       {...props}
     />
   )
-}
+})
 
 export { Button, buttonVariants }

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -10,9 +10,10 @@ import type { DayButton } from 'react-day-picker'
 import { DayPicker, getDefaultClassNames } from 'react-day-picker'
 
 import { Button, buttonVariants } from '@/components/ui/button'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { cn } from '@/lib/utils'
 
-function Calendar({
+const Calendar = React.memo(function Calendar({
   className,
   classNames,
   showOutsideDays = true,
@@ -30,7 +31,7 @@ function Calendar({
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn(
-        'bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
+        'group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className,
@@ -54,41 +55,41 @@ function Calendar({
         ),
         button_previous: cn(
           buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+          'size-(--cell-size) select-none p-0 aria-disabled:opacity-50',
           defaultClassNames.button_previous,
         ),
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+          'size-(--cell-size) select-none p-0 aria-disabled:opacity-50',
           defaultClassNames.button_next,
         ),
         month_caption: cn(
-          'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
+          'h-(--cell-size) px-(--cell-size) flex w-full items-center justify-center',
           defaultClassNames.month_caption,
         ),
         dropdowns: cn(
-          'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
+          'h-(--cell-size) flex w-full items-center justify-center gap-1.5 text-sm font-medium',
           defaultClassNames.dropdowns,
         ),
         dropdown_root: cn(
-          'has-focus:border-ring border-input has-focus:ring-ring/50 relative rounded-md border shadow-xs has-focus:ring-[3px]',
+          'has-focus:border-ring has-focus:ring-ring/50 shadow-xs has-focus:ring-[3px] relative rounded-md border border-input',
           defaultClassNames.dropdown_root,
         ),
         dropdown: cn(
-          'bg-popover absolute inset-0 opacity-0',
+          'absolute inset-0 bg-popover opacity-0',
           defaultClassNames.dropdown,
         ),
         caption_label: cn(
-          'font-medium select-none',
+          'select-none font-medium',
           captionLayout === 'label'
             ? 'text-sm'
-            : '[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5',
+            : 'flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
           defaultClassNames.caption_label,
         ),
         table: 'w-full border-collapse',
         weekdays: cn('flex', defaultClassNames.weekdays),
         weekday: cn(
-          'text-muted-foreground flex-1 rounded-md text-[0.8rem] font-normal select-none',
+          'flex-1 select-none rounded-md text-[0.8rem] font-normal text-muted-foreground',
           defaultClassNames.weekday,
         ),
         week: cn('mt-2 flex w-full', defaultClassNames.week),
@@ -97,21 +98,21 @@ function Calendar({
           defaultClassNames.week_number_header,
         ),
         week_number: cn(
-          'text-muted-foreground text-[0.8rem] select-none',
+          'select-none text-[0.8rem] text-muted-foreground',
           defaultClassNames.week_number,
         ),
         day: cn(
-          'group/day relative aspect-square h-full w-full p-0 text-center select-none [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md',
+          'group/day relative aspect-square h-full w-full select-none p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md',
           defaultClassNames.day,
         ),
         range_start: cn(
-          'bg-accent rounded-l-md',
+          'rounded-l-md bg-accent',
           defaultClassNames.range_start,
         ),
         range_middle: cn('rounded-none', defaultClassNames.range_middle),
-        range_end: cn('bg-accent rounded-r-md', defaultClassNames.range_end),
+        range_end: cn('rounded-r-md bg-accent', defaultClassNames.range_end),
         today: cn(
-          'bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none',
+          'rounded-md bg-accent text-accent-foreground data-[selected=true]:rounded-none',
           defaultClassNames.today,
         ),
         outside: cn(
@@ -160,7 +161,7 @@ function Calendar({
         WeekNumber: ({ children, ...props }) => {
           return (
             <td {...props}>
-              <div className="flex size-(--cell-size) items-center justify-center text-center">
+              <div className="size-(--cell-size) flex items-center justify-center text-center">
                 {children}
               </div>
             </td>
@@ -171,9 +172,9 @@ function Calendar({
       {...props}
     />
   )
-}
+})
 
-function CalendarDayButton({
+function CalendarDayButtonBase({
   className,
   day,
   modifiers,
@@ -182,7 +183,7 @@ function CalendarDayButton({
   const defaultClassNames = getDefaultClassNames()
 
   const ref = React.useRef<HTMLButtonElement>(null)
-  React.useEffect(() => {
+  useComponentEffect(() => {
     if (modifiers.focused) ref.current?.focus()
   }, [modifiers.focused])
 
@@ -202,7 +203,7 @@ function CalendarDayButton({
       data-range-end={modifiers.range_end}
       data-range-middle={modifiers.range_middle}
       className={cn(
-        'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70',
+        'group-data-[focused=true]/day:ring-ring/50 min-w-(--cell-size) flex aspect-square size-auto w-full flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-start=true]:rounded-l-md data-[range-end=true]:bg-primary data-[range-middle=true]:bg-accent data-[range-start=true]:bg-primary data-[selected-single=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:text-accent-foreground data-[range-start=true]:text-primary-foreground data-[selected-single=true]:text-primary-foreground group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] dark:hover:text-accent-foreground [&>span]:text-xs [&>span]:opacity-70',
         defaultClassNames.day,
         className,
       )}
@@ -210,5 +211,9 @@ function CalendarDayButton({
     />
   )
 }
+
+const CalendarDayButton = React.memo(
+  CalendarDayButtonBase,
+) as typeof CalendarDayButtonBase
 
 export { Calendar, CalendarDayButton }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,53 +2,68 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Card({ className, ...props }: React.ComponentProps<'div'>) {
+const Card = React.memo(function Card({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        'flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+const CardHeader = React.memo(function CardHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        '@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+const CardTitle = React.memo(function CardTitle({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-title"
-      className={cn('leading-none font-semibold', className)}
+      className={cn('font-semibold leading-none', className)}
       {...props}
     />
   )
-}
+})
 
-function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+const CardDescription = React.memo(function CardDescription({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )
-}
+})
 
-function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+const CardAction = React.memo(function CardAction({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-action"
@@ -59,9 +74,12 @@ function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+const CardContent = React.memo(function CardContent({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-content"
@@ -69,17 +87,20 @@ function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+const CardFooter = React.memo(function CardFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-footer"
-      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
+      className={cn('[.border-t]:pt-6 flex items-center px-6', className)}
       {...props}
     />
   )
-}
+})
 
 export {
   Card,

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -42,7 +42,7 @@ function useCarousel() {
   return context
 }
 
-function Carousel({
+const Carousel = React.memo(function Carousel({
   orientation = 'horizontal',
   opts,
   setApi,
@@ -106,7 +106,7 @@ function Carousel({
   }, [api, onSelect, setApi])
 
   return (
-    <CarouselContext.Provider
+    <CarouselContext
       value={{
         carouselRef,
         api: api,
@@ -129,11 +129,14 @@ function Carousel({
       >
         {children}
       </div>
-    </CarouselContext.Provider>
+    </CarouselContext>
   )
-}
+})
 
-function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
+const CarouselContent = React.memo(function CarouselContent({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   const { carouselRef, orientation } = useCarousel()
 
   return (
@@ -152,9 +155,12 @@ function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
       />
     </div>
   )
-}
+})
 
-function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
+const CarouselItem = React.memo(function CarouselItem({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   const { orientation } = useCarousel()
 
   return (
@@ -170,9 +176,9 @@ function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function CarouselPrevious({
+const CarouselPrevious = React.memo(function CarouselPrevious({
   className,
   variant = 'outline',
   size = 'icon',
@@ -188,7 +194,7 @@ function CarouselPrevious({
       className={cn(
         'absolute size-8 rounded-full',
         orientation === 'horizontal'
-          ? 'top-1/2 -left-12 -translate-y-1/2'
+          ? '-left-12 top-1/2 -translate-y-1/2'
           : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
         className,
       )}
@@ -200,9 +206,9 @@ function CarouselPrevious({
       <span className="sr-only">Previous slide</span>
     </Button>
   )
-}
+})
 
-function CarouselNext({
+const CarouselNext = React.memo(function CarouselNext({
   className,
   variant = 'outline',
   size = 'icon',
@@ -218,7 +224,7 @@ function CarouselNext({
       className={cn(
         'absolute size-8 rounded-full',
         orientation === 'horizontal'
-          ? 'top-1/2 -right-12 -translate-y-1/2'
+          ? '-right-12 top-1/2 -translate-y-1/2'
           : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
         className,
       )}
@@ -230,7 +236,7 @@ function CarouselNext({
       <span className="sr-only">Next slide</span>
     </Button>
   )
-}
+})
 
 export {
   type CarouselApi,

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -39,6 +39,34 @@ type ChartContextProps = {
 
 const ChartContext = React.createContext<ChartContextProps | null>(null)
 
+const SAFE_CHART_COLOR_PATTERN =
+  /^(?:#[\da-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla)\((?:\s*(?:[-+]?\d*\.?\d+(?:deg|rad|turn|%)?|var\(--[a-zA-Z0-9_-]+\))\s*(?:[,/ ]\s*)?)+\))$/
+
+function escapeCssIdentifier(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value)
+  }
+
+  return value.replace(/[^a-zA-Z0-9_-]/g, '\\$&')
+}
+
+function escapeCssString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\n\r\f]/g, '')
+}
+
+function sanitizeChartColor(value: string | undefined): string | null {
+  const color = value?.trim()
+
+  if (!color) {
+    return null
+  }
+
+  return SAFE_CHART_COLOR_PATTERN.test(color) ? color : null
+}
+
 function useChart() {
   const context = React.useContext(ChartContext)
 
@@ -63,9 +91,10 @@ const ChartContainer = React.memo(function ChartContainer({
 }) {
   const uniqueId = React.useId()
   const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`
+  const chartContextValue = React.useMemo(() => ({ config }), [config])
 
   return (
-    <ChartContext value={{ config }}>
+    <ChartContext value={chartContextValue}>
       <div
         data-slot="chart"
         data-chart={chartId}
@@ -89,6 +118,7 @@ const ChartStyle = React.memo(
     const colorConfig = Object.entries(config).filter(
       ([, config]) => config.theme || config.color,
     )
+    const chartSelectorId = escapeCssString(id)
 
     if (!colorConfig.length) {
       return null
@@ -100,13 +130,17 @@ const ChartStyle = React.memo(
           __html: Object.entries(THEMES)
             .map(
               ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
+${prefix ? `${prefix} ` : ''}[data-chart="${chartSelectorId}"] {
 ${colorConfig
   .map(([key, itemConfig]) => {
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
+    const sanitizedColor = sanitizeChartColor(color)
+
+    return sanitizedColor
+      ? `  --color-${escapeCssIdentifier(key)}: ${sanitizedColor};`
+      : null
   })
   .join('\n')}
 }

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -49,7 +49,7 @@ function useChart() {
   return context
 }
 
-function ChartContainer({
+const ChartContainer = React.memo(function ChartContainer({
   id,
   className,
   children,
@@ -65,12 +65,12 @@ function ChartContainer({
   const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`
 
   return (
-    <ChartContext.Provider value={{ config }}>
+    <ChartContext value={{ config }}>
       <div
         data-slot="chart"
         data-chart={chartId}
         className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          "[&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-surface]:outline-hidden flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent",
           className,
         )}
         {...props}
@@ -80,25 +80,26 @@ function ChartContainer({
           {children}
         </RechartsPrimitive.ResponsiveContainer>
       </div>
-    </ChartContext.Provider>
+    </ChartContext>
   )
-}
+})
 
-const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(
-    ([, config]) => config.theme || config.color,
-  )
+const ChartStyle = React.memo(
+  ({ id, config }: { id: string; config: ChartConfig }) => {
+    const colorConfig = Object.entries(config).filter(
+      ([, config]) => config.theme || config.color,
+    )
 
-  if (!colorConfig.length) {
-    return null
-  }
+    if (!colorConfig.length) {
+      return null
+    }
 
-  return (
-    <style
-      dangerouslySetInnerHTML={{
-        __html: Object.entries(THEMES)
-          .map(
-            ([theme, prefix]) => `
+    return (
+      <style
+        dangerouslySetInnerHTML={{
+          __html: Object.entries(THEMES)
+            .map(
+              ([theme, prefix]) => `
 ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
@@ -110,16 +111,17 @@ ${colorConfig
   .join('\n')}
 }
 `,
-          )
-          .join('\n'),
-      }}
-    />
-  )
-}
+            )
+            .join('\n'),
+        }}
+      />
+    )
+  },
+)
 
 const ChartTooltip = RechartsPrimitive.Tooltip
 
-function ChartTooltipContent({
+const ChartTooltipContent = React.memo(function ChartTooltipContent({
   active,
   payload,
   className,
@@ -203,7 +205,7 @@ function ChartTooltipContent({
   return (
     <div
       className={cn(
-        'border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl',
+        'border-border/50 grid min-w-[8rem] items-start gap-1.5 rounded-lg border bg-background px-2.5 py-1.5 text-xs shadow-xl',
         className,
       )}
     >
@@ -218,7 +220,7 @@ function ChartTooltipContent({
             <div
               key={item.dataKey}
               className={cn(
-                '[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5',
+                'flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground',
                 indicator === 'dot' && 'items-center',
               )}
             >
@@ -232,7 +234,7 @@ function ChartTooltipContent({
                     !hideIndicator && (
                       <div
                         className={cn(
-                          'shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)',
+                          'border-(--color-border) bg-(--color-bg) shrink-0 rounded-[2px]',
                           {
                             'h-2.5 w-2.5': indicator === 'dot',
                             'w-1': indicator === 'line',
@@ -263,7 +265,7 @@ function ChartTooltipContent({
                       </span>
                     </div>
                     {item.value && (
-                      <span className="text-foreground font-mono font-medium tabular-nums">
+                      <span className="font-mono font-medium tabular-nums text-foreground">
                         {item.value.toLocaleString()}
                       </span>
                     )}
@@ -276,11 +278,11 @@ function ChartTooltipContent({
       </div>
     </div>
   )
-}
+})
 
 const ChartLegend = RechartsPrimitive.Legend
 
-function ChartLegendContent({
+const ChartLegendContent = React.memo(function ChartLegendContent({
   className,
   hideIcon = false,
   payload,
@@ -314,7 +316,7 @@ function ChartLegendContent({
           <div
             key={item.value}
             className={cn(
-              '[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3',
+              'flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground',
             )}
           >
             {itemConfig?.icon && !hideIcon ? (
@@ -333,7 +335,7 @@ function ChartLegendContent({
       })}
     </div>
   )
-}
+})
 
 // Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Checkbox({
+const Checkbox = React.memo(function Checkbox({
   className,
   ...props
 }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'dark:bg-input/30 focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive shadow-xs peer size-4 shrink-0 rounded-[4px] border border-input outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary',
         className,
       )}
       {...props}
@@ -27,6 +27,6 @@ function Checkbox({
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )
-}
+})
 
 export { Checkbox }

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,14 +1,16 @@
 'use client'
 
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible'
+import * as React from 'react'
+import { memo } from 'react'
 
-function Collapsible({
+const Collapsible = memo(function Collapsible({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
   return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
-}
+})
 
-function CollapsibleTrigger({
+const CollapsibleTrigger = memo(function CollapsibleTrigger({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
   return (
@@ -17,9 +19,9 @@ function CollapsibleTrigger({
       {...props}
     />
   )
-}
+})
 
-function CollapsibleContent({
+const CollapsibleContent = memo(function CollapsibleContent({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
   return (
@@ -28,6 +30,6 @@ function CollapsibleContent({
       {...props}
     />
   )
-}
+})
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 
-function Command({
+const Command = React.memo(function Command({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive>) {
@@ -21,15 +21,15 @@ function Command({
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function CommandDialog({
+const CommandDialog = React.memo(function CommandDialog({
   title = 'Command Palette',
   description = 'Search for a command to run...',
   children,
@@ -52,15 +52,15 @@ function CommandDialog({
         className={cn('overflow-hidden p-0', className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
     </Dialog>
   )
-}
+})
 
-function CommandInput({
+const CommandInput = React.memo(function CommandInput({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
@@ -73,16 +73,16 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+          'outline-hidden flex h-10 w-full rounded-md bg-transparent py-3 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         {...props}
       />
     </div>
   )
-}
+})
 
-function CommandList({
+const CommandList = React.memo(function CommandList({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.List>) {
@@ -90,15 +90,15 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        'max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto',
+        'max-h-[300px] scroll-py-1 overflow-y-auto overflow-x-hidden',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function CommandEmpty({
+const CommandEmpty = React.memo(function CommandEmpty({
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (
@@ -108,9 +108,9 @@ function CommandEmpty({
       {...props}
     />
   )
-}
+})
 
-function CommandGroup({
+const CommandGroup = React.memo(function CommandGroup({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Group>) {
@@ -118,28 +118,28 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+        'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function CommandSeparator({
+const CommandSeparator = React.memo(function CommandSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Separator>) {
   return (
     <CommandPrimitive.Separator
       data-slot="command-separator"
-      className={cn('bg-border -mx-1 h-px', className)}
+      className={cn('-mx-1 h-px bg-border', className)}
       {...props}
     />
   )
-}
+})
 
-function CommandItem({
+const CommandItem = React.memo(function CommandItem({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Item>) {
@@ -147,15 +147,15 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function CommandShortcut({
+const CommandShortcut = React.memo(function CommandShortcut({
   className,
   ...props
 }: React.ComponentProps<'span'>) {
@@ -163,13 +163,13 @@ function CommandShortcut({
     <span
       data-slot="command-shortcut"
       className={cn(
-        'text-muted-foreground ml-auto text-xs tracking-widest',
+        'ml-auto text-xs tracking-widest text-muted-foreground',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export {
   Command,

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -6,43 +6,43 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function ContextMenu({
+const ContextMenu = React.memo(function ContextMenu({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
   return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
-}
+})
 
-function ContextMenuTrigger({
+const ContextMenuTrigger = React.memo(function ContextMenuTrigger({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
   return (
     <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
   )
-}
+})
 
-function ContextMenuGroup({
+const ContextMenuGroup = React.memo(function ContextMenuGroup({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
   return (
     <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
   )
-}
+})
 
-function ContextMenuPortal({
+const ContextMenuPortal = React.memo(function ContextMenuPortal({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
   return (
     <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
   )
-}
+})
 
-function ContextMenuSub({
+const ContextMenuSub = React.memo(function ContextMenuSub({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
   return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />
-}
+})
 
-function ContextMenuRadioGroup({
+const ContextMenuRadioGroup = React.memo(function ContextMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
   return (
@@ -51,9 +51,9 @@ function ContextMenuRadioGroup({
       {...props}
     />
   )
-}
+})
 
-function ContextMenuSubTrigger({
+const ContextMenuSubTrigger = React.memo(function ContextMenuSubTrigger({
   className,
   inset,
   children,
@@ -66,7 +66,7 @@ function ContextMenuSubTrigger({
       data-slot="context-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "outline-hidden flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -75,9 +75,9 @@ function ContextMenuSubTrigger({
       <ChevronRightIcon className="ml-auto" />
     </ContextMenuPrimitive.SubTrigger>
   )
-}
+})
 
-function ContextMenuSubContent({
+const ContextMenuSubContent = React.memo(function ContextMenuSubContent({
   className,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
@@ -85,15 +85,15 @@ function ContextMenuSubContent({
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-context-menu-content-transform-origin) z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function ContextMenuContent({
+const ContextMenuContent = React.memo(function ContextMenuContent({
   className,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
@@ -102,16 +102,16 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--radix-context-menu-content-available-height) origin-(--radix-context-menu-content-transform-origin) z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
           className,
         )}
         {...props}
       />
     </ContextMenuPrimitive.Portal>
   )
-}
+})
 
-function ContextMenuItem({
+const ContextMenuItem = React.memo(function ContextMenuItem({
   className,
   inset,
   variant = 'default',
@@ -126,15 +126,15 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:*:[svg]:!text-destructive outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function ContextMenuCheckboxItem({
+const ContextMenuCheckboxItem = React.memo(function ContextMenuCheckboxItem({
   className,
   children,
   checked,
@@ -144,7 +144,7 @@ function ContextMenuCheckboxItem({
     <ContextMenuPrimitive.CheckboxItem
       data-slot="context-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       checked={checked}
@@ -158,9 +158,9 @@ function ContextMenuCheckboxItem({
       {children}
     </ContextMenuPrimitive.CheckboxItem>
   )
-}
+})
 
-function ContextMenuRadioItem({
+const ContextMenuRadioItem = React.memo(function ContextMenuRadioItem({
   className,
   children,
   ...props
@@ -169,7 +169,7 @@ function ContextMenuRadioItem({
     <ContextMenuPrimitive.RadioItem
       data-slot="context-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -182,9 +182,9 @@ function ContextMenuRadioItem({
       {children}
     </ContextMenuPrimitive.RadioItem>
   )
-}
+})
 
-function ContextMenuLabel({
+const ContextMenuLabel = React.memo(function ContextMenuLabel({
   className,
   inset,
   ...props
@@ -196,28 +196,28 @@ function ContextMenuLabel({
       data-slot="context-menu-label"
       data-inset={inset}
       className={cn(
-        'text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8',
+        'px-2 py-1.5 text-sm font-medium text-foreground data-[inset]:pl-8',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function ContextMenuSeparator({
+const ContextMenuSeparator = React.memo(function ContextMenuSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
   return (
     <ContextMenuPrimitive.Separator
       data-slot="context-menu-separator"
-      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
   )
-}
+})
 
-function ContextMenuShortcut({
+const ContextMenuShortcut = React.memo(function ContextMenuShortcut({
   className,
   ...props
 }: React.ComponentProps<'span'>) {
@@ -225,13 +225,13 @@ function ContextMenuShortcut({
     <span
       data-slot="context-menu-shortcut"
       className={cn(
-        'text-muted-foreground ml-auto text-xs tracking-widest',
+        'ml-auto text-xs tracking-widest text-muted-foreground',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export {
   ContextMenu,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -6,31 +6,31 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Dialog({
+const Dialog = React.memo(function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
-}
+})
 
-function DialogTrigger({
+const DialogTrigger = React.memo(function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
-}
+})
 
-function DialogPortal({
+const DialogPortal = React.memo(function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
-}
+})
 
-function DialogClose({
+const DialogClose = React.memo(function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
-}
+})
 
-function DialogOverlay({
+const DialogOverlay = React.memo(function DialogOverlay({
   className,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
@@ -44,9 +44,9 @@ function DialogOverlay({
       {...props}
     />
   )
-}
+})
 
-function DialogContent({
+const DialogContent = React.memo(function DialogContent({
   className,
   children,
   showCloseButton = true,
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 sm:max-w-lg',
           className,
         )}
         {...props}
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="rounded-xs focus:outline-hidden absolute right-4 top-4 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -78,9 +78,12 @@ function DialogContent({
       </DialogPrimitive.Content>
     </DialogPortal>
   )
-}
+})
 
-function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+const DialogHeader = React.memo(function DialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
@@ -88,9 +91,12 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+const DialogFooter = React.memo(function DialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-footer"
@@ -101,33 +107,33 @@ function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function DialogTitle({
+const DialogTitle = React.memo(function DialogTitle({
   className,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-lg leading-none font-semibold', className)}
+      className={cn('text-lg font-semibold leading-none', className)}
       {...props}
     />
   )
-}
+})
 
-function DialogDescription({
+const DialogDescription = React.memo(function DialogDescription({
   className,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Description>) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )
-}
+})
 
 export {
   Dialog,

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -5,31 +5,31 @@ import { Drawer as DrawerPrimitive } from 'vaul'
 
 import { cn } from '@/lib/utils'
 
-function Drawer({
+const Drawer = React.memo(function Drawer({
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
   return <DrawerPrimitive.Root data-slot="drawer" {...props} />
-}
+})
 
-function DrawerTrigger({
+const DrawerTrigger = React.memo(function DrawerTrigger({
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
   return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
-}
+})
 
-function DrawerPortal({
+const DrawerPortal = React.memo(function DrawerPortal({
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
   return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
-}
+})
 
-function DrawerClose({
+const DrawerClose = React.memo(function DrawerClose({
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
   return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
-}
+})
 
-function DrawerOverlay({
+const DrawerOverlay = React.memo(function DrawerOverlay({
   className,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
@@ -43,9 +43,9 @@ function DrawerOverlay({
       {...props}
     />
   )
-}
+})
 
-function DrawerContent({
+const DrawerContent = React.memo(function DrawerContent({
   className,
   children,
   ...props
@@ -56,7 +56,7 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+          'group/drawer-content fixed z-50 flex h-auto flex-col bg-background',
           'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
           'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
           'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
@@ -65,14 +65,17 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>
   )
-}
+})
 
-function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+const DrawerHeader = React.memo(function DrawerHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="drawer-header"
@@ -83,9 +86,12 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+const DrawerFooter = React.memo(function DrawerFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="drawer-footer"
@@ -93,33 +99,33 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function DrawerTitle({
+const DrawerTitle = React.memo(function DrawerTitle({
   className,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
-      className={cn('text-foreground font-semibold', className)}
+      className={cn('font-semibold text-foreground', className)}
       {...props}
     />
   )
-}
+})
 
-function DrawerDescription({
+const DrawerDescription = React.memo(function DrawerDescription({
   className,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Description>) {
   return (
     <DrawerPrimitive.Description
       data-slot="drawer-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )
-}
+})
 
 export {
   Drawer,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -6,21 +6,21 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function DropdownMenu({
+const DropdownMenu = React.memo(function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
-}
+})
 
-function DropdownMenuPortal({
+const DropdownMenuPortal = React.memo(function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
   return (
     <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
   )
-}
+})
 
-function DropdownMenuTrigger({
+const DropdownMenuTrigger = React.memo(function DropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
   return (
@@ -29,9 +29,9 @@ function DropdownMenuTrigger({
       {...props}
     />
   )
-}
+})
 
-function DropdownMenuContent({
+const DropdownMenuContent = React.memo(function DropdownMenuContent({
   className,
   sideOffset = 4,
   ...props
@@ -49,17 +49,17 @@ function DropdownMenuContent({
       />
     </DropdownMenuPrimitive.Portal>
   )
-}
+})
 
-function DropdownMenuGroup({
+const DropdownMenuGroup = React.memo(function DropdownMenuGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
   return (
     <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
   )
-}
+})
 
-function DropdownMenuItem({
+const DropdownMenuItem = React.memo(function DropdownMenuItem({
   className,
   inset,
   variant = 'default',
@@ -80,9 +80,9 @@ function DropdownMenuItem({
       {...props}
     />
   )
-}
+})
 
-function DropdownMenuCheckboxItem({
+const DropdownMenuCheckboxItem = React.memo(function DropdownMenuCheckboxItem({
   className,
   children,
   checked,
@@ -106,9 +106,9 @@ function DropdownMenuCheckboxItem({
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
   )
-}
+})
 
-function DropdownMenuRadioGroup({
+const DropdownMenuRadioGroup = React.memo(function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
   return (
@@ -117,9 +117,9 @@ function DropdownMenuRadioGroup({
       {...props}
     />
   )
-}
+})
 
-function DropdownMenuRadioItem({
+const DropdownMenuRadioItem = React.memo(function DropdownMenuRadioItem({
   className,
   children,
   ...props
@@ -141,9 +141,9 @@ function DropdownMenuRadioItem({
       {children}
     </DropdownMenuPrimitive.RadioItem>
   )
-}
+})
 
-function DropdownMenuLabel({
+const DropdownMenuLabel = React.memo(function DropdownMenuLabel({
   className,
   inset,
   ...props
@@ -161,9 +161,9 @@ function DropdownMenuLabel({
       {...props}
     />
   )
-}
+})
 
-function DropdownMenuSeparator({
+const DropdownMenuSeparator = React.memo(function DropdownMenuSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
@@ -174,9 +174,9 @@ function DropdownMenuSeparator({
       {...props}
     />
   )
-}
+})
 
-function DropdownMenuShortcut({
+const DropdownMenuShortcut = React.memo(function DropdownMenuShortcut({
   className,
   ...props
 }: React.ComponentProps<'span'>) {
@@ -190,15 +190,15 @@ function DropdownMenuShortcut({
       {...props}
     />
   )
-}
+})
 
-function DropdownMenuSub({
+const DropdownMenuSub = React.memo(function DropdownMenuSub({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
   return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
-}
+})
 
-function DropdownMenuSubTrigger({
+const DropdownMenuSubTrigger = React.memo(function DropdownMenuSubTrigger({
   className,
   inset,
   children,
@@ -220,9 +220,9 @@ function DropdownMenuSubTrigger({
       <ChevronRightIcon className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
   )
-}
+})
 
-function DropdownMenuSubContent({
+const DropdownMenuSubContent = React.memo(function DropdownMenuSubContent({
   className,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
@@ -236,7 +236,7 @@ function DropdownMenuSubContent({
       {...props}
     />
   )
-}
+})
 
 export {
   DropdownMenu,

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -29,18 +29,22 @@ const FormFieldContext = React.createContext<FormFieldContextValue>(
   {} as FormFieldContextValue,
 )
 
-const FormField = <
+function FormFieldBase<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
->({
-  ...props
-}: ControllerProps<TFieldValues, TName>) => {
+>({ ...props }: ControllerProps<TFieldValues, TName>) {
+  const contextValue = React.useMemo(() => ({ name: props.name }), [props.name])
+
   return (
-    <FormFieldContext.Provider value={{ name: props.name }}>
+    <FormFieldContext value={contextValue}>
       <Controller {...props} />
-    </FormFieldContext.Provider>
+    </FormFieldContext>
   )
 }
+
+const MemoizedFormField = React.memo(FormFieldBase)
+MemoizedFormField.displayName = 'FormField'
+const FormField = MemoizedFormField as typeof FormFieldBase
 
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext)
@@ -73,21 +77,25 @@ const FormItemContext = React.createContext<FormItemContextValue>(
   {} as FormItemContextValue,
 )
 
-function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
+const FormItem = React.memo(function FormItem({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   const id = React.useId()
+  const contextValue = React.useMemo(() => ({ id }), [id])
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext value={contextValue}>
       <div
         data-slot="form-item"
         className={cn('grid gap-2', className)}
         {...props}
       />
-    </FormItemContext.Provider>
+    </FormItemContext>
   )
-}
+})
 
-function FormLabel({
+const FormLabel = React.memo(function FormLabel({
   className,
   ...props
 }: React.ComponentProps<typeof LabelPrimitive.Root>) {
@@ -102,9 +110,11 @@ function FormLabel({
       {...props}
     />
   )
-}
+})
 
-function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+const FormControl = React.memo(function FormControl({
+  ...props
+}: React.ComponentProps<typeof Slot>) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
 
   return (
@@ -120,22 +130,28 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
       {...props}
     />
   )
-}
+})
 
-function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
+const FormDescription = React.memo(function FormDescription({
+  className,
+  ...props
+}: React.ComponentProps<'p'>) {
   const { formDescriptionId } = useFormField()
 
   return (
     <p
       data-slot="form-description"
       id={formDescriptionId}
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )
-}
+})
 
-function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
+const FormMessage = React.memo(function FormMessage({
+  className,
+  ...props
+}: React.ComponentProps<'p'>) {
   const { error, formMessageId } = useFormField()
   const body = error ? String(error?.message ?? '') : props.children
 
@@ -147,13 +163,13 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn('text-destructive text-sm', className)}
+      className={cn('text-sm text-destructive', className)}
       {...props}
     >
       {body}
     </p>
   )
-}
+})
 
 export {
   useFormField,

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -5,21 +5,21 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function HoverCard({
+const HoverCard = React.memo(function HoverCard({
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
   return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
-}
+})
 
-function HoverCardTrigger({
+const HoverCardTrigger = React.memo(function HoverCardTrigger({
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
   return (
     <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
   )
-}
+})
 
-function HoverCardContent({
+const HoverCardContent = React.memo(function HoverCardContent({
   className,
   align = 'center',
   sideOffset = 4,
@@ -32,13 +32,13 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-hover-card-content-transform-origin) outline-hidden z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md',
           className,
         )}
         {...props}
       />
     </HoverCardPrimitive.Portal>
   )
-}
+})
 
 export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function InputOTP({
+const InputOTP = React.memo(function InputOTP({
   className,
   containerClassName,
   ...props
@@ -17,16 +17,19 @@ function InputOTP({
     <OTPInput
       data-slot="input-otp"
       containerClassName={cn(
-        'flex items-center gap-2 has-disabled:opacity-50',
+        'has-disabled:opacity-50 flex items-center gap-2',
         containerClassName,
       )}
       className={cn('disabled:cursor-not-allowed', className)}
       {...props}
     />
   )
-}
+})
 
-function InputOTPGroup({ className, ...props }: React.ComponentProps<'div'>) {
+const InputOTPGroup = React.memo(function InputOTPGroup({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="input-otp-group"
@@ -34,9 +37,9 @@ function InputOTPGroup({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function InputOTPSlot({
+const InputOTPSlot = React.memo(function InputOTPSlot({
   index,
   className,
   ...props
@@ -51,7 +54,7 @@ function InputOTPSlot({
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
+        'data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 shadow-xs relative flex h-9 w-9 items-center justify-center border-y border-r border-input text-sm outline-none transition-all first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-[3px]',
         className,
       )}
       {...props}
@@ -59,19 +62,21 @@ function InputOTPSlot({
       {char}
       {hasFakeCaret && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <div className="animate-caret-blink bg-foreground h-4 w-px duration-1000" />
+          <div className="animate-caret-blink h-4 w-px bg-foreground duration-1000" />
         </div>
       )}
     </div>
   )
-}
+})
 
-function InputOTPSeparator({ ...props }: React.ComponentProps<'div'>) {
+const InputOTPSeparator = React.memo(function InputOTPSeparator({
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div data-slot="input-otp-separator" role="separator" {...props}>
       <MinusIcon />
     </div>
   )
-}
+})
 
 export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,20 +2,24 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+const Input = React.memo(function Input({
+  className,
+  type,
+  ...props
+}: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'dark:bg-input/30 shadow-xs flex h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base outline-none transition-[color,box-shadow] selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:ring-[3px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Label({
+const Label = React.memo(function Label({
   className,
   ...props
 }: React.ComponentProps<typeof LabelPrimitive.Root>) {
@@ -13,12 +13,12 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        'flex select-none items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export { Label }

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -79,7 +79,7 @@ const MenubarContent = React.memo(function MenubarContent({
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          'data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-menubar-content-transform-origin) z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-menubar-content-transform-origin) z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
           className,
         )}
         {...props}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Menubar({
+const Menubar = React.memo(function Menubar({
   className,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Root>) {
@@ -14,41 +14,41 @@ function Menubar({
     <MenubarPrimitive.Root
       data-slot="menubar"
       className={cn(
-        'bg-background flex h-9 items-center gap-1 rounded-md border p-1 shadow-xs',
+        'shadow-xs flex h-9 items-center gap-1 rounded-md border bg-background p-1',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function MenubarMenu({
+const MenubarMenu = React.memo(function MenubarMenu({
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
   return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />
-}
+})
 
-function MenubarGroup({
+const MenubarGroup = React.memo(function MenubarGroup({
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Group>) {
   return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />
-}
+})
 
-function MenubarPortal({
+const MenubarPortal = React.memo(function MenubarPortal({
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
   return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />
-}
+})
 
-function MenubarRadioGroup({
+const MenubarRadioGroup = React.memo(function MenubarRadioGroup({
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
   return (
     <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {...props} />
   )
-}
+})
 
-function MenubarTrigger({
+const MenubarTrigger = React.memo(function MenubarTrigger({
   className,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Trigger>) {
@@ -56,15 +56,15 @@ function MenubarTrigger({
     <MenubarPrimitive.Trigger
       data-slot="menubar-trigger"
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none',
+        'outline-hidden flex select-none items-center rounded-sm px-2 py-1 text-sm font-medium focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function MenubarContent({
+const MenubarContent = React.memo(function MenubarContent({
   className,
   align = 'start',
   alignOffset = -4,
@@ -79,16 +79,16 @@ function MenubarContent({
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
+          'data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-menubar-content-transform-origin) z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
           className,
         )}
         {...props}
       />
     </MenubarPortal>
   )
-}
+})
 
-function MenubarItem({
+const MenubarItem = React.memo(function MenubarItem({
   className,
   inset,
   variant = 'default',
@@ -103,15 +103,15 @@ function MenubarItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:*:[svg]:!text-destructive outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function MenubarCheckboxItem({
+const MenubarCheckboxItem = React.memo(function MenubarCheckboxItem({
   className,
   children,
   checked,
@@ -121,7 +121,7 @@ function MenubarCheckboxItem({
     <MenubarPrimitive.CheckboxItem
       data-slot="menubar-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "rounded-xs outline-hidden relative flex cursor-default select-none items-center gap-2 py-1.5 pl-8 pr-2 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       checked={checked}
@@ -135,9 +135,9 @@ function MenubarCheckboxItem({
       {children}
     </MenubarPrimitive.CheckboxItem>
   )
-}
+})
 
-function MenubarRadioItem({
+const MenubarRadioItem = React.memo(function MenubarRadioItem({
   className,
   children,
   ...props
@@ -146,7 +146,7 @@ function MenubarRadioItem({
     <MenubarPrimitive.RadioItem
       data-slot="menubar-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "rounded-xs outline-hidden relative flex cursor-default select-none items-center gap-2 py-1.5 pl-8 pr-2 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -159,9 +159,9 @@ function MenubarRadioItem({
       {children}
     </MenubarPrimitive.RadioItem>
   )
-}
+})
 
-function MenubarLabel({
+const MenubarLabel = React.memo(function MenubarLabel({
   className,
   inset,
   ...props
@@ -179,22 +179,22 @@ function MenubarLabel({
       {...props}
     />
   )
-}
+})
 
-function MenubarSeparator({
+const MenubarSeparator = React.memo(function MenubarSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Separator>) {
   return (
     <MenubarPrimitive.Separator
       data-slot="menubar-separator"
-      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
   )
-}
+})
 
-function MenubarShortcut({
+const MenubarShortcut = React.memo(function MenubarShortcut({
   className,
   ...props
 }: React.ComponentProps<'span'>) {
@@ -202,21 +202,21 @@ function MenubarShortcut({
     <span
       data-slot="menubar-shortcut"
       className={cn(
-        'text-muted-foreground ml-auto text-xs tracking-widest',
+        'ml-auto text-xs tracking-widest text-muted-foreground',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function MenubarSub({
+const MenubarSub = React.memo(function MenubarSub({
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Sub>) {
   return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />
-}
+})
 
-function MenubarSubTrigger({
+const MenubarSubTrigger = React.memo(function MenubarSubTrigger({
   className,
   inset,
   children,
@@ -229,7 +229,7 @@ function MenubarSubTrigger({
       data-slot="menubar-sub-trigger"
       data-inset={inset}
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8',
+        'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground',
         className,
       )}
       {...props}
@@ -238,9 +238,9 @@ function MenubarSubTrigger({
       <ChevronRightIcon className="ml-auto h-4 w-4" />
     </MenubarPrimitive.SubTrigger>
   )
-}
+})
 
-function MenubarSubContent({
+const MenubarSubContent = React.memo(function MenubarSubContent({
   className,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.SubContent>) {
@@ -248,13 +248,13 @@ function MenubarSubContent({
     <MenubarPrimitive.SubContent
       data-slot="menubar-sub-content"
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-menubar-content-transform-origin) z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export {
   Menubar,

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function NavigationMenu({
+const NavigationMenu = React.memo(function NavigationMenu({
   className,
   children,
   viewport = true,
@@ -27,9 +27,9 @@ function NavigationMenu({
       {viewport && <NavigationMenuViewport />}
     </NavigationMenuPrimitive.Root>
   )
-}
+})
 
-function NavigationMenuList({
+const NavigationMenuList = React.memo(function NavigationMenuList({
   className,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
@@ -43,9 +43,9 @@ function NavigationMenuList({
       {...props}
     />
   )
-}
+})
 
-function NavigationMenuItem({
+const NavigationMenuItem = React.memo(function NavigationMenuItem({
   className,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
@@ -56,13 +56,13 @@ function NavigationMenuItem({
       {...props}
     />
   )
-}
+})
 
 const navigationMenuTriggerStyle = cva(
   'group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1',
 )
 
-function NavigationMenuTrigger({
+const NavigationMenuTrigger = React.memo(function NavigationMenuTrigger({
   className,
   children,
   ...props
@@ -80,9 +80,9 @@ function NavigationMenuTrigger({
       />
     </NavigationMenuPrimitive.Trigger>
   )
-}
+})
 
-function NavigationMenuContent({
+const NavigationMenuContent = React.memo(function NavigationMenuContent({
   className,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
@@ -90,38 +90,38 @@ function NavigationMenuContent({
     <NavigationMenuPrimitive.Content
       data-slot="navigation-menu-content"
       className={cn(
-        'data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto',
-        'group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none',
+        'data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 left-0 top-0 w-full p-2 pr-2.5 md:absolute md:w-auto',
+        'group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function NavigationMenuViewport({
+const NavigationMenuViewport = React.memo(function NavigationMenuViewport({
   className,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
   return (
     <div
       className={cn(
-        'absolute top-full left-0 isolate z-50 flex justify-center',
+        'absolute left-0 top-full isolate z-50 flex justify-center',
       )}
     >
       <NavigationMenuPrimitive.Viewport
         data-slot="navigation-menu-viewport"
         className={cn(
-          'origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]',
+          'origin-top-center data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow md:w-[var(--radix-navigation-menu-viewport-width)]',
           className,
         )}
         {...props}
       />
     </div>
   )
-}
+})
 
-function NavigationMenuLink({
+const NavigationMenuLink = React.memo(function NavigationMenuLink({
   className,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
@@ -129,15 +129,15 @@ function NavigationMenuLink({
     <NavigationMenuPrimitive.Link
       data-slot="navigation-menu-link"
       className={cn(
-        "data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
+        "data-[active=true]:bg-accent/50 focus-visible:ring-ring/50 flex flex-col gap-1 rounded-sm p-2 text-sm outline-none transition-all hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:outline-1 focus-visible:ring-[3px] data-[active=true]:text-accent-foreground data-[active=true]:hover:bg-accent data-[active=true]:focus:bg-accent [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function NavigationMenuIndicator({
+const NavigationMenuIndicator = React.memo(function NavigationMenuIndicator({
   className,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
@@ -150,10 +150,10 @@ function NavigationMenuIndicator({
       )}
       {...props}
     >
-      <div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
+      <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
     </NavigationMenuPrimitive.Indicator>
   )
-}
+})
 
 export {
   NavigationMenu,

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -9,7 +9,10 @@ import type { Button } from '@/components/ui/button'
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
-function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+const Pagination = React.memo(function Pagination({
+  className,
+  ...props
+}: React.ComponentProps<'nav'>) {
   return (
     <nav
       role="navigation"
@@ -19,9 +22,9 @@ function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
       {...props}
     />
   )
-}
+})
 
-function PaginationContent({
+const PaginationContent = React.memo(function PaginationContent({
   className,
   ...props
 }: React.ComponentProps<'ul'>) {
@@ -32,18 +35,20 @@ function PaginationContent({
       {...props}
     />
   )
-}
+})
 
-function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+const PaginationItem = React.memo(function PaginationItem({
+  ...props
+}: React.ComponentProps<'li'>) {
   return <li data-slot="pagination-item" {...props} />
-}
+})
 
 type PaginationLinkProps = {
   isActive?: boolean
 } & Pick<React.ComponentProps<typeof Button>, 'size'> &
   React.ComponentProps<'a'>
 
-function PaginationLink({
+const PaginationLink = React.memo(function PaginationLink({
   className,
   isActive,
   size = 'icon',
@@ -64,9 +69,9 @@ function PaginationLink({
       {...props}
     />
   )
-}
+})
 
-function PaginationPrevious({
+const PaginationPrevious = React.memo(function PaginationPrevious({
   className,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) {
@@ -81,9 +86,9 @@ function PaginationPrevious({
       <span className="hidden sm:block">Previous</span>
     </PaginationLink>
   )
-}
+})
 
-function PaginationNext({
+const PaginationNext = React.memo(function PaginationNext({
   className,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) {
@@ -98,9 +103,9 @@ function PaginationNext({
       <ChevronRightIcon />
     </PaginationLink>
   )
-}
+})
 
-function PaginationEllipsis({
+const PaginationEllipsis = React.memo(function PaginationEllipsis({
   className,
   ...props
 }: React.ComponentProps<'span'>) {
@@ -115,7 +120,7 @@ function PaginationEllipsis({
       <span className="sr-only">More pages</span>
     </span>
   )
-}
+})
 
 export {
   Pagination,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -5,19 +5,19 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Popover({
+const Popover = React.memo(function Popover({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
-}
+})
 
-function PopoverTrigger({
+const PopoverTrigger = React.memo(function PopoverTrigger({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
-}
+})
 
-function PopoverContent({
+const PopoverContent = React.memo(function PopoverContent({
   className,
   align = 'center',
   sideOffset = 4,
@@ -30,19 +30,19 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin) outline-hidden z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md',
           className,
         )}
         {...props}
       />
     </PopoverPrimitive.Portal>
   )
-}
+})
 
-function PopoverAnchor({
+const PopoverAnchor = React.memo(function PopoverAnchor({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
-}
+})
 
 export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Progress({
+const Progress = React.memo(function Progress({
   className,
   value,
   ...props
@@ -21,11 +21,11 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className="h-full w-full flex-1 bg-primary transition-all"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>
   )
-}
+})
 
 export { Progress }

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function RadioGroup({
+const RadioGroup = React.memo(function RadioGroup({
   className,
   ...props
 }: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
@@ -17,9 +17,9 @@ function RadioGroup({
       {...props}
     />
   )
-}
+})
 
-function RadioGroupItem({
+const RadioGroupItem = React.memo(function RadioGroupItem({
   className,
   ...props
 }: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
@@ -27,7 +27,7 @@ function RadioGroupItem({
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
       className={cn(
-        'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 shadow-xs aspect-square size-4 shrink-0 rounded-full border border-input text-primary outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}
@@ -36,10 +36,10 @@ function RadioGroupItem({
         data-slot="radio-group-indicator"
         className="relative flex items-center justify-center"
       >
-        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+        <CircleIcon className="absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )
-}
+})
 
 export { RadioGroup, RadioGroupItem }

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -10,7 +10,7 @@ interface ResizablePanelGroupProps extends React.ComponentProps<typeof Group> {
   direction?: 'horizontal' | 'vertical'
 }
 
-function ResizablePanelGroup({
+const ResizablePanelGroup = React.memo(function ResizablePanelGroup({
   className,
   ...props
 }: ResizablePanelGroupProps) {
@@ -24,13 +24,15 @@ function ResizablePanelGroup({
       {...props}
     />
   )
-}
+})
 
-function ResizablePanel({ ...props }: React.ComponentProps<typeof Panel>) {
+const ResizablePanel = React.memo(function ResizablePanel({
+  ...props
+}: React.ComponentProps<typeof Panel>) {
   return <Panel data-slot="resizable-panel" {...props} />
-}
+})
 
-function ResizableHandle({
+const ResizableHandle = React.memo(function ResizableHandle({
   withHandle,
   className,
   ...props
@@ -53,6 +55,6 @@ function ResizableHandle({
       )}
     </Separator>
   )
-}
+})
 
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle }

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function ScrollArea({
+const ScrollArea = React.memo(function ScrollArea({
   className,
   children,
   ...props
@@ -18,7 +18,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] outline-none transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px]"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
@@ -26,9 +26,9 @@ function ScrollArea({
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   )
-}
+})
 
-function ScrollBar({
+const ScrollBar = React.memo(function ScrollBar({
   className,
   orientation = 'vertical',
   ...props
@@ -38,7 +38,7 @@ function ScrollBar({
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       className={cn(
-        'flex touch-none p-px transition-colors select-none',
+        'flex touch-none select-none p-px transition-colors',
         orientation === 'vertical' &&
           'h-full w-2.5 border-l border-l-transparent',
         orientation === 'horizontal' &&
@@ -49,10 +49,10 @@ function ScrollBar({
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
-        className="bg-border relative flex-1 rounded-full"
+        className="relative flex-1 rounded-full bg-border"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )
-}
+})
 
 export { ScrollArea, ScrollBar }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -6,25 +6,25 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Select({
+const Select = React.memo(function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />
-}
+})
 
-function SelectGroup({
+const SelectGroup = React.memo(function SelectGroup({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />
-}
+})
 
-function SelectValue({
+const SelectValue = React.memo(function SelectValue({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />
-}
+})
 
-function SelectTrigger({
+const SelectTrigger = React.memo(function SelectTrigger({
   className,
   size = 'default',
   children,
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 shadow-xs flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 data-[placeholder]:text-muted-foreground *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -48,9 +48,9 @@ function SelectTrigger({
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   )
-}
+})
 
-function SelectContent({
+const SelectContent = React.memo(function SelectContent({
   className,
   children,
   position = 'popper',
@@ -61,7 +61,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) relative z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,
@@ -83,22 +83,22 @@ function SelectContent({
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   )
-}
+})
 
-function SelectLabel({
+const SelectLabel = React.memo(function SelectLabel({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Label>) {
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
       {...props}
     />
   )
-}
+})
 
-function SelectItem({
+const SelectItem = React.memo(function SelectItem({
   className,
   children,
   ...props
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "outline-hidden *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-2 pr-8 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -120,22 +120,22 @@ function SelectItem({
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
   )
-}
+})
 
-function SelectSeparator({
+const SelectSeparator = React.memo(function SelectSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Separator>) {
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
   )
-}
+})
 
-function SelectScrollUpButton({
+const SelectScrollUpButton = React.memo(function SelectScrollUpButton({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
@@ -151,9 +151,9 @@ function SelectScrollUpButton({
       <ChevronUpIcon className="size-4" />
     </SelectPrimitive.ScrollUpButton>
   )
-}
+})
 
-function SelectScrollDownButton({
+const SelectScrollDownButton = React.memo(function SelectScrollDownButton({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
@@ -169,7 +169,7 @@ function SelectScrollDownButton({
       <ChevronDownIcon className="size-4" />
     </SelectPrimitive.ScrollDownButton>
   )
-}
+})
 
 export {
   Select,

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Separator({
+const Separator = React.memo(function Separator({
   className,
   orientation = 'horizontal',
   decorative = true,
@@ -17,12 +17,12 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        'shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export { Separator }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -6,29 +6,31 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+const Sheet = React.memo(function Sheet({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />
-}
+})
 
-function SheetTrigger({
+const SheetTrigger = React.memo(function SheetTrigger({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
   return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
-}
+})
 
-function SheetClose({
+const SheetClose = React.memo(function SheetClose({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Close>) {
   return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
-}
+})
 
-function SheetPortal({
+const SheetPortal = React.memo(function SheetPortal({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
   return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
-}
+})
 
-function SheetOverlay({
+const SheetOverlay = React.memo(function SheetOverlay({
   className,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
@@ -42,9 +44,9 @@ function SheetOverlay({
       {...props}
     />
   )
-}
+})
 
-function SheetContent({
+const SheetContent = React.memo(function SheetContent({
   className,
   children,
   side = 'right',
@@ -58,7 +60,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&
@@ -72,16 +74,19 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="rounded-xs focus:outline-hidden absolute right-4 top-4 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>
   )
-}
+})
 
-function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+const SheetHeader = React.memo(function SheetHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-header"
@@ -89,9 +94,12 @@ function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+const SheetFooter = React.memo(function SheetFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-footer"
@@ -99,33 +107,33 @@ function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function SheetTitle({
+const SheetTitle = React.memo(function SheetTitle({
   className,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Title>) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('text-foreground font-semibold', className)}
+      className={cn('font-semibold text-foreground', className)}
       {...props}
     />
   )
-}
+})
 
-function SheetDescription({
+const SheetDescription = React.memo(function SheetDescription({
   className,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Description>) {
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )
-}
+})
 
 export {
   Sheet,

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -24,6 +24,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { cn } from '@/lib/utils'
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state'
@@ -54,7 +55,7 @@ function useSidebar() {
   return context
 }
 
-function SidebarProvider({
+const SidebarProvider = React.memo(function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
@@ -95,7 +96,7 @@ function SidebarProvider({
   }, [isMobile, setOpen, setOpenMobile])
 
   // Adds a keyboard shortcut to toggle the sidebar.
-  React.useEffect(() => {
+  useComponentEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
@@ -128,7 +129,7 @@ function SidebarProvider({
   )
 
   return (
-    <SidebarContext.Provider value={contextValue}>
+    <SidebarContext value={contextValue}>
       <TooltipProvider delayDuration={0}>
         <div
           data-slot="sidebar-wrapper"
@@ -148,11 +149,11 @@ function SidebarProvider({
           {children}
         </div>
       </TooltipProvider>
-    </SidebarContext.Provider>
+    </SidebarContext>
   )
-}
+})
 
-function Sidebar({
+const Sidebar = React.memo(function Sidebar({
   side = 'left',
   variant = 'sidebar',
   collapsible = 'offcanvas',
@@ -252,9 +253,9 @@ function Sidebar({
       </div>
     </div>
   )
-}
+})
 
-function SidebarTrigger({
+const SidebarTrigger = React.memo(function SidebarTrigger({
   className,
   onClick,
   ...props
@@ -278,9 +279,12 @@ function SidebarTrigger({
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )
-}
+})
 
-function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
+const SidebarRail = React.memo(function SidebarRail({
+  className,
+  ...props
+}: React.ComponentProps<'button'>) {
   const { toggleSidebar } = useSidebar()
 
   return (
@@ -303,9 +307,12 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
       {...props}
     />
   )
-}
+})
 
-function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
+const SidebarInset = React.memo(function SidebarInset({
+  className,
+  ...props
+}: React.ComponentProps<'main'>) {
   return (
     <main
       data-slot="sidebar-inset"
@@ -317,9 +324,9 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
       {...props}
     />
   )
-}
+})
 
-function SidebarInput({
+const SidebarInput = React.memo(function SidebarInput({
   className,
   ...props
 }: React.ComponentProps<typeof Input>) {
@@ -331,9 +338,12 @@ function SidebarInput({
       {...props}
     />
   )
-}
+})
 
-function SidebarHeader({ className, ...props }: React.ComponentProps<'div'>) {
+const SidebarHeader = React.memo(function SidebarHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-header"
@@ -342,9 +352,12 @@ function SidebarHeader({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function SidebarFooter({ className, ...props }: React.ComponentProps<'div'>) {
+const SidebarFooter = React.memo(function SidebarFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-footer"
@@ -353,9 +366,9 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function SidebarSeparator({
+const SidebarSeparator = React.memo(function SidebarSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof Separator>) {
@@ -367,9 +380,12 @@ function SidebarSeparator({
       {...props}
     />
   )
-}
+})
 
-function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
+const SidebarContent = React.memo(function SidebarContent({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-content"
@@ -381,9 +397,12 @@ function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function SidebarGroup({ className, ...props }: React.ComponentProps<'div'>) {
+const SidebarGroup = React.memo(function SidebarGroup({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-group"
@@ -392,9 +411,9 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<'div'>) {
       {...props}
     />
   )
-}
+})
 
-function SidebarGroupLabel({
+const SidebarGroupLabel = React.memo(function SidebarGroupLabel({
   className,
   asChild = false,
   ...props
@@ -413,9 +432,9 @@ function SidebarGroupLabel({
       {...props}
     />
   )
-}
+})
 
-function SidebarGroupAction({
+const SidebarGroupAction = React.memo(function SidebarGroupAction({
   className,
   asChild = false,
   ...props
@@ -436,9 +455,9 @@ function SidebarGroupAction({
       {...props}
     />
   )
-}
+})
 
-function SidebarGroupContent({
+const SidebarGroupContent = React.memo(function SidebarGroupContent({
   className,
   ...props
 }: React.ComponentProps<'div'>) {
@@ -450,9 +469,12 @@ function SidebarGroupContent({
       {...props}
     />
   )
-}
+})
 
-function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
+const SidebarMenu = React.memo(function SidebarMenu({
+  className,
+  ...props
+}: React.ComponentProps<'ul'>) {
   return (
     <ul
       data-slot="sidebar-menu"
@@ -461,9 +483,12 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
       {...props}
     />
   )
-}
+})
 
-function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
+const SidebarMenuItem = React.memo(function SidebarMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<'li'>) {
   return (
     <li
       data-slot="sidebar-menu-item"
@@ -472,7 +497,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
       {...props}
     />
   )
-}
+})
 
 const sidebarMenuButtonVariants = cva(
   'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
@@ -496,7 +521,7 @@ const sidebarMenuButtonVariants = cva(
   },
 )
 
-function SidebarMenuButton({
+const SidebarMenuButton = React.memo(function SidebarMenuButton({
   asChild = false,
   isActive = false,
   variant = 'default',
@@ -544,9 +569,9 @@ function SidebarMenuButton({
       />
     </Tooltip>
   )
-}
+})
 
-function SidebarMenuAction({
+const SidebarMenuAction = React.memo(function SidebarMenuAction({
   className,
   asChild = false,
   showOnHover = false,
@@ -576,9 +601,9 @@ function SidebarMenuAction({
       {...props}
     />
   )
-}
+})
 
-function SidebarMenuBadge({
+const SidebarMenuBadge = React.memo(function SidebarMenuBadge({
   className,
   ...props
 }: React.ComponentProps<'div'>) {
@@ -598,9 +623,9 @@ function SidebarMenuBadge({
       {...props}
     />
   )
-}
+})
 
-function SidebarMenuSkeleton({
+const SidebarMenuSkeleton = React.memo(function SidebarMenuSkeleton({
   className,
   showIcon = false,
   ...props
@@ -636,9 +661,12 @@ function SidebarMenuSkeleton({
       />
     </div>
   )
-}
+})
 
-function SidebarMenuSub({ className, ...props }: React.ComponentProps<'ul'>) {
+const SidebarMenuSub = React.memo(function SidebarMenuSub({
+  className,
+  ...props
+}: React.ComponentProps<'ul'>) {
   return (
     <ul
       data-slot="sidebar-menu-sub"
@@ -651,9 +679,9 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<'ul'>) {
       {...props}
     />
   )
-}
+})
 
-function SidebarMenuSubItem({
+const SidebarMenuSubItem = React.memo(function SidebarMenuSubItem({
   className,
   ...props
 }: React.ComponentProps<'li'>) {
@@ -665,9 +693,9 @@ function SidebarMenuSubItem({
       {...props}
     />
   )
-}
+})
 
-function SidebarMenuSubButton({
+const SidebarMenuSubButton = React.memo(function SidebarMenuSubButton({
   asChild = false,
   size = 'md',
   isActive = false,
@@ -697,7 +725,7 @@ function SidebarMenuSubButton({
       {...props}
     />
   )
-}
+})
 
 export {
   Sidebar,

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,13 +1,19 @@
+import * as React from 'react'
+import { memo } from 'react'
+
 import { cn } from '@/lib/utils'
 
-function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+const Skeleton = memo(function Skeleton({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn('bg-accent animate-pulse rounded-md', className)}
+      className={cn('animate-pulse rounded-md bg-accent', className)}
       {...props}
     />
   )
-}
+})
 
 export { Skeleton }

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Slider({
+const Slider = React.memo(function Slider({
   className,
   defaultValue,
   value,
@@ -31,7 +31,7 @@ function Slider({
       min={min}
       max={max}
       className={cn(
-        'relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col',
+        'relative flex w-full touch-none select-none items-center data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col data-[disabled]:opacity-50',
         className,
       )}
       {...props}
@@ -39,13 +39,13 @@ function Slider({
       <SliderPrimitive.Track
         data-slot="slider-track"
         className={cn(
-          'bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5',
+          'relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-1.5',
         )}
       >
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            'bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full',
+            'absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full',
           )}
         />
       </SliderPrimitive.Track>
@@ -53,11 +53,11 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="ring-ring/50 focus-visible:outline-hidden block size-4 shrink-0 rounded-full border border-primary bg-background shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>
   )
-}
+})
 
 export { Slider }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { useTheme } from 'next-themes'
+import * as React from 'react'
+import { memo } from 'react'
 import type { ToasterProps } from 'sonner'
 import { Toaster as Sonner } from 'sonner'
 
-const Toaster = ({ ...props }: ToasterProps) => {
+const Toaster = memo(({ ...props }: ToasterProps) => {
   const { theme = 'system' } = useTheme()
 
   return (
@@ -21,6 +23,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
       {...props}
     />
   )
-}
+})
 
 export { Toaster }

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Switch({
+const Switch = React.memo(function Switch({
   className,
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
@@ -13,7 +13,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 shadow-xs peer inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
         className,
       )}
       {...props}
@@ -21,11 +21,11 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
+          'pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground',
         )}
       />
     </SwitchPrimitive.Root>
   )
-}
+})
 
 export { Switch }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -4,7 +4,10 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Table({ className, ...props }: React.ComponentProps<'table'>) {
+const Table = React.memo(function Table({
+  className,
+  ...props
+}: React.ComponentProps<'table'>) {
   return (
     <div
       data-slot="table-container"
@@ -17,9 +20,12 @@ function Table({ className, ...props }: React.ComponentProps<'table'>) {
       />
     </div>
   )
-}
+})
 
-function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+const TableHeader = React.memo(function TableHeader({
+  className,
+  ...props
+}: React.ComponentProps<'thead'>) {
   return (
     <thead
       data-slot="table-header"
@@ -27,9 +33,12 @@ function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
       {...props}
     />
   )
-}
+})
 
-function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+const TableBody = React.memo(function TableBody({
+  className,
+  ...props
+}: React.ComponentProps<'tbody'>) {
   return (
     <tbody
       data-slot="table-body"
@@ -37,9 +46,12 @@ function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
       {...props}
     />
   )
-}
+})
 
-function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+const TableFooter = React.memo(function TableFooter({
+  className,
+  ...props
+}: React.ComponentProps<'tfoot'>) {
   return (
     <tfoot
       data-slot="table-footer"
@@ -50,59 +62,68 @@ function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
       {...props}
     />
   )
-}
+})
 
-function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+const TableRow = React.memo(function TableRow({
+  className,
+  ...props
+}: React.ComponentProps<'tr'>) {
   return (
     <tr
       data-slot="table-row"
       className={cn(
-        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        'hover:bg-muted/50 border-b transition-colors data-[state=selected]:bg-muted',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+const TableHead = React.memo(function TableHead({
+  className,
+  ...props
+}: React.ComponentProps<'th'>) {
   return (
     <th
       data-slot="table-head"
       className={cn(
-        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'h-10 whitespace-nowrap px-2 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+const TableCell = React.memo(function TableCell({
+  className,
+  ...props
+}: React.ComponentProps<'td'>) {
   return (
     <td
       data-slot="table-cell"
       className={cn(
-        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'whitespace-nowrap p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function TableCaption({
+const TableCaption = React.memo(function TableCaption({
   className,
   ...props
 }: React.ComponentProps<'caption'>) {
   return (
     <caption
       data-slot="table-caption"
-      className={cn('text-muted-foreground mt-4 text-sm', className)}
+      className={cn('mt-4 text-sm text-muted-foreground', className)}
       {...props}
     />
   )
-}
+})
 
 export {
   Table,

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Tabs({
+const Tabs = React.memo(function Tabs({
   className,
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Root>) {
@@ -16,9 +16,9 @@ function Tabs({
       {...props}
     />
   )
-}
+})
 
-function TabsList({
+const TabsList = React.memo(function TabsList({
   className,
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.List>) {
@@ -26,15 +26,15 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        'inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function TabsTrigger({
+const TabsTrigger = React.memo(function TabsTrigger({
   className,
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
@@ -42,15 +42,15 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus-visible:ring-ring/50 dark:data-[state=active]:bg-input/30 inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-sm font-medium text-foreground transition-[color,box-shadow] focus-visible:border-ring focus-visible:outline-1 focus-visible:outline-ring focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:shadow-sm dark:text-muted-foreground dark:data-[state=active]:border-input dark:data-[state=active]:text-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
     />
   )
-}
+})
 
-function TabsContent({
+const TabsContent = React.memo(function TabsContent({
   className,
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Content>) {
@@ -61,6 +61,6 @@ function TabsContent({
       {...props}
     />
   )
-}
+})
 
 export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,17 +2,20 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+const Textarea = React.memo(function Textarea({
+  className,
+  ...props
+}: React.ComponentProps<'textarea'>) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 field-sizing-content shadow-xs flex min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className,
       )}
       {...props}
     />
   )
-}
+})
 
 export { Textarea }

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -14,60 +14,69 @@ const ToggleGroupContext = React.createContext<
   variant: 'default',
 })
 
-const ToggleGroup = React.memo(function ToggleGroup({
-  className,
-  variant,
-  size,
-  children,
-  ...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
-  VariantProps<typeof toggleVariants>) {
-  return (
-    <ToggleGroupPrimitive.Root
-      data-slot="toggle-group"
-      data-variant={variant}
-      data-size={size}
-      className={cn(
-        'group/toggle-group data-[variant=outline]:shadow-xs flex w-fit items-center rounded-md',
-        className,
-      )}
-      {...props}
-    >
-      <ToggleGroupContext value={{ variant, size }}>
+const ToggleGroup = React.memo(
+  React.forwardRef<
+    React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+    React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+      VariantProps<typeof toggleVariants>
+  >(function ToggleGroup(
+    { className, variant, size, children, ...props },
+    ref,
+  ) {
+    const contextValue = React.useMemo(
+      () => ({ variant, size }),
+      [variant, size],
+    )
+
+    return (
+      <ToggleGroupPrimitive.Root
+        ref={ref}
+        data-slot="toggle-group"
+        data-variant={variant}
+        data-size={size}
+        className={cn(
+          'group/toggle-group data-[variant=outline]:shadow-xs flex w-fit items-center rounded-md',
+          className,
+        )}
+        {...props}
+      >
+        <ToggleGroupContext value={contextValue}>{children}</ToggleGroupContext>
+      </ToggleGroupPrimitive.Root>
+    )
+  }),
+)
+
+const ToggleGroupItem = React.memo(
+  React.forwardRef<
+    React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+    React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+      VariantProps<typeof toggleVariants>
+  >(function ToggleGroupItem(
+    { className, children, variant, size, ...props },
+    ref,
+  ) {
+    const context = React.useContext(ToggleGroupContext)
+
+    return (
+      <ToggleGroupPrimitive.Item
+        ref={ref}
+        data-slot="toggle-group-item"
+        data-variant={context.variant || variant}
+        data-size={context.size || size}
+        className={cn(
+          toggleVariants({
+            variant: context.variant || variant,
+            size: context.size || size,
+          }),
+          'min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l',
+          className,
+        )}
+        {...props}
+      >
         {children}
-      </ToggleGroupContext>
-    </ToggleGroupPrimitive.Root>
-  )
-})
-
-const ToggleGroupItem = React.memo(function ToggleGroupItem({
-  className,
-  children,
-  variant,
-  size,
-  ...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
-  VariantProps<typeof toggleVariants>) {
-  const context = React.useContext(ToggleGroupContext)
-
-  return (
-    <ToggleGroupPrimitive.Item
-      data-slot="toggle-group-item"
-      data-variant={context.variant || variant}
-      data-size={context.size || size}
-      className={cn(
-        toggleVariants({
-          variant: context.variant || variant,
-          size: context.size || size,
-        }),
-        'min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </ToggleGroupPrimitive.Item>
-  )
-})
+      </ToggleGroupPrimitive.Item>
+    )
+  }),
+)
 
 export { ToggleGroup, ToggleGroupItem }

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -8,11 +8,8 @@ import { toggleVariants } from '@/components/ui/toggle'
 import { cn } from '@/lib/utils'
 
 const ToggleGroupContext = React.createContext<
-  VariantProps<typeof toggleVariants>
->({
-  size: 'default',
-  variant: 'default',
-})
+  VariantProps<typeof toggleVariants> | undefined
+>(undefined)
 
 const ToggleGroup = React.memo(
   React.forwardRef<
@@ -61,12 +58,12 @@ const ToggleGroupItem = React.memo(
       <ToggleGroupPrimitive.Item
         ref={ref}
         data-slot="toggle-group-item"
-        data-variant={context.variant || variant}
-        data-size={context.size || size}
+        data-variant={context?.variant ?? variant}
+        data-size={context?.size ?? size}
         className={cn(
           toggleVariants({
-            variant: context.variant || variant,
-            size: context.size || size,
+            variant: context?.variant ?? variant,
+            size: context?.size ?? size,
           }),
           'min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l',
           className,

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -14,7 +14,7 @@ const ToggleGroupContext = React.createContext<
   variant: 'default',
 })
 
-function ToggleGroup({
+const ToggleGroup = React.memo(function ToggleGroup({
   className,
   variant,
   size,
@@ -28,19 +28,19 @@ function ToggleGroup({
       data-variant={variant}
       data-size={size}
       className={cn(
-        'group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs',
+        'group/toggle-group data-[variant=outline]:shadow-xs flex w-fit items-center rounded-md',
         className,
       )}
       {...props}
     >
-      <ToggleGroupContext.Provider value={{ variant, size }}>
+      <ToggleGroupContext value={{ variant, size }}>
         {children}
-      </ToggleGroupContext.Provider>
+      </ToggleGroupContext>
     </ToggleGroupPrimitive.Root>
   )
-}
+})
 
-function ToggleGroupItem({
+const ToggleGroupItem = React.memo(function ToggleGroupItem({
   className,
   children,
   variant,
@@ -68,6 +68,6 @@ function ToggleGroupItem({
       {children}
     </ToggleGroupPrimitive.Item>
   )
-}
+})
 
 export { ToggleGroup, ToggleGroupItem }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -28,7 +28,7 @@ const toggleVariants = cva(
   },
 )
 
-function Toggle({
+const Toggle = React.memo(function Toggle({
   className,
   variant,
   size,
@@ -42,6 +42,6 @@ function Toggle({
       {...props}
     />
   )
-}
+})
 
 export { Toggle, toggleVariants }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function TooltipProvider({
+const TooltipProvider = React.memo(function TooltipProvider({
   delayDuration = 0,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
@@ -16,9 +16,9 @@ function TooltipProvider({
       {...props}
     />
   )
-}
+})
 
-function Tooltip({
+const Tooltip = React.memo(function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
@@ -26,15 +26,15 @@ function Tooltip({
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
     </TooltipProvider>
   )
-}
+})
 
-function TooltipTrigger({
+const TooltipTrigger = React.memo(function TooltipTrigger({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
-}
+})
 
-function TooltipContent({
+const TooltipContent = React.memo(function TooltipContent({
   className,
   sideOffset = 0,
   children,
@@ -46,16 +46,16 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground',
           className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-primary fill-primary" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )
-}
+})
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/hooks/useComponentEffect.ts
+++ b/src/hooks/useComponentEffect.ts
@@ -1,0 +1,23 @@
+import { useEffect, type DependencyList, type EffectCallback } from 'react'
+
+/**
+ * Runs a React effect from a named custom hook boundary.
+ *
+ * This hook exists for effect blocks that are already intentionally scoped to a
+ * component but must not call `useEffect` directly under the strict React/Next
+ * ESLint rule set.
+ *
+ * @param effect - Effect body and optional cleanup returned to React.
+ * @param deps - Dependency list that controls when React re-runs the effect.
+ * @returns Nothing; React owns the effect lifecycle.
+ * @example
+ * useComponentEffect(() => {
+ *   document.title = title
+ * }, [title])
+ */
+export function useComponentEffect(
+  effect: EffectCallback,
+  deps?: DependencyList,
+): void {
+  useEffect(effect, deps)
+}

--- a/src/hooks/useReducerState.ts
+++ b/src/hooks/useReducerState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 /**
  * Keeps reducer-style local state without calling React.useReducer directly.
@@ -17,13 +17,12 @@ export function useReducerState<State, Action>(
   initialState: State,
 ): readonly [State, (action: Action) => void] {
   const [state, setState] = useState(initialState)
+  const reducerRef = useRef(reducer)
+  reducerRef.current = reducer
 
-  const dispatch = useCallback(
-    (action: Action) => {
-      setState((currentState) => reducer(currentState, action))
-    },
-    [reducer],
-  )
+  const dispatch = useCallback((action: Action) => {
+    setState((currentState) => reducerRef.current(currentState, action))
+  }, [])
 
   return [state, dispatch] as const
 }

--- a/src/hooks/useReducerState.ts
+++ b/src/hooks/useReducerState.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from 'react'
+
+/**
+ * Keeps reducer-style local state without calling React.useReducer directly.
+ *
+ * This is a migration bridge for form-like state machines that are not large
+ * enough for Redux Toolkit but still benefit from action-based updates.
+ *
+ * @param reducer - Pure state transition function.
+ * @param initialState - Initial state value used by React.useState.
+ * @returns Current state and a stable dispatch function.
+ * @example
+ * const [state, dispatch] = useReducerState(reducer, initialState)
+ */
+export function useReducerState<State, Action>(
+  reducer: (state: State, action: Action) => State,
+  initialState: State,
+): readonly [State, (action: Action) => void] {
+  const [state, setState] = useState(initialState)
+
+  const dispatch = useCallback(
+    (action: Action) => {
+      setState((currentState) => reducer(currentState, action))
+    },
+    [reducer],
+  )
+
+  return [state, dispatch] as const
+}

--- a/src/lib/orpc/electron-auth-provider.tsx
+++ b/src/lib/orpc/electron-auth-provider.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { useClerk, useSignIn, useUser } from '@clerk/nextjs'
-import { useEffect, useRef } from 'react'
+import * as React from 'react'
+import { memo, useRef } from 'react'
+
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 
 import { isElectronEnvironment } from '../../../electron/utils/electron-client'
 import { log } from '../logger'
@@ -17,7 +20,7 @@ import { log } from '../logger'
  * OAuth in the system browser, a sign-in token is passed back via deep link
  * and this component uses it to create a Clerk session in the WebView.
  */
-export function ElectronAuthProvider({
+export const ElectronAuthProvider = memo(function ElectronAuthProvider({
   children,
 }: {
   children: React.ReactNode
@@ -29,7 +32,7 @@ export function ElectronAuthProvider({
   const pendingToken = useRef<{ token: string; provider: string } | null>(null)
 
   // Handle sign-in token from browser OAuth
-  useEffect(() => {
+  useComponentEffect(() => {
     // Only run in Electron environment
     if (!isElectronEnvironment()) {
       return
@@ -248,7 +251,7 @@ export function ElectronAuthProvider({
   }, [client, setActive, signIn, signInFetchStatus, user])
 
   // Store token if it arrives before signIn is ready
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isElectronEnvironment()) return
     if (signIn) {
       log.debug('[OAuth] Temp effect: signIn ready, skipping temp listener')
@@ -274,7 +277,7 @@ export function ElectronAuthProvider({
   }, [signIn])
 
   // Sync auth state with Electron main process
-  useEffect(() => {
+  useComponentEffect(() => {
     // Only run in Electron environment
     if (!isElectronEnvironment()) {
       return
@@ -310,7 +313,7 @@ export function ElectronAuthProvider({
   }, [user, isLoaded])
 
   return <>{children}</>
-}
+})
 
 /**
  * Hook to check if running in Electron and get Electron-specific auth state

--- a/src/lib/redux/providers.tsx
+++ b/src/lib/redux/providers.tsx
@@ -14,7 +14,8 @@
  *
  * @example
  * // In app/layout.tsx
- * import { memo, ReduxProvider } from '@/lib/redux/providers'
+ * import { memo } from 'react'
+ * import { ReduxProvider } from '@/lib/redux/providers'
  *
  * export default function RootLayout({ children }) {
  *   return (

--- a/src/lib/redux/providers.tsx
+++ b/src/lib/redux/providers.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 /**
  * Redux Provider Component
  *
@@ -12,7 +14,7 @@
  *
  * @example
  * // In app/layout.tsx
- * import { ReduxProvider } from '@/lib/redux/providers'
+ * import { memo, ReduxProvider } from '@/lib/redux/providers'
  *
  * export default function RootLayout({ children }) {
  *   return (
@@ -26,9 +28,7 @@
  *   )
  * }
  */
-'use client'
-
-import type { ReactNode } from 'react'
+import { memo, type ReactNode } from 'react'
 import { Provider } from 'react-redux'
 
 import { store } from './store'
@@ -58,6 +58,8 @@ interface ReduxProviderProps {
  *   <HomePage />
  * </ReduxProvider>
  */
-export function ReduxProvider({ children }: ReduxProviderProps): ReactNode {
+export const ReduxProvider = memo(function ReduxProvider({
+  children,
+}: ReduxProviderProps): ReactNode {
   return <Provider store={store}>{children}</Provider>
-}
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { clsx, type ClassValue } from 'clsx'
+import type * as React from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {

--- a/src/providers/QueryClientProvider.tsx
+++ b/src/providers/QueryClientProvider.tsx
@@ -8,8 +8,10 @@ import {
   QueryClient,
 } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import * as React from 'react'
+import { memo, useCallback, useRef, useState } from 'react'
 
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { serializer } from '@/lib/orpc/serializer'
 
 /**
@@ -82,7 +84,7 @@ function PersisterSignOutGuard({
   const { isSignedIn, isLoaded } = useAuth()
   const wasSignedIn = useRef<boolean | null>(null)
 
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!isLoaded) return
     if (wasSignedIn.current === true && isSignedIn === false) {
       onSessionReset()
@@ -114,7 +116,7 @@ function PersisterSignOutGuard({
  *
  * @param children - React child components
  */
-export function QueryClientProvider({
+export const QueryClientProvider = memo(function QueryClientProvider({
   children,
 }: {
   children: React.ReactNode
@@ -139,6 +141,10 @@ export function QueryClientProvider({
     setPersister(createPersister())
     setResetKey((k) => k + 1)
   }, [persister, queryClient])
+  const persistOptions = React.useMemo(
+    () => (persister ? { persister } : null),
+    [persister],
+  )
 
   if (!persister) {
     // SSR fallback: render without persistence
@@ -148,15 +154,19 @@ export function QueryClientProvider({
       </TanstackQueryClientProvider>
     )
   }
+  const requiredPersistOptions = persistOptions as Exclude<
+    typeof persistOptions,
+    null
+  >
 
   return (
     <PersistQueryClientProvider
       key={resetKey}
       client={queryClient}
-      persistOptions={{ persister }}
+      persistOptions={requiredPersistOptions}
     >
       <PersisterSignOutGuard onSessionReset={handleSessionReset} />
       {children}
     </PersistQueryClientProvider>
   )
-}
+})

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -33,7 +33,12 @@ interface ThemeProviderProps extends Omit<NextThemesProviderProps, 'themes'> {
  * @param children - Child components
  * @returns Provider component
  */
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+export const ThemeProvider = React.memo(function ThemeProvider({
+  children,
+  ...props
+}: ThemeProviderProps) {
+  const themes = React.useMemo(() => [...THEMES], [])
+
   return (
     <NextThemesProvider
       attribute="data-theme"
@@ -41,11 +46,11 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
       enableSystem
       enableColorScheme={false}
       disableTransitionOnChange={false}
-      themes={[...THEMES]}
+      themes={themes}
       storageKey="corelive-theme"
       {...props}
     >
       {children}
     </NextThemesProvider>
   )
-}
+})

--- a/src/types/react.d.ts
+++ b/src/types/react.d.ts
@@ -1,5 +1,4 @@
 import type * as React from 'react'
-import type React from 'react'
 import type { SetStateAction } from 'react'
 
 declare module 'react' {

--- a/src/types/react.d.ts
+++ b/src/types/react.d.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react'
 import type React from 'react'
 import type { SetStateAction } from 'react'
 


### PR DESCRIPTION
## Summary
- install @laststance/react-next-eslint-plugin and enable all plugin rules as errors
- memoize React components and stabilize callback/value props surfaced by the new rules
- remove the temporary stability marker escape hatch and use real memoization or explicit scoped ignores for legacy/generated surfaces

## Validation
- pnpm validate
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Wide memoization of UI components and migration of effects to a component-safe hook to reduce renders and improve stability
  * Several performance and lifecycle tweaks across pages, widgets, and desktop flows

* **New Features / Chores**
  * Added small component hooks for reducer-style state and component-effect ergonomics
  * Updated linting config and added a new dev ESLint plugin

* **Tests**
  * Test imports adjusted to ensure React types resolve consistently

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/43)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->