### PR TITLE
Fix BrainDump settings hook order crash

### DIFF
--- a/src/components/electron/BrainDumpSettings.test.tsx
+++ b/src/components/electron/BrainDumpSettings.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BrainDumpSettings } from './BrainDumpSettings'
+
+const getSyncModeMock = vi.fn()
+const setSyncModeMock = vi.fn()
+const getOpacityMock = vi.fn()
+const setOpacityMock = vi.fn()
+const getShortcutMock = vi.fn()
+const setShortcutMock = vi.fn()
+const toggleMock = vi.fn()
+
+type BrainDumpBridge = {
+  getSyncMode: () => Promise<boolean>
+  setSyncMode: (enabled: boolean) => Promise<boolean>
+  getOpacity: () => Promise<number>
+  setOpacity: (value: number) => Promise<number>
+  getShortcut: () => Promise<string>
+  setShortcut: (accelerator: string) => Promise<boolean>
+  toggle: () => Promise<void>
+}
+
+/**
+ * Defines the preload bridge shape the Settings card expects during renderer tests.
+ *
+ * @param api - Fake Electron preload API, or undefined for a web renderer.
+ * @returns Nothing; mutates the happy-dom window object for this test.
+ * @example
+ * installElectronAPI({ brainDump: fakeBridge })
+ */
+function installElectronAPI(
+  api: { brainDump?: BrainDumpBridge } | undefined,
+): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: api,
+  })
+}
+
+/**
+ * Installs a successful BrainDump preload bridge so loading can advance to ready state.
+ *
+ * @param saved - Persisted settings returned by the main process mocks.
+ * @returns Nothing; prepares all BrainDump mocks for a component render.
+ * @example
+ * installBrainDumpBridge({ syncMode: false, opacity: 0.7, shortcut: 'CommandOrControl+Shift+B' })
+ */
+function installBrainDumpBridge(saved: {
+  syncMode: boolean
+  opacity: number
+  shortcut: string
+}): void {
+  getSyncModeMock.mockResolvedValue(saved.syncMode)
+  setSyncModeMock.mockResolvedValue(true)
+  getOpacityMock.mockResolvedValue(saved.opacity)
+  setOpacityMock.mockResolvedValue(saved.opacity)
+  getShortcutMock.mockResolvedValue(saved.shortcut)
+  setShortcutMock.mockResolvedValue(true)
+  toggleMock.mockResolvedValue(undefined)
+
+  installElectronAPI({
+    brainDump: {
+      getSyncMode: getSyncModeMock,
+      setSyncMode: setSyncModeMock,
+      getOpacity: getOpacityMock,
+      setOpacity: setOpacityMock,
+      getShortcut: getShortcutMock,
+      setShortcut: setShortcutMock,
+      toggle: toggleMock,
+    },
+  })
+}
+
+describe('BrainDumpSettings', () => {
+  beforeEach(() => {
+    getSyncModeMock.mockReset()
+    setSyncModeMock.mockReset()
+    getOpacityMock.mockReset()
+    setOpacityMock.mockReset()
+    getShortcutMock.mockReset()
+    setShortcutMock.mockReset()
+    toggleMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows saved BrainDump settings after loading without changing hook order', async () => {
+    // Arrange: the preload bridge resolves and flips the card from loading to ready.
+    installBrainDumpBridge({
+      syncMode: false,
+      opacity: 0.7,
+      shortcut: 'CommandOrControl+Shift+B',
+    })
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    // Act
+    render(<BrainDumpSettings />)
+
+    // Assert: the ready UI renders; the old conditional useMemo crash would abort here.
+    expect(await screen.findByText('Window opacity')).toBeInTheDocument()
+    expect(screen.getByText('70%')).toBeInTheDocument()
+    expect(
+      screen.getByDisplayValue('CommandOrControl+Shift+B'),
+    ).toBeInTheDocument()
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        'React has detected a change in the order of Hooks',
+      ),
+    )
+  })
+})

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -202,6 +202,7 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
     },
     [],
   )
+  const opacityValue = useMemo(() => [opacity], [opacity])
 
   // Defer the non-Electron fallback until after hydration so server and
   // first client render produce the same markup. Until `hasMounted` is
@@ -237,7 +238,6 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
   }
 
   const opacityPercent = Math.round(opacity * 100)
-  const opacityValue = useMemo(() => [opacity], [opacity])
 
   return (
     <Card className={className}>


### PR DESCRIPTION
## Summary
- Move BrainDump Settings opacity memo before early returns so hook order remains stable during loading-to-ready transitions.
- Add a regression test that renders the ready state after the Electron preload bridge resolves.

## Validation
- mise exec node@24.13.0 -- pnpm test -- src/components/electron/BrainDumpSettings.test.tsx
- mise exec node@24.13.0 -- pnpm typecheck
- mise exec node@24.13.0 -- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a rendering issue in the BrainDumpSettings component that could occur during component initialization and state transitions, ensuring stable display of settings.

* **Tests**
  * Added comprehensive test suite for BrainDumpSettings component, validating initialization with saved settings, correct display of opacity and shortcut values, smooth state transitions, and error-free rendering across different component states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->