### PR TITLE
Block renderer-created Electron popups

### DIFF
--- a/e2e/electron/startup.spec.ts
+++ b/e2e/electron/startup.spec.ts
@@ -46,3 +46,32 @@ test('app reports the expected name from the main process', async () => {
   expect(appName).toBeTruthy()
   expect(typeof appName).toBe('string')
 })
+
+test('renderer window.open requests do not create unmanaged BrowserWindows', async () => {
+  const mainWindow = await electronApp.firstWindow()
+  await mainWindow.waitForLoadState('domcontentloaded')
+  await mainWindow.waitForURL(/(login|home|sign-in)/, {
+    timeout: LOAD_TIMEOUT_MS,
+  })
+
+  const windowCountBefore = await electronApp.evaluate(({ BrowserWindow }) => {
+    return BrowserWindow.getAllWindows().length
+  })
+  const unexpectedWindow = electronApp
+    .waitForEvent('window', { timeout: 1_000 })
+    .then(() => true)
+    .catch(() => false)
+
+  const popupResult = await mainWindow.evaluate(() => {
+    const popup = window.open('https://example.com/qa-popup', '_blank')
+    return popup === null ? 'blocked' : 'opened'
+  })
+
+  expect(popupResult).toBe('blocked')
+  expect(await unexpectedWindow).toBe(false)
+
+  const windowCountAfter = await electronApp.evaluate(({ BrowserWindow }) => {
+    return BrowserWindow.getAllWindows().length
+  })
+  expect(windowCountAfter).toBe(windowCountBefore)
+})

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2331,9 +2331,12 @@ app.on('web-contents-created', (_event, contents: WebContents) => {
    * If legitimate popups are needed, implement them
    * through controlled IPC calls instead.
    */
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }))
+
   contents.on('did-create-window', () => {
-    // Note: 'new-window' is deprecated, using 'did-create-window'
-    // Popups are blocked by the webPreferences.disablePopups option
+    // Defense-in-depth telemetry if a future Electron path creates a popup
+    // despite the window-open handler above.
+    log.warn('Blocked unexpected renderer-created window')
   })
 
   /**


### PR DESCRIPTION
## Summary
- Add setWindowOpenHandler denial for every Electron WebContents so renderer popup attempts cannot create unmanaged BrowserWindows.
- Keep did-create-window as defensive telemetry if a future Electron path bypasses the handler.
- Add an Electron E2E regression that proves a qa-popup window.open attempt does not increase BrowserWindow count.

## Validation
- mise exec node@24.13.0 -- pnpm validate
- kill-port 3011
- docker compose up -d
- mise exec node@24.13.0 -- pnpm e2e:electron e2e/electron/startup.spec.ts
- docker compose down
- kill-port 3011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Renderer-initiated popup windows are now blocked, preventing creation of unmanaged windows in the application.
  * Added logging for blocked popup attempts.

* **Tests**
  * Added end-to-end test to verify popup-blocking behavior works as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->