### PR TITLE
Wait for startup panel auth redirects

### DIFF
--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -977,8 +977,8 @@ export class WindowManager {
   }
 
   /**
-   * Decide a startup panel's fate from its first navigation: show it if the
-   * load lands on the panel route, or suppress it + surface main if the load
+   * Decide a startup panel's fate from its settled load: show it if the load
+   * lands on the panel route, or suppress it + surface main if the load
    * redirects to an auth page or fails (offline/timeout/5xx).
    *
    * Ordering note: `createFloatingNavigator`/`createBrainDumpWindow` call
@@ -1000,6 +1000,7 @@ export class WindowManager {
     // Guard so the show-or-suppress decision is made exactly once per load,
     // even though `did-navigate` and `did-fail-load` can both fire.
     let decided = false
+    let latestMainFrameUrl: string | null = null
 
     const finish = (authenticated: boolean): void => {
       if (decided) return
@@ -1025,7 +1026,19 @@ export class WindowManager {
     }
 
     const onDidNavigate = (_event: Electron.Event, url: string): void => {
-      finish(!this.isAuthPathname(url))
+      latestMainFrameUrl = url
+      // Auth redirects are terminal for this startup attempt: keep the panel
+      // hidden and surface main immediately so a login page never flashes in
+      // the auxiliary panel.
+      if (this.isAuthPathname(url)) finish(false)
+    }
+
+    const onDidFinishLoad = (): void => {
+      // Non-auth panel routes are only trusted after load settles; during an
+      // unauthenticated cold boot Chromium can report the requested panel URL
+      // before the redirect lands on /login.
+      const currentUrl = webContents.getURL() || latestMainFrameUrl
+      finish(currentUrl === null ? false : !this.isAuthPathname(currentUrl))
     }
 
     const onDidFailLoad = (
@@ -1042,9 +1055,11 @@ export class WindowManager {
     }
 
     webContents.on('did-navigate', onDidNavigate)
+    webContents.on('did-finish-load', onDidFinishLoad)
     webContents.on('did-fail-load', onDidFailLoad)
     removeListeners.push(
       () => webContents.removeListener('did-navigate', onDidNavigate),
+      () => webContents.removeListener('did-finish-load', onDidFinishLoad),
       () => webContents.removeListener('did-fail-load', onDidFailLoad),
     )
   }

--- a/electron/__tests__/WindowManager.startup-panel.test.ts
+++ b/electron/__tests__/WindowManager.startup-panel.test.ts
@@ -58,6 +58,7 @@ const createdWindows: CapturedMockWindow[] = []
 vi.mock('electron', () => ({
   BrowserWindow: vi.fn(function () {
     const webHandlers: Record<string, Array<(...args: unknown[]) => void>> = {}
+    let currentUrl = ''
     const win: MockBrowserWindow = {
       show: vi.fn(),
       hide: vi.fn(),
@@ -70,7 +71,9 @@ vi.mock('electron', () => ({
       setOpacity: vi.fn(),
       getOpacity: vi.fn(() => 1),
       setVisibleOnAllWorkspaces: vi.fn(),
-      loadURL: vi.fn(),
+      loadURL: vi.fn((url: string) => {
+        currentUrl = url
+      }),
       on: vi.fn(),
       once: vi.fn(),
       webContents: {
@@ -89,16 +92,22 @@ vi.mock('electron', () => ({
             }
           },
         ),
-        loadURL: vi.fn(),
+        loadURL: vi.fn((url: string) => {
+          currentUrl = url
+        }),
         reload: vi.fn(),
         send: vi.fn(),
         openDevTools: vi.fn(),
-        getURL: vi.fn(() => ''),
+        getURL: vi.fn(() => currentUrl),
       },
     }
     createdWindows.push({
       win,
       fireWebContents: (event: string, ...args: unknown[]) => {
+        const navigatedUrl = args[1]
+        if (event === 'did-navigate' && typeof navigatedUrl === 'string') {
+          currentUrl = navigatedUrl
+        }
         ;(webHandlers[event] ?? []).forEach((handler) => handler(...args))
       },
     })
@@ -167,6 +176,33 @@ describe('WindowManager startup panel nav-watch', () => {
     expect(windowManager.getStartupAuthFallbacks().has('floating')).toBe(true)
   })
 
+  it('waits for the panel load to settle so auth redirects can win', () => {
+    // Arrange: panel-only cold boot starts at the requested panel route.
+    const windowManager = new WindowManager(SERVER_URL)
+    windowManager.createMainWindow(false)
+    windowManager.openStartupPanel('floating')
+    const mainWindow = getWindow(0)
+    const panelWindow = getWindow(1)
+
+    // Act: Chromium first reports the requested URL, then proxy.ts redirects
+    // to /login before the load settles.
+    panelWindow.fireWebContents(
+      'did-navigate',
+      {},
+      `${SERVER_URL}/floating-navigator`,
+    )
+    panelWindow.fireWebContents(
+      'did-navigate',
+      {},
+      `${SERVER_URL}/login?redirect_url=/floating-navigator`,
+    )
+
+    // Assert: the panel was never revealed from the transient panel URL.
+    expect(panelWindow.win.show).not.toHaveBeenCalled()
+    expect(mainWindow.win.show).toHaveBeenCalledTimes(1)
+    expect(windowManager.getStartupAuthFallbacks().has('floating')).toBe(true)
+  })
+
   it('treats a /sign-up landing as unauthenticated and surfaces the main window', () => {
     // Arrange
     const windowManager = new WindowManager(SERVER_URL)
@@ -198,6 +234,7 @@ describe('WindowManager startup panel nav-watch', () => {
       {},
       `${SERVER_URL}/floating-navigator`,
     )
+    panelWindow.fireWebContents('did-finish-load')
 
     // Assert: panel revealed, main untouched, no fallback recorded.
     expect(panelWindow.win.show).toHaveBeenCalledTimes(1)
@@ -294,6 +331,7 @@ describe('WindowManager startup panel nav-watch', () => {
       {},
       `${SERVER_URL}/floating-navigator`,
     )
+    panelWindow.fireWebContents('did-finish-load')
 
     // Assert: the panel was reloaded to its route and then revealed.
     expect(panelWindow.win.webContents.loadURL).toHaveBeenCalledWith(
@@ -328,6 +366,7 @@ describe('WindowManager startup panel nav-watch', () => {
     windowManager.openStartupPanel('braindump')
     const panelWindow = getWindow(1)
     panelWindow.fireWebContents('did-navigate', {}, `${SERVER_URL}/braindump`)
+    panelWindow.fireWebContents('did-finish-load')
 
     // Assert: brain dump loaded its route and was revealed once authenticated.
     expect(panelWindow.win.loadURL).toHaveBeenCalledWith(
@@ -351,6 +390,7 @@ describe('WindowManager startup panel nav-watch', () => {
       {},
       `${SERVER_URL}/floating-navigator`,
     )
+    panelWindow.fireWebContents('did-finish-load')
     panelWindow.fireWebContents(
       'did-fail-load',
       {},


### PR DESCRIPTION
## Summary
- Delay the startup-panel authenticated decision until the panel load settles instead of trusting the first did-navigate event.
- Treat auth redirects as terminal immediately so signed-out panel-only startup surfaces the main login window and never flashes login inside Floating Navigator.
- Add a WindowManager regression where the requested panel URL arrives before the login redirect.

## Validation
- mise exec node@24.13.0 -- pnpm test:electron -- WindowManager.startup-panel
- mise exec node@24.13.0 -- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panel visibility timing during navigation to wait for page load completion before showing or hiding auxiliary windows.
  * Enhanced handling of panel visibility on authentication pages to prevent unnecessary display during redirects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->