### PR TITLE
Keep floating state from showing windows

### DIFF
--- a/electron/WindowStateManager.ts
+++ b/electron/WindowStateManager.ts
@@ -758,9 +758,9 @@ export class WindowStateManager {
         browserWindow.setAlwaysOnTop(state.isAlwaysOnTop)
       }
 
-      if (state.isVisible && windowType === 'floating') {
-        browserWindow.show()
-      }
+      // Visibility is owned by WindowManager's explicit show paths. Restoring
+      // it here would let stale window-state.json bypass startup config and the
+      // signed-out auth gate for auxiliary panels.
 
       return true
     } catch (error) {

--- a/electron/__tests__/WindowStateManager.startup.test.ts
+++ b/electron/__tests__/WindowStateManager.startup.test.ts
@@ -15,6 +15,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 
+import type { BrowserWindow } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // A mutable holder so the hoisted electron mock can resolve a fresh temp
@@ -88,6 +89,30 @@ function writeWindowStateFile(rawStates: Record<string, unknown>): void {
     JSON.stringify(rawStates),
     'utf8',
   )
+}
+
+/**
+ * Builds the BrowserWindow surface `applyWindowState` needs without creating
+ * a real Electron window.
+ *
+ * @returns BrowserWindow-shaped mock with spies for state application.
+ * @example
+ * const window = createBrowserWindowMock()
+ */
+function createBrowserWindowMock(): BrowserWindow & {
+  show: ReturnType<typeof vi.fn>
+  setAlwaysOnTop: ReturnType<typeof vi.fn>
+} {
+  return {
+    isDestroyed: vi.fn(() => false),
+    maximize: vi.fn(),
+    setFullScreen: vi.fn(),
+    setAlwaysOnTop: vi.fn(),
+    show: vi.fn(),
+  } as unknown as BrowserWindow & {
+    show: ReturnType<typeof vi.fn>
+    setAlwaysOnTop: ReturnType<typeof vi.fn>
+  }
 }
 
 describe('WindowStateManager floating startup visibility', () => {
@@ -170,5 +195,28 @@ describe('WindowStateManager persisted floating visibility', () => {
     expect(floating?.width).toBe(480)
     expect(floating?.height).toBe(720)
     expect(floating?.isVisible).toBe(false)
+  })
+
+  it('does not show the floating window while applying persisted state', () => {
+    // Arrange: startup wants the panel, but auth gating must still decide when
+    // it becomes visible; state application may only restore non-visibility bits.
+    writeWindowStateFile({
+      floating: {
+        isVisible: true,
+        isAlwaysOnTop: false,
+        width: 480,
+        height: 720,
+      },
+    })
+    const manager = new WindowStateManager(createConfigManager(true))
+    const browserWindow = createBrowserWindowMock()
+
+    // Act
+    const applied = manager.applyWindowState('floating', browserWindow)
+
+    // Assert
+    expect(applied).toBe(true)
+    expect(browserWindow.setAlwaysOnTop).toHaveBeenCalledWith(false)
+    expect(browserWindow.show).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Stop WindowStateManager.applyWindowState from calling show for the Floating Navigator.
- Keep geometry and always-on-top restoration, but make visibility owned by WindowManager explicit show paths.
- Add a regression proving persisted floating visibility cannot bypass the startup config/auth gate.

## Validation
- mise exec node@24.13.0 -- pnpm test:electron -- WindowStateManager.startup
- mise exec node@24.13.0 -- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floating window visibility during startup to prioritize configuration settings over previously persisted state. Window properties like "always on top" continue to be restored as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->