### PR TITLE
Expose login item settings getter

### DIFF
--- a/e2e/electron/preload.spec.ts
+++ b/e2e/electron/preload.spec.ts
@@ -53,3 +53,18 @@ test('preload IPC round-trip reaches the main process', async () => {
   expect(typeof version).toBe('string')
   expect(version.length).toBeGreaterThan(0)
 })
+
+test('settings login item getter reaches the main process', async () => {
+  const loginItemSettings = await mainWindow.evaluate(async () => {
+    const getLoginItemSettings =
+      window.electronAPI?.settings?.getLoginItemSettings
+    if (!getLoginItemSettings) {
+      throw new Error(
+        'window.electronAPI.settings.getLoginItemSettings is not exposed',
+      )
+    }
+    return getLoginItemSettings()
+  })
+
+  expect(typeof loginItemSettings.openAtLogin).toBe('boolean')
+})

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -34,6 +34,7 @@ import type {
   ConfigSection,
   DeepLinkExamples,
   IPCEventChannel,
+  IPCResponse,
   NotificationOptions,
   NotificationPreferences,
   ShortcutDefinition,
@@ -1585,6 +1586,24 @@ contextBridge.exposeInMainWorld('electronAPI', {
       } catch (error) {
         log.error('Failed to set start at login:', error)
         return false
+      }
+    },
+
+    /**
+     * Read the OS login-item state from the main process.
+     *
+     * @returns The current login-item settings, or openAtLogin=false on failure.
+     * @example
+     * const { openAtLogin } = await window.electronAPI.settings.getLoginItemSettings()
+     */
+    getLoginItemSettings: async (): Promise<
+      IPCResponse<'settings:getLoginItemSettings'>
+    > => {
+      try {
+        return await typedInvoke('settings:getLoginItemSettings')
+      } catch (error) {
+        log.error('Failed to read login item settings:', error)
+        return { openAtLogin: false }
       }
     },
 

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -25,6 +25,7 @@ import type {
   ConfigSection,
   DeepLinkExamples,
   UpdaterStatus,
+  IPCResponse,
   IPCEventChannel,
   IPCEventData,
 } from './ipc'
@@ -455,6 +456,13 @@ export interface ElectronAPI {
      * @returns Promise resolving to success status
      */
     setStartAtLogin: (enable: boolean) => Promise<boolean>
+    /**
+     * Read the current OS login-item settings.
+     * @returns Promise resolving to the login-item state
+     */
+    getLoginItemSettings: () => Promise<
+      IPCResponse<'settings:getLoginItemSettings'>
+    >
     /**
      * Persist which window(s) open at Electron launch. The >=1-true invariant is
      * enforced in the main process, so an all-false request is repaired before

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -6,6 +6,7 @@
 // not affect the `declare global` Window augmentation below.
 import type {
   AuxWindowVisibility,
+  IPCResponse,
   StartupWindowConfig,
 } from '@/electron/types/ipc'
 
@@ -252,6 +253,10 @@ interface ElectronAPI {
     setShowInMenuBar: (show: boolean) => Promise<boolean>
     /** Set whether the app should start at system login */
     setStartAtLogin: (enable: boolean) => Promise<boolean>
+    /** Read the current OS login-item settings */
+    getLoginItemSettings: () => Promise<
+      IPCResponse<'settings:getLoginItemSettings'>
+    >
     /**
      * Persist which window(s) open at Electron launch (main / brain dump /
      * floating navigator). The >=1-true invariant is enforced in the main


### PR DESCRIPTION
## Summary
- Add settings.getLoginItemSettings to the preload settings bridge.
- Keep Electron API d.ts and renderer Window.electronAPI mirror in sync with the typed IPC response.
- Add an Electron preload E2E round-trip that proves the getter is exposed and reaches the main process.

## Validation
- mise exec node@24.13.0 -- pnpm validate
- kill-port 3011
- docker compose up -d
- mise exec node@24.13.0 -- pnpm e2e:electron e2e/electron/preload.spec.ts
- docker compose down
- kill-port 3011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API to retrieve system login item settings, enabling access to application startup configuration details.

* **Tests**
  * Added end-to-end test coverage for the new login settings API functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->