### PR TITLE
test: stabilize Electron window selection

### DIFF
--- a/e2e/electron/_helpers/launch.ts
+++ b/e2e/electron/_helpers/launch.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 import { _electron as electron } from 'playwright'
@@ -21,26 +22,37 @@ export async function launchElectronForTest(
   // dynamic test metadata could otherwise write outside `LOG_DIR`.
   const safeSpecName = path.basename(specName.replace(/\s+/g, '-'))
   const logPath = path.join(LOG_DIR, `electron-main-${safeSpecName}.log`)
+  const userDataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `corelive-electron-${safeSpecName}-`),
+  )
 
   fs.writeFileSync(
     logPath,
     `=== launch env ===\n` +
       `NODE_ENV=test\n` +
       `ELECTRON_RENDERER_URL=${RENDERER_URL}\n` +
+      `ELECTRON_E2E_USER_DATA_DIR=${userDataDir}\n` +
       `ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION=true\n` +
       `=== main-process output (stdout + stderr interleaved) ===\n`,
   )
 
-  const electronApp = await electron.launch({
-    args: [ELECTRON_MAIN_ENTRY],
-    env: {
-      ...process.env,
-      NODE_ENV: 'test',
-      ELECTRON_RENDERER_URL: RENDERER_URL,
-      PLAYWRIGHT_REMOTE_DEBUGGING_PORT: REMOTE_DEBUG_PORT,
-      ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION: 'true',
-    },
-  })
+  let electronApp: ElectronApplication
+  try {
+    electronApp = await electron.launch({
+      args: [ELECTRON_MAIN_ENTRY],
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        ELECTRON_RENDERER_URL: RENDERER_URL,
+        PLAYWRIGHT_REMOTE_DEBUGGING_PORT: REMOTE_DEBUG_PORT,
+        ELECTRON_E2E_DISABLE_SYSTEM_INTEGRATION: 'true',
+        ELECTRON_E2E_USER_DATA_DIR: userDataDir,
+      },
+    })
+  } catch (error) {
+    fs.rmSync(userDataDir, { recursive: true, force: true })
+    throw error
+  }
 
   // Attach listeners immediately — main-process output can flow during
   // `deferredInit` before the first window is ready, and a deferredInit
@@ -53,8 +65,65 @@ export async function launchElectronForTest(
   proc.stderr?.on('data', (chunk) => {
     fs.appendFileSync(logPath, chunk)
   })
+  proc.once('exit', () => {
+    fs.rmSync(userDataDir, { recursive: true, force: true })
+  })
 
   return electronApp
+}
+
+/**
+ * Detects the main renderer page by its preload bridge, not creation order.
+ *
+ * @param page - Electron renderer page to probe.
+ * @returns True when the page exposes the main-window preload API.
+ * @example
+ * const isMain = await pageHasMainPreload(page)
+ */
+async function pageHasMainPreload(page: Page): Promise<boolean> {
+  try {
+    await page.waitForLoadState('domcontentloaded', {
+      timeout: LOAD_TIMEOUT_MS,
+    })
+    return await page.evaluate(() => {
+      return Boolean(
+        window.electronEnv?.isElectron && window.electronAPI?.app?.getVersion,
+      )
+    })
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Waits for the main window even when auxiliary panels are created first.
+ *
+ * @param electronApp - Launched Electron application under test.
+ * @returns The Playwright page backed by the main BrowserWindow.
+ * @example
+ * const mainWindow = await waitForMainWindow(electronApp)
+ */
+export async function waitForMainWindow(
+  electronApp: ElectronApplication,
+): Promise<Page> {
+  const firstWindow = await electronApp.firstWindow()
+  const deadline = Date.now() + LOAD_TIMEOUT_MS
+
+  while (Date.now() < deadline) {
+    const windows = [firstWindow, ...electronApp.windows()]
+    for (const window of windows) {
+      if (await pageHasMainPreload(window)) {
+        return window
+      }
+    }
+
+    await electronApp
+      .waitForEvent('window', { timeout: 250 })
+      .catch(() => undefined)
+  }
+
+  const urls = electronApp.windows().map((window) => window.url())
+  throw new Error(`Main Electron window was not found. Open URLs: ${urls}`)
 }
 
 /**
@@ -69,7 +138,7 @@ export async function setupElectronTest(specName: string): Promise<{
   mainWindow: Page
 }> {
   const electronApp = await launchElectronForTest(specName)
-  const mainWindow = await electronApp.firstWindow()
+  const mainWindow = await waitForMainWindow(electronApp)
   await mainWindow.waitForLoadState('domcontentloaded')
   return { electronApp, mainWindow }
 }

--- a/e2e/electron/window-controls.spec.ts
+++ b/e2e/electron/window-controls.spec.ts
@@ -13,6 +13,7 @@ import { setupElectronTest } from './_helpers/launch'
 
 /** Tolerance (px) for window bounds/size round-trips under xvfb DPI scaling. */
 const DPI_TOLERANCE_PX = 1
+const MAIN_WINDOW_URL_PATTERN = /\/(home|login|sign-in)(?:\?|$|\/)/
 
 let electronApp: ElectronApplication
 
@@ -33,7 +34,11 @@ test.afterAll(async () => {
 
 test('main window has non-zero bounds after creation', async () => {
   const bounds = await electronApp.evaluate(({ BrowserWindow }) => {
-    const window = BrowserWindow.getAllWindows()[0]
+    const window = BrowserWindow.getAllWindows().find((candidate) => {
+      return /\/(home|login|sign-in)(?:\?|$|\/)/.test(
+        candidate.webContents.getURL(),
+      )
+    })
     return window?.getBounds() ?? null
   })
 
@@ -46,15 +51,18 @@ test('setBounds round-trips with DPI tolerance', async () => {
   const targetBounds = { x: 50, y: 50, width: 1024, height: 768 }
 
   const actualBounds = await electronApp.evaluate(
-    ({ BrowserWindow }, target) => {
-      const window = BrowserWindow.getAllWindows()[0]
+    ({ BrowserWindow }, { patternSource, target }) => {
+      const mainWindowPattern = new RegExp(patternSource)
+      const window = BrowserWindow.getAllWindows().find((candidate) => {
+        return mainWindowPattern.test(candidate.webContents.getURL())
+      })
       if (!window) {
         throw new Error('No BrowserWindow available')
       }
       window.setBounds(target)
       return window.getBounds()
     },
-    targetBounds,
+    { patternSource: MAIN_WINDOW_URL_PATTERN.source, target: targetBounds },
   )
 
   // ±1px tolerance: xvfb at non-1.0 DPI scales rounds the size — see
@@ -80,7 +88,11 @@ test('setSize is idempotent', async () => {
   // Read via `getBounds()` (Rectangle object) instead of `getSize()`
   // (number[] tuple) so strict-index typing doesn't surface noise here.
   const sizes = await electronApp.evaluate(({ BrowserWindow }, target) => {
-    const window = BrowserWindow.getAllWindows()[0]
+    const window = BrowserWindow.getAllWindows().find((candidate) => {
+      return /\/(home|login|sign-in)(?:\?|$|\/)/.test(
+        candidate.webContents.getURL(),
+      )
+    })
     if (!window) {
       throw new Error('No BrowserWindow available')
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -150,6 +150,13 @@ const isDev = process.env.NODE_ENV === 'development'
 const isTestEnvironment = process.env.NODE_ENV === 'test'
 
 /**
+ * Test-only userData override for Playwright Electron E2E isolation.
+ */
+if (isTestEnvironment && process.env.ELECTRON_E2E_USER_DATA_DIR) {
+  app.setPath('userData', process.env.ELECTRON_E2E_USER_DATA_DIR)
+}
+
+/**
  * E2E system-integration kill switch.
  *
  * Linux CI runs Electron under `xvfb` (virtual display). Several lazy-loaded


### PR DESCRIPTION
## Summary
- isolate Electron E2E runs with a temporary userData directory
- wait for the main-window preload bridge instead of trusting creation order
- target the main BrowserWindow by URL in window-control assertions

## Validation
- mise exec node@24.13.0 -- pnpm e2e:electron
- mise exec node@24.13.0 -- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Electron E2E testing infrastructure with better window detection and isolated user-data directories for test isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->