### PR TITLE
chore: bump Electron release to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corelive",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A comprehensive design system and web application built with Next.js, featuring authentication, database integration, and desktop support",
   "author": "Ryota Murakami <dojce1048@gmail.com> (https://github.com/ryota-murakami)",
   "private": true,


### PR DESCRIPTION
## Summary
- bump CoreLive Electron app version from 0.6.0 to 0.7.0

## Validation
- mise exec node@24.13.0 -- pnpm validate
- mise exec node@24.13.0 -- pnpm electron:build:dir
- post-fix macOS Electron QA: 11/11 passed, evidence in .gstack/qa-reports/evidence/electron-mac-postfix-2026-05-27/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.7.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->