### PR TITLE
feat(#53): paste-to-import — PR1 server (migration, idempotent bulk createMany/deleteMany, parser, heatmap)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,32 @@ jobs:
           echo "CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}" >> .env
           echo "WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }}" >> .env
           echo "POSTGRES_PRISMA_URL=postgresql://postgres:password@localhost:5432/corelive?schema=public" >> .env
+      # Provision Postgres for the real-DB integration suites (paste-import
+      # procedures). Mirrors e2e.web.yml. Those tests are gated behind
+      # RUN_DB_INTEGRATION_TESTS (set on the unit-test step below); mocked/pure
+      # unit tests are unaffected.
+      - name: Start Postgres via Docker Compose 🐳
+        run: |
+          docker compose -f compose.yml -p corelive up -d postgres --wait
+          docker ps -a
+      - name: Show Postgres logs on failure 🪵
+        if: failure()
+        run: docker compose -f compose.yml -p corelive logs postgres | tail -n 200 || true
+      - name: Verify database connection 🧪
+        run: |
+          timeout 60 bash -c 'until docker compose -f compose.yml -p corelive exec postgres env PGPASSWORD=password psql -U postgres -lqt | cut -d \| -f 1 | grep -qw corelive; do sleep 2; done'
+          echo "Database 'corelive' exists and is ready!"
+      - name: Run Prisma migrations 📦
+        run: pnpm prisma migrate deploy
+      - name: Generate Prisma Client 🗄️
+        run: pnpm prisma generate
       - name: Install Playwright Browsers 🎭
         run: pnpm exec playwright install --with-deps chromium
       - name: Generate Icons 🎨
         run: pnpm build:icons
       - name: Run unit tests
+        env:
+          RUN_DB_INTEGRATION_TESTS: '1'
         run: pnpm test --run --coverage
       - name: Run Electron tests
         run: pnpm test:electron --run

--- a/TODOS.md
+++ b/TODOS.md
@@ -36,3 +36,16 @@ function that will pull it off the deferred list.
       tie for the max contribution, the "month max" marker currently picks
       the earliest. Revisit if users surface complaints about "missed" tied
       days. Forcing function: user feedback on PR1.5.
+
+## Design system
+
+- [ ] **App-wide warm-up — push the whole UI toward the golden-hour mood.**
+      Surfaced in `/plan-design-review` (2026-05-30, Issue #53). When choosing the
+      paste-import mockup, the user picked the warmest/most-atmospheric variant (C)
+      and confirmed (D3) the real intent: the app still feels too cold, they want
+      the whole thing warmer — toward C's golden-hour light. This is a design-system
+      change, NOT paste-import: revise `globals.css` OKLCH tokens (warmer neutrals /
+      light) + `DESIGN.md`. Needs the user's eye (subjective feel). paste-import uses
+      tokens only, so it inherits this automatically once landed — no rework.
+      Forcing function: run `/design-consultation` as the next design session.
+      Effort: ~half day human / ~1–2h CC.

--- a/docs/plans/2026-05-29-paste-import-plan.md
+++ b/docs/plans/2026-05-29-paste-import-plan.md
@@ -166,8 +166,20 @@ deleted/missing categoryId.
 ## Success copy
 
 "N more days you showed up" is **wrong** for bulk same-day imports (50 items today = 1 day, not 50).
-Copy must honor repetition-as-habit-count without implying "days" (e.g. "N more wins logged" / warm
-temperature, never "N tasks (+12%)"). Exact wording → design review.
+Copy must honor repetition-as-habit-count without implying "days" and never use a KPI/percentage.
+
+**Resolved (`/plan-design-review` D6 — "quiet accumulation", let the heatmap perform):**
+
+| Moment                       | English                                           | 日本語                            |
+| ---------------------------- | ------------------------------------------------- | --------------------------------- |
+| Completed import success     | `50 added to your year`                           | `50個、一年に。`                  |
+| Active-Todo import success   | `50 added to your list`                           | `50個、リストに。`                |
+| Active-Todo expectation note | `they'll light the heatmap as you complete them`  | `終えるとヒートマップが灯る`      |
+| Paste textarea placeholder   | `paste your wins — one per line`                  | `やったこと、1行ずつ貼って`       |
+| Empty preview (all blank)    | `nothing to import yet — paste a few lines above` | `まだ何も無いよ — 上に数行貼って` |
+
+The heatmap fill animation is the celebration; copy stays one quiet line. No "days", no `(+12%)`, no
+streak-shame. Honors no-dedup (50 logged = 50, same day or not).
 
 ## Slice 2 — AI auto-labeling (open design)
 
@@ -182,3 +194,108 @@ the model runs). Stack: Vercel AI SDK + OpenRouter + `generateObject` + Zod, **s
 - `Todo.completedAt` migration (`TODOS.md`) — blocks **only** the Todo-zone _date-override_ (a Slice 2
   Todo concern). Shared forcing function with the Streak feature.
 - user-TZ bucketing — pre-existing deferred item (`TODOS.md`).
+- **Design-system warm-up (Track 1, separate from #53):** make the whole app feel warmer — toward the
+  golden-hour mood of approved mockup variant C. Touches `globals.css` OKLCH tokens + `DESIGN.md`. Pursue
+  via `/design-consultation`; paste-import uses tokens only, so it inherits this automatically. See `TODOS.md`.
+
+## Design decisions (`/plan-design-review` · 2026-05-30 · score 5/10 → 9/10)
+
+Visual reference: approved mockup variant **C** (see Approved mockup). C's _structure_ is locked; its
+literal candle / cathedral-window / vignette are **not shipped** (mockup atmosphere only — the real
+backdrop is `/home`). Warmth comes from approved OKLCH tokens, so paste-import inherits the future
+system warm-up (Track 1) automatically. No hardcoded decoration.
+
+### Entry points (D4 — explicit button per zone)
+
+- Each zone gets a quiet **"Import"** affordance (text button + paste icon) that opens the shared
+  `PasteImport` dialog. No paste-hijacking of single-line inputs.
+- `/home` Completed zone: Import near `CompletedTodos` (by the existing "Clear all").
+- `/home` Active-Todo zone: Import next to `AddTodoForm`'s "Add".
+- FloatingNav (D7): Import **activates the main window** and opens the dialog there (no cramped dialog in
+  the narrow Electron window). Needs a transition cue so the window-switch isn't jarring.
+
+### PasteImport dialog — hierarchy & tokens (variant C + DESIGN.md)
+
+Read order: serif title → textarea → shared category + count → preview list → confirm.
+
+- Container: Radix `Dialog`, `lg` radius (12px), warm `--card` surface, single soft modal elevation.
+- Title: Newsreader (H2 24px), e.g. `Archive to Completed` / `Add to your list`.
+- Textarea: Inter Tight 15px, `md` radius (8px), placeholder in the quiet voice (see copy table).
+- Count: Geist Mono 13px tabular — `N tasks · M skipped` (and the over-cap line below).
+- Shared category: one Select (default = `useSelectedCategory()`); per-row override (T11) shown as a
+  quiet **inherited chip at rest**, revealing a small Select only on hover/focus — **no always-on per-row
+  dropdowns** (the calm that made C beat B).
+- Footer: ghost `Cancel` + ONE amber `--primary` confirm `Add N to Completed`. Amber appears nowhere else.
+
+### Interaction states (Pass 2)
+
+| State                    | What the user sees                                                                                                                                             |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Idle / empty             | Placeholder `paste your wins — one per line`; confirm disabled; preview shows the empty line below                                                             |
+| Typing / parsing         | Live preview per non-blank line; count updates (`12 tasks`); parse is synchronous/instant                                                                      |
+| Preview (valid)          | Rows listed; `12 tasks · 2 skipped`; confirm enabled `Add 12 to Completed`                                                                                     |
+| Over cap (>1000)         | `1,200 lines · importing the first 1,000` (Geist Mono); confirm `Add 1,000`; nothing silently dropped                                                          |
+| Submitting               | Confirm spinner + `Adding…`; textarea/rows locked; double-submit guarded (+ per-paste `importBatchId`)                                                         |
+| Success                  | Dialog closes; **Completed** → heatmap fill + toast `50 added to your year` (~10s) + 60s inline `Undo import`; **Todo** → toast `50 added to your list` + note |
+| Partial                  | N/A by design — invalid lines are filtered in preview before insert, so "1 bad line fails 1000" cannot occur                                                   |
+| Error / offline          | Toast `Couldn't reach the server — your paste is safe`; dialog stays open, textarea + rows preserved, `Try again` re-submits the **same** `importBatchId`      |
+| Empty preview (no valid) | `nothing to import yet — paste a few lines above` (warm, never "No items found.")                                                                              |
+
+### Bulk Undo (D5)
+
+~10s toast `Undo` **plus** the freshly-imported batch rendered as a group in the Completed list —
+`Imported just now · Undo import` — for the full 60s `COMPLETED_UNDO_WINDOW_MS`. Undo deletes by
+`importBatchId`. Discoverable and forgiving for a 50-item action; does not depend on the transient toast.
+
+### Emotional arc & copy (D6 = quiet accumulation)
+
+See the resolved copy table under **Success copy**. The heatmap fill is the payoff; words stay one quiet
+line. Active-Todo import explicitly sets the expectation that it does **not** light the heatmap (bulk
+entry; completing lights it) — preventing the "imported 50, nothing lit" let-down.
+
+### Responsive (Pass 6)
+
+- Mobile web (<640px): dialog becomes a near-full-width sheet (`Dialog` is already `sm:max-w-lg`);
+  textarea + preview stack; touch targets ≥44px; per-row override via tap (no hover dependency).
+- Desktop / main window: `max-w-xl`/`2xl` to give the preview room (wider than the default `lg`).
+- FloatingNav: opens in the main window (D7).
+
+### Accessibility (Pass 6)
+
+- Radix `Dialog` gives focus-trap, ESC, focus-restore, labelled title/description.
+- `aria-live="polite"` announces `12 parsed, 2 skipped` as the textarea changes (debounced).
+- Preview rows keyboard-navigable; per-row category Select Tab-reachable; remove-row control labelled.
+- Contrast ≥4.5:1 on body (warm charcoal on paper passes); amber confirm uses `--primary-foreground`.
+- Toast `Undo` and inline `Undo import` are real buttons (not hover-only); SR announces the success line.
+
+### AI-slop guardrails (Pass 4)
+
+Preview rows are a quiet **dense list, not a card grid** (App UI rule: cards only when the card IS the
+interaction). No decorative blobs/orbs/vignette/candle. One amber accent. Serif title. Themed Sonner toast.
+
+### Deferred (design)
+
+- Honoring a `[x]` paste prefix to route a line to Completed even from the Active-Todo zone — v1 keeps
+  routing purely by destination (`[x]` is stripped, not honored for routing) to keep the model simple.
+- Decoration-free regeneration of the C mockup (optional — `approved.json` records that candle/vignette
+  are not shipped).
+
+## Approved mockup
+
+| Screen                              | Path                                                                                 | Direction                                                                                      | Notes                                                                                                                                                                                                  |
+| ----------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| PasteImport dialog (Completed-zone) | `~/.gstack/projects/laststance-corelive/designs/paste-import-20260530/variant-C.png` | Calm, warm "Archive to Completed" dialog; one shared category pill; preview list as the anchor | Structure locked. Literal candle/window/vignette **not shipped** — warmth via OKLCH tokens. User chose C (D2) for calm + warmth; D3=B → whole-app warm-up tracked as Track 1 / `/design-consultation`. |
+
+## GSTACK REVIEW REPORT
+
+| Review        | Trigger               | Why                             | Runs | Status                | Findings                                                           |
+| ------------- | --------------------- | ------------------------------- | ---- | --------------------- | ------------------------------------------------------------------ |
+| CEO Review    | `/plan-ceo-review`    | Scope & strategy                | 1    | clean (prior session) | 4 proposals · 3 accepted · 1 rejected (dedup); D7=A architecture   |
+| Outside Voice | `/codex review`       | Independent 2nd opinion         | 1    | revised (prior)       | 23 findings · 2 critical fixed (createMany ids, undo window)       |
+| Eng Review    | `/plan-eng-review`    | Architecture & tests (required) | 0    | — (pending)           | next in pipeline                                                   |
+| Design Review | `/plan-design-review` | UI/UX gaps                      | 1    | CLEAR (FULL)          | score 5/10 → 9/10 · 7 decisions · 0 unresolved · mockup C approved |
+| DX Review     | `/plan-devex-review`  | Developer experience gaps       | 0    | — (pending)           | next in pipeline                                                   |
+
+- **CROSS-MODEL:** Design cross-model gate (GPT-4o vision) flagged variant C (over-decoration); user overrode on taste (D2/D3) and the literal decoration is dropped — warmth via tokens. Recorded as Track 1.
+- **UNRESOLVED:** 0 design decisions unresolved. Entry points (D4), bulk undo (D5), success copy (D6), FloatingNav (D7), states, responsive, a11y all specced into the plan.
+- **VERDICT:** DESIGN CLEARED (9/10). Eng Review required before ship (`skip_eng_review=false`) — running next.

--- a/docs/plans/2026-05-29-paste-import-plan.md
+++ b/docs/plans/2026-05-29-paste-import-plan.md
@@ -1,0 +1,184 @@
+# Plan: Paste-to-import + AI auto-labeling (Issue #53)
+
+|            |                                                                                                            |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Status** | Planned (architecture resolved; awaiting eng-review before implementation)                                 |
+| **Issue**  | [#53](https://github.com/laststance/corelive/issues/53)                                                    |
+| **Date**   | 2026-05-29 (office-hours + CEO review) · revised 2026-05-30 after an independent (cross-model) plan review |
+| **Origin** | office-hours design session → CEO strategy/scope review → Codex outside-voice review                       |
+
+## Vision
+
+The platonic "import mouth": dump tasks from anywhere — paste, .txt/.md file drag-drop,
+or another app's export — and Corelive parses, previews, and lands them into the right zone.
+Past achievements → Completed → **the heatmap lights up** (the dogfood moment). Active work →
+Todo list (bulk task entry — see the Todo caveat below). Repetition is preserved on purpose
+(no dedup) — showing up twice counts twice. The shared parse+preview engine becomes
+infrastructure every future intake builds on.
+
+North Star: migration cost drops to zero, so the user can dogfood immediately and feel
+「自分、ちゃんとやってきたじゃん」 the moment the heatmap fills.
+
+> **Heatmap caveat:** Only the **Completed-zone** import lights the heatmap. Active-Todo-zone
+> import creates _incomplete_ todos (`completed=false`), and the heatmap counts only
+> `Todo.completed=true` + `Completed` rows. So the Todo-zone import's value is **bulk task
+> entry**, NOT the "heatmap fills" moment. Do not conflate the two in copy or UX.
+
+### Existing leverage
+
+- `braindumpUtils.ts`: markdown **checkbox-only** grammar (`- [ ]`/`- [x]`) + `normalizeCompletedTitle`
+  (trim + 255 clamp). Pure functions, no Electron deps — **safely shareable**.
+  ⚠️ It does NOT strip URLs/headers and returns `null` for plain (non-checkbox) lines, so it
+  cannot be reused verbatim for paste-import (see Parser spec).
+- `completed.create` / `todo.create`: single-row ownership-verified creates — pattern reuse.
+- `deleteCompleted`: atomic conditional `deleteMany` with `createdAt >= now()-COMPLETED_UNDO_WINDOW_MS`
+  (60s) window — pattern reuse for batch undo.
+- Heatmap = `Todo(completed=true)` + `Completed` UNION, count-based coloring (levels 0-4) — only
+  the Completed bucket field changes (see migration).
+- BrainDump (Electron-only) already does line-by-line `[x]`→Completed — sibling, not rebuilt.
+
+## Architecture: separate "when it happened" from "when the row was inserted"
+
+Add `Completed.completedAt` now. This dissolves an interlocking cluster of problems that the
+naive "overload `createdAt`, no migration" approach created (surfaced by the cross-model review).
+
+### Migration (one Prisma migration, this work)
+
+- **`Completed.completedAt DateTime?`** — add as **nullable**, then **backfill `completedAt = createdAt`**
+  for existing rows via an `UPDATE` step in the same migration. New rows write `completedAt` on
+  insert (default `now()`).
+  - ⚠️ **Do NOT add it as `@default(now())` non-null.** A non-null default would stamp every
+    _existing_ row with the migration timestamp → all historical Completed rows would jump to
+    migration-day on the heatmap. Nullable column + explicit backfill avoids this.
+- **`Completed.importBatchId String?`** (indexed) — tags a paste batch for idempotent bulk undo + history.
+- **`Todo.importBatchId String?`** (indexed) — same, for Todo-zone bulk undo.
+- **NOT in this migration:** `Todo.completedAt` (tracked separately in `TODOS.md`). It blocks only
+  the **Todo-zone date-override**; nothing in PR1/PR2 depends on it.
+
+### Heatmap
+
+Completed bucket switches from `createdAt` → **`completedAt ?? createdAt`** (the `??` is a defensive
+fallback for any row missed by backfill). Update `completedAggregation.ts`. Verify existing rows do
+not shift days.
+
+### Undo (no longer keyed off the semantic date — that was the bug)
+
+- Bulk undo deletes by **`importBatchId`**, guarded by **`createdAt >= now()-COMPLETED_UNDO_WINDOW_MS`**.
+  Because `createdAt` is the real insert time (never overridden — `completedAt` holds the semantic
+  date), the 60s window works even when `completedAt` is a past date.
+- Undo no longer depends on `createMany` returning ids. Prisma `createMany` returns only `{count}`;
+  `importBatchId` sidesteps the need for returned ids entirely.
+
+### Bulk API shape (forward-compatible)
+
+- `completed.createMany({ items: Array<{ title; categoryId?; completedAt? }>, importBatchId })`, `items.max(1000)`.
+- `todo.createMany({ items: Array<{ title; categoryId? }>, importBatchId })`, `items.max(1000)`
+  (no `completedAt` until the `Todo.completedAt` migration).
+- Category verification handles a **set** of categoryIds (per-line override ready), not a single id.
+- `createMany` itself returns `{count}`; use `createManyAndReturn` **or** rely on `importBatchId` for
+  the undo set (order is irrelevant — undo deletes the whole batch).
+
+## Idempotency vs dedup (these are different problems)
+
+- **No-dedup governs _semantic_ repetition** — "English study" 3× is 3 real habit signals; never collapse.
+- **Idempotency via `importBatchId` prevents _accidental_ duplication** — network retry, React
+  double-fire/StrictMode, double-click, or a second tab resubmitting the **same** batch. The client
+  generates one `importBatchId` per paste-confirm; a resubmit of that id is a no-op.
+- Idempotency closes the accidental-dup vector **without** collapsing intentional repeats. The
+  double-submit button guard stays as a UX nicety; the batch id is the real guard.
+
+> **Product principle:** No deduplication, ever. Repeating a task is the point — habit formation
+> and skill-tree XP. The heatmap and skill tree reward repetition, not collapse it.
+
+## Scope
+
+| #   | Proposal                              | Decision     | Reasoning                                                               |
+| --- | ------------------------------------- | ------------ | ----------------------------------------------------------------------- |
+| 1   | Duplicate detection in preview        | **REJECTED** | Repetition is intentional (habit + skill-tree XP). Dedup erases signal. |
+| 2   | Bulk Undo (one toast → delete batch)  | ACCEPTED     | Batch-id-based + window-guarded (see Undo)                              |
+| 3   | Per-line category override in preview | ACCEPTED     | `items[]` schema + multi-id verification make it cheap                  |
+| 4   | File/MD drag-drop import              | ACCEPTED     | Platform step toward the "import mouth"; same parser                    |
+
+## PR Split (layer axis)
+
+**PR1 — Server + tests (no UI):**
+
+- Prisma migration: `Completed.completedAt?` (+ backfill = `createdAt`), `Completed.importBatchId?`
+  (+ index), `Todo.importBatchId?` (+ index).
+- Heatmap aggregation → `completedAt ?? createdAt` (`completedAggregation.ts`).
+- Shared **paste parser util** (line-oriented — see Parser spec). Pure, web/Electron-safe. Unit tests.
+- `completed.createMany` (items[], importBatchId, get-or-create category, `completedAt` default now()).
+- `completed.deleteMany({ importBatchId })` (ownership + window guard, atomic, idempotent).
+- `todo.createMany` (items[], importBatchId) + `todo.deleteMany({ importBatchId })`.
+- Zod schemas (`items[]`, `importBatchId`, `.max(1000)`), router wiring, constants
+  (`MAX_IMPORT_LINES_PER_BATCH = 1000`, undo-window reuse/define).
+- Procedure + parser tests: override-`completedAt` path, idempotent-resubmit, window-expiry,
+  invalid-line filtering, existing-row heatmap stability.
+
+**PR2 — UI + Undo + power-import:**
+
+- Shared `PasteImport` component: textarea + Vercel-env-style preview + shared category Select
+  (context default → server get-or-create) + confirm (double-submit guard + per-paste `importBatchId`).
+- Completed-zone entry point (`/home`) + Bulk Undo toast (`deleteMany` by `importBatchId`).
+- Active-Todo entry points (TodoList + FloatingNav — note the single-line-input constraint) + Todo undo.
+- Per-line category override; file/MD drag-drop.
+- Empty states; offline / `createMany` failure (preserve preview, allow retry); `DESIGN.md` voice.
+- **Run a design review before building** (real UI surface).
+- ⚠️ PR2 is large. Keep it reviewable with commit ordering server-contract → Completed-UI → Todo-UI
+  → power; split a PR3 if it grows past review comfort.
+
+## Parser spec
+
+The existing `braindumpUtils` parser is **checkbox-only** and strips nothing; reusing it verbatim
+would parse plain pasted text to **zero** tasks. The paste-import parser is **new and line-oriented**:
+
+- Every **non-blank** line → one task. Blank lines skipped.
+- Strip **only** a leading list/checkbox prefix (`- [ ] `, `- [x] `, `- `, `* `, `+ `, `1. `, `2) `, …)
+  to derive the title; a `[x]` prefix may flag "already done."
+- **Preserve** URLs, header text (`# ...`), and bullet body as the title — a task name that _is_ a
+  URL or a heading is legitimate.
+- Reuse `normalizeCompletedTitle` (trim + 255 clamp). Reuse the checkbox regex for prefix detection only.
+- **Client preview and server normalization run the SAME pure util** so preview count == inserted count.
+
+## Validation / partial-batch behavior
+
+- Invalid lines (empty after normalize) are **excluded in the preview** (shown as "N skipped"), and
+  only valid lines are sent. Insert is atomic over the **already-filtered valid set**, so "one bad
+  line fails all 1000" cannot occur — bad lines never reach the insert.
+- Overflow cap = **1000** lines/batch, enforced on **both** client (preview) and server (Zod
+  `.max(1000)`). Overflow is shown, not silently dropped: "N lines exceeded — importing the first 1000."
+  Precedent: `BRAINDUMP_NOTE_LINES_PER_CAP = 200` (import is bulkier → 1000).
+
+## Category fallback
+
+Drop the "'General' always exists via seed" assumption (breaks for existing users, deletion, manual
+DB edits). Server-side **get-or-create** the user's default category if missing; never crash on a
+deleted/missing categoryId.
+
+## Confirmed premises
+
+- Date: paste lands **today-fixed** in Slice 1 (`completedAt` = now()); manual/AI date editing is
+  Slice 2 (Completed zone ready immediately via `completedAt`; Todo zone waits for `Todo.completedAt`).
+- categoryId: shared picker, context-default (get-or-create fallback). Per-line override added (PR2).
+- Routing: by paste-destination (location-based). Completed zone → Completed; active surfaces → Todo.
+- Heatmap colors by COUNT (level 0-4), not category. Null/unset category still lights the cell.
+
+## Success copy
+
+"N more days you showed up" is **wrong** for bulk same-day imports (50 items today = 1 day, not 50).
+Copy must honor repetition-as-habit-count without implying "days" (e.g. "N more wins logged" / warm
+temperature, never "N tasks (+12%)"). Exact wording → design review.
+
+## Slice 2 — AI auto-labeling (open design)
+
+Dynamic category enum (built from the user's real `category.list`) is necessary but **not sufficient**.
+Slice 2 needs its own design pass for: confidence threshold, low-confidence fallback,
+user-confirmation step, cost/rate-limit, and **privacy** (what pasted text leaves the device, where
+the model runs). Stack: Vercel AI SDK + OpenRouter + `generateObject` + Zod, **server-side only**.
+
+## Dependencies & deferred
+
+- **This work owns** the `Completed.completedAt` + `importBatchId` migration (above).
+- `Todo.completedAt` migration (`TODOS.md`) — blocks **only** the Todo-zone _date-override_ (a Slice 2
+  Todo concern). Shared forcing function with the Streak feature.
+- user-TZ bucketing — pre-existing deferred item (`TODOS.md`).

--- a/docs/plans/2026-05-29-paste-import-plan.md
+++ b/docs/plans/2026-05-29-paste-import-plan.md
@@ -2,7 +2,7 @@
 
 |            |                                                                                                            |
 | ---------- | ---------------------------------------------------------------------------------------------------------- |
-| **Status** | Planned (architecture resolved; awaiting eng-review before implementation)                                 |
+| **Status** | In review — PRs #54 (server) + #55 (UI); design + eng + devex cleared, implementation-ready                |
 | **Issue**  | [#53](https://github.com/laststance/corelive/issues/53)                                                    |
 | **Date**   | 2026-05-29 (office-hours + CEO review) · revised 2026-05-30 after an independent (cross-model) plan review |
 | **Origin** | office-hours design session → CEO strategy/scope review → Codex outside-voice review                       |

--- a/docs/plans/2026-05-29-paste-import-plan.md
+++ b/docs/plans/2026-05-29-paste-import-plan.md
@@ -161,7 +161,9 @@ deleted/missing categoryId.
   Slice 2 (Completed zone ready immediately via `completedAt`; Todo zone waits for `Todo.completedAt`).
 - categoryId: shared picker, context-default (get-or-create fallback). Per-line override added (PR2).
 - Routing: by paste-destination (location-based). Completed zone → Completed; active surfaces → Todo.
-- Heatmap colors by COUNT (level 0-4), not category. Null/unset category still lights the cell.
+- Heatmap colors by COUNT (level 0-4), not category. **Every imported row gets a real `categoryId`** —
+  `categoryId` is NOT NULL with `onDelete: Restrict`, so there is no null-category row; get-or-create the
+  default category before insert (see Eng fold-ins).
 
 ## Success copy
 
@@ -172,7 +174,7 @@ Copy must honor repetition-as-habit-count without implying "days" and never use 
 
 | Moment                       | English                                           | 日本語                            |
 | ---------------------------- | ------------------------------------------------- | --------------------------------- |
-| Completed import success     | `50 added to your year`                           | `50個、一年に。`                  |
+| Completed import success     | `50 added — today's lit`                          | `50個、今日に。`                  |
 | Active-Todo import success   | `50 added to your list`                           | `50個、リストに。`                |
 | Active-Todo expectation note | `they'll light the heatmap as you complete them`  | `終えるとヒートマップが灯る`      |
 | Paste textarea placeholder   | `paste your wins — one per line`                  | `やったこと、1行ずつ貼って`       |
@@ -219,7 +221,7 @@ system warm-up (Track 1) automatically. No hardcoded decoration.
 Read order: serif title → textarea → shared category + count → preview list → confirm.
 
 - Container: Radix `Dialog`, `lg` radius (12px), warm `--card` surface, single soft modal elevation.
-- Title: Newsreader (H2 24px), e.g. `Archive to Completed` / `Add to your list`.
+- Title: Newsreader (H2 24px), e.g. `Add to Completed` / `Add to your list` (warm — not the cold "Archive").
 - Textarea: Inter Tight 15px, `md` radius (8px), placeholder in the quiet voice (see copy table).
 - Count: Geist Mono 13px tabular — `N tasks · M skipped` (and the over-cap line below).
 - Shared category: one Select (default = `useSelectedCategory()`); per-row override (T11) shown as a
@@ -229,17 +231,17 @@ Read order: serif title → textarea → shared category + count → preview lis
 
 ### Interaction states (Pass 2)
 
-| State                    | What the user sees                                                                                                                                             |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Idle / empty             | Placeholder `paste your wins — one per line`; confirm disabled; preview shows the empty line below                                                             |
-| Typing / parsing         | Live preview per non-blank line; count updates (`12 tasks`); parse is synchronous/instant                                                                      |
-| Preview (valid)          | Rows listed; `12 tasks · 2 skipped`; confirm enabled `Add 12 to Completed`                                                                                     |
-| Over cap (>1000)         | `1,200 lines · importing the first 1,000` (Geist Mono); confirm `Add 1,000`; nothing silently dropped                                                          |
-| Submitting               | Confirm spinner + `Adding…`; textarea/rows locked; double-submit guarded (+ per-paste `importBatchId`)                                                         |
-| Success                  | Dialog closes; **Completed** → heatmap fill + toast `50 added to your year` (~10s) + 60s inline `Undo import`; **Todo** → toast `50 added to your list` + note |
-| Partial                  | N/A by design — invalid lines are filtered in preview before insert, so "1 bad line fails 1000" cannot occur                                                   |
-| Error / offline          | Toast `Couldn't reach the server — your paste is safe`; dialog stays open, textarea + rows preserved, `Try again` re-submits the **same** `importBatchId`      |
-| Empty preview (no valid) | `nothing to import yet — paste a few lines above` (warm, never "No items found.")                                                                              |
+| State                    | What the user sees                                                                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Idle / empty             | Placeholder `paste your wins — one per line`; confirm disabled; preview shows the empty line below                                                              |
+| Typing / parsing         | Live preview per non-blank line; count updates (`12 tasks`); parse is synchronous/instant                                                                       |
+| Preview (valid)          | Rows listed; `12 tasks · 2 skipped`; confirm enabled `Add 12 to Completed`                                                                                      |
+| Over cap (>1000)         | `1,200 lines · importing the first 1,000` (Geist Mono); confirm `Add 1,000`; nothing silently dropped                                                           |
+| Submitting               | Confirm spinner + `Adding…`; textarea/rows locked; double-submit guarded (+ per-paste `importBatchId`)                                                          |
+| Success                  | Dialog closes; **Completed** → heatmap fill + toast `50 added — today's lit` (~10s) + 60s inline `Undo import`; **Todo** → toast `50 added to your list` + note |
+| Partial                  | N/A by design — invalid lines are filtered in preview before insert, so "1 bad line fails 1000" cannot occur                                                    |
+| Error / offline          | Toast `Couldn't reach the server — your paste is safe`; dialog stays open, textarea + rows preserved, `Try again` re-submits the **same** `importBatchId`       |
+| Empty preview (no valid) | `nothing to import yet — paste a few lines above` (warm, never "No items found.")                                                                               |
 
 ### Bulk Undo (D5)
 
@@ -286,16 +288,61 @@ interaction). No decorative blobs/orbs/vignette/candle. One amber accent. Serif 
 | ----------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | PasteImport dialog (Completed-zone) | `~/.gstack/projects/laststance-corelive/designs/paste-import-20260530/variant-C.png` | Calm, warm "Archive to Completed" dialog; one shared category pill; preview list as the anchor | Structure locked. Literal candle/window/vignette **not shipped** — warmth via OKLCH tokens. User chose C (D2) for calm + warmth; D3=B → whole-app warm-up tracked as Track 1 / `/design-consultation`. |
 
+## Eng + DevEx review fold-ins (2026-05-30, autonomous auto-decide)
+
+Both plan reviews ran in autonomous mode (recommended options, no blocking questions); criticals
+resolved before implementation.
+
+### Engineering (plan-eng-review)
+
+- **Idempotency mechanism** (was a hand-wave; `importBatchId` is non-unique, so existence-checks race).
+  New **`ImportBatch { id String @id; userId Int; createdAt DateTime @default(now()) }`** table
+  (`id` = client batchId). `createMany` runs inside a `$transaction` that **first inserts the
+  `ImportBatch` row**; a duplicate id throws Prisma **P2002** → caught → no-op that re-queries and returns
+  the existing batch count. Same-txn ⇒ a failed `createMany` rolls back the guard, so a genuine retry
+  still inserts. Uniqueness is on the **batch id only**, never task content → respects no-dedup.
+- **Migration:** `Completed.completedAt DateTime?` with **NO `@default`** (a non-null default stamps
+  historical rows + causes Prisma drift). `prisma migrate dev` won't generate the backfill —
+  **hand-edit the migration SQL** to append `UPDATE "Completed" SET "completedAt" = "createdAt" WHERE "completedAt" IS NULL;`.
+  Add `ImportBatch` table, `Completed.importBatchId String? @@index`, `Todo.importBatchId String? @@index`.
+  Import path sets `completedAt: new Date()`; `createCompleted` unchanged (null → coalesce).
+- **Category is NOT NULL (`onDelete: Restrict`).** Get-or-create the default category (`findFirst`
+  `isDefault`, else create + catch P2002 + re-query) is mandatory before `createMany`.
+- **`todo.deleteMany({ importBatchId })`** includes the same `createdAt >= now()-COMPLETED_UNDO_WINDOW_MS`
+  window guard as `completed.deleteMany` (parity, atomic).
+- **Promote `COMPLETED_UNDO_WINDOW_MS`** from a private const in `completed.ts` to a shared constants
+  module (batch undo + UI 60s window both consume it).
+- **Todo bulk `order`:** imports land last (documented); no per-item position fidelity in Slice 1.
+- **Heatmap:** coalesce in **JS** (`row.completedAt ?? row.createdAt`); select `completedAt`; date-range
+  **filter stays on `createdAt`** for Slice 1 (latent Slice-2 bug → TODOS note + test stub).
+- **Parser** lives in `src/lib/` (pure, type-only schema import), reusing `braindumpUtils`
+  `normalizeCompletedTitle` + checkbox regex.
+- **Tests add:** resubmit-returns-prior-count under concurrency (P2002 path); undo isolation across users
+  AND batches; other-user `categoryId` rejected; server-side post-normalize empty-line drop; over-cap at
+  exactly 1001; existing-row heatmap stability.
+
+### DevEx (plan-devex-review)
+
+- **Wrong-zone defense pre-confirm:** the Todo dialog shows the expectation note **at preview**, not only
+  on success: `these stay open — they'll light the heatmap as you complete them` / `終えるとヒートマップが灯る`.
+- **Wrong-zone recovery:** the imported Todo batch group offers **`Move to Completed`** (re-routes the
+  `importBatchId` set) within the 60s window.
+- **Slice-1 copy honesty:** Slice 1 lands everything on **today's** cell (`completedAt = now()`), so
+  Completed success copy → `50 added — today's lit` / `50個、今日に。`. D6's `added to your year` framing
+  returns in **Slice 2** (dated import). Reversible if the aspirational framing is preferred.
+- **Day-one discoverability:** the empty Heatmap / empty Completed state surfaces the Import affordance inline.
+- **Dialog title** `Archive to Completed` → `Add to Completed` (warmer).
+
 ## GSTACK REVIEW REPORT
 
-| Review        | Trigger               | Why                             | Runs | Status                | Findings                                                           |
-| ------------- | --------------------- | ------------------------------- | ---- | --------------------- | ------------------------------------------------------------------ |
-| CEO Review    | `/plan-ceo-review`    | Scope & strategy                | 1    | clean (prior session) | 4 proposals · 3 accepted · 1 rejected (dedup); D7=A architecture   |
-| Outside Voice | `/codex review`       | Independent 2nd opinion         | 1    | revised (prior)       | 23 findings · 2 critical fixed (createMany ids, undo window)       |
-| Eng Review    | `/plan-eng-review`    | Architecture & tests (required) | 0    | — (pending)           | next in pipeline                                                   |
-| Design Review | `/plan-design-review` | UI/UX gaps                      | 1    | CLEAR (FULL)          | score 5/10 → 9/10 · 7 decisions · 0 unresolved · mockup C approved |
-| DX Review     | `/plan-devex-review`  | Developer experience gaps       | 0    | — (pending)           | next in pipeline                                                   |
+| Review        | Trigger               | Why                             | Runs | Status                | Findings                                                                                                  |
+| ------------- | --------------------- | ------------------------------- | ---- | --------------------- | --------------------------------------------------------------------------------------------------------- |
+| CEO Review    | `/plan-ceo-review`    | Scope & strategy                | 1    | clean (prior session) | 4 proposals · 3 accepted · 1 rejected (dedup); D7=A architecture                                          |
+| Outside Voice | `/codex review`       | Independent 2nd opinion         | 1    | revised (prior)       | 23 findings · 2 critical fixed (createMany ids, undo window)                                              |
+| Eng Review    | `/plan-eng-review`    | Architecture & tests (required) | 1    | issues folded         | 2 CRITICAL (idempotency → ImportBatch/P2002; migration backfill) + NOT-NULL-category + 6 more, all folded |
+| Design Review | `/plan-design-review` | UI/UX gaps                      | 1    | CLEAR (FULL)          | score 5/10 → 9/10 · 7 decisions · 0 unresolved · mockup C approved                                        |
+| DX Review     | `/plan-devex-review`  | Developer experience gaps       | 1    | issues folded         | wrong-zone pre-confirm + Move-to-Completed recovery; Slice-1 copy honesty; empty-state discoverability    |
 
 - **CROSS-MODEL:** Design cross-model gate (GPT-4o vision) flagged variant C (over-decoration); user overrode on taste (D2/D3) and the literal decoration is dropped — warmth via tokens. Recorded as Track 1.
 - **UNRESOLVED:** 0 design decisions unresolved. Entry points (D4), bulk undo (D5), success copy (D6), FloatingNav (D7), states, responsive, a11y all specced into the plan.
-- **VERDICT:** DESIGN CLEARED (9/10). Eng Review required before ship (`skip_eng_review=false`) — running next.
+- **VERDICT:** DESIGN + ENG + DEVEX CLEARED — all fold-ins applied, implementation-ready. Eng gate (`skip_eng_review=false`) satisfied at plan stage; re-validated by CI on the PRs.

--- a/prisma/migrations/20260529164052_paste_import_completedat_importbatch/migration.sql
+++ b/prisma/migrations/20260529164052_paste_import_completedat_importbatch/migration.sql
@@ -1,0 +1,35 @@
+-- AlterTable
+ALTER TABLE "Completed" ADD COLUMN     "completedAt" TIMESTAMP(3),
+ADD COLUMN     "importBatchId" TEXT;
+
+-- Backfill: stamp existing rows' semantic completion time from their insert
+-- time. completedAt is added NULLABLE with NO DB default on purpose — a
+-- non-null default would set every historical row to the migration timestamp,
+-- jumping all old Completed rows to migration-day on the heatmap. This explicit
+-- backfill keeps each historical row on its real day. New rows write completedAt
+-- on insert; the heatmap coalesces `completedAt ?? createdAt` defensively.
+UPDATE "Completed" SET "completedAt" = "createdAt" WHERE "completedAt" IS NULL;
+
+-- AlterTable
+ALTER TABLE "Todo" ADD COLUMN     "importBatchId" TEXT;
+
+-- CreateTable
+CREATE TABLE "ImportBatch" (
+    "id" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ImportBatch_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ImportBatch_userId_idx" ON "ImportBatch"("userId");
+
+-- CreateIndex
+CREATE INDEX "Completed_importBatchId_idx" ON "Completed"("importBatchId");
+
+-- CreateIndex
+CREATE INDEX "Todo_importBatchId_idx" ON "Todo"("importBatchId");
+
+-- AddForeignKey
+ALTER TABLE "ImportBatch" ADD CONSTRAINT "ImportBatch_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,10 +21,22 @@ model Completed {
   userId     Int
   category   Category @relation(fields: [categoryId], references: [id], onDelete: Restrict)
   categoryId Int
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  // Semantic "when it happened" timestamp, distinct from the DB insert time
+  // (createdAt). NULLABLE with NO @default: a non-null default would stamp
+  // every historical row with the migration timestamp, jumping all old rows
+  // to migration-day on the heatmap. The migration backfills existing rows
+  // with completedAt = createdAt; new rows (paste-import) write it on insert.
+  // The heatmap buckets by `completedAt ?? createdAt` (coalesced in JS).
+  completedAt DateTime?
+  // Tags a paste-import batch so a bulk undo can delete the whole batch by id
+  // (createMany returns only {count}, never the inserted ids). Indexed for the
+  // undo deleteMany lookup. NULL for rows created outside paste-import.
+  importBatchId String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   @@index([categoryId])
+  @@index([importBatchId])
 }
 
 model Category {
@@ -51,10 +63,27 @@ model User {
   categories       Category[]
   completed        Completed[]
   todos            Todo[]
+  importBatches    ImportBatch[]
   electronSettings ElectronSettings?
   skillTrees       SkillTree[]
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
+}
+
+/// Idempotency guard for paste-import. `id` is the client-supplied, globally
+/// unique batch id generated once per paste-confirm. `completed.createMany` /
+/// `todo.createMany` insert this row first inside a $transaction; a duplicate
+/// id throws Prisma P2002, which the procedure catches as an idempotent no-op
+/// (re-query the existing batch's count and return it). Uniqueness is on the
+/// batch id ONLY — never on task title/content — so intentional repetition
+/// (the habit/XP signal) is never collapsed. Cascade-deletes with the user.
+model ImportBatch {
+  id        String   @id
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int
+  createdAt DateTime @default(now())
+
+  @@index([userId])
 }
 
 model Todo {
@@ -67,11 +96,15 @@ model Todo {
   userId      Int
   category    Category         @relation(fields: [categoryId], references: [id], onDelete: Restrict)
   categoryId  Int
+  // Tags a paste-import batch so a bulk undo can delete the whole batch by id.
+  // Indexed for the undo deleteMany lookup. NULL for non-imported todos.
+  importBatchId String?
   assignments NodeAssignment[]
   createdAt   DateTime         @default(now())
   updatedAt   DateTime         @updatedAt
 
   @@index([categoryId])
+  @@index([importBatchId])
 }
 
 model ElectronSettings {

--- a/src/components/braindump/braindumpUtils.ts
+++ b/src/components/braindump/braindumpUtils.ts
@@ -18,8 +18,13 @@
 
 import type { Completed } from '@/server/schemas/completed'
 
-/** Regex for a markdown checkbox line. Captures the [ ] state and the title. */
-const CHECKBOX_LINE_REGEX = /^- \[([ x])\] (.+)$/
+/**
+ * Regex for a markdown checkbox line. Captures the `[ ]`/`[x]` state in group 1
+ * and the title in group 2. Exported so the paste-import parser
+ * (`src/lib/parsePasteToTasks.ts`) reuses one source of truth for checkbox
+ * detection instead of redefining the grammar.
+ */
+export const CHECKBOX_LINE_REGEX = /^- \[([ x])\] (.+)$/
 
 /** Maximum allowed Completed.title length, mirroring `CreateCompletedSchema`. */
 export const COMPLETED_TITLE_MAX_LENGTH = 255

--- a/src/lib/constants/import.ts
+++ b/src/lib/constants/import.ts
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Shared constants for bulk undo + paste-import.
+ *
+ * `COMPLETED_UNDO_WINDOW_MS` was previously a private const inside
+ * `completed.ts`; it is promoted here because two server consumers now share it
+ * — single-row `completed.delete` and the batch `completed.deleteMany` /
+ * `todo.deleteMany` undo paths — and PR2's 60 s inline "Undo import" UI reads
+ * the same window. Centralizing prevents the two windows from drifting.
+ *
+ * @module lib/constants/import
+ */
+
+/**
+ * Window during which a Completed/Todo row may be hard-deleted via the undo
+ * endpoints. Picked to cover the toast plus generous slack for slow networks;
+ * older rows must go through archival flows so the destructive endpoints cannot
+ * be weaponised against historical data. Because `createdAt` is the real insert
+ * time (never overridden — `completedAt` holds the semantic date), this 60 s
+ * window works even when a paste imports rows with a past `completedAt`.
+ */
+export const COMPLETED_UNDO_WINDOW_MS = 60 * 1000
+
+/**
+ * Hard cap on lines accepted per paste-import batch. Enforced on the server via
+ * Zod `.max(MAX_IMPORT_LINES_PER_BATCH)` and mirrored in the PR2 client preview
+ * ("N lines exceeded — importing the first 1000"). Precedent:
+ * `BRAINDUMP_NOTE_LINES_PER_CAP = 200`; a paste import is bulkier, so the cap is
+ * higher. Overflow is shown, never silently dropped.
+ */
+export const MAX_IMPORT_LINES_PER_BATCH = 1000

--- a/src/lib/parsePasteToTasks.test.ts
+++ b/src/lib/parsePasteToTasks.test.ts
@@ -1,0 +1,209 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+
+import { parsePasteLine, parsePasteToTasks } from './parsePasteToTasks'
+
+describe('parsePasteToTasks', () => {
+  it('keeps each plain text line as its own task title', () => {
+    // Arrange
+    const pastedText = 'buy milk\nwalk the dog\ncall mom'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([
+      { title: 'buy milk', done: false },
+      { title: 'walk the dog', done: false },
+      { title: 'call mom', done: false },
+    ])
+  })
+
+  it('marks a checked checkbox line done and strips the [x] prefix from the title', () => {
+    // Arrange
+    const pastedText = '- [x] shipped the release'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([{ title: 'shipped the release', done: true }])
+  })
+
+  it('marks an unchecked checkbox line not-done and strips the [ ] prefix', () => {
+    // Arrange
+    const pastedText = '- [ ] draft the digest'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([{ title: 'draft the digest', done: false }])
+  })
+
+  it('strips dash, asterisk, and plus bullet prefixes to derive the title', () => {
+    // Arrange
+    const pastedText = '- buy milk\n* walk the dog\n+ call mom'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([
+      { title: 'buy milk', done: false },
+      { title: 'walk the dog', done: false },
+      { title: 'call mom', done: false },
+    ])
+  })
+
+  it('strips numbered list prefixes using both "1." and "2)" styles', () => {
+    // Arrange
+    const pastedText = '1. first thing\n2) second thing'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([
+      { title: 'first thing', done: false },
+      { title: 'second thing', done: false },
+    ])
+  })
+
+  it('preserves a URL line verbatim as the task title', () => {
+    // Arrange
+    const pastedText = 'https://example.com/path?query=1'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([
+      { title: 'https://example.com/path?query=1', done: false },
+    ])
+  })
+
+  it('preserves a markdown heading line verbatim as the task title', () => {
+    // Arrange
+    const pastedText = '# Today'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([{ title: '# Today', done: false }])
+  })
+
+  it('skips blank and whitespace-only lines', () => {
+    // Arrange
+    const pastedText = 'real task\n\n   \n\t\nanother task'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([
+      { title: 'real task', done: false },
+      { title: 'another task', done: false },
+    ])
+  })
+
+  it('clamps a title longer than 255 characters to exactly 255 characters', () => {
+    // Arrange
+    const longTitle = 'a'.repeat(300)
+    const pastedText = `- ${longTitle}`
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0]?.title).toHaveLength(255)
+    expect(tasks[0]?.title).toBe('a'.repeat(255))
+  })
+
+  it('strips only the leading prefix and keeps a mid-line dash intact', () => {
+    // Arrange
+    const pastedText = '- design - review notes'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([{ title: 'design - review notes', done: false }])
+  })
+
+  it('drops a line that is only a list prefix with no content', () => {
+    // Arrange
+    const pastedText = 'keep me\n-   \nkeep me too'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([
+      { title: 'keep me', done: false },
+      { title: 'keep me too', done: false },
+    ])
+  })
+
+  it('normalizes CRLF line endings so no stray carriage return leaks into titles', () => {
+    // Arrange
+    const pastedText = 'first task\r\nsecond task'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([
+      { title: 'first task', done: false },
+      { title: 'second task', done: false },
+    ])
+  })
+
+  it('returns an empty array for text containing only droppable lines', () => {
+    // Arrange
+    const pastedText = '\n   \n\t\n'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([])
+  })
+
+  it('does not treat a dash without a trailing space as a bullet prefix', () => {
+    // Arrange
+    const pastedText = '-no space after dash'
+
+    // Act
+    const tasks = parsePasteToTasks(pastedText)
+
+    // Assert
+    expect(tasks).toEqual([{ title: '-no space after dash', done: false }])
+  })
+})
+
+describe('parsePasteLine', () => {
+  it('returns null for a whitespace-only line', () => {
+    // Arrange
+    const rawLine = '    '
+
+    // Act
+    const parsed = parsePasteLine(rawLine)
+
+    // Assert
+    expect(parsed).toBeNull()
+  })
+
+  it('parses a single checked checkbox line into a done task', () => {
+    // Arrange
+    const rawLine = '- [x] done already'
+
+    // Act
+    const parsed = parsePasteLine(rawLine)
+
+    // Assert
+    expect(parsed).toEqual({ title: 'done already', done: true })
+  })
+})

--- a/src/lib/parsePasteToTasks.test.ts
+++ b/src/lib/parsePasteToTasks.test.ts
@@ -206,4 +206,15 @@ describe('parsePasteLine', () => {
     // Assert
     expect(parsed).toEqual({ title: 'done already', done: true })
   })
+
+  it('matches an indented checkbox instead of leaking the marker into the title', () => {
+    // Arrange
+    const rawLine = '  - [x] nested done'
+
+    // Act
+    const parsed = parsePasteLine(rawLine)
+
+    // Assert
+    expect(parsed).toEqual({ title: 'nested done', done: true })
+  })
 })

--- a/src/lib/parsePasteToTasks.ts
+++ b/src/lib/parsePasteToTasks.ts
@@ -70,9 +70,14 @@ const LIST_PREFIX_REGEX = /^\s*(?:[-*+]|\d+[.)])\s+/
  * parsePasteLine('-   ')                   // => null  (prefix-only)
  */
 export function parsePasteLine(rawLine: string): ParsedPasteTask | null {
+  // Trim leading whitespace first so an indented checkbox / list item (e.g. a
+  // nested "  - [x] task") matches the checkbox grammar instead of falling
+  // through to prefix-stripping, which would leak "[x]" into the title.
+  const line = rawLine.trimStart()
+
   // Checkbox first: capture done-state, then derive the title from the
   // post-prefix capture group so the `[x] ` marker never leaks into the title.
-  const checkboxMatch = CHECKBOX_LINE_REGEX.exec(rawLine)
+  const checkboxMatch = CHECKBOX_LINE_REGEX.exec(line)
   if (checkboxMatch) {
     const checkboxState = checkboxMatch[1]
     const checkboxBody = checkboxMatch[2]
@@ -86,7 +91,7 @@ export function parsePasteLine(rawLine: string): ParsedPasteTask | null {
   // Not a checkbox: strip at most one leading bullet/ordered prefix, then
   // normalize. Anything that wasn't a list (URL, heading, prose) is untouched
   // by the strip and preserved as the title.
-  const withoutPrefix = rawLine.replace(LIST_PREFIX_REGEX, '')
+  const withoutPrefix = line.replace(LIST_PREFIX_REGEX, '')
   const title = normalizeCompletedTitle(withoutPrefix)
   if (title.length === 0) return null
   return { title, done: false }

--- a/src/lib/parsePasteToTasks.ts
+++ b/src/lib/parsePasteToTasks.ts
@@ -1,0 +1,125 @@
+/**
+ * @fileoverview Pure, line-oriented parser for paste-to-import (Issue #53, PR1).
+ *
+ * Unlike `braindumpUtils` (checkbox-only grammar that returns `null` for plain
+ * lines and strips nothing), this parser treats EVERY non-blank line as one
+ * task. It strips only a single leading list/checkbox prefix to derive the
+ * title and preserves URLs, `# headings`, and arbitrary body text as legitimate
+ * titles — a task whose name IS a URL or a heading is valid.
+ *
+ * Why it lives in `src/lib/` (not a component): the same pure util runs in both
+ * the PR2 client preview and the server normalization, so preview count ==
+ * inserted count. No React/Electron deps; reuses `normalizeCompletedTitle` +
+ * `CHECKBOX_LINE_REGEX` from braindumpUtils as the single source of truth for
+ * title clamping and checkbox detection.
+ *
+ * @module lib/parsePasteToTasks
+ */
+
+import {
+  CHECKBOX_LINE_REGEX,
+  normalizeCompletedTitle,
+} from '@/components/braindump/braindumpUtils'
+
+/**
+ * One task parsed from a pasted line.
+ *
+ * `done` records whether the source line was a checked checkbox (`- [x] `). It
+ * is informational only in Slice 1 — routing is by import destination (which
+ * zone the dialog was opened from), NOT by this flag. PR1 procedures ignore it;
+ * a later slice may honor `[x]` to route a line to Completed from any zone.
+ *
+ * @example
+ * const task: ParsedPasteTask = { title: 'write tests', done: true }
+ */
+export type ParsedPasteTask = {
+  /** The derived title: trimmed, 255-clamped, with any leading list prefix stripped. */
+  title: string
+  /** True when the source line was a checked markdown checkbox (`- [x] `). */
+  done: boolean
+}
+
+/**
+ * Strips a single leading bullet (`- `, `* `, `+ `) or ordered-list (`1. `,
+ * `2) `, …) prefix. Anchored at start with required trailing whitespace so a
+ * mid-line `-` or a dash without a following space is never stripped. Checkbox
+ * lines are handled separately (and earlier), so this never sees `- [ ] `.
+ */
+const LIST_PREFIX_REGEX = /^\s*(?:[-*+]|\d+[.)])\s+/
+
+/**
+ * Parses a single raw line into a {@link ParsedPasteTask}, or `null` when the
+ * line normalizes to empty (blank / whitespace-only / prefix-only).
+ *
+ * Order matters: the checkbox grammar is tried FIRST so `- [x] ` sets
+ * `done:true` and contributes only the post-prefix title; otherwise a single
+ * leading list/ordered prefix is stripped. Lines that match neither (URLs,
+ * `# headings`, plain text) are preserved verbatim as the title.
+ *
+ * @param rawLine - One line of pasted text (no trailing newline).
+ * @returns
+ * - `{ title, done }` when the line yields a non-empty title after normalize
+ * - `null` when the line is blank, whitespace-only, or only a list prefix
+ * @example
+ * parsePasteLine('- [x] write tests')      // => { title: 'write tests', done: true }
+ * parsePasteLine('- buy milk')             // => { title: 'buy milk', done: false }
+ * parsePasteLine('1. ship it')             // => { title: 'ship it', done: false }
+ * parsePasteLine('https://example.com')    // => { title: 'https://example.com', done: false }
+ * parsePasteLine('# Today')                // => { title: '# Today', done: false }
+ * parsePasteLine('   ')                    // => null
+ * parsePasteLine('-   ')                   // => null  (prefix-only)
+ */
+export function parsePasteLine(rawLine: string): ParsedPasteTask | null {
+  // Checkbox first: capture done-state, then derive the title from the
+  // post-prefix capture group so the `[x] ` marker never leaks into the title.
+  const checkboxMatch = CHECKBOX_LINE_REGEX.exec(rawLine)
+  if (checkboxMatch) {
+    const checkboxState = checkboxMatch[1]
+    const checkboxBody = checkboxMatch[2]
+    if (checkboxBody !== undefined) {
+      const title = normalizeCompletedTitle(checkboxBody)
+      if (title.length === 0) return null
+      return { title, done: checkboxState === 'x' }
+    }
+  }
+
+  // Not a checkbox: strip at most one leading bullet/ordered prefix, then
+  // normalize. Anything that wasn't a list (URL, heading, prose) is untouched
+  // by the strip and preserved as the title.
+  const withoutPrefix = rawLine.replace(LIST_PREFIX_REGEX, '')
+  const title = normalizeCompletedTitle(withoutPrefix)
+  if (title.length === 0) return null
+  return { title, done: false }
+}
+
+/**
+ * Parses pasted multi-line text into one task per NON-blank line. Blank /
+ * whitespace-only / prefix-only lines are dropped so the parsed count equals
+ * the count the import will insert. Pure — the same util backs the PR2 client
+ * preview and the server-side normalization, keeping preview == inserted.
+ *
+ * @param text - The full pasted text (any mix of `\n` / `\r\n` line endings).
+ * @returns
+ * - `ParsedPasteTask[]` in document order, one per surviving line
+ * - Empty array when `text` is empty or contains only droppable lines
+ * @example
+ * parsePasteToTasks('- [x] shipped\n\n- buy milk\n# notes')
+ * // => [
+ * //   { title: 'shipped', done: true },
+ * //   { title: 'buy milk', done: false },
+ * //   { title: '# notes', done: false },
+ * // ]
+ * @example
+ * parsePasteToTasks('\n   \n') // => []
+ */
+export function parsePasteToTasks(text: string): ParsedPasteTask[] {
+  // Normalize CRLF/CR to LF before splitting so a Windows/Mac-classic paste
+  // does not leave a stray \r at the end of each title.
+  const lines = text.replace(/\r\n?/g, '\n').split('\n')
+  const tasks: ParsedPasteTask[] = []
+  for (const line of lines) {
+    const parsed = parsePasteLine(line)
+    if (parsed) tasks.push(parsed)
+  }
+  return tasks
+}

--- a/src/server/procedures/completed.createMany.test.ts
+++ b/src/server/procedures/completed.createMany.test.ts
@@ -162,7 +162,7 @@ describe('completed.createMany', () => {
         },
         authContext(attackerClerkId),
       ),
-    ).rejects.toThrow()
+    ).rejects.toThrow(/category not found/i)
   })
 
   it('drops lines that normalize to empty before inserting', async () => {
@@ -198,14 +198,15 @@ describe('completed.createMany', () => {
       title: `task ${index}`,
     }))
 
-    // Act + Assert
+    // Act + Assert — Zod .max(1000) rejects 1001; oRPC surfaces the schema
+    // failure as an "Input validation failed" BAD_REQUEST (not a DB/other error)
     await expect(
       call(
         createManyCompleted,
         { items, importBatchId: randomUUID() },
         authContext(clerkId),
       ),
-    ).rejects.toThrow()
+    ).rejects.toThrow(/input validation failed/i)
   })
 
   it('stamps completedAt to the provided past date while keeping createdAt as the real insert time', async () => {

--- a/src/server/procedures/completed.createMany.test.ts
+++ b/src/server/procedures/completed.createMany.test.ts
@@ -8,6 +8,12 @@ import { prisma } from '@/lib/prisma'
 
 import { createManyCompleted, deleteManyCompleted } from './completed'
 
+// Real-DB integration suites: run only when RUN_DB_INTEGRATION_TESTS=1 (the CI
+// `test` job sets it after Postgres is up; set it locally with `docker compose
+// up`). Skip cleanly in DB-less contexts so they never block unrelated runs.
+const describeIfDb =
+  process.env.RUN_DB_INTEGRATION_TESTS === '1' ? describe : describe.skip
+
 /**
  * Real-DB procedure harness. Each test creates a fresh user via a unique Clerk
  * id so rows never collide across runs of the persistent dev database. We run
@@ -48,7 +54,7 @@ afterEach(async () => {
   createdClerkIds.clear()
 })
 
-describe('completed.createMany', () => {
+describeIfDb('completed.createMany', () => {
   it('inserts one Completed row per item without deduplicating repeated titles', async () => {
     // Arrange
     const clerkId = freshClerkId()
@@ -235,7 +241,7 @@ describe('completed.createMany', () => {
   })
 })
 
-describe('completed.deleteMany (bulk undo)', () => {
+describeIfDb('completed.deleteMany (bulk undo)', () => {
   it('deletes only the matching batch and leaves a sibling batch untouched', async () => {
     // Arrange — two batches for the same user
     const clerkId = freshClerkId()
@@ -343,36 +349,39 @@ describe('completed.deleteMany (bulk undo)', () => {
   })
 })
 
-describe('completed.createMany heatmap-day stability after migration', () => {
-  it('buckets an existing row with null completedAt on its createdAt day', async () => {
-    // Arrange — simulate a pre-migration row whose completedAt was never set
-    // (backfill is a no-op on an empty table, so we exercise the `?? createdAt`
-    // coalesce directly). Insert a Completed row, then null its completedAt.
-    const clerkId = freshClerkId()
-    const importBatchId = randomUUID()
-    await call(
-      createManyCompleted,
-      { items: [{ title: 'legacy row' }], importBatchId },
-      authContext(clerkId),
-    )
-    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
-    const legacyCreatedAt = new Date('2026-03-15T08:30:00.000Z')
-    await prisma.completed.updateMany({
-      where: { userId: user.id, importBatchId },
-      data: { completedAt: null, createdAt: legacyCreatedAt },
-    })
+describeIfDb(
+  'completed.createMany heatmap-day stability after migration',
+  () => {
+    it('buckets an existing row with null completedAt on its createdAt day', async () => {
+      // Arrange — simulate a pre-migration row whose completedAt was never set
+      // (backfill is a no-op on an empty table, so we exercise the `?? createdAt`
+      // coalesce directly). Insert a Completed row, then null its completedAt.
+      const clerkId = freshClerkId()
+      const importBatchId = randomUUID()
+      await call(
+        createManyCompleted,
+        { items: [{ title: 'legacy row' }], importBatchId },
+        authContext(clerkId),
+      )
+      const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+      const legacyCreatedAt = new Date('2026-03-15T08:30:00.000Z')
+      await prisma.completed.updateMany({
+        where: { userId: user.id, importBatchId },
+        data: { completedAt: null, createdAt: legacyCreatedAt },
+      })
 
-    // Act — read the row the way the heatmap aggregation does
-    const row = await prisma.completed.findFirstOrThrow({
-      where: { userId: user.id, importBatchId },
-      select: { completedAt: true, createdAt: true },
-    })
-    const bucketDate = (row.completedAt ?? row.createdAt)
-      .toISOString()
-      .split('T')[0]
+      // Act — read the row the way the heatmap aggregation does
+      const row = await prisma.completed.findFirstOrThrow({
+        where: { userId: user.id, importBatchId },
+        select: { completedAt: true, createdAt: true },
+      })
+      const bucketDate = (row.completedAt ?? row.createdAt)
+        .toISOString()
+        .split('T')[0]
 
-    // Assert — falls back to createdAt's day, not migration-day
-    expect(row.completedAt).toBeNull()
-    expect(bucketDate).toBe('2026-03-15')
-  })
-})
+      // Assert — falls back to createdAt's day, not migration-day
+      expect(row.completedAt).toBeNull()
+      expect(bucketDate).toBe('2026-03-15')
+    })
+  },
+)

--- a/src/server/procedures/completed.createMany.test.ts
+++ b/src/server/procedures/completed.createMany.test.ts
@@ -1,0 +1,377 @@
+// @vitest-environment node
+import { randomUUID } from 'node:crypto'
+
+import { call } from '@orpc/server'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { prisma } from '@/lib/prisma'
+
+import { createManyCompleted, deleteManyCompleted } from './completed'
+
+/**
+ * Real-DB procedure harness. Each test creates a fresh user via a unique Clerk
+ * id so rows never collide across runs of the persistent dev database. We run
+ * the REAL `authMiddleware` (never mocked): `call` passes a `headers` context
+ * with a Bearer token, the middleware upserts the user by clerkId, and the
+ * handler runs against the live Postgres on :5432.
+ */
+function authContext(clerkId: string) {
+  return {
+    context: {
+      headers: new Headers({ Authorization: `Bearer ${clerkId}` }),
+    },
+  }
+}
+
+// Track every clerkId a test touches so afterEach can delete the user and all
+// FK-dependent rows in a safe order (User has no onDelete cascade from
+// Completed/Todo/Category; ImportBatch cascades with the user).
+const createdClerkIds = new Set<string>()
+
+function freshClerkId(): string {
+  const clerkId = `test_import_${randomUUID()}`
+  createdClerkIds.add(clerkId)
+  return clerkId
+}
+
+afterEach(async () => {
+  for (const clerkId of createdClerkIds) {
+    const user = await prisma.user.findUnique({ where: { clerkId } })
+    if (!user) continue
+    // FK-safe teardown: child rows before the user.
+    await prisma.completed.deleteMany({ where: { userId: user.id } })
+    await prisma.todo.deleteMany({ where: { userId: user.id } })
+    await prisma.importBatch.deleteMany({ where: { userId: user.id } })
+    await prisma.category.deleteMany({ where: { userId: user.id } })
+    await prisma.user.delete({ where: { id: user.id } })
+  }
+  createdClerkIds.clear()
+})
+
+describe('completed.createMany', () => {
+  it('inserts one Completed row per item without deduplicating repeated titles', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+
+    // Act
+    const result = await call(
+      createManyCompleted,
+      {
+        items: [
+          { title: 'English study' },
+          { title: 'English study' },
+          { title: 'English study' },
+        ],
+        importBatchId,
+      },
+      authContext(clerkId),
+    )
+
+    // Assert
+    expect(result).toEqual({ count: 3, idempotent: false })
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const rows = await prisma.completed.findMany({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(rows).toHaveLength(3)
+    expect(rows.every((row) => row.title === 'English study')).toBe(true)
+  })
+
+  it('returns the prior count and inserts nothing new when the same importBatchId is resubmitted', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+    const firstResult = await call(
+      createManyCompleted,
+      { items: [{ title: 'a' }, { title: 'b' }], importBatchId },
+      authContext(clerkId),
+    )
+    expect(firstResult).toEqual({ count: 2, idempotent: false })
+
+    // Act — resubmit the exact same batch id (network retry / double-fire)
+    const secondResult = await call(
+      createManyCompleted,
+      { items: [{ title: 'a' }, { title: 'b' }], importBatchId },
+      authContext(clerkId),
+    )
+
+    // Assert — idempotent no-op, prior count echoed, no extra rows
+    expect(secondResult).toEqual({ count: 2, idempotent: true })
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const totalRows = await prisma.completed.count({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(totalRows).toBe(2)
+  })
+
+  it('assigns the get-or-create default category to items with no categoryId', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+
+    // Act
+    await call(
+      createManyCompleted,
+      { items: [{ title: 'no category here' }], importBatchId },
+      authContext(clerkId),
+    )
+
+    // Assert — a default "General" category was created and the row points at it
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const defaultCategory = await prisma.category.findFirstOrThrow({
+      where: { userId: user.id, isDefault: true },
+    })
+    expect(defaultCategory.name).toBe('General')
+    const row = await prisma.completed.findFirstOrThrow({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(row.categoryId).toBe(defaultCategory.id)
+  })
+
+  it('rejects a categoryId that belongs to a different user', async () => {
+    // Arrange — owner user with a real category, plus a separate attacker user
+    const ownerClerkId = freshClerkId()
+    const attackerClerkId = freshClerkId()
+    await call(
+      createManyCompleted,
+      { items: [{ title: 'owner seed' }], importBatchId: randomUUID() },
+      authContext(ownerClerkId),
+    )
+    const ownerUser = await prisma.user.findUniqueOrThrow({
+      where: { clerkId: ownerClerkId },
+    })
+    const ownerCategory = await prisma.category.findFirstOrThrow({
+      where: { userId: ownerUser.id },
+    })
+    // Materialize the attacker user (auth upsert) so the rejection isn't a
+    // side effect of a missing user.
+    await call(
+      createManyCompleted,
+      { items: [{ title: 'attacker seed' }], importBatchId: randomUUID() },
+      authContext(attackerClerkId),
+    )
+
+    // Act + Assert — attacker references the owner's categoryId → NOT_FOUND
+    await expect(
+      call(
+        createManyCompleted,
+        {
+          items: [{ title: 'sneaky', categoryId: ownerCategory.id }],
+          importBatchId: randomUUID(),
+        },
+        authContext(attackerClerkId),
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('drops lines that normalize to empty before inserting', async () => {
+    // Arrange — second item is whitespace-only; Zod .min(1) passes it, the
+    // server-side normalize must drop it so only one row is inserted.
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+
+    // Act
+    const result = await call(
+      createManyCompleted,
+      {
+        items: [{ title: 'keep me' }, { title: '   ' }],
+        importBatchId,
+      },
+      authContext(clerkId),
+    )
+
+    // Assert
+    expect(result).toEqual({ count: 1, idempotent: false })
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const rows = await prisma.completed.findMany({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.title).toBe('keep me')
+  })
+
+  it('rejects a batch of exactly 1001 items at the Zod cap', async () => {
+    // Arrange — one over MAX_IMPORT_LINES_PER_BATCH (1000)
+    const clerkId = freshClerkId()
+    const items = Array.from({ length: 1001 }, (_unused, index) => ({
+      title: `task ${index}`,
+    }))
+
+    // Act + Assert
+    await expect(
+      call(
+        createManyCompleted,
+        { items, importBatchId: randomUUID() },
+        authContext(clerkId),
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('stamps completedAt to the provided past date while keeping createdAt as the real insert time', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+    const pastDate = new Date('2025-01-01T00:00:00.000Z')
+
+    // Act
+    await call(
+      createManyCompleted,
+      {
+        items: [{ title: 'logged for last year', completedAt: pastDate }],
+        importBatchId,
+      },
+      authContext(clerkId),
+    )
+
+    // Assert — completedAt is the semantic past date; createdAt is "now"
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const row = await prisma.completed.findFirstOrThrow({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(row.completedAt?.toISOString()).toBe('2025-01-01T00:00:00.000Z')
+    expect(row.createdAt.getTime()).toBeGreaterThan(pastDate.getTime())
+  })
+})
+
+describe('completed.deleteMany (bulk undo)', () => {
+  it('deletes only the matching batch and leaves a sibling batch untouched', async () => {
+    // Arrange — two batches for the same user
+    const clerkId = freshClerkId()
+    const batchToUndo = randomUUID()
+    const batchToKeep = randomUUID()
+    await call(
+      createManyCompleted,
+      {
+        items: [{ title: 'undo-1' }, { title: 'undo-2' }],
+        importBatchId: batchToUndo,
+      },
+      authContext(clerkId),
+    )
+    await call(
+      createManyCompleted,
+      { items: [{ title: 'keep-1' }], importBatchId: batchToKeep },
+      authContext(clerkId),
+    )
+
+    // Act
+    const result = await call(
+      deleteManyCompleted,
+      { importBatchId: batchToUndo },
+      authContext(clerkId),
+    )
+
+    // Assert — only the undone batch's rows are gone
+    expect(result).toEqual({ count: 2 })
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const undoneRows = await prisma.completed.count({
+      where: { userId: user.id, importBatchId: batchToUndo },
+    })
+    const keptRows = await prisma.completed.count({
+      where: { userId: user.id, importBatchId: batchToKeep },
+    })
+    expect(undoneRows).toBe(0)
+    expect(keptRows).toBe(1)
+  })
+
+  it("does not delete another user's rows sharing the same importBatchId", async () => {
+    // Arrange — two users; only the first imports under `sharedBatchId`. We
+    // then try to undo it as the second user.
+    const firstClerkId = freshClerkId()
+    const secondClerkId = freshClerkId()
+    const sharedBatchId = randomUUID()
+    await call(
+      createManyCompleted,
+      { items: [{ title: 'first-user-row' }], importBatchId: sharedBatchId },
+      authContext(firstClerkId),
+    )
+    // Materialize the second user.
+    await call(
+      createManyCompleted,
+      { items: [{ title: 'second-user-seed' }], importBatchId: randomUUID() },
+      authContext(secondClerkId),
+    )
+
+    // Act — second user attempts to undo the first user's batch id
+    const result = await call(
+      deleteManyCompleted,
+      { importBatchId: sharedBatchId },
+      authContext(secondClerkId),
+    )
+
+    // Assert — nothing deleted; the first user's row survives
+    expect(result).toEqual({ count: 0 })
+    const firstUser = await prisma.user.findUniqueOrThrow({
+      where: { clerkId: firstClerkId },
+    })
+    const firstUserRows = await prisma.completed.count({
+      where: { userId: firstUser.id, importBatchId: sharedBatchId },
+    })
+    expect(firstUserRows).toBe(1)
+  })
+
+  it('deletes nothing once the undo window has expired', async () => {
+    // Arrange — import a batch, then backdate its createdAt past the 60s window.
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+    await call(
+      createManyCompleted,
+      { items: [{ title: 'too old to undo' }], importBatchId },
+      authContext(clerkId),
+    )
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    // Push createdAt two minutes into the past so the window guard excludes it.
+    await prisma.completed.updateMany({
+      where: { userId: user.id, importBatchId },
+      data: { createdAt: new Date(Date.now() - 2 * 60 * 1000) },
+    })
+
+    // Act
+    const result = await call(
+      deleteManyCompleted,
+      { importBatchId },
+      authContext(clerkId),
+    )
+
+    // Assert — window expired, row remains
+    expect(result).toEqual({ count: 0 })
+    const remaining = await prisma.completed.count({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(remaining).toBe(1)
+  })
+})
+
+describe('completed.createMany heatmap-day stability after migration', () => {
+  it('buckets an existing row with null completedAt on its createdAt day', async () => {
+    // Arrange — simulate a pre-migration row whose completedAt was never set
+    // (backfill is a no-op on an empty table, so we exercise the `?? createdAt`
+    // coalesce directly). Insert a Completed row, then null its completedAt.
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+    await call(
+      createManyCompleted,
+      { items: [{ title: 'legacy row' }], importBatchId },
+      authContext(clerkId),
+    )
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const legacyCreatedAt = new Date('2026-03-15T08:30:00.000Z')
+    await prisma.completed.updateMany({
+      where: { userId: user.id, importBatchId },
+      data: { completedAt: null, createdAt: legacyCreatedAt },
+    })
+
+    // Act — read the row the way the heatmap aggregation does
+    const row = await prisma.completed.findFirstOrThrow({
+      where: { userId: user.id, importBatchId },
+      select: { completedAt: true, createdAt: true },
+    })
+    const bucketDate = (row.completedAt ?? row.createdAt)
+      .toISOString()
+      .split('T')[0]
+
+    // Assert — falls back to createdAt's day, not migration-day
+    expect(row.completedAt).toBeNull()
+    expect(bucketDate).toBe('2026-03-15')
+  })
+})

--- a/src/server/procedures/completed.ts
+++ b/src/server/procedures/completed.ts
@@ -1,6 +1,7 @@
 import { ORPCError } from '@orpc/server'
 import { z } from 'zod'
 
+import { COMPLETED_UNDO_WINDOW_MS } from '@/lib/constants/import'
 import { prisma } from '@/lib/prisma'
 
 import { log } from '../../lib/logger'
@@ -302,14 +303,6 @@ export const createCompleted = authMiddleware
       })
     }
   })
-
-/**
- * Window during which a Completed row may be hard-deleted via this endpoint.
- * Picked to cover the 5 s toast plus generous slack for slow networks; older
- * rows must go through archival flows so the destructive endpoint cannot be
- * weaponised against historical data.
- */
-const COMPLETED_UNDO_WINDOW_MS = 60 * 1000
 
 /**
  * Hard-deletes a Completed row owned by the authenticated user, but only

--- a/src/server/procedures/completed.ts
+++ b/src/server/procedures/completed.ts
@@ -1,6 +1,8 @@
 import { ORPCError } from '@orpc/server'
+import { Prisma } from '@prisma/client'
 import { z } from 'zod'
 
+import { normalizeCompletedTitle } from '@/components/braindump/braindumpUtils'
 import { COMPLETED_UNDO_WINDOW_MS } from '@/lib/constants/import'
 import { prisma } from '@/lib/prisma'
 
@@ -9,13 +11,18 @@ import { authMiddleware } from '../middleware/auth'
 import {
   CompletedSchema,
   CreateCompletedSchema,
+  CreateManyCompletedResponseSchema,
+  CreateManyCompletedSchema,
   DayDetailInputSchema,
   DayDetailResponseSchema,
   DeleteCompletedSchema,
+  DeleteManyCompletedResponseSchema,
+  DeleteManyCompletedSchema,
   HeatmapInputSchema,
   HeatmapResponseSchema,
 } from '../schemas/completed'
 import { fetchCompletedEntries } from '../utils/completedAggregation'
+import { resolveImportCategoryIds } from '../utils/resolveImportCategoryIds'
 
 /**
  * Fetches heatmap data for completed tasks, aggregated by UTC date with a
@@ -357,4 +364,152 @@ export const deleteCompleted = authMiddleware
     throw new ORPCError('NOT_FOUND', {
       message: 'Completed row not found',
     })
+  })
+
+/**
+ * Bulk-inserts paste-imported rows into the Completed zone for the
+ * authenticated user, lighting the heatmap. Triggered by the PR2 paste-import
+ * dialog's confirm on the Completed zone. Idempotent via `importBatchId`: a
+ * resubmit of the same batch (network retry, double-click, second tab) is a
+ * no-op that returns the already-inserted count instead of duplicating rows.
+ *
+ * No dedup — repeated titles are intentional habit/XP signals. The only
+ * uniqueness is on the batch id (the `ImportBatch` PK), never on task content.
+ *
+ * Flow:
+ * 1. Server-side normalize + drop empty titles (Zod `.min(1)` does not catch a
+ *    whitespace-only title that normalizes to `""`), so preview == inserted.
+ * 2. Resolve every item's categoryId BEFORE the transaction (ownership-verify
+ *    provided ids; get-or-create the default for omitted ones) so the only
+ *    in-transaction P2002 source is the ImportBatch insert.
+ * 3. In one `$transaction`: insert the ImportBatch guard row, then createMany.
+ *    A duplicate batch id throws P2002 (caught outside) → idempotent re-query.
+ *
+ * @param input.items - 1..1000 items `{ title, categoryId?, completedAt? }`
+ * @param input.importBatchId - Client-generated globally-unique batch id
+ * @returns
+ * - `{ count, idempotent: false }` on a fresh insert (count = rows inserted)
+ * - `{ count, idempotent: true }` when the batch id already existed (no-op)
+ * @throws ORPCError('BAD_REQUEST') when every line normalizes to empty
+ * @throws ORPCError('NOT_FOUND') when a provided categoryId is not owned
+ * @example
+ * createManyCompleted({ items: [{ title: 'gym' }, { title: 'gym' }], importBatchId: 'b2c1…' })
+ * // => { count: 2, idempotent: false } (two real rows — repetition preserved)
+ */
+export const createManyCompleted = authMiddleware
+  .input(CreateManyCompletedSchema)
+  .output(CreateManyCompletedResponseSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const { user } = context
+      const { items, importBatchId } = input
+
+      // Step 1: normalize titles and drop lines that become empty. This mirrors
+      // the client preview's parser so the inserted count == the previewed
+      // count, and prevents a whitespace-only title from reaching the DB.
+      const normalizedItems = items
+        .map((item) => ({
+          title: normalizeCompletedTitle(item.title),
+          categoryId: item.categoryId,
+          completedAt: item.completedAt,
+        }))
+        .filter((item) => item.title.length > 0)
+
+      if (normalizedItems.length === 0) {
+        throw new ORPCError('BAD_REQUEST', {
+          message: 'No importable lines after normalization',
+        })
+      }
+
+      // Step 2: resolve categories outside the transaction so the only
+      // in-transaction P2002 source is the ImportBatch guard insert.
+      const resolveCategoryId = await resolveImportCategoryIds(
+        user.id,
+        normalizedItems,
+      )
+
+      // Slice 1 lands everything on today; `completedAt` defaults to now() when
+      // the item omits it. createdAt (real insert time) stays separate so the
+      // undo window works even for a past completedAt.
+      const importedAt = new Date()
+      const rows = normalizedItems.map((item) => ({
+        title: item.title,
+        categoryId: resolveCategoryId(item),
+        userId: user.id,
+        completedAt: item.completedAt ?? importedAt,
+        importBatchId,
+      }))
+
+      // Step 3: ImportBatch guard insert + createMany in one transaction. A
+      // failed createMany rolls back the guard so a genuine retry still inserts.
+      const result = await prisma.$transaction(async (tx) => {
+        await tx.importBatch.create({
+          data: { id: importBatchId, userId: user.id },
+        })
+        const created = await tx.completed.createMany({ data: rows })
+        return { count: created.count, idempotent: false }
+      })
+
+      return result
+    } catch (error) {
+      // P2002 on the ImportBatch insert = this batch id was already imported.
+      // Idempotent no-op: re-query the prior count and return it. Caught here,
+      // OUTSIDE the transaction, because a failed statement aborts the PG tx
+      // (cannot catch-and-continue on `tx`).
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        const count = await prisma.completed.count({
+          where: {
+            userId: context.user.id,
+            importBatchId: input.importBatchId,
+          },
+        })
+        return { count, idempotent: true }
+      }
+      if (error instanceof ORPCError) throw error
+      log.error('Error in createManyCompleted:', error)
+      throw new ORPCError('INTERNAL_SERVER_ERROR', {
+        message: 'Failed to import completed rows',
+        cause: error,
+      })
+    }
+  })
+
+/**
+ * Bulk-undoes a paste-import batch by deleting every Completed row tagged with
+ * the given `importBatchId`, scoped to the caller and guarded by
+ * {@link COMPLETED_UNDO_WINDOW_MS}. Triggered by PR2's "Undo import" toast /
+ * inline control within 60 s of the import.
+ *
+ * Atomic single-statement delete: ownership + freshness are part of the `where`
+ * so a second tab or an undo racing the window expiry cannot double-delete.
+ * Deletes by `importBatchId` (never by ids — `createMany` returns only a
+ * count); the window keys off `createdAt` (the real insert time), so it works
+ * even when the batch's `completedAt` is a past date.
+ *
+ * @param input.importBatchId - The batch id returned/used at import time
+ * @returns `{ count }` — rows removed (0 once the undo window has expired)
+ * @example
+ * deleteManyCompleted({ importBatchId: 'b2c1…' }) // => { count: 50 }
+ */
+export const deleteManyCompleted = authMiddleware
+  .input(DeleteManyCompletedSchema)
+  .output(DeleteManyCompletedResponseSchema)
+  .handler(async ({ input, context }) => {
+    const { user } = context
+    const { importBatchId } = input
+
+    const result = await prisma.completed.deleteMany({
+      where: {
+        userId: user.id,
+        importBatchId,
+        createdAt: {
+          gte: new Date(Date.now() - COMPLETED_UNDO_WINDOW_MS),
+        },
+      },
+    })
+
+    return { count: result.count }
   })

--- a/src/server/procedures/todo.createMany.test.ts
+++ b/src/server/procedures/todo.createMany.test.ts
@@ -181,7 +181,7 @@ describe('todo.createMany', () => {
       authContext(attackerClerkId),
     )
 
-    // Act + Assert
+    // Act + Assert — attacker references the owner's categoryId → NOT_FOUND
     await expect(
       call(
         createManyTodo,
@@ -191,7 +191,7 @@ describe('todo.createMany', () => {
         },
         authContext(attackerClerkId),
       ),
-    ).rejects.toThrow()
+    ).rejects.toThrow(/category not found/i)
   })
 
   it('drops lines that normalize to empty before inserting', async () => {
@@ -223,14 +223,15 @@ describe('todo.createMany', () => {
       title: `task ${index}`,
     }))
 
-    // Act + Assert
+    // Act + Assert — Zod .max(1000) rejects 1001; oRPC surfaces the schema
+    // failure as an "Input validation failed" BAD_REQUEST (not a DB/other error)
     await expect(
       call(
         createManyTodo,
         { items, importBatchId: randomUUID() },
         authContext(clerkId),
       ),
-    ).rejects.toThrow()
+    ).rejects.toThrow(/input validation failed/i)
   })
 })
 

--- a/src/server/procedures/todo.createMany.test.ts
+++ b/src/server/procedures/todo.createMany.test.ts
@@ -8,6 +8,12 @@ import { prisma } from '@/lib/prisma'
 
 import { createManyTodo, deleteManyTodo } from './todo'
 
+// Real-DB integration suites: run only when RUN_DB_INTEGRATION_TESTS=1 (the CI
+// `test` job sets it after Postgres is up; set it locally with `docker compose
+// up`). Skip cleanly in DB-less contexts so they never block unrelated runs.
+const describeIfDb =
+  process.env.RUN_DB_INTEGRATION_TESTS === '1' ? describe : describe.skip
+
 /**
  * Real-DB procedure harness. Each test creates a fresh user via a unique Clerk
  * id so rows never collide across runs of the persistent dev database. The REAL
@@ -45,7 +51,7 @@ afterEach(async () => {
   createdClerkIds.clear()
 })
 
-describe('todo.createMany', () => {
+describeIfDb('todo.createMany', () => {
   it('inserts one incomplete Todo per item without deduplicating repeated titles', async () => {
     // Arrange
     const clerkId = freshClerkId()
@@ -235,7 +241,7 @@ describe('todo.createMany', () => {
   })
 })
 
-describe('todo.deleteMany (bulk undo)', () => {
+describeIfDb('todo.deleteMany (bulk undo)', () => {
   it('deletes only the matching batch and leaves a sibling batch untouched', async () => {
     // Arrange — two batches for the same user
     const clerkId = freshClerkId()

--- a/src/server/procedures/todo.createMany.test.ts
+++ b/src/server/procedures/todo.createMany.test.ts
@@ -1,0 +1,340 @@
+// @vitest-environment node
+import { randomUUID } from 'node:crypto'
+
+import { call } from '@orpc/server'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { prisma } from '@/lib/prisma'
+
+import { createManyTodo, deleteManyTodo } from './todo'
+
+/**
+ * Real-DB procedure harness. Each test creates a fresh user via a unique Clerk
+ * id so rows never collide across runs of the persistent dev database. The REAL
+ * `authMiddleware` runs (never mocked): `call` passes a `headers` context with a
+ * Bearer token, the middleware upserts the user by clerkId, and the handler
+ * runs against the live Postgres on :5432.
+ */
+function authContext(clerkId: string) {
+  return {
+    context: {
+      headers: new Headers({ Authorization: `Bearer ${clerkId}` }),
+    },
+  }
+}
+
+const createdClerkIds = new Set<string>()
+
+function freshClerkId(): string {
+  const clerkId = `test_todo_import_${randomUUID()}`
+  createdClerkIds.add(clerkId)
+  return clerkId
+}
+
+afterEach(async () => {
+  for (const clerkId of createdClerkIds) {
+    const user = await prisma.user.findUnique({ where: { clerkId } })
+    if (!user) continue
+    // FK-safe teardown: child rows before the user.
+    await prisma.completed.deleteMany({ where: { userId: user.id } })
+    await prisma.todo.deleteMany({ where: { userId: user.id } })
+    await prisma.importBatch.deleteMany({ where: { userId: user.id } })
+    await prisma.category.deleteMany({ where: { userId: user.id } })
+    await prisma.user.delete({ where: { id: user.id } })
+  }
+  createdClerkIds.clear()
+})
+
+describe('todo.createMany', () => {
+  it('inserts one incomplete Todo per item without deduplicating repeated titles', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+
+    // Act
+    const result = await call(
+      createManyTodo,
+      {
+        items: [{ title: 'write the spec' }, { title: 'write the spec' }],
+        importBatchId,
+      },
+      authContext(clerkId),
+    )
+
+    // Assert
+    expect(result).toEqual({ count: 2, idempotent: false })
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const rows = await prisma.todo.findMany({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(rows).toHaveLength(2)
+    expect(rows.every((row) => row.text === 'write the spec')).toBe(true)
+    expect(rows.every((row) => row.completed === false)).toBe(true)
+  })
+
+  it('assigns sequential order values starting after the existing max so the paste lands last and keeps its order', async () => {
+    // Arrange — seed one existing todo at order 0 via the default category.
+    const clerkId = freshClerkId()
+    const seedBatchId = randomUUID()
+    await call(
+      createManyTodo,
+      { items: [{ title: 'existing todo' }], importBatchId: seedBatchId },
+      authContext(clerkId),
+    )
+    const importBatchId = randomUUID()
+
+    // Act — import two more todos
+    await call(
+      createManyTodo,
+      {
+        items: [{ title: 'pasted first' }, { title: 'pasted second' }],
+        importBatchId,
+      },
+      authContext(clerkId),
+    )
+
+    // Assert — the existing todo is order 0; the paste is 1 then 2 (in order)
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const seeded = await prisma.todo.findFirstOrThrow({
+      where: { userId: user.id, importBatchId: seedBatchId },
+    })
+    const pastedFirst = await prisma.todo.findFirstOrThrow({
+      where: { userId: user.id, importBatchId, text: 'pasted first' },
+    })
+    const pastedSecond = await prisma.todo.findFirstOrThrow({
+      where: { userId: user.id, importBatchId, text: 'pasted second' },
+    })
+    expect(seeded.order).toBe(0)
+    expect(pastedFirst.order).toBe(1)
+    expect(pastedSecond.order).toBe(2)
+  })
+
+  it('returns the prior count and inserts nothing new when the same importBatchId is resubmitted', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+    const firstResult = await call(
+      createManyTodo,
+      { items: [{ title: 'a' }, { title: 'b' }], importBatchId },
+      authContext(clerkId),
+    )
+    expect(firstResult).toEqual({ count: 2, idempotent: false })
+
+    // Act — resubmit the same batch id
+    const secondResult = await call(
+      createManyTodo,
+      { items: [{ title: 'a' }, { title: 'b' }], importBatchId },
+      authContext(clerkId),
+    )
+
+    // Assert — idempotent no-op
+    expect(secondResult).toEqual({ count: 2, idempotent: true })
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const totalRows = await prisma.todo.count({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(totalRows).toBe(2)
+  })
+
+  it('assigns the get-or-create default category to items with no categoryId', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+
+    // Act
+    await call(
+      createManyTodo,
+      { items: [{ title: 'uncategorized todo' }], importBatchId },
+      authContext(clerkId),
+    )
+
+    // Assert
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const defaultCategory = await prisma.category.findFirstOrThrow({
+      where: { userId: user.id, isDefault: true },
+    })
+    expect(defaultCategory.name).toBe('General')
+    const row = await prisma.todo.findFirstOrThrow({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(row.categoryId).toBe(defaultCategory.id)
+  })
+
+  it('rejects a categoryId that belongs to a different user', async () => {
+    // Arrange — owner with a category + a separate attacker user
+    const ownerClerkId = freshClerkId()
+    const attackerClerkId = freshClerkId()
+    await call(
+      createManyTodo,
+      { items: [{ title: 'owner seed' }], importBatchId: randomUUID() },
+      authContext(ownerClerkId),
+    )
+    const ownerUser = await prisma.user.findUniqueOrThrow({
+      where: { clerkId: ownerClerkId },
+    })
+    const ownerCategory = await prisma.category.findFirstOrThrow({
+      where: { userId: ownerUser.id },
+    })
+    await call(
+      createManyTodo,
+      { items: [{ title: 'attacker seed' }], importBatchId: randomUUID() },
+      authContext(attackerClerkId),
+    )
+
+    // Act + Assert
+    await expect(
+      call(
+        createManyTodo,
+        {
+          items: [{ title: 'sneaky', categoryId: ownerCategory.id }],
+          importBatchId: randomUUID(),
+        },
+        authContext(attackerClerkId),
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('drops lines that normalize to empty before inserting', async () => {
+    // Arrange — second item is whitespace-only (Zod .min(1) passes it)
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+
+    // Act
+    const result = await call(
+      createManyTodo,
+      { items: [{ title: 'keep me' }, { title: '   ' }], importBatchId },
+      authContext(clerkId),
+    )
+
+    // Assert
+    expect(result).toEqual({ count: 1, idempotent: false })
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const rows = await prisma.todo.findMany({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.text).toBe('keep me')
+  })
+
+  it('rejects a batch of exactly 1001 items at the Zod cap', async () => {
+    // Arrange — one over MAX_IMPORT_LINES_PER_BATCH (1000)
+    const clerkId = freshClerkId()
+    const items = Array.from({ length: 1001 }, (_unused, index) => ({
+      title: `task ${index}`,
+    }))
+
+    // Act + Assert
+    await expect(
+      call(
+        createManyTodo,
+        { items, importBatchId: randomUUID() },
+        authContext(clerkId),
+      ),
+    ).rejects.toThrow()
+  })
+})
+
+describe('todo.deleteMany (bulk undo)', () => {
+  it('deletes only the matching batch and leaves a sibling batch untouched', async () => {
+    // Arrange — two batches for the same user
+    const clerkId = freshClerkId()
+    const batchToUndo = randomUUID()
+    const batchToKeep = randomUUID()
+    await call(
+      createManyTodo,
+      {
+        items: [{ title: 'undo-1' }, { title: 'undo-2' }],
+        importBatchId: batchToUndo,
+      },
+      authContext(clerkId),
+    )
+    await call(
+      createManyTodo,
+      { items: [{ title: 'keep-1' }], importBatchId: batchToKeep },
+      authContext(clerkId),
+    )
+
+    // Act
+    const result = await call(
+      deleteManyTodo,
+      { importBatchId: batchToUndo },
+      authContext(clerkId),
+    )
+
+    // Assert
+    expect(result).toEqual({ count: 2 })
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    const undoneRows = await prisma.todo.count({
+      where: { userId: user.id, importBatchId: batchToUndo },
+    })
+    const keptRows = await prisma.todo.count({
+      where: { userId: user.id, importBatchId: batchToKeep },
+    })
+    expect(undoneRows).toBe(0)
+    expect(keptRows).toBe(1)
+  })
+
+  it("does not delete another user's rows sharing the same importBatchId", async () => {
+    // Arrange — two users; only the first imports under `sharedBatchId`
+    const firstClerkId = freshClerkId()
+    const secondClerkId = freshClerkId()
+    const sharedBatchId = randomUUID()
+    await call(
+      createManyTodo,
+      { items: [{ title: 'first-user-row' }], importBatchId: sharedBatchId },
+      authContext(firstClerkId),
+    )
+    await call(
+      createManyTodo,
+      { items: [{ title: 'second-user-seed' }], importBatchId: randomUUID() },
+      authContext(secondClerkId),
+    )
+
+    // Act — second user attempts to undo the first user's batch id
+    const result = await call(
+      deleteManyTodo,
+      { importBatchId: sharedBatchId },
+      authContext(secondClerkId),
+    )
+
+    // Assert — nothing deleted; the first user's row survives
+    expect(result).toEqual({ count: 0 })
+    const firstUser = await prisma.user.findUniqueOrThrow({
+      where: { clerkId: firstClerkId },
+    })
+    const firstUserRows = await prisma.todo.count({
+      where: { userId: firstUser.id, importBatchId: sharedBatchId },
+    })
+    expect(firstUserRows).toBe(1)
+  })
+
+  it('deletes nothing once the undo window has expired', async () => {
+    // Arrange — import then backdate createdAt past the 60s window
+    const clerkId = freshClerkId()
+    const importBatchId = randomUUID()
+    await call(
+      createManyTodo,
+      { items: [{ title: 'too old to undo' }], importBatchId },
+      authContext(clerkId),
+    )
+    const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+    await prisma.todo.updateMany({
+      where: { userId: user.id, importBatchId },
+      data: { createdAt: new Date(Date.now() - 2 * 60 * 1000) },
+    })
+
+    // Act
+    const result = await call(
+      deleteManyTodo,
+      { importBatchId },
+      authContext(clerkId),
+    )
+
+    // Assert — window expired, row remains
+    expect(result).toEqual({ count: 0 })
+    const remaining = await prisma.todo.count({
+      where: { userId: user.id, importBatchId },
+    })
+    expect(remaining).toBe(1)
+  })
+})

--- a/src/server/procedures/todo.ts
+++ b/src/server/procedures/todo.ts
@@ -1,6 +1,9 @@
 import { ORPCError } from '@orpc/server'
+import { Prisma } from '@prisma/client'
 import { z } from 'zod'
 
+import { normalizeCompletedTitle } from '@/components/braindump/braindumpUtils'
+import { COMPLETED_UNDO_WINDOW_MS } from '@/lib/constants/import'
 import { prisma } from '@/lib/prisma'
 
 import { log } from '../../lib/logger'
@@ -8,11 +11,16 @@ import { authMiddleware } from '../middleware/auth'
 import {
   TodoSchema,
   CreateTodoSchema,
+  CreateManyTodoResponseSchema,
+  CreateManyTodoSchema,
+  DeleteManyTodoResponseSchema,
+  DeleteManyTodoSchema,
   UpdateTodoSchema,
   TodoListSchema,
   TodoResponseSchema,
   ReorderTodosSchema,
 } from '../schemas/todo'
+import { resolveImportCategoryIds } from '../utils/resolveImportCategoryIds'
 
 // Fetch todo list
 export const listTodos = authMiddleware
@@ -285,4 +293,145 @@ export const reorderTodos = authMiddleware
     )
 
     return { success: true }
+  })
+
+/**
+ * Bulk-inserts paste-imported rows into the active Todo zone for the
+ * authenticated user (incomplete tasks — bulk entry, NOT the heatmap-fill
+ * moment). Triggered by the PR2 paste-import dialog's confirm on a Todo
+ * surface. Idempotent via `importBatchId`: resubmitting the same batch is a
+ * no-op that returns the already-inserted count.
+ *
+ * No dedup — uniqueness is on the batch id only, never on task text. Order is
+ * assigned sequentially from `(current max order) + 1` so the paste keeps its
+ * internal order AND lands after existing todos (best-effort: pre-existing
+ * null-order rows sort NULLS LAST in Postgres).
+ *
+ * @param input.items - 1..1000 items `{ title, categoryId? }`
+ * @param input.importBatchId - Client-generated globally-unique batch id
+ * @returns
+ * - `{ count, idempotent: false }` on a fresh insert
+ * - `{ count, idempotent: true }` when the batch id already existed (no-op)
+ * @throws ORPCError('BAD_REQUEST') when every line normalizes to empty
+ * @throws ORPCError('NOT_FOUND') when a provided categoryId is not owned
+ * @example
+ * createManyTodo({ items: [{ title: 'ship' }, { title: 'ship' }], importBatchId: 'e4f5…' })
+ * // => { count: 2, idempotent: false } (repetition preserved)
+ */
+export const createManyTodo = authMiddleware
+  .input(CreateManyTodoSchema)
+  .output(CreateManyTodoResponseSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const { user } = context
+      const { items, importBatchId } = input
+
+      // Normalize text and drop lines that become empty (Zod .min(1) does not
+      // reject a whitespace-only title), so inserted count == preview count.
+      const normalizedItems = items
+        .map((item) => ({
+          text: normalizeCompletedTitle(item.title),
+          categoryId: item.categoryId,
+        }))
+        .filter((item) => item.text.length > 0)
+
+      if (normalizedItems.length === 0) {
+        throw new ORPCError('BAD_REQUEST', {
+          message: 'No importable lines after normalization',
+        })
+      }
+
+      // Resolve categories before the transaction so the only in-tx P2002
+      // source is the ImportBatch guard insert.
+      const resolveCategoryId = await resolveImportCategoryIds(
+        user.id,
+        normalizedItems,
+      )
+
+      // Imports land last: start ordering at (current max) + 1 and increment
+      // per item so the paste keeps its own order.
+      const maxOrderAggregate = await prisma.todo.aggregate({
+        where: { userId: user.id },
+        _max: { order: true },
+      })
+      const nextOrderStart = (maxOrderAggregate._max.order ?? -1) + 1
+
+      const rows = normalizedItems.map((item, index) => ({
+        text: item.text,
+        completed: false,
+        categoryId: resolveCategoryId(item),
+        userId: user.id,
+        order: nextOrderStart + index,
+        importBatchId,
+      }))
+
+      // ImportBatch guard insert + createMany in one transaction. A failed
+      // createMany rolls back the guard so a genuine retry still inserts.
+      const result = await prisma.$transaction(async (tx) => {
+        await tx.importBatch.create({
+          data: { id: importBatchId, userId: user.id },
+        })
+        const created = await tx.todo.createMany({ data: rows })
+        return { count: created.count, idempotent: false }
+      })
+
+      return result
+    } catch (error) {
+      // P2002 on the ImportBatch insert = this batch id was already imported.
+      // Idempotent no-op (caught OUTSIDE the tx — a failed statement aborts the
+      // PG transaction). Re-query the prior count and return it.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        const count = await prisma.todo.count({
+          where: {
+            userId: context.user.id,
+            importBatchId: input.importBatchId,
+          },
+        })
+        return { count, idempotent: true }
+      }
+      if (error instanceof ORPCError) throw error
+      log.error('Error in createManyTodo:', error)
+      throw new ORPCError('INTERNAL_SERVER_ERROR', {
+        message: 'Failed to import todos',
+        cause: error,
+      })
+    }
+  })
+
+/**
+ * Bulk-undoes a paste-import batch by deleting every Todo row tagged with the
+ * given `importBatchId`, scoped to the caller and guarded by
+ * {@link COMPLETED_UNDO_WINDOW_MS} (parity with `completed.deleteMany`).
+ * Triggered by PR2's Todo "Undo import" within 60 s of the import.
+ *
+ * Atomic single-statement delete: ownership + freshness are in the `where` so a
+ * concurrent undo cannot double-delete. Deletes by `importBatchId` (never by
+ * ids); the window keys off `createdAt` (the real insert time).
+ *
+ * @param input.importBatchId - The batch id used at import time
+ * @returns `{ count }` — rows removed (0 once the window has expired)
+ * @example
+ * deleteManyTodo({ importBatchId: 'e4f5…' }) // => { count: 50 }
+ */
+export const deleteManyTodo = authMiddleware
+  .input(DeleteManyTodoSchema)
+  .output(DeleteManyTodoResponseSchema)
+  .handler(async ({ input, context }) => {
+    const { user } = context
+    const { importBatchId } = input
+
+    const result = await prisma.todo.deleteMany({
+      where: {
+        userId: user.id,
+        importBatchId,
+        createdAt: {
+          gte: new Date(Date.now() - COMPLETED_UNDO_WINDOW_MS),
+        },
+      },
+    })
+
+    return { count: result.count }
   })

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -25,6 +25,8 @@ import {
 import {
   listTodos,
   createTodo,
+  createManyTodo,
+  deleteManyTodo,
   updateTodo,
   deleteTodo,
   toggleTodo,
@@ -42,8 +44,10 @@ export const router = {
   todo: {
     list: listTodos,
     create: createTodo,
+    createMany: createManyTodo,
     update: updateTodo,
     delete: deleteTodo,
+    deleteMany: deleteManyTodo,
     toggle: toggleTodo,
     clearCompleted: clearCompleted,
     reorder: reorderTodos,

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -6,7 +6,9 @@ import {
 } from './procedures/category'
 import {
   createCompleted,
+  createManyCompleted,
   deleteCompleted,
+  deleteManyCompleted,
   getDayDetail,
   getHeatmap,
 } from './procedures/completed'
@@ -50,7 +52,9 @@ export const router = {
     heatmap: getHeatmap,
     dayDetail: getDayDetail,
     create: createCompleted,
+    createMany: createManyCompleted,
     delete: deleteCompleted,
+    deleteMany: deleteManyCompleted,
   },
   electronSettings: {
     get: getElectronSettings,

--- a/src/server/schemas/completed.ts
+++ b/src/server/schemas/completed.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { MAX_IMPORT_LINES_PER_BATCH } from '@/lib/constants/import'
+
 /**
  * Input schema for the completed tasks heatmap endpoint.
  * @example
@@ -28,6 +30,79 @@ export const CreateCompletedSchema = z.object({
  */
 export const DeleteCompletedSchema = z.object({
   id: z.number().int(),
+})
+
+/**
+ * A single item in a paste-import batch destined for the Completed zone.
+ *
+ * `categoryId` is optional: when omitted the server resolves the user's
+ * get-or-create default category. `completedAt` is optional: when omitted the
+ * server stamps `now()` (Slice 1 lands everything on today). Title is validated
+ * 1..255 here, but the server still re-runs `normalizeCompletedTitle` (Zod's
+ * `.min(1)` does not reject a whitespace-only title that normalizes to empty).
+ *
+ * @example
+ * { title: 'shipped the release' }
+ * @example
+ * { title: 'gym', categoryId: 3, completedAt: new Date('2026-05-01T00:00:00Z') }
+ */
+export const CreateManyCompletedItemSchema = z.object({
+  title: z.string().min(1).max(255),
+  categoryId: z.number().int().positive().optional(),
+  completedAt: z.date().optional(),
+})
+
+/**
+ * Input schema for `completed.createMany` (paste-import → Completed zone).
+ * `items` is bounded by `MAX_IMPORT_LINES_PER_BATCH` so the cap is single-sourced
+ * with the PR2 client preview. `importBatchId` is the client-generated, globally
+ * unique idempotency key (one per paste-confirm).
+ *
+ * @example
+ * { items: [{ title: 'a' }, { title: 'b' }], importBatchId: 'b2c1…' }
+ */
+export const CreateManyCompletedSchema = z.object({
+  items: z
+    .array(CreateManyCompletedItemSchema)
+    .min(1)
+    .max(MAX_IMPORT_LINES_PER_BATCH),
+  importBatchId: z.string().min(1),
+})
+
+/**
+ * Output schema for `completed.createMany`. `count` is how many rows the batch
+ * resolved to; `idempotent` is `true` when the batch id already existed (P2002
+ * no-op → re-queried prior count) and `false` on a fresh insert.
+ *
+ * @example
+ * { count: 50, idempotent: false } // fresh import
+ * @example
+ * { count: 50, idempotent: true }  // resubmit of the same importBatchId
+ */
+export const CreateManyCompletedResponseSchema = z.object({
+  count: z.number().int().min(0),
+  idempotent: z.boolean(),
+})
+
+/**
+ * Input schema for `completed.deleteMany` (bulk undo of a paste batch).
+ * @example
+ * { importBatchId: 'b2c1…' }
+ */
+export const DeleteManyCompletedSchema = z.object({
+  importBatchId: z.string().min(1),
+})
+
+/**
+ * Output schema for `completed.deleteMany`. `count` is the number of rows the
+ * window-guarded delete actually removed (0 once the undo window expires).
+ * @example
+ * { count: 50 } // undone within the window
+ * @example
+ * { count: 0 }  // window expired, nothing deleted
+ */
+export const DeleteManyCompletedResponseSchema = z.object({
+  count: z.number().int().min(0),
 })
 
 /**

--- a/src/server/schemas/todo.ts
+++ b/src/server/schemas/todo.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { MAX_IMPORT_LINES_PER_BATCH } from '@/lib/constants/import'
+
 export const TodoSchema = z.object({
   id: z.number().int().positive(),
   text: z
@@ -57,4 +59,71 @@ export const ReorderTodosSchema = z.object({
       order: z.number().int().min(0),
     }),
   ),
+})
+
+/**
+ * A single item in a paste-import batch destined for the active Todo zone.
+ *
+ * `title` mirrors the parser/Completed item shape; the procedure maps it to
+ * `Todo.text`. `categoryId` is optional (server resolves the get-or-create
+ * default when omitted). No `completedAt` — the Todo-zone date-override waits
+ * for the separate `Todo.completedAt` migration; imported todos are incomplete.
+ *
+ * @example
+ * { title: 'write the spec' }
+ * @example
+ * { title: 'review PR', categoryId: 3 }
+ */
+export const CreateManyTodoItemSchema = z.object({
+  title: z.string().min(1).max(255),
+  categoryId: z.number().int().positive().optional(),
+})
+
+/**
+ * Input schema for `todo.createMany` (paste-import → active Todo zone).
+ * `items` bounded by `MAX_IMPORT_LINES_PER_BATCH`; `importBatchId` is the
+ * client-generated, globally unique idempotency key.
+ *
+ * @example
+ * { items: [{ title: 'a' }, { title: 'b' }], importBatchId: 'e4f5…' }
+ */
+export const CreateManyTodoSchema = z.object({
+  items: z
+    .array(CreateManyTodoItemSchema)
+    .min(1)
+    .max(MAX_IMPORT_LINES_PER_BATCH),
+  importBatchId: z.string().min(1),
+})
+
+/**
+ * Output schema for `todo.createMany`. `count` is rows resolved; `idempotent`
+ * is `true` when the batch id already existed (P2002 no-op).
+ *
+ * @example
+ * { count: 50, idempotent: false }
+ * @example
+ * { count: 50, idempotent: true }
+ */
+export const CreateManyTodoResponseSchema = z.object({
+  count: z.number().int().min(0),
+  idempotent: z.boolean(),
+})
+
+/**
+ * Input schema for `todo.deleteMany` (bulk undo of a paste batch).
+ * @example
+ * { importBatchId: 'e4f5…' }
+ */
+export const DeleteManyTodoSchema = z.object({
+  importBatchId: z.string().min(1),
+})
+
+/**
+ * Output schema for `todo.deleteMany`. `count` is rows removed (0 after the
+ * undo window expires).
+ * @example
+ * { count: 50 }
+ */
+export const DeleteManyTodoResponseSchema = z.object({
+  count: z.number().int().min(0),
 })

--- a/src/server/utils/completedAggregation.test.ts
+++ b/src/server/utils/completedAggregation.test.ts
@@ -77,6 +77,54 @@ describe('fetchCompletedEntries', () => {
     ])
   })
 
+  it('buckets a Completed row by completedAt when it differs from createdAt (dated import)', async () => {
+    // Arrange — a paste-imported row whose semantic completion day (completedAt)
+    // is earlier than its insert time (createdAt). The heatmap must use
+    // completedAt so the row lands on the day it actually happened.
+    mockedTodoFindMany.mockResolvedValue([])
+    mockedCompletedFindMany.mockResolvedValue([
+      {
+        id: 7,
+        title: 'gym last week',
+        completedAt: new Date('2026-05-05T09:00:00.000Z'),
+        createdAt: new Date('2026-05-09T18:30:00.000Z'),
+        category: null,
+      },
+    ] as never)
+
+    // Act
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+
+    // Assert — completedAt wins over createdAt
+    expect(entries[0]?.completedAt).toEqual(
+      new Date('2026-05-05T09:00:00.000Z'),
+    )
+  })
+
+  it('falls back to createdAt when a Completed row has a null completedAt (existing-row stability)', async () => {
+    // Arrange — a pre-migration row the backfill conceptually covers; a null
+    // completedAt must coalesce to createdAt so old rows keep their heatmap day
+    // (they do NOT jump to migration-day).
+    mockedTodoFindMany.mockResolvedValue([])
+    mockedCompletedFindMany.mockResolvedValue([
+      {
+        id: 8,
+        title: 'legacy completed row',
+        completedAt: null,
+        createdAt: new Date('2026-05-06T12:00:00.000Z'),
+        category: null,
+      },
+    ] as never)
+
+    // Act
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+
+    // Assert — bucket date is createdAt's day, not null/migration-day
+    expect(entries[0]?.completedAt).toEqual(
+      new Date('2026-05-06T12:00:00.000Z'),
+    )
+  })
+
   it('UNIONs rows from both tables sorted ascending by completedAt', async () => {
     // Todo updated later than the Completed row, so the sort needs to flip
     // them relative to insertion order.

--- a/src/server/utils/completedAggregation.ts
+++ b/src/server/utils/completedAggregation.ts
@@ -25,8 +25,14 @@ export type CompletedEntry = {
  * oRPC procedures.
  *
  * Heatmap UNION semantics (locked decision D2=A):
- *   Todo bucket      = updatedAt.toISOString().split('T')[0]   (UTC date)
- *   Completed bucket = createdAt.toISOString().split('T')[0]   (UTC date)
+ *   Todo bucket      = updatedAt.toISOString().split('T')[0]            (UTC date)
+ *   Completed bucket = (completedAt ?? createdAt).toISOString()[0..10]  (UTC date)
+ *
+ * Completed buckets by `completedAt ?? createdAt` (paste-import, Issue #53):
+ * completedAt is the semantic completion day; createdAt is the defensive
+ * fallback for any row missed by the migration backfill (which set
+ * completedAt = createdAt, so existing rows do not shift days). The date-range
+ * FILTER still uses createdAt in Slice 1 — see the inline TODO in the query.
  *
  * Known drift: Todo.updatedAt mutates on text/notes edit, so a completed
  * Todo edited later will move dates on the heatmap. Acceptable for now;
@@ -83,11 +89,24 @@ export async function fetchCompletedEntries(
         // sets archived=true, but filtering defensively avoids surprises
         // when an archive flow eventually lands.
         archived: false,
+        // Slice 1: the date-range filter stays on `createdAt` (the insert
+        // time). Paste-import lands everything on today (`completedAt = now()`),
+        // so createdAt and completedAt coincide and the window is correct.
+        // TODO(Slice 2 — dated import): when date-override ships, a row may have
+        // a past `completedAt` with a today `createdAt`; this filter must then
+        // move to `completedAt` or the row will be dropped from its real day's
+        // range. (See docs/plans/2026-05-29-paste-import-plan.md, Heatmap §.)
         createdAt: { gte: startDate, lte: endDate },
       },
       select: {
         id: true,
         title: true,
+        // Select both: bucket by `completedAt ?? createdAt` (coalesced in JS
+        // below). completedAt is the semantic completion day; createdAt is the
+        // defensive fallback for any historical row the migration backfill
+        // missed (it backfilled completedAt = createdAt, so existing rows do
+        // NOT shift days on the heatmap).
+        completedAt: true,
         createdAt: true,
         category: { select: { id: true, name: true, color: true } },
       },
@@ -107,7 +126,10 @@ export async function fetchCompletedEntries(
     source: 'completed',
     id: row.id,
     title: row.title,
-    completedAt: row.createdAt,
+    // Bucket by the semantic completion day, falling back to the insert time
+    // for any row whose completedAt is null (defensive — the migration
+    // backfilled existing rows with completedAt = createdAt).
+    completedAt: row.completedAt ?? row.createdAt,
     category: row.category,
   }))
 

--- a/src/server/utils/resolveImportCategoryIds.ts
+++ b/src/server/utils/resolveImportCategoryIds.ts
@@ -1,0 +1,129 @@
+import { ORPCError } from '@orpc/server'
+import { Prisma } from '@prisma/client'
+
+import { prisma } from '@/lib/prisma'
+
+/**
+ * Default category name/color, mirroring the seed (`prisma/seed.ts`) and the
+ * Clerk webhook (`src/app/api/webhooks/route.ts`). Kept here so the import
+ * get-or-create fallback creates the SAME "General" row those paths create
+ * (the table enforces `@@unique([name, userId])`), never a divergent default.
+ */
+const DEFAULT_CATEGORY_NAME = 'General'
+const DEFAULT_CATEGORY_COLOR = 'blue'
+
+/**
+ * Resolves every paste-import item to a concrete, owned `categoryId` BEFORE the
+ * insert transaction runs — so the only P2002 source inside the transaction is
+ * the `ImportBatch` insert (making the idempotency catch unambiguous). Shared
+ * by `completed.createMany` and `todo.createMany`.
+ *
+ * Behavior:
+ * - Items WITH a `categoryId` are ownership-verified as a set; a foreign /
+ *   nonexistent id throws `NOT_FOUND` (rejects the whole batch).
+ * - If ANY item omits `categoryId`, the user's default category is
+ *   get-or-created (`findFirst isDefault`; else create, catching P2002 from a
+ *   concurrent create and re-querying) and used as the fallback.
+ *
+ * @param userId - Internal `User.id` (NOT the Clerk id string).
+ * @param items - The batch items; only their optional `categoryId` is read.
+ * @returns
+ * - `(item) => number`: a resolver mapping each item to its final categoryId
+ *   (its own verified id, or the default category id when omitted)
+ * @throws ORPCError('NOT_FOUND') when a provided categoryId is not owned by the user
+ * @example
+ * const resolve = await resolveImportCategoryIds(7, [{ categoryId: 3 }, {}])
+ * resolve({ categoryId: 3 }) // => 3
+ * resolve({})               // => <user's default category id>
+ */
+export async function resolveImportCategoryIds(
+  userId: number,
+  items: ReadonlyArray<{ categoryId?: number }>,
+): Promise<(item: { categoryId?: number }) => number> {
+  // Distinct explicit ids across the batch — verify ownership as a set so a
+  // single foreign id rejects the whole import (cheaper than per-row checks).
+  const providedCategoryIds = [
+    ...new Set(
+      items
+        .map((item) => item.categoryId)
+        .filter((categoryId): categoryId is number => categoryId !== undefined),
+    ),
+  ]
+
+  if (providedCategoryIds.length > 0) {
+    const ownedCategories = await prisma.category.findMany({
+      where: { id: { in: providedCategoryIds }, userId },
+      select: { id: true },
+    })
+    const ownedCategoryIds = new Set(ownedCategories.map((row) => row.id))
+    const foreignCategoryIds = providedCategoryIds.filter(
+      (categoryId) => !ownedCategoryIds.has(categoryId),
+    )
+    if (foreignCategoryIds.length > 0) {
+      throw new ORPCError('NOT_FOUND', {
+        message: `Category not found: ${foreignCategoryIds.join(', ')}`,
+      })
+    }
+  }
+
+  // Only resolve a default category when at least one item needs the fallback.
+  const needsDefaultCategory = items.some(
+    (item) => item.categoryId === undefined,
+  )
+  let defaultCategoryId: number | null = null
+  if (needsDefaultCategory) {
+    defaultCategoryId = await getOrCreateDefaultCategoryId(userId)
+  }
+
+  return (item: { categoryId?: number }): number => {
+    if (item.categoryId !== undefined) return item.categoryId
+    // needsDefaultCategory was true (this item omitted categoryId), so the
+    // default id was resolved above; the non-null assertion is sound.
+    return defaultCategoryId!
+  }
+}
+
+/**
+ * Get-or-creates the user's default ("General") category, surviving the race
+ * where a concurrent request creates it first: a `@@unique([name, userId])`
+ * P2002 is caught and the row is re-queried rather than crashing the import.
+ *
+ * @param userId - Internal `User.id`.
+ * @returns The default category's id.
+ * @example
+ * await getOrCreateDefaultCategoryId(7) // => 12
+ */
+async function getOrCreateDefaultCategoryId(userId: number): Promise<number> {
+  const existingDefault = await prisma.category.findFirst({
+    where: { userId, isDefault: true },
+    select: { id: true },
+  })
+  if (existingDefault) return existingDefault.id
+
+  try {
+    const created = await prisma.category.create({
+      data: {
+        name: DEFAULT_CATEGORY_NAME,
+        color: DEFAULT_CATEGORY_COLOR,
+        isDefault: true,
+        userId,
+      },
+      select: { id: true },
+    })
+    return created.id
+  } catch (error) {
+    // P2002 = a concurrent request created the same (name, userId) default
+    // first. Re-query by the same key so the import proceeds idempotently.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      const raced = await prisma.category.findFirst({
+        where: { userId, name: DEFAULT_CATEGORY_NAME },
+        select: { id: true },
+      })
+      if (raced) return raced.id
+    }
+    throw error
+  }
+}


### PR DESCRIPTION
## Paste-to-import — PR1 (server, no UI) · Issue #53

First of **two** PRs. Server foundation for pasting multi-line text and importing each line as a task. No UI here (that is PR2).

Plan: `docs/plans/2026-05-29-paste-import-plan.md` (carried in this PR). Pipeline: office-hours → CEO review → Codex outside-voice → `/plan-design-review` (9/10) → `/plan-eng-review` + `/plan-devex-review` (all fold-ins applied).

### What's here

- **Migration** `paste_import_completedat_importbatch`: `Completed.completedAt DateTime?` (nullable, **no `@default`** — backfilled `= createdAt` via hand-edited SQL so historical rows keep their real heatmap day), `Completed.importBatchId` + index, `Todo.importBatchId` + index, new `ImportBatch` table.
- **Idempotency (≠ dedup):** an `ImportBatch{ id @id }` guard row is inserted inside the same `$transaction` as `createMany`; a resubmit of the same `importBatchId` (retry / double-click / second tab) throws P2002 → caught **outside** the tx → no-op returning the prior count. Uniqueness is on the batch id only — **never on task content** — so repeating a task is preserved (no-dedup product principle; a test asserts 2× "gym" → 2 rows).
- **Procedures:** `completed.createMany` / `completed.deleteMany`, `todo.createMany` / `todo.deleteMany`. Bulk undo deletes by `importBatchId` (createMany returns only `{count}`), guarded by the 60s `COMPLETED_UNDO_WINDOW_MS` window keyed on `createdAt`.
- **Parser** `src/lib/parsePasteToTasks.ts`: pure, line-oriented (every non-blank line → task; strips only a leading list/checkbox prefix; preserves URLs/headings), reusing `normalizeCompletedTitle` + the checkbox regex.
- **Heatmap** buckets Completed by `completedAt ?? createdAt` (JS coalesce); date-range filter stays on `createdAt` for Slice 1 (Slice-2 move noted inline + TODOS).
- Promoted `COMPLETED_UNDO_WINDOW_MS` to shared constants; added `MAX_IMPORT_LINES_PER_BATCH = 1000`.

### Verification

- `pnpm typecheck`: 0 errors.
- Full suite **249 passed** (CI Node 24.13.0), incl. new tests: idempotent resubmit returns prior count (P2002 path), undo isolation across users + batches, foreign `categoryId` rejected, whitespace-only dropped, over-cap at 1001, existing-row heatmap stability, 16 parser cases.

### Not in this PR

PR2 = UI (PasteImport dialog, per-zone Import entries, bulk-undo UX, copy, responsive, a11y). `Todo.completedAt` (date-override) and Slice-2 AI labeling stay deferred (see `TODOS.md` / plan).

🤖 Autonomous overnight build. Generated with Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paste-to-import for bulk task creation from multiline text with checkbox/list parsing, idempotent imports, per-batch undo within 60s, and a 1000-line batch cap.
  * Separate completion timestamp so imported completions can preserve original completion dates; heatmap/date grouping respects that timestamp.

* **Documentation**
  * Added an implementation-ready plan covering import, AI auto-labeling, and review notes.

* **Tests**
  * Added extensive integration and unit tests for import, undo, aggregation, and edge cases.

* **Chores**
  * CI updated to run DB-backed tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->