### PR TITLE
feat(#53): paste-to-import — PR2 UI (dialog, per-zone entries, bulk undo, a11y/responsive)

### DIFF
--- a/src/app/(main)/home/_components/CompletedImportEntry.tsx
+++ b/src/app/(main)/home/_components/CompletedImportEntry.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { ClipboardPaste } from 'lucide-react'
+import { memo, useCallback, useState } from 'react'
+
+import { ImportUndoBanner } from '@/components/import/ImportUndoBanner'
+import { PasteImport, type LastImport } from '@/components/import/PasteImport'
+import { Button } from '@/components/ui/button'
+import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
+import { orpc } from '@/lib/orpc/client-query'
+import { subscribeToOpenCompletedImport } from '@/lib/paste-import-channel'
+import { broadcastTodoSync } from '@/lib/todo-sync-channel'
+
+/**
+ * Completed-zone paste-import entry point (D4). Renders the Import button +
+ * dialog and the 60s inline undo banner (D5), owns the dialog open state, and
+ * re-invalidates the heatmap + day-detail + todo caches on import/undo so the
+ * heatmap fill (the celebration) and the Completed list update immediately.
+ * Subscribes to the cross-window open-intent so the Floating Navigator's Import
+ * (D7) can open this dialog after focusing the main window.
+ *
+ * @param props.variant - `'button'` for the toolbar affordance (default),
+ *   `'inline'` for the empty-state discoverability surface.
+ * @returns The Completed Import button + dialog + undo banner.
+ * @example
+ * <CompletedImportEntry />
+ * @example
+ * <CompletedImportEntry variant="inline" />
+ */
+export const CompletedImportEntry = memo(function CompletedImportEntry({
+  variant = 'button',
+}: {
+  variant?: 'button' | 'inline'
+}) {
+  const queryClient = useQueryClient()
+  const isClerkQueryReady = useClerkQueryReady()
+  const [open, setOpen] = useState(false)
+  const [lastImport, setLastImport] = useState<LastImport | null>(null)
+
+  // Categories injected as a prop into PasteImport (never fetched inside it).
+  const { data: categoryData } = useQuery({
+    ...orpc.category.list.queryOptions({}),
+    enabled: isClerkQueryReady,
+  })
+  const categories = categoryData?.categories ?? []
+
+  // Semantic open handler (instead of passing the raw setOpen setter down).
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next)
+  }, [])
+
+  const dismissBanner = useCallback(() => {
+    setLastImport(null)
+  }, [])
+
+  // Cross-window D7: the floating navigator broadcasts an open-intent after it
+  // focuses the main window; only this main-window entry opens the dialog.
+  useComponentEffect(() => {
+    return subscribeToOpenCompletedImport(() => setOpen(true))
+  }, [])
+
+  // Invalidate everything the Completed import touches: heatmap (fill), the
+  // day-detail dialog cache, and the todo/completed lists; broadcast so the
+  // floating navigator + braindump windows stay in lockstep.
+  const invalidateCompleted = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
+    queryClient.invalidateQueries({ queryKey: orpc.completed.dayDetail.key() })
+    queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
+    broadcastTodoSync()
+  }, [queryClient])
+
+  const handleImported = useCallback(
+    (result: LastImport) => {
+      invalidateCompleted()
+      // count===0 marks an undo → drop the banner; otherwise arm the 60s undo.
+      setLastImport(result.count === 0 ? null : result)
+    },
+    [invalidateCompleted],
+  )
+
+  const trigger =
+    variant === 'inline' ? (
+      <Button type="button" variant="outline" size="sm">
+        <ClipboardPaste className="size-4" aria-hidden="true" />
+        Import past wins
+      </Button>
+    ) : (
+      <Button type="button" variant="outline" size="sm">
+        <ClipboardPaste className="size-4" aria-hidden="true" />
+        Import
+      </Button>
+    )
+
+  return (
+    <div className="flex flex-col gap-2">
+      <PasteImport
+        zone="completed"
+        categories={categories}
+        trigger={trigger}
+        open={open}
+        onOpenChange={handleOpenChange}
+        onImported={handleImported}
+      />
+      <ImportUndoBanner
+        lastImport={lastImport}
+        onDismiss={dismissBanner}
+        onChanged={invalidateCompleted}
+      />
+    </div>
+  )
+})

--- a/src/app/(main)/home/_components/CompletedTodos.tsx
+++ b/src/app/(main)/home/_components/CompletedTodos.tsx
@@ -185,6 +185,10 @@ export const CompletedTodos = React.memo(function CompletedTodos({
             <p>No completed tasks yet</p>
             {/* Day-one discoverability: surface the Import affordance inline. */}
             <CompletedImportEntry variant="inline" />
+            {/* Quiet hint: completed imports write to the heatmap, not this list. */}
+            <p className="text-xs text-muted-foreground">
+              Imported wins appear on your heatmap ↑
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/src/app/(main)/home/_components/CompletedTodos.tsx
+++ b/src/app/(main)/home/_components/CompletedTodos.tsx
@@ -25,6 +25,7 @@ import { Separator } from '@/components/ui/separator'
 import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { orpc } from '@/lib/orpc/client-query'
 
+import { CompletedImportEntry } from './CompletedImportEntry'
 import { TodoItem } from './TodoItem'
 import type { Todo } from './TodoItem'
 
@@ -179,9 +180,11 @@ export const CompletedTodos = React.memo(function CompletedTodos({
           <CardDescription>Completed tasks will appear here</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-1 items-center justify-center p-8">
-          <div className="text-center text-muted-foreground">
-            <CheckCircle2 className="mx-auto mb-4 h-12 w-12 opacity-50" />
+          <div className="flex flex-col items-center gap-4 text-center text-muted-foreground">
+            <CheckCircle2 className="h-12 w-12 opacity-50" />
             <p>No completed tasks yet</p>
+            {/* Day-one discoverability: surface the Import affordance inline. */}
+            <CompletedImportEntry variant="inline" />
           </div>
         </CardContent>
       </Card>
@@ -203,7 +206,9 @@ export const CompletedTodos = React.memo(function CompletedTodos({
           </CardTitle>
           <CardDescription>Recently completed tasks</CardDescription>
           {allTodos.length > 0 && (
-            <div className="flex justify-end pt-2">
+            <div className="flex items-center justify-end gap-2 pt-2">
+              {/* Completed-zone Import entry (D4) — next to Clear all. */}
+              <CompletedImportEntry />
               <Button
                 variant="outline"
                 size="sm"

--- a/src/app/(main)/home/_components/TodoImportEntry.tsx
+++ b/src/app/(main)/home/_components/TodoImportEntry.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { ClipboardPaste } from 'lucide-react'
+import { memo, useCallback, useState } from 'react'
+
+import { ImportUndoBanner } from '@/components/import/ImportUndoBanner'
+import { PasteImport, type LastImport } from '@/components/import/PasteImport'
+import { Button } from '@/components/ui/button'
+import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { broadcastCategorySync } from '@/lib/category-sync-channel'
+import { orpc } from '@/lib/orpc/client-query'
+import { broadcastTodoSync } from '@/lib/todo-sync-channel'
+
+/**
+ * Active-Todo-zone paste-import entry point (D4). Renders the Import button +
+ * dialog and the 60s inline undo banner (D5, which for Todo also offers
+ * Move-to-Completed — P2 wrong-zone recovery), owns the dialog open state, and
+ * re-invalidates the todo list + category counts on import/undo/move. Todo
+ * imports are incomplete tasks (bulk entry), so they do NOT light the heatmap —
+ * the dialog's pre-confirm note sets that expectation.
+ *
+ * @param props.variant - `'button'` for the toolbar affordance (default),
+ *   `'inline'` for the empty-state discoverability surface.
+ * @returns The Todo Import button + dialog + undo banner.
+ * @example
+ * <TodoImportEntry />
+ */
+export const TodoImportEntry = memo(function TodoImportEntry({
+  variant = 'button',
+}: {
+  variant?: 'button' | 'inline'
+}) {
+  const queryClient = useQueryClient()
+  const isClerkQueryReady = useClerkQueryReady()
+  const [open, setOpen] = useState(false)
+  const [lastImport, setLastImport] = useState<LastImport | null>(null)
+
+  const { data: categoryData } = useQuery({
+    ...orpc.category.list.queryOptions({}),
+    enabled: isClerkQueryReady,
+  })
+  const categories = categoryData?.categories ?? []
+
+  // Todo import touches the todo list + category counts. Move-to-Completed also
+  // touches the heatmap, so invalidate it too (cheap; covers the recovery path).
+  const invalidateTodo = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
+    queryClient.invalidateQueries({ queryKey: orpc.category.list.key() })
+    queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
+    broadcastTodoSync()
+    broadcastCategorySync()
+  }, [queryClient])
+
+  // Semantic open handler (instead of passing the raw setOpen setter down).
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next)
+  }, [])
+
+  const dismissBanner = useCallback(() => {
+    setLastImport(null)
+  }, [])
+
+  const handleImported = useCallback(
+    (result: LastImport) => {
+      invalidateTodo()
+      setLastImport(result.count === 0 ? null : result)
+    },
+    [invalidateTodo],
+  )
+
+  const trigger =
+    variant === 'inline' ? (
+      <Button type="button" variant="outline" size="sm">
+        <ClipboardPaste className="size-4" aria-hidden="true" />
+        Import a list
+      </Button>
+    ) : (
+      <Button type="button" variant="outline" size="sm">
+        <ClipboardPaste className="size-4" aria-hidden="true" />
+        Import
+      </Button>
+    )
+
+  return (
+    <div className="flex flex-col gap-2">
+      <PasteImport
+        zone="todo"
+        categories={categories}
+        trigger={trigger}
+        open={open}
+        onOpenChange={handleOpenChange}
+        onImported={handleImported}
+      />
+      <ImportUndoBanner
+        lastImport={lastImport}
+        onDismiss={dismissBanner}
+        onChanged={invalidateTodo}
+      />
+    </div>
+  )
+})

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -31,6 +31,7 @@ import { CompletedTodos } from './CompletedTodos'
 import { ContributionGraph } from './ContributionGraph'
 import { SortableTodoItem } from './SortableTodoItem'
 import { SundayDigestCard } from './SundayDigestCard'
+import { TodoImportEntry } from './TodoImportEntry'
 import type { Todo } from './TodoItem'
 import { WeeklySummaryCard } from './WeeklySummaryCard'
 import { YearInReviewModal } from './YearInReviewModal'
@@ -339,16 +340,22 @@ export const TodoList = memo(function TodoList() {
               onAddTodo={addTodo}
               disabled={selectedCategoryId === null}
             />
+            {/* Active-Todo-zone Import entry (D4) — next to the Add form. */}
+            <div className="flex justify-end">
+              <TodoImportEntry />
+            </div>
           </CardContent>
         </Card>
 
         {pendingTodos.length === 0 ? (
           <Card>
-            <CardContent className="p-8 text-center">
-              <Circle className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+            <CardContent className="flex flex-col items-center gap-4 p-8 text-center">
+              <Circle className="h-12 w-12 text-muted-foreground" />
               <p className="text-muted-foreground">
                 No pending tasks. Add a new task to get started.
               </p>
+              {/* Empty-state discoverability for bulk import. */}
+              <TodoImportEntry variant="inline" />
             </CardContent>
           </Card>
         ) : (

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -19,6 +19,7 @@ import { isFloatingNavigatorEnvironment } from '@/electron/utils/electron-client
 import { COLOR_DOT_CLASSES } from '@/lib/category-colors'
 import { todoSortableSensors } from '@/lib/dnd-kit-sensors'
 import { log } from '@/lib/logger'
+import { requestOpenCompletedImport } from '@/lib/paste-import-channel'
 import { isEnterKeyPress } from '@/lib/utils'
 import type {
   CategoryColor,
@@ -64,6 +65,9 @@ const Settings = lazy(async () =>
 )
 const Brain = lazy(async () =>
   import('lucide-react').then((mod) => ({ default: mod.Brain })),
+)
+const ClipboardPaste = lazy(async () =>
+  import('lucide-react').then((mod) => ({ default: mod.ClipboardPaste })),
 )
 
 // Icon fallback component for loading state
@@ -516,6 +520,21 @@ export const FloatingNavigator = React.memo(function FloatingNavigator({
     }
   }, [])
 
+  // D7: the floating window is too narrow for the import dialog, so Import
+  // broadcasts an open-intent (the main window's Completed entry subscribes)
+  // and surfaces the main window. Broadcast first so the subscriber fires even
+  // if focusing the window is what brings the main renderer to the foreground.
+  const handleOpenImport = useCallback(async () => {
+    requestOpenCompletedImport()
+    if (isFloatingNavigatorEnvironment()) {
+      try {
+        await window.floatingNavigatorAPI!.window.focusMainWindow()
+      } catch (error) {
+        log.error('Failed to focus main window for import:', error)
+      }
+    }
+  }, [])
+
   // Toggle the BrainDump Note window via the floating navigator preload bridge.
   const handleToggleBrainDump = useCallback(async () => {
     if (!isFloatingNavigatorEnvironment()) return
@@ -632,6 +651,18 @@ export const FloatingNavigator = React.memo(function FloatingNavigator({
             >
               <Suspense fallback={<IconFallback />}>
                 <Brain className="h-3 w-3" aria-hidden="true" />
+              </Suspense>
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleOpenImport}
+              className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              aria-label="Import to Completed in main window"
+              title="Import to Completed"
+            >
+              <Suspense fallback={<IconFallback />}>
+                <ClipboardPaste className="h-3 w-3" aria-hidden="true" />
               </Suspense>
             </Button>
             <Button

--- a/src/components/import/ImportUndoBanner.test.tsx
+++ b/src/components/import/ImportUndoBanner.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ImportUndoBanner } from './ImportUndoBanner'
+import type { LastImport } from './PasteImport'
+
+function buildImport(overrides: Partial<LastImport> = {}): LastImport {
+  return {
+    importBatchId: 'batch-1',
+    zone: 'completed',
+    count: 3,
+    titles: ['a', 'b', 'c'],
+    expiresAt: Date.now() + 60000,
+    ...overrides,
+  }
+}
+
+function renderBanner(lastImport: LastImport | null) {
+  const client = new QueryClient()
+  return render(
+    <QueryClientProvider client={client}>
+      <ImportUndoBanner
+        lastImport={lastImport}
+        onDismiss={vi.fn()}
+        onChanged={vi.fn()}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ImportUndoBanner', () => {
+  it('renders the just-imported count without a render loop', () => {
+    // Arrange + Act — a fresh batch within the undo window.
+    renderBanner(buildImport())
+
+    // Assert — mounts cleanly (a getSnapshot loop would throw max-depth here).
+    expect(screen.getByText('Imported 3 just now')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Undo import' }),
+    ).toBeInTheDocument()
+  })
+
+  it('offers Move to Completed only for a Todo-zone batch', () => {
+    // Arrange + Act
+    renderBanner(buildImport({ zone: 'todo' }))
+
+    // Assert
+    expect(
+      screen.getByRole('button', { name: 'Move to Completed' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no recent import', () => {
+    // Arrange + Act
+    const { container } = renderBanner(null)
+
+    // Assert
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing once the undo window has already expired', () => {
+    // Arrange + Act — expiry in the past.
+    const { container } = renderBanner(
+      buildImport({ expiresAt: Date.now() - 1000 }),
+    )
+
+    // Assert
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/import/ImportUndoBanner.test.tsx
+++ b/src/components/import/ImportUndoBanner.test.tsx
@@ -1,29 +1,111 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type * as ReactQuery from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ImportUndoBanner } from './ImportUndoBanner'
 import type { LastImport } from './PasteImport'
+
+// ---------------------------------------------------------------------------
+// Hoisted mutation spies — must be declared before vi.mock() hoisting fires.
+// These track call order for the create-before-delete ordering test.
+// ---------------------------------------------------------------------------
+const { mockCreateCompleted, mockDeleteTodo, resetMutationMocks } = vi.hoisted(
+  () => {
+    // Call log shared between the two mock fns so we can assert order.
+    const callLog: string[] = []
+
+    const mockCreateCompleted = vi.fn(
+      (_vars: unknown, callbacks?: { onError?: (err: unknown) => void }) => {
+        callLog.push('createCompleted')
+        // Simulate an offline failure so the delete step must NOT fire.
+        callbacks?.onError?.(new Error('offline'))
+      },
+    )
+    const mockDeleteTodo = vi.fn(() => {
+      callLog.push('deleteTodo')
+    })
+
+    // Expose a reset helper so individual tests can clear between runs.
+    const resetMutationMocks = () => {
+      callLog.length = 0
+      mockCreateCompleted.mockClear()
+      mockDeleteTodo.mockClear()
+      // Re-install the error-simulating implementation after clear.
+      mockCreateCompleted.mockImplementation(
+        (_vars: unknown, callbacks?: { onError?: (err: unknown) => void }) => {
+          callLog.push('createCompleted')
+          callbacks?.onError?.(new Error('offline'))
+        },
+      )
+    }
+
+    return { mockCreateCompleted, mockDeleteTodo, callLog, resetMutationMocks }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Mock @tanstack/react-query so we can intercept useMutation calls in order.
+// The banner instantiates three mutations (deleteCompleted, deleteTodo,
+// createCompleted) in that stable declaration order.
+// ---------------------------------------------------------------------------
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const original = await importOriginal<typeof ReactQuery>()
+  let callCount = 0
+  return {
+    ...original,
+    useMutation: (opts: unknown) => {
+      // Use modulo so the 3-call pattern repeats cleanly across all test renders.
+      // The banner always calls useMutation in this stable order per instance:
+      //   0 mod 3 = deleteCompleted, 1 mod 3 = deleteTodo, 2 mod 3 = createCompleted.
+      const callIndex = callCount++ % 3
+      const mutateFn =
+        callIndex === 2
+          ? mockCreateCompleted
+          : callIndex === 1
+            ? mockDeleteTodo
+            : vi.fn()
+      void opts
+      return { mutate: mutateFn, isPending: false }
+    },
+  }
+})
+
+// QueryClient must come after the mock so it uses the mocked useMutation.
+const { QueryClient, QueryClientProvider } =
+  await import('@tanstack/react-query')
+
+// Stable item fixtures for the todo-zone batch (includes a categoryId override
+// to verify P2-2: categories are preserved through Move-to-Completed).
+const TODO_ITEMS = [
+  { title: 'a' },
+  { title: 'gym', categoryId: 3 },
+  { title: 'c' },
+]
 
 function buildImport(overrides: Partial<LastImport> = {}): LastImport {
   return {
     importBatchId: 'batch-1',
     zone: 'completed',
     count: 3,
-    titles: ['a', 'b', 'c'],
+    items: [{ title: 'a' }, { title: 'b' }, { title: 'c' }],
     expiresAt: Date.now() + 60000,
     ...overrides,
   }
 }
 
-function renderBanner(lastImport: LastImport | null) {
+function renderBanner(
+  lastImport: LastImport | null,
+  onDismiss = vi.fn(),
+  onChanged = vi.fn(),
+) {
   const client = new QueryClient()
   return render(
     <QueryClientProvider client={client}>
       <ImportUndoBanner
         lastImport={lastImport}
-        onDismiss={vi.fn()}
-        onChanged={vi.fn()}
+        onDismiss={onDismiss}
+        onChanged={onChanged}
       />
     </QueryClientProvider>,
   )
@@ -43,12 +125,37 @@ describe('ImportUndoBanner', () => {
 
   it('offers Move to Completed only for a Todo-zone batch', () => {
     // Arrange + Act
-    renderBanner(buildImport({ zone: 'todo' }))
+    renderBanner(buildImport({ zone: 'todo', items: TODO_ITEMS }))
 
     // Assert
     expect(
       screen.getByRole('button', { name: 'Move to Completed' }),
     ).toBeInTheDocument()
+  })
+
+  it('does not call deleteTodo when createCompleted fails (create-before-delete invariant)', async () => {
+    // Arrange — the hoisted mock wires mockCreateCompleted to call 2 (createCompleted)
+    // and mockDeleteTodo to call 1 (deleteTodo). mockCreateCompleted is pre-loaded
+    // with an onError-invoking implementation that simulates an offline failure.
+    resetMutationMocks()
+
+    const todoBatch = buildImport({
+      zone: 'todo',
+      importBatchId: 'todo-batch-42',
+      items: TODO_ITEMS,
+    })
+
+    // Act
+    renderBanner(todoBatch)
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Move to Completed' }),
+    )
+
+    // Assert — createCompleted fired, deleteTodo must NOT have fired because
+    // the create step failed. This locks the create-before-delete ordering
+    // that prevents irrecoverable task loss (P2-1 fix invariant).
+    expect(mockCreateCompleted).toHaveBeenCalledOnce()
+    expect(mockDeleteTodo).not.toHaveBeenCalled()
   })
 
   it('renders nothing when there is no recent import', () => {

--- a/src/components/import/ImportUndoBanner.tsx
+++ b/src/components/import/ImportUndoBanner.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import { Undo2, ArrowRightLeft } from 'lucide-react'
+import * as React from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { orpc } from '@/lib/orpc/client-query'
+
+import type { LastImport } from './PasteImport'
+
+/**
+ * Subscribes to a wall-clock tick so the banner can hide itself the instant the
+ * 60s undo window closes (no setInterval state, SSR-safe). Re-renders ~once per
+ * second while mounted.
+ *
+ * @param callback - React's store-changed callback.
+ * @returns Cleanup that clears the interval.
+ */
+function subscribeToClock(callback: () => void): () => void {
+  const id = window.setInterval(callback, 1000)
+  return () => window.clearInterval(id)
+}
+
+/** Snapshot getter: current epoch ms (the value the banner compares to expiry). */
+function getNowSnapshot(): number {
+  return Date.now()
+}
+
+/** SSR fallback: 0 → banner never renders during server render. */
+function getNowServerSnapshot(): number {
+  return 0
+}
+
+/**
+ * Props for the inline post-import undo banner.
+ */
+export interface ImportUndoBannerProps {
+  /** The most recent import, or null when there's nothing to offer undo for. */
+  lastImport: LastImport | null
+  /** Clears the parent's `lastImport` (called after undo, move, or expiry). */
+  onDismiss: () => void
+  /** Re-invalidate the caller's queries after a destructive action. */
+  onChanged: () => void
+}
+
+/**
+ * Discoverable 60s inline undo affordance (D5) shown above the relevant list:
+ * `Imported N just now · Undo import`. For the Todo zone it also offers
+ * `Move to Completed` (P2 wrong-zone recovery) — client-orchestrated:
+ * `todo.deleteMany(oldBatch)` then `completed.createMany` of the retained
+ * titles under a NEW batch id (no new server proc). Hides on undo, move, or
+ * window expiry. Complements the transient success toast.
+ *
+ * @param props - See {@link ImportUndoBannerProps}.
+ * @returns The banner, or null when there is nothing to undo / the window expired.
+ * @example
+ * <ImportUndoBanner lastImport={batch} onDismiss={() => setBatch(null)} onChanged={invalidate} />
+ */
+export const ImportUndoBanner = React.memo(function ImportUndoBanner({
+  lastImport,
+  onDismiss,
+  onChanged,
+}: ImportUndoBannerProps) {
+  const now = useSyncExternalStore(
+    subscribeToClock,
+    getNowSnapshot,
+    getNowServerSnapshot,
+  )
+
+  const deleteCompletedMutation = useMutation(
+    orpc.completed.deleteMany.mutationOptions({}),
+  )
+  const deleteTodoMutation = useMutation(
+    orpc.todo.deleteMany.mutationOptions({}),
+  )
+  const createCompletedMutation = useMutation(
+    orpc.completed.createMany.mutationOptions({}),
+  )
+
+  const isBusy =
+    deleteCompletedMutation.isPending ||
+    deleteTodoMutation.isPending ||
+    createCompletedMutation.isPending
+
+  const handleUndo = useCallback(() => {
+    if (!lastImport) return
+    const undo =
+      lastImport.zone === 'completed'
+        ? deleteCompletedMutation
+        : deleteTodoMutation
+    undo.mutate(
+      { importBatchId: lastImport.importBatchId },
+      {
+        onSuccess: () => {
+          onChanged()
+          onDismiss()
+        },
+        onError: () => {
+          toast.error("Couldn't undo — the import is still saved")
+        },
+      },
+    )
+  }, [
+    deleteCompletedMutation,
+    deleteTodoMutation,
+    lastImport,
+    onChanged,
+    onDismiss,
+  ])
+
+  const handleMoveToCompleted = useCallback(() => {
+    if (!lastImport || lastImport.zone !== 'todo') return
+    // Re-route: delete the Todo batch, then re-create the SAME titles in
+    // Completed under a fresh batch id. We still hold the parsed titles.
+    deleteTodoMutation.mutate(
+      { importBatchId: lastImport.importBatchId },
+      {
+        onSuccess: () => {
+          createCompletedMutation.mutate(
+            {
+              items: lastImport.titles.map((title) => ({ title })),
+              importBatchId: crypto.randomUUID(),
+            },
+            {
+              onSuccess: (result) => {
+                toast.success(
+                  `${result.count.toLocaleString()} moved — today's lit`,
+                )
+                onChanged()
+                onDismiss()
+              },
+              onError: () => {
+                // The Todo rows are already gone; surface a clear recovery hint.
+                toast.error(
+                  "Moved out of your list but couldn't add to Completed — paste them again",
+                )
+                onChanged()
+                onDismiss()
+              },
+            },
+          )
+        },
+        onError: () => {
+          toast.error("Couldn't move — your tasks are still in the list")
+        },
+      },
+    )
+  }, [
+    createCompletedMutation,
+    deleteTodoMutation,
+    lastImport,
+    onChanged,
+    onDismiss,
+  ])
+
+  // Nothing to show, or the 60s window has closed → render nothing.
+  if (!lastImport || lastImport.count === 0) return null
+  if (now !== 0 && now >= lastImport.expiresAt) return null
+
+  return (
+    <div
+      className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-card px-3 py-2"
+      role="status"
+    >
+      <span className="text-sm text-muted-foreground">
+        Imported {lastImport.count.toLocaleString()} just now
+      </span>
+      <div className="flex items-center gap-1">
+        {lastImport.zone === 'todo' ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleMoveToCompleted}
+            disabled={isBusy}
+          >
+            <ArrowRightLeft className="size-4" aria-hidden="true" />
+            Move to Completed
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleUndo}
+          disabled={isBusy}
+        >
+          <Undo2 className="size-4" aria-hidden="true" />
+          Undo import
+        </Button>
+      </div>
+    </div>
+  )
+})

--- a/src/components/import/ImportUndoBanner.tsx
+++ b/src/components/import/ImportUndoBanner.tsx
@@ -3,36 +3,14 @@
 import { useMutation } from '@tanstack/react-query'
 import { Undo2, ArrowRightLeft } from 'lucide-react'
 import * as React from 'react'
-import { useCallback, useSyncExternalStore } from 'react'
+import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { orpc } from '@/lib/orpc/client-query'
 
 import type { LastImport } from './PasteImport'
-
-/**
- * Subscribes to a wall-clock tick so the banner can hide itself the instant the
- * 60s undo window closes (no setInterval state, SSR-safe). Re-renders ~once per
- * second while mounted.
- *
- * @param callback - React's store-changed callback.
- * @returns Cleanup that clears the interval.
- */
-function subscribeToClock(callback: () => void): () => void {
-  const id = window.setInterval(callback, 1000)
-  return () => window.clearInterval(id)
-}
-
-/** Snapshot getter: current epoch ms (the value the banner compares to expiry). */
-function getNowSnapshot(): number {
-  return Date.now()
-}
-
-/** SSR fallback: 0 → banner never renders during server render. */
-function getNowServerSnapshot(): number {
-  return 0
-}
 
 /**
  * Props for the inline post-import undo banner.
@@ -64,11 +42,22 @@ export const ImportUndoBanner = React.memo(function ImportUndoBanner({
   onDismiss,
   onChanged,
 }: ImportUndoBannerProps) {
-  const now = useSyncExternalStore(
-    subscribeToClock,
-    getNowSnapshot,
-    getNowServerSnapshot,
-  )
+  // The banner shows no countdown — just "Imported N just now" — so a single
+  // timer that flips an `expired` flag at the window edge is enough (no
+  // per-second clock, no unstable `Date.now()` snapshot that would re-render
+  // loop). Re-arms whenever a new batch (new `lastImport` object) arrives.
+  const [expired, setExpired] = useState(false)
+  useComponentEffect(() => {
+    if (!lastImport) return
+    const remainingMs = lastImport.expiresAt - Date.now()
+    if (remainingMs <= 0) {
+      setExpired(true)
+      return
+    }
+    setExpired(false)
+    const timeoutId = window.setTimeout(() => setExpired(true), remainingMs)
+    return () => window.clearTimeout(timeoutId)
+  }, [lastImport])
 
   const deleteCompletedMutation = useMutation(
     orpc.completed.deleteMany.mutationOptions({}),
@@ -156,9 +145,12 @@ export const ImportUndoBanner = React.memo(function ImportUndoBanner({
     onDismiss,
   ])
 
-  // Nothing to show, or the 60s window has closed → render nothing.
+  // Nothing to show, or the 60s window has closed → render nothing. The
+  // `expired` flag handles the live transition; the inline Date.now() guard
+  // covers an already-expired batch on first render (a plain render read is
+  // safe — unlike a useSyncExternalStore snapshot it never re-renders).
   if (!lastImport || lastImport.count === 0) return null
-  if (now !== 0 && now >= lastImport.expiresAt) return null
+  if (expired || Date.now() >= lastImport.expiresAt) return null
 
   return (
     <div

--- a/src/components/import/ImportUndoBanner.tsx
+++ b/src/components/import/ImportUndoBanner.tsx
@@ -27,10 +27,12 @@ export interface ImportUndoBannerProps {
 /**
  * Discoverable 60s inline undo affordance (D5) shown above the relevant list:
  * `Imported N just now · Undo import`. For the Todo zone it also offers
- * `Move to Completed` (P2 wrong-zone recovery) — client-orchestrated:
- * `todo.deleteMany(oldBatch)` then `completed.createMany` of the retained
- * titles under a NEW batch id (no new server proc). Hides on undo, move, or
- * window expiry. Complements the transient success toast.
+ * `Move to Completed` (P2 wrong-zone recovery) — client-orchestrated, ordered
+ * create-before-delete so a network blip on the delete step leaves recoverable
+ * duplicates rather than irrecoverable loss: `completed.createMany` (new batch
+ * id, full items with categoryIds) first; only on its success, `todo.deleteMany`
+ * (old batch id). On create failure the banner stays mounted for retry.
+ * Hides on undo, successful move, or window expiry.
  *
  * @param props - See {@link ImportUndoBannerProps}.
  * @returns The banner, or null when there is nothing to undo / the window expired.
@@ -102,29 +104,35 @@ export const ImportUndoBanner = React.memo(function ImportUndoBanner({
 
   const handleMoveToCompleted = useCallback(() => {
     if (!lastImport || lastImport.zone !== 'todo') return
-    // Re-route: delete the Todo batch, then re-create the SAME titles in
-    // Completed under a fresh batch id. We still hold the parsed titles.
-    deleteTodoMutation.mutate(
-      { importBatchId: lastImport.importBatchId },
+    // Create-before-delete: add to Completed first (new batch id, all categoryId
+    // overrides retained). Only on create success do we delete the Todo batch.
+    // If create fails → banner stays mounted for retry, todos untouched (no loss).
+    // If delete fails after a successful create → duplicates in both zones, but
+    // that is recoverable via Undo in either banner; irrecoverable loss is not.
+    createCompletedMutation.mutate(
       {
-        onSuccess: () => {
-          createCompletedMutation.mutate(
+        items: lastImport.items,
+        importBatchId: crypto.randomUUID(),
+      },
+      {
+        onSuccess: (createResult) => {
+          deleteTodoMutation.mutate(
+            { importBatchId: lastImport.importBatchId },
             {
-              items: lastImport.titles.map((title) => ({ title })),
-              importBatchId: crypto.randomUUID(),
-            },
-            {
-              onSuccess: (result) => {
+              onSuccess: () => {
                 toast.success(
-                  `${result.count.toLocaleString()} moved — today's lit`,
+                  `${createResult.count.toLocaleString()} moved — today's lit`,
                 )
                 onChanged()
                 onDismiss()
               },
               onError: () => {
-                // The Todo rows are already gone; surface a clear recovery hint.
-                toast.error(
-                  "Moved out of your list but couldn't add to Completed — paste them again",
+                // Create succeeded, delete failed → tasks appear in both zones.
+                // Primary goal (Completed) is achieved. Dismiss cleanly and let
+                // the user undo via either zone's banner. A second move attempt
+                // would create another Completed batch, making it worse.
+                toast.success(
+                  `Added to Completed — your list may still show them too`,
                 )
                 onChanged()
                 onDismiss()
@@ -133,6 +141,7 @@ export const ImportUndoBanner = React.memo(function ImportUndoBanner({
           )
         },
         onError: () => {
+          // Create failed → todos untouched, banner stays visible for retry.
           toast.error("Couldn't move — your tasks are still in the list")
         },
       },

--- a/src/components/import/PasteImport.stories.tsx
+++ b/src/components/import/PasteImport.stories.tsx
@@ -1,0 +1,173 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+
+import type { CategoryWithCount } from '@/server/schemas/category'
+
+import type { PasteImportItem } from './paste-import-types'
+import { PasteImportDialog } from './PasteImportDialog'
+
+/**
+ * Stories target the PRESENTATIONAL dialog (no oRPC / react-query / Toaster),
+ * so they render in Storybook + storybook-test with zero providers. The parse
+ * is pure/synchronous, so every interaction state is reachable from `zone` +
+ * `initialText` args alone. This doubles as the design-review / QA surface.
+ */
+const SAMPLE_CATEGORIES: CategoryWithCount[] = [
+  {
+    id: 1,
+    name: 'General',
+    color: 'blue',
+    isDefault: true,
+    userId: 1,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    _count: { todos: 4 },
+  },
+  {
+    id: 2,
+    name: 'Writing',
+    color: 'amber',
+    isDefault: false,
+    userId: 1,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    _count: { todos: 2 },
+  },
+  {
+    id: 3,
+    name: 'Health',
+    color: 'green',
+    isDefault: false,
+    userId: 1,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    _count: { todos: 7 },
+  },
+]
+
+// A paste with a couple of droppable (blank / prefix-only) lines → "skipped".
+const PREVIEW_WITH_SKIPS_TEXT = [
+  '- shipped the 0.7.0 release',
+  '',
+  '- [x] reviewed three PRs',
+  '   ',
+  'wrote the weekly digest',
+  '- ',
+  'https://corelive.app/changelog',
+].join('\n')
+
+// 1,200 non-blank lines → over the 1,000 cap.
+const OVER_CAP_TEXT = Array.from(
+  { length: 1200 },
+  (_, index) => `task number ${index + 1}`,
+).join('\n')
+
+const noop = (_items: PasteImportItem[]) => {}
+
+const meta: Meta<typeof PasteImportDialog> = {
+  title: 'Import/PasteImport',
+  component: PasteImportDialog,
+  parameters: { layout: 'fullscreen' },
+}
+
+export default meta
+type Story = StoryObj<typeof PasteImportDialog>
+
+/**
+ * Renders the dialog open + controllable so the modal content is visible in the
+ * canvas (Radix portals the content; controlled `open` keeps it mounted).
+ */
+function Template(args: React.ComponentProps<typeof PasteImportDialog>) {
+  const [open, setOpen] = useState(true)
+  return (
+    <div style={{ minHeight: 600 }}>
+      <PasteImportDialog {...args} open={open} onOpenChange={setOpen} />
+    </div>
+  )
+}
+
+/** Idle / empty: confirm disabled, warm empty hint below. */
+export const Empty: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    zone: 'completed',
+    categories: SAMPLE_CATEGORIES,
+    defaultCategoryId: 1,
+    isSubmitting: false,
+    error: null,
+    onConfirm: noop,
+    initialText: '',
+  },
+}
+
+/** Preview with skipped lines: dense list + `N tasks · M skipped`. */
+export const PreviewWithSkips: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    zone: 'completed',
+    categories: SAMPLE_CATEGORIES,
+    defaultCategoryId: 1,
+    isSubmitting: false,
+    error: null,
+    onConfirm: noop,
+    initialText: PREVIEW_WITH_SKIPS_TEXT,
+  },
+}
+
+/** Over-cap: `1,200 lines · importing the first 1,000`; confirm `Add 1,000`. */
+export const OverCap: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    zone: 'completed',
+    categories: SAMPLE_CATEGORIES,
+    defaultCategoryId: 1,
+    isSubmitting: false,
+    error: null,
+    onConfirm: noop,
+    initialText: OVER_CAP_TEXT,
+  },
+}
+
+/** Todo zone: shows the pre-confirm "these stay open…" expectation note. */
+export const TodoZone: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    zone: 'todo',
+    categories: SAMPLE_CATEGORIES,
+    defaultCategoryId: 1,
+    isSubmitting: false,
+    error: null,
+    onConfirm: noop,
+    initialText: ['draft the Q3 plan', 'book the venue', 'email the team'].join(
+      '\n',
+    ),
+  },
+}
+
+/** Submitting: inputs locked, confirm shows the spinner + `Adding…`. */
+export const Submitting: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    zone: 'completed',
+    categories: SAMPLE_CATEGORIES,
+    defaultCategoryId: 1,
+    isSubmitting: true,
+    error: null,
+    onConfirm: noop,
+    initialText: ['shipped the release', 'reviewed PRs'].join('\n'),
+  },
+}
+
+/** Error / offline: dialog stays open, paste preserved, confirm → `Try again`. */
+export const ErrorOffline: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    zone: 'completed',
+    categories: SAMPLE_CATEGORIES,
+    defaultCategoryId: 1,
+    isSubmitting: false,
+    error: "Couldn't reach the server — your paste is safe",
+    onConfirm: noop,
+    initialText: ['shipped the release', 'reviewed PRs'].join('\n'),
+  },
+}

--- a/src/components/import/PasteImport.tsx
+++ b/src/components/import/PasteImport.tsx
@@ -30,17 +30,19 @@ const UNDO_WINDOW_MS = COMPLETED_UNDO_WINDOW_MS
 /**
  * Records the just-imported batch so the caller can render a 60s inline undo
  * banner (D5) and, for the Todo zone, a Move-to-Completed recovery (P2). The
- * parsed `titles` are retained (not just the count) so Move-to-Completed can
- * re-route the same items under a new batch id without re-parsing.
+ * full `items` (title + categoryId) are retained so Move-to-Completed can
+ * re-route the same items — including per-row categories — under a new batch
+ * id without re-parsing or discarding user overrides.
  *
  * @example
- * { importBatchId: 'b2c1…', zone: 'todo', count: 3, titles: ['a','b','c'], expiresAt: 1717000000000 }
+ * { importBatchId: 'b2c1…', zone: 'todo', count: 3, items: [{title:'a'},{title:'gym',categoryId:3}], expiresAt: 1717000000000 }
  */
 export type LastImport = {
   importBatchId: string
   zone: PasteImportZone
   count: number
-  titles: string[]
+  /** Full parsed items (title + optional categoryId per row) for undo and Move-to-Completed replay. */
+  items: PasteImportItem[]
   /** Epoch ms when the 60s undo window closes. */
   expiresAt: number
 }
@@ -184,7 +186,6 @@ export const PasteImport = React.memo(function PasteImport({
         batchIdRef.current = crypto.randomUUID()
       }
       const importBatchId = batchIdRef.current
-      const titles = items.map((item) => item.title)
 
       try {
         const result = await match(zone)
@@ -200,7 +201,9 @@ export const PasteImport = React.memo(function PasteImport({
           importBatchId,
           zone,
           count: result.count,
-          titles,
+          // Retain full items (title + categoryId) so Move-to-Completed can
+          // replay them with all per-row overrides intact, not just titles.
+          items,
           expiresAt: Date.now() + UNDO_WINDOW_MS,
         }
 

--- a/src/components/import/PasteImport.tsx
+++ b/src/components/import/PasteImport.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 import { match } from 'ts-pattern'
 
 import { useSelectedCategory } from '@/hooks/useSelectedCategory'
+import { COMPLETED_UNDO_WINDOW_MS } from '@/lib/constants/import'
 import { orpc } from '@/lib/orpc/client-query'
 import type { CategoryWithCount } from '@/server/schemas/category'
 
@@ -18,6 +19,13 @@ import { PasteImportDialog } from './PasteImportDialog'
 
 /** How long the success toast (with Undo) stays up. */
 const UNDO_TOAST_MS = 10000
+
+/**
+ * The 60s undo window the banner's expiry is keyed to. Single-sourced from the
+ * server constant so the UI window can never drift from the server's
+ * window-guarded `deleteMany` (plan eng fold-in).
+ */
+const UNDO_WINDOW_MS = COMPLETED_UNDO_WINDOW_MS
 
 /**
  * Records the just-imported batch so the caller can render a 60s inline undo
@@ -58,9 +66,6 @@ export interface PasteImportProps {
   /** Controlled open setter (optional). */
   onOpenChange?: (open: boolean) => void
 }
-
-/** Undo window (kept in sync with the server's COMPLETED_UNDO_WINDOW_MS = 60s). */
-const UNDO_WINDOW_MS = 60 * 1000
 
 /**
  * oRPC container for paste-import. Wires `completed.createMany` /

--- a/src/components/import/PasteImport.tsx
+++ b/src/components/import/PasteImport.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import * as React from 'react'
+import { useCallback, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { match } from 'ts-pattern'
+
+import { useSelectedCategory } from '@/hooks/useSelectedCategory'
+import { orpc } from '@/lib/orpc/client-query'
+import type { CategoryWithCount } from '@/server/schemas/category'
+
+import {
+  type PasteImportItem,
+  type PasteImportZone,
+} from './paste-import-types'
+import { PasteImportDialog } from './PasteImportDialog'
+
+/** How long the success toast (with Undo) stays up. */
+const UNDO_TOAST_MS = 10000
+
+/**
+ * Records the just-imported batch so the caller can render a 60s inline undo
+ * banner (D5) and, for the Todo zone, a Move-to-Completed recovery (P2). The
+ * parsed `titles` are retained (not just the count) so Move-to-Completed can
+ * re-route the same items under a new batch id without re-parsing.
+ *
+ * @example
+ * { importBatchId: 'b2c1…', zone: 'todo', count: 3, titles: ['a','b','c'], expiresAt: 1717000000000 }
+ */
+export type LastImport = {
+  importBatchId: string
+  zone: PasteImportZone
+  count: number
+  titles: string[]
+  /** Epoch ms when the 60s undo window closes. */
+  expiresAt: number
+}
+
+/**
+ * Props for the paste-import container. The caller supplies the `trigger`, the
+ * `categories` list (injected, never fetched here — matches BrainDumpEditor),
+ * and `onImported` (where the caller invalidates the right react-query keys so
+ * the heatmap fill / list update happens). `open`/`onOpenChange` are optional:
+ * pass them to make the dialog controllable (D7 opens it without a trigger).
+ */
+export interface PasteImportProps {
+  /** Destination zone — selects copy + which `createMany` runs. */
+  zone: PasteImportZone
+  /** The element that opens the dialog (e.g. an "Import" button). */
+  trigger?: React.ReactNode
+  /** Categories for the shared + per-row Select. */
+  categories: CategoryWithCount[]
+  /** Called after a successful import so the caller invalidates its queries. */
+  onImported?: (result: LastImport) => void
+  /** Controlled open state (optional — omit for trigger-only usage). */
+  open?: boolean
+  /** Controlled open setter (optional). */
+  onOpenChange?: (open: boolean) => void
+}
+
+/** Undo window (kept in sync with the server's COMPLETED_UNDO_WINDOW_MS = 60s). */
+const UNDO_WINDOW_MS = 60 * 1000
+
+/**
+ * oRPC container for paste-import. Wires `completed.createMany` /
+ * `todo.createMany` to the presentational {@link PasteImportDialog}, owns the
+ * idempotent `importBatchId` lifecycle (generated at first confirm, REUSED on
+ * retry so a committed-but-timed-out submit is a P2002 no-op, cleared on
+ * success + close), fires the success toast with bulk Undo, and reports the
+ * batch up via `onImported`. Triggered from each zone's Import entry point.
+ *
+ * @param props - See {@link PasteImportProps}.
+ * @returns The wired paste-import dialog.
+ * @example
+ * <PasteImport zone="completed" categories={cats} trigger={<Button>Import</Button>}
+ *   onImported={(batch) => invalidateHeatmap()} />
+ */
+export const PasteImport = React.memo(function PasteImport({
+  zone,
+  trigger,
+  categories,
+  onImported,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+}: PasteImportProps) {
+  const [selectedCategoryId] = useSelectedCategory()
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Support both controlled (D7) and uncontrolled (trigger-only) usage.
+  const isControlled = controlledOpen !== undefined
+  const open = isControlled ? controlledOpen : uncontrolledOpen
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (isControlled) controlledOnOpenChange?.(next)
+      else setUncontrolledOpen(next)
+    },
+    [controlledOnOpenChange, isControlled],
+  )
+
+  // The batch id persists across retries (idempotency) and is cleared on
+  // success + close so a fresh paste gets a new id.
+  const batchIdRef = useRef<string | null>(null)
+
+  const createCompletedMutation = useMutation(
+    orpc.completed.createMany.mutationOptions({}),
+  )
+  const createTodoMutation = useMutation(
+    orpc.todo.createMany.mutationOptions({}),
+  )
+  const deleteCompletedMutation = useMutation(
+    orpc.completed.deleteMany.mutationOptions({}),
+  )
+  const deleteTodoMutation = useMutation(
+    orpc.todo.deleteMany.mutationOptions({}),
+  )
+
+  const isSubmitting =
+    createCompletedMutation.isPending || createTodoMutation.isPending
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) {
+        // Fresh id + cleared error on every close so a reopen is a new batch.
+        batchIdRef.current = null
+        setError(null)
+      }
+      setOpen(next)
+    },
+    [setOpen],
+  )
+
+  /**
+   * Fire the success toast with a 10s Undo that deletes the whole batch by id.
+   * Undo re-invalidates via `onImported` so the heatmap/list snap back.
+   */
+  const showUndoToast = useCallback(
+    (batch: LastImport) => {
+      const successCopy =
+        batch.zone === 'completed'
+          ? `${batch.count.toLocaleString()} added — today's lit`
+          : `${batch.count.toLocaleString()} added to your list`
+
+      const toastId = toast.success(successCopy, {
+        duration: UNDO_TOAST_MS,
+        action: {
+          label: 'Undo',
+          onClick: () => {
+            const undo =
+              batch.zone === 'completed'
+                ? deleteCompletedMutation
+                : deleteTodoMutation
+            undo.mutate(
+              { importBatchId: batch.importBatchId },
+              {
+                onSuccess: () => {
+                  toast.dismiss(toastId)
+                  // Re-invalidate so the undone rows disappear immediately.
+                  onImported?.({ ...batch, count: 0 })
+                },
+                onError: () => {
+                  toast.error("Couldn't undo — the import is still saved")
+                },
+              },
+            )
+          },
+        },
+      })
+    },
+    [deleteCompletedMutation, deleteTodoMutation, onImported],
+  )
+
+  const handleConfirm = useCallback(
+    async (items: PasteImportItem[]) => {
+      setError(null)
+      // Generate once; reuse on retry → idempotent on the server (P2002 no-op).
+      if (batchIdRef.current === null) {
+        batchIdRef.current = crypto.randomUUID()
+      }
+      const importBatchId = batchIdRef.current
+      const titles = items.map((item) => item.title)
+
+      try {
+        const result = await match(zone)
+          .with('completed', async () =>
+            createCompletedMutation.mutateAsync({ items, importBatchId }),
+          )
+          .with('todo', async () =>
+            createTodoMutation.mutateAsync({ items, importBatchId }),
+          )
+          .exhaustive()
+
+        const batch: LastImport = {
+          importBatchId,
+          zone,
+          count: result.count,
+          titles,
+          expiresAt: Date.now() + UNDO_WINDOW_MS,
+        }
+
+        // Success: clear the id (next open = new batch), close, notify, toast.
+        batchIdRef.current = null
+        setOpen(false)
+        onImported?.(batch)
+        showUndoToast(batch)
+      } catch {
+        // Offline / server error: keep the dialog open, preserve the paste, and
+        // keep the SAME batch id so "Try again" is idempotent. The error line
+        // renders inside the dialog; a toast mirrors it for discoverability.
+        setError("Couldn't reach the server — your paste is safe")
+        toast.error("Couldn't reach the server — your paste is safe")
+      }
+    },
+    [
+      createCompletedMutation,
+      createTodoMutation,
+      onImported,
+      setOpen,
+      showUndoToast,
+      zone,
+    ],
+  )
+
+  return (
+    <PasteImportDialog
+      zone={zone}
+      categories={categories}
+      defaultCategoryId={selectedCategoryId}
+      open={open}
+      onOpenChange={handleOpenChange}
+      trigger={trigger}
+      isSubmitting={isSubmitting}
+      error={error}
+      onConfirm={handleConfirm}
+    />
+  )
+})

--- a/src/components/import/PasteImportDialog.test.tsx
+++ b/src/components/import/PasteImportDialog.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CategoryWithCount } from '@/server/schemas/category'
+
+import {
+  PasteImportDialog,
+  type PasteImportDialogProps,
+} from './PasteImportDialog'
+
+const CATEGORIES: CategoryWithCount[] = [
+  {
+    id: 1,
+    name: 'General',
+    color: 'blue',
+    isDefault: true,
+    userId: 1,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    _count: { todos: 0 },
+  },
+]
+
+/**
+ * Renders the dialog open with sane defaults; per-test overrides via `props`.
+ */
+function renderDialog(props: Partial<PasteImportDialogProps> = {}) {
+  const onConfirm = vi.fn()
+  const onOpenChange = vi.fn()
+  render(
+    <PasteImportDialog
+      zone="completed"
+      categories={CATEGORIES}
+      defaultCategoryId={1}
+      open={true}
+      onOpenChange={onOpenChange}
+      isSubmitting={false}
+      error={null}
+      onConfirm={onConfirm}
+      {...props}
+    />,
+  )
+  return { onConfirm, onOpenChange }
+}
+
+describe('PasteImportDialog', () => {
+  it('shows the warm empty hint and disables confirm when there is nothing to import', () => {
+    // Arrange + Act
+    renderDialog({ initialText: '' })
+
+    // Assert
+    expect(
+      screen.getByText('nothing to import yet — paste a few lines above'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Add 0 to Completed/ }),
+    ).toBeDisabled()
+  })
+
+  it('lists parsed rows and labels the confirm with the importable count', () => {
+    // Arrange — 2 real lines, 1 blank.
+    renderDialog({ initialText: 'shipped release\n\nreviewed PRs' })
+
+    // Act + Assert
+    expect(screen.getByText('shipped release')).toBeInTheDocument()
+    expect(screen.getByText('reviewed PRs')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Add 2 to Completed' }),
+    ).toBeEnabled()
+  })
+
+  it('shows the over-cap line and caps the confirm label at 1,000', () => {
+    // Arrange — 1,200 non-blank lines.
+    const text = Array.from({ length: 1200 }, (_, i) => `task ${i}`).join('\n')
+    renderDialog({ initialText: text })
+
+    // Assert — exact copy from the spec, with locale commas.
+    expect(
+      screen.getByText('1,200 lines · importing the first 1,000'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Add 1,000 to Completed' }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the Todo expectation note in the Todo zone', () => {
+    // Arrange + Act
+    renderDialog({ zone: 'todo', initialText: 'draft plan\nbook venue' })
+
+    // Assert
+    expect(
+      screen.getByText(
+        "these stay open — they'll light the heatmap as you complete them",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Add 2 to your list' }),
+    ).toBeInTheDocument()
+  })
+
+  it('sends only the parsed titles with the inherited category on confirm', async () => {
+    // Arrange
+    const { onConfirm } = renderDialog({
+      initialText: '- gym\n\n- [x] read',
+    })
+
+    // Act — click the amber confirm.
+    const confirm = screen.getByRole('button', { name: 'Add 2 to Completed' })
+    confirm.click()
+
+    // Assert — blank line dropped; both rows carry the shared category id (1).
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onConfirm).toHaveBeenCalledWith([
+      { title: 'gym', categoryId: 1 },
+      { title: 'read', categoryId: 1 },
+    ])
+  })
+
+  it('locks the confirm and shows the adding state while submitting', () => {
+    // Arrange + Act
+    renderDialog({ initialText: 'shipped release', isSubmitting: true })
+
+    // Assert
+    const confirm = screen.getByRole('button', { name: /Adding/ })
+    expect(confirm).toBeDisabled()
+    expect(confirm).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('keeps the dialog open with a Try again action and an alert on error', () => {
+    // Arrange + Act
+    renderDialog({
+      initialText: 'shipped release',
+      error: "Couldn't reach the server — your paste is safe",
+    })
+
+    // Assert — the paste is preserved in the textarea, the error is announced,
+    // and a retry control is offered (the dialog stays open).
+    expect(screen.getByRole('textbox')).toHaveValue('shipped release')
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "Couldn't reach the server — your paste is safe",
+    )
+    expect(
+      screen.getByRole('button', { name: 'Try again' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/import/PasteImportDialog.tsx
+++ b/src/components/import/PasteImportDialog.tsx
@@ -1,0 +1,621 @@
+'use client'
+
+import { Loader2, X } from 'lucide-react'
+import * as React from 'react'
+import { useCallback, useDeferredValue, useId, useMemo, useState } from 'react'
+import { match } from 'ts-pattern'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import type { CategoryWithCount } from '@/server/schemas/category'
+
+import {
+  computePasteImportPreview,
+  type PasteImportItem,
+  type PasteImportZone,
+} from './paste-import-types'
+
+/**
+ * Zone-specific copy. Centralized so the title, placeholder, confirm verb, and
+ * the Todo pre-confirm expectation note all read from one table (mirrors the
+ * plan's copy table). English strings — the shipped app is English.
+ */
+const ZONE_COPY: Record<
+  PasteImportZone,
+  {
+    title: string
+    placeholder: string
+    /** Confirm label builder, e.g. "Add 12 to Completed". */
+    confirmLabel: (count: string) => string
+    /** Shown only for the Todo zone, above the confirm. */
+    note?: string
+  }
+> = {
+  completed: {
+    title: 'Add to Completed',
+    placeholder: 'paste your wins — one per line',
+    confirmLabel: (count) => `Add ${count} to Completed`,
+  },
+  todo: {
+    title: 'Add to your list',
+    placeholder: 'paste your tasks — one per line',
+    confirmLabel: (count) => `Add ${count} to your list`,
+    note: "these stay open — they'll light the heatmap as you complete them",
+  },
+}
+
+/**
+ * Props for the presentational paste-import dialog. Deliberately oRPC-free:
+ * the parent ({@link PasteImport}) injects `categories`, owns the mutation, and
+ * passes `isSubmitting` / `error` / `onConfirm`. This seam lets the Storybook
+ * stories render the full UI with zero providers (no react-query, no Toaster).
+ */
+export interface PasteImportDialogProps {
+  /** Destination zone — selects copy + which procedure the parent will call. */
+  zone: PasteImportZone
+  /** Categories for the shared + per-row Select (injected, never fetched here). */
+  categories: CategoryWithCount[]
+  /** Initial shared category (from `useSelectedCategory()`); null = first/none. */
+  defaultCategoryId: number | null
+  /** Controlled open state (lifted so D7 can open it without a trigger click). */
+  open: boolean
+  /** Open-state setter from the parent. */
+  onOpenChange: (open: boolean) => void
+  /** Optional trigger node (e.g. an "Import" button) rendered as the dialog trigger. */
+  trigger?: React.ReactNode
+  /** True while the confirm submit is in flight — locks inputs + shows the spinner. */
+  isSubmitting: boolean
+  /** Non-null when the last submit failed — keeps the dialog open with a retry. */
+  error: string | null
+  /**
+   * Confirm handler. Receives the capped item list + a stable batch id (the
+   * parent holds the id so a retry reuses it → idempotent). Resolves when the
+   * parent finishes (success closes; failure surfaces via `error`).
+   */
+  onConfirm: (items: PasteImportItem[]) => void | Promise<void>
+  /**
+   * Seed text for the textarea. Defaults to `''`. Exists so Storybook stories
+   * and unit tests can render the preview/over-cap states without simulating
+   * typing; production callers leave it unset.
+   */
+  initialText?: string
+}
+
+/**
+ * Presentational variant-C paste-import dialog: serif title → textarea → shared
+ * category + live count → quiet dense preview list → confirm. Parses on every
+ * change (cheap/sync) and renders all interaction states. Holds only local UI
+ * state (text, shared category, per-row overrides); all async + data come from
+ * props so it renders in Storybook with no providers.
+ *
+ * @param props - See {@link PasteImportDialogProps}.
+ * @returns The paste-import dialog (trigger + modal content).
+ * @example
+ * <PasteImportDialog zone="completed" categories={cats} defaultCategoryId={1}
+ *   open={open} onOpenChange={setOpen} isSubmitting={false} error={null}
+ *   onConfirm={(items) => console.log(items)} trigger={<Button>Import</Button>} />
+ */
+export const PasteImportDialog = React.memo(function PasteImportDialog({
+  zone,
+  categories,
+  defaultCategoryId,
+  open,
+  onOpenChange,
+  trigger,
+  isSubmitting,
+  error,
+  onConfirm,
+  initialText = '',
+}: PasteImportDialogProps) {
+  const [text, setText] = useState(initialText)
+  // The shared category falls back to the explicit default, else the first
+  // category, else null (Select stays empty until categories load).
+  const initialSharedCategory = defaultCategoryId ?? categories[0]?.id ?? null
+  const [sharedCategoryId, setSharedCategoryId] = useState<number | null>(
+    initialSharedCategory,
+  )
+  // Per-row overrides keyed by row index. Cleared whenever the parse changes
+  // (the BrainDump line-index-drift bug: an edit shifts rows, so a stale
+  // index-keyed override would mis-apply). Calm-first for Slice 1.
+  const [rowOverrides, setRowOverrides] = useState<Map<number, number>>(
+    () => new Map(),
+  )
+  // Tracks which row is revealing its override Select (hover/focus on desktop,
+  // tap on mobile). Keeps the list calm at rest — no always-on dropdowns.
+  const [activeOverrideRow, setActiveOverrideRow] = useState<number | null>(
+    null,
+  )
+
+  const ariaLiveId = useId()
+
+  // Visible count is instant; the SR announcement is debounced via the
+  // deferred text so a screen reader is not spammed on every keystroke.
+  const preview = useMemo(() => computePasteImportPreview(text), [text])
+  const deferredText = useDeferredValue(text)
+  const deferredPreview = useMemo(
+    () => computePasteImportPreview(deferredText),
+    [deferredText],
+  )
+
+  const categoryName = useCallback(
+    (id: number | null): string => {
+      if (id === null) return 'Uncategorized'
+      return (
+        categories.find((category) => category.id === id)?.name ?? 'Category'
+      )
+    },
+    [categories],
+  )
+
+  // Reset all transient state when the dialog closes so a reopen is fresh.
+  const resetState = useCallback(() => {
+    setText(initialText)
+    setSharedCategoryId(initialSharedCategory)
+    setRowOverrides(new Map())
+    setActiveOverrideRow(null)
+  }, [initialSharedCategory, initialText])
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      // Block close while submitting so an in-flight import is never abandoned.
+      if (!next && isSubmitting) return
+      if (!next) resetState()
+      onOpenChange(next)
+    },
+    [isSubmitting, onOpenChange, resetState],
+  )
+
+  const handleTextChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setText(event.target.value)
+      // Parse changed → drop overrides + any open override Select.
+      setRowOverrides((current) => (current.size === 0 ? current : new Map()))
+      setActiveOverrideRow(null)
+    },
+    [],
+  )
+
+  const handleSharedCategoryChange = useCallback((value: string) => {
+    setSharedCategoryId(Number(value))
+  }, [])
+
+  const handleRowOverrideChange = useCallback(
+    (rowIndex: number, value: string) => {
+      setRowOverrides((current) => {
+        const next = new Map(current)
+        next.set(rowIndex, Number(value))
+        return next
+      })
+      setActiveOverrideRow(null)
+    },
+    [],
+  )
+
+  const clearRowOverride = useCallback((rowIndex: number) => {
+    setRowOverrides((current) => {
+      if (!current.has(rowIndex)) return current
+      const next = new Map(current)
+      next.delete(rowIndex)
+      return next
+    })
+  }, [])
+
+  // Semantic reveal handlers (instead of passing the raw setter down) — keeps
+  // the per-row override Select hidden at rest, revealed on hover/focus/tap.
+  const revealRowOverride = useCallback((rowIndex: number) => {
+    setActiveOverrideRow(rowIndex)
+  }, [])
+
+  const hideRowOverride = useCallback(() => {
+    setActiveOverrideRow(null)
+  }, [])
+
+  const handleConfirm = useCallback(() => {
+    if (preview.total === 0 || isSubmitting) return
+    const items: PasteImportItem[] = preview.rows.map((row, index) => {
+      const override = rowOverrides.get(index)
+      // Inherit the shared category by sending its id; only attach a per-row
+      // id when it actually differs (omitting lets the server default it).
+      const categoryId = override ?? sharedCategoryId ?? undefined
+      return categoryId === undefined
+        ? { title: row.title }
+        : { title: row.title, categoryId }
+    })
+    void onConfirm(items)
+  }, [
+    isSubmitting,
+    onConfirm,
+    preview.rows,
+    preview.total,
+    rowOverrides,
+    sharedCategoryId,
+  ])
+
+  const handleCancel = useCallback(() => {
+    handleOpenChange(false)
+  }, [handleOpenChange])
+
+  // Block dismissal (outside-click / ESC) while a submit is in flight so an
+  // in-progress import is never abandoned mid-request.
+  const preventDismissWhileSubmitting = useCallback(
+    (event: Event) => {
+      if (isSubmitting) event.preventDefault()
+    },
+    [isSubmitting],
+  )
+
+  const copy = ZONE_COPY[zone]
+  const hasCategories = categories.length > 0
+  const confirmDisabled = preview.total === 0 || isSubmitting
+  const countLabel = preview.total.toLocaleString()
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      {trigger ? <DialogTrigger asChild>{trigger}</DialogTrigger> : null}
+      <DialogContent
+        className="gap-5 sm:max-w-xl lg:max-w-2xl"
+        // Keep focus inside while submitting; let Radix restore on close.
+        onInteractOutside={preventDismissWhileSubmitting}
+        onEscapeKeyDown={preventDismissWhileSubmitting}
+      >
+        <DialogHeader>
+          {/* Serif H2 — the warm anchor (matches DayDetailDialog / YearInReview). */}
+          <DialogTitle className="font-serif text-2xl font-medium text-foreground">
+            {copy.title}
+          </DialogTitle>
+          {/* SR-only description satisfies Radix's aria-describedby contract
+              without adding visible chrome (the spec's read order is title →
+              textarea, no visible subtitle). */}
+          <DialogDescription className="sr-only">
+            Paste one task per line, then review and confirm to import them.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Textarea — the import mouth. */}
+        <Textarea
+          value={text}
+          onChange={handleTextChange}
+          disabled={isSubmitting}
+          placeholder={copy.placeholder}
+          aria-label={copy.title}
+          spellCheck={false}
+          className="min-h-32 resize-y font-sans"
+        />
+
+        {/* Shared category + live count row. */}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Category</span>
+            <Select
+              value={sharedCategoryId === null ? '' : String(sharedCategoryId)}
+              onValueChange={handleSharedCategoryChange}
+              disabled={isSubmitting || !hasCategories}
+            >
+              <SelectTrigger
+                size="sm"
+                aria-label="Shared category for imported items"
+                className="min-w-36"
+              >
+                <SelectValue placeholder="Default" />
+              </SelectTrigger>
+              <SelectContent>
+                {categories.map((category) => (
+                  <SelectItem key={category.id} value={String(category.id)}>
+                    {category.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <PasteImportCount preview={preview} />
+        </div>
+
+        {/* Polite, debounced announcement of the parse result for SR users. */}
+        <div id={ariaLiveId} aria-live="polite" className="sr-only">
+          {`${deferredPreview.total} parsed, ${deferredPreview.skipped} skipped`}
+        </div>
+
+        {/* The anchor: quiet dense preview list (never a card grid). */}
+        <PasteImportPreviewList
+          preview={preview}
+          categories={categories}
+          sharedCategoryId={sharedCategoryId}
+          rowOverrides={rowOverrides}
+          activeOverrideRow={activeOverrideRow}
+          isSubmitting={isSubmitting}
+          categoryName={categoryName}
+          onRevealOverride={revealRowOverride}
+          onHideOverride={hideRowOverride}
+          onOverrideChange={handleRowOverrideChange}
+          onClearOverride={clearRowOverride}
+        />
+
+        {/* Todo-only expectation note — set the "no heatmap fill" expectation
+            at preview, not only on success. */}
+        {copy.note && preview.total > 0 ? (
+          <p className="text-sm text-muted-foreground">{copy.note}</p>
+        ) : null}
+
+        {/* Error / offline line — dialog stays open, paste preserved. */}
+        {error ? (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleCancel}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={confirmDisabled}
+            aria-busy={isSubmitting}
+          >
+            {match({ isSubmitting, hasError: Boolean(error) })
+              .with({ isSubmitting: true }, () => (
+                <>
+                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                  Adding…
+                </>
+              ))
+              .with({ hasError: true }, () => 'Try again')
+              .otherwise(() => copy.confirmLabel(countLabel))}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+})
+
+/**
+ * The Geist-Mono tabular count line: `N tasks`, ` · M skipped` when lines were
+ * dropped, and the over-cap line. Single-sourced from the preview so the
+ * numbers always reconcile with what the confirm sends.
+ *
+ * @param props.preview - The derived preview.
+ * @returns The count line(s).
+ * @example
+ * <PasteImportCount preview={{ total: 12, skipped: 2, ... }} /> // "12 tasks · 2 skipped"
+ */
+const PasteImportCount = React.memo(function PasteImportCount({
+  preview,
+}: {
+  preview: ReturnType<typeof computePasteImportPreview>
+}) {
+  const taskWord = preview.total === 1 ? 'task' : 'tasks'
+  return (
+    <div className="text-right font-mono text-sm tabular-nums text-muted-foreground">
+      <span>
+        {preview.total.toLocaleString()} {taskWord}
+        {/* Only mention skips when something was actually dropped. */}
+        {preview.skipped > 0 && !preview.isOverCap
+          ? ` · ${preview.skipped.toLocaleString()} skipped`
+          : null}
+      </span>
+      {preview.isOverCap ? (
+        <div>
+          {preview.rawLineCount.toLocaleString()} lines · importing the first{' '}
+          {preview.cap.toLocaleString()}
+        </div>
+      ) : null}
+    </div>
+  )
+})
+
+/**
+ * The quiet dense preview list. Renders one compact row per parsed line with an
+ * at-rest inherited category chip; revealing a per-row override Select only on
+ * hover/focus (desktop) or tap (mobile). Shows the warm empty hint when nothing
+ * parses yet.
+ *
+ * @param props - Preview data, category lookups, override state, and handlers.
+ * @returns The preview list or the empty hint.
+ */
+const PasteImportPreviewList = React.memo(function PasteImportPreviewList({
+  preview,
+  categories,
+  sharedCategoryId,
+  rowOverrides,
+  activeOverrideRow,
+  isSubmitting,
+  categoryName,
+  onRevealOverride,
+  onHideOverride,
+  onOverrideChange,
+  onClearOverride,
+}: {
+  preview: ReturnType<typeof computePasteImportPreview>
+  categories: CategoryWithCount[]
+  sharedCategoryId: number | null
+  rowOverrides: Map<number, number>
+  activeOverrideRow: number | null
+  isSubmitting: boolean
+  categoryName: (id: number | null) => string
+  onRevealOverride: (rowIndex: number) => void
+  onHideOverride: () => void
+  onOverrideChange: (rowIndex: number, value: string) => void
+  onClearOverride: (rowIndex: number) => void
+}) {
+  if (preview.total === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+        nothing to import yet — paste a few lines above
+      </div>
+    )
+  }
+
+  return (
+    <ul
+      className="max-h-64 divide-y divide-border overflow-y-auto rounded-md border border-border"
+      aria-label={`${preview.total} items to import`}
+    >
+      {preview.rows.map((row, index) => {
+        const overrideId = rowOverrides.get(index)
+        return (
+          <PasteImportPreviewRow
+            key={index}
+            rowIndex={index}
+            title={row.title}
+            effectiveCategoryId={overrideId ?? sharedCategoryId}
+            isOverridden={overrideId !== undefined}
+            isRevealing={activeOverrideRow === index}
+            hasCategories={categories.length > 0}
+            categories={categories}
+            categoryName={categoryName}
+            isSubmitting={isSubmitting}
+            onRevealOverride={onRevealOverride}
+            onHideOverride={onHideOverride}
+            onOverrideChange={onOverrideChange}
+            onClearOverride={onClearOverride}
+          />
+        )
+      })}
+    </ul>
+  )
+})
+
+/**
+ * One preview row: the title plus the category affordance. At rest it shows the
+ * inherited category as a quiet outline chip (a real button); on hover/focus/tap
+ * it reveals a per-row override Select with a reset control. Owns its own stable
+ * per-row handlers (bound to `rowIndex`) so the list passes no index-closing
+ * inline functions.
+ *
+ * @param props - The row's title, resolved category, reveal/override state, and handlers.
+ * @returns A single `<li>` preview row.
+ */
+const PasteImportPreviewRow = React.memo(function PasteImportPreviewRow({
+  rowIndex,
+  title,
+  effectiveCategoryId,
+  isOverridden,
+  isRevealing,
+  hasCategories,
+  categories,
+  categoryName,
+  isSubmitting,
+  onRevealOverride,
+  onHideOverride,
+  onOverrideChange,
+  onClearOverride,
+}: {
+  rowIndex: number
+  title: string
+  effectiveCategoryId: number | null
+  isOverridden: boolean
+  isRevealing: boolean
+  hasCategories: boolean
+  categories: CategoryWithCount[]
+  categoryName: (id: number | null) => string
+  isSubmitting: boolean
+  onRevealOverride: (rowIndex: number) => void
+  onHideOverride: () => void
+  onOverrideChange: (rowIndex: number, value: string) => void
+  onClearOverride: (rowIndex: number) => void
+}) {
+  // Stable callbacks for the MEMOIZED Select/SelectTrigger (the lint rule wants
+  // useCallback for memoized-component props but plain inline functions for
+  // intrinsic elements like <li>/<button> — hence the split below).
+  const changeOverride = useCallback(
+    (value: string) => onOverrideChange(rowIndex, value),
+    [onOverrideChange, rowIndex],
+  )
+  const revealOnFocus = useCallback(
+    () => onRevealOverride(rowIndex),
+    [onRevealOverride, rowIndex],
+  )
+
+  return (
+    <li
+      className="flex items-center gap-3 px-3 py-2"
+      onMouseEnter={() => onRevealOverride(rowIndex)}
+      onMouseLeave={onHideOverride}
+    >
+      <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+        {title}
+      </span>
+
+      {hasCategories ? (
+        isRevealing || isOverridden ? (
+          <div className="flex items-center gap-1">
+            <Select
+              value={
+                effectiveCategoryId === null ? '' : String(effectiveCategoryId)
+              }
+              onValueChange={changeOverride}
+              disabled={isSubmitting}
+            >
+              <SelectTrigger
+                size="sm"
+                aria-label={`Category for "${title}"`}
+                className="min-w-28"
+                onFocus={revealOnFocus}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {categories.map((category) => (
+                  <SelectItem key={category.id} value={String(category.id)}>
+                    {category.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {isOverridden ? (
+              <button
+                type="button"
+                onClick={() => onClearOverride(rowIndex)}
+                disabled={isSubmitting}
+                aria-label={`Reset "${title}" to the shared category`}
+                className="flex size-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          // At rest: a quiet inherited chip; tap/focus reveals the Select.
+          <button
+            type="button"
+            onClick={() => onRevealOverride(rowIndex)}
+            onFocus={() => onRevealOverride(rowIndex)}
+            className="flex min-h-9 shrink-0 items-center"
+            aria-label={`Category ${categoryName(effectiveCategoryId)} — change`}
+          >
+            <Badge
+              variant="outline"
+              className="font-normal text-muted-foreground"
+            >
+              {categoryName(effectiveCategoryId)}
+            </Badge>
+          </button>
+        )
+      ) : null}
+    </li>
+  )
+})

--- a/src/components/import/PasteImportDialog.tsx
+++ b/src/components/import/PasteImportDialog.tsx
@@ -592,7 +592,7 @@ const PasteImportPreviewRow = React.memo(function PasteImportPreviewRow({
                 onClick={() => onClearOverride(rowIndex)}
                 disabled={isSubmitting}
                 aria-label={`Reset "${title}" to the shared category`}
-                className="flex size-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                className="flex size-11 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
               >
                 <X className="size-4" aria-hidden="true" />
               </button>
@@ -604,7 +604,7 @@ const PasteImportPreviewRow = React.memo(function PasteImportPreviewRow({
             type="button"
             onClick={() => onRevealOverride(rowIndex)}
             onFocus={() => onRevealOverride(rowIndex)}
-            className="flex min-h-9 shrink-0 items-center"
+            className="flex min-h-11 shrink-0 items-center"
             aria-label={`Category ${categoryName(effectiveCategoryId)} — change`}
           >
             <Badge

--- a/src/components/import/paste-import-types.test.ts
+++ b/src/components/import/paste-import-types.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAX_IMPORT_LINES_PER_BATCH } from '@/lib/constants/import'
+
+import { computePasteImportPreview } from './paste-import-types'
+
+describe('computePasteImportPreview', () => {
+  it('reports zero tasks and zero skipped for empty text', () => {
+    // Arrange
+    const text = ''
+
+    // Act
+    const preview = computePasteImportPreview(text)
+
+    // Assert
+    expect(preview.total).toBe(0)
+    expect(preview.skipped).toBe(0)
+    expect(preview.isOverCap).toBe(false)
+  })
+
+  it('counts each non-blank line as one task and drops blank lines as skipped', () => {
+    // Arrange — 3 real tasks, 1 blank line in the middle.
+    const text = '- shipped release\n\n- reviewed PRs\nwrote digest'
+
+    // Act
+    const preview = computePasteImportPreview(text)
+
+    // Assert
+    expect(preview.total).toBe(3)
+    expect(preview.skipped).toBe(1)
+    expect(preview.rows.map((row) => row.title)).toEqual([
+      'shipped release',
+      'reviewed PRs',
+      'wrote digest',
+    ])
+  })
+
+  it('does not count a single trailing newline as a skipped line', () => {
+    // Arrange — two tasks plus the editor's final Enter keystroke.
+    const text = 'task one\ntask two\n'
+
+    // Act
+    const preview = computePasteImportPreview(text)
+
+    // Assert
+    expect(preview.total).toBe(2)
+    expect(preview.skipped).toBe(0)
+  })
+
+  it('caps the preview at the batch limit and flags over-cap', () => {
+    // Arrange — 1,200 non-blank lines (over the 1,000 cap).
+    const text = Array.from({ length: 1200 }, (_, i) => `task ${i}`).join('\n')
+
+    // Act
+    const preview = computePasteImportPreview(text)
+
+    // Assert
+    expect(preview.isOverCap).toBe(true)
+    expect(preview.total).toBe(MAX_IMPORT_LINES_PER_BATCH)
+    expect(preview.rows).toHaveLength(MAX_IMPORT_LINES_PER_BATCH)
+    expect(preview.rawLineCount).toBe(1200)
+  })
+
+  it('keeps the visible task count equal to the rows that will be sent', () => {
+    // Arrange — mix of bullets, a checkbox, a URL, and droppable lines.
+    const text = '- a\n* b\n1. c\n- [x] d\nhttps://x.test\n\n- '
+
+    // Act
+    const preview = computePasteImportPreview(text)
+
+    // Assert — invariant: total === rows.length (preview == what we insert).
+    expect(preview.total).toBe(preview.rows.length)
+    expect(preview.rows.map((row) => row.title)).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+      'https://x.test',
+    ])
+  })
+})

--- a/src/components/import/paste-import-types.ts
+++ b/src/components/import/paste-import-types.ts
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Shared client types + pure preview helpers for the paste-import
+ * UI (Issue #53, PR2). Lives beside the dialog so both the presentational
+ * `PasteImportDialog`, the oRPC container `PasteImport`, the entry wrappers, and
+ * the Storybook stories import one source of truth — and so the count/cap math
+ * (load-bearing: preview count must equal the count the server inserts) stays
+ * pure and unit-reachable without rendering React.
+ *
+ * @module components/import/paste-import-types
+ */
+
+import { MAX_IMPORT_LINES_PER_BATCH } from '@/lib/constants/import'
+import { parsePasteToTasks } from '@/lib/parsePasteToTasks'
+
+/**
+ * Which zone a paste-import lands in. Drives copy, the success toast, and which
+ * oRPC procedure the container calls. Routing is purely by destination zone
+ * (the `[x]` checkbox flag is informational only in Slice 1).
+ */
+export type PasteImportZone = 'completed' | 'todo'
+
+/**
+ * One item sent to the server on confirm. `categoryId` is omitted when the row
+ * inherits the shared category (server get-or-creates the default for omitted
+ * ids); a per-row override sets it explicitly.
+ *
+ * @example
+ * { title: 'shipped the release' }
+ * @example
+ * { title: 'gym', categoryId: 3 }
+ */
+export type PasteImportItem = {
+  /** The derived, normalized title (1..255 chars; server re-normalizes). */
+  title: string
+  /** Per-row category override; omitted = inherit the shared category. */
+  categoryId?: number
+}
+
+/**
+ * The fully-derived preview the dialog renders: the visible rows, the counts,
+ * and whether the paste exceeded the cap. Computed in one pass from the raw
+ * textarea text so the visible `tasks` count equals the number of items the
+ * confirm sends (which equals the number the server inserts).
+ *
+ * @example
+ * { rows: [{ title: 'a', done: false }], total: 1, skipped: 2, isOverCap: false, rawLineCount: 3, cap: 1000 }
+ */
+export type PasteImportPreview = {
+  /** Parsed rows, capped at {@link MAX_IMPORT_LINES_PER_BATCH}. */
+  rows: { title: string; done: boolean }[]
+  /** Number of importable rows == `rows.length` (after the cap). */
+  total: number
+  /** Non-blank lines that survived parse but were dropped by the cap, plus blank/prefix-only lines. */
+  skipped: number
+  /** True when the raw non-blank line count exceeded the cap. */
+  isOverCap: boolean
+  /** Count of raw lines the user typed (trailing blank line excluded). */
+  rawLineCount: number
+  /** The cap, surfaced so the dialog's over-cap copy stays single-sourced. */
+  cap: number
+}
+
+/**
+ * Derives the full preview from raw pasted text in a single pure pass. Excludes
+ * a single trailing newline so an editor's final `\n` does not inflate
+ * `skipped`. Slices the parsed rows to the cap so the preview, the confirm
+ * label, and the payload all agree (the server enforces the same `.max()`).
+ *
+ * @param text - The raw textarea contents.
+ * @returns A {@link PasteImportPreview} (rows capped; counts reconciled).
+ * @example
+ * computePasteImportPreview('- a\n\n- b')
+ * // => { rows: [{title:'a',done:false},{title:'b',done:false}], total: 2, skipped: 1, isOverCap: false, rawLineCount: 3, cap: 1000 }
+ * @example
+ * computePasteImportPreview('') // => { rows: [], total: 0, skipped: 0, isOverCap: false, rawLineCount: 0, cap: 1000 }
+ */
+export function computePasteImportPreview(text: string): PasteImportPreview {
+  // Drop exactly one trailing newline so a final Enter keystroke is not counted
+  // as a skipped blank line. Count remaining raw lines for the over-cap copy.
+  const trimmedTrailing = text.replace(/\n$/, '')
+  const rawLineCount =
+    trimmedTrailing.length === 0 ? 0 : trimmedTrailing.split('\n').length
+
+  const parsed = parsePasteToTasks(text)
+  const isOverCap = parsed.length > MAX_IMPORT_LINES_PER_BATCH
+  const rows = isOverCap ? parsed.slice(0, MAX_IMPORT_LINES_PER_BATCH) : parsed
+
+  // skipped = every raw line the preview does NOT show: blank/prefix-only lines
+  // (parsed dropped them) plus any rows beyond the cap.
+  const skipped = Math.max(rawLineCount - rows.length, 0)
+
+  return {
+    rows,
+    total: rows.length,
+    skipped,
+    isOverCap,
+    rawLineCount,
+    cap: MAX_IMPORT_LINES_PER_BATCH,
+  }
+}

--- a/src/lib/paste-import-channel.ts
+++ b/src/lib/paste-import-channel.ts
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Cross-window "open the Completed paste-import dialog" intent
+ * channel (Issue #53, PR2 · D7). The Floating Navigator lives in a separate
+ * Electron BrowserWindow, so its Import button cannot directly toggle the main
+ * window's dialog state. It calls the preload `focusMainWindow()` IPC to surface
+ * the main window AND broadcasts this intent; the main-window Completed entry
+ * subscribes and opens the dialog. Mirrors `todo-sync-channel` (BroadcastChannel
+ * crosses Electron windows in this app) — no new Electron IPC plumbing.
+ *
+ * @module lib/paste-import-channel
+ */
+
+const PASTE_IMPORT_CHANNEL_NAME = 'corelive-paste-import-intent'
+const OPEN_COMPLETED_IMPORT_EVENT = 'open-completed-import'
+
+type PasteImportIntentMessage = Readonly<{
+  type: typeof OPEN_COMPLETED_IMPORT_EVENT
+}>
+
+/**
+ * Whether BroadcastChannel-based cross-window intents are supported here.
+ * @returns
+ * - `true` in a browser/Electron-renderer context with BroadcastChannel
+ * - `false` during SSR or in an unsupported runtime
+ * @example
+ * isPasteImportChannelSupported() // => true
+ */
+const isPasteImportChannelSupported = (): boolean => {
+  return (
+    typeof window !== 'undefined' && typeof BroadcastChannel !== 'undefined'
+  )
+}
+
+/**
+ * Creates the intent channel, or null when unsupported.
+ * @returns A BroadcastChannel, or `null`.
+ */
+const createPasteImportChannel = (): BroadcastChannel | null => {
+  if (!isPasteImportChannelSupported()) return null
+  return new BroadcastChannel(PASTE_IMPORT_CHANNEL_NAME)
+}
+
+/**
+ * Narrows an unknown payload to the open-Completed-import intent.
+ * @param data - Payload received on the channel.
+ * @returns `true` when it is the open-import intent.
+ */
+const isPasteImportIntentMessage = (
+  data: unknown,
+): data is PasteImportIntentMessage => {
+  if (typeof data !== 'object' || data === null) return false
+  return (data as PasteImportIntentMessage).type === OPEN_COMPLETED_IMPORT_EVENT
+}
+
+/**
+ * Broadcasts the intent to open the Completed paste-import dialog in the main
+ * window. Called by the Floating Navigator's Import button (alongside
+ * `focusMainWindow()`).
+ * @returns
+ * - `true` when the intent was broadcast
+ * - `false` when BroadcastChannel is unavailable
+ * @example
+ * requestOpenCompletedImport() // => true
+ */
+export const requestOpenCompletedImport = (): boolean => {
+  const channel = createPasteImportChannel()
+  if (!channel) return false
+  channel.postMessage({
+    type: OPEN_COMPLETED_IMPORT_EVENT,
+  } satisfies PasteImportIntentMessage)
+  channel.close()
+  return true
+}
+
+/**
+ * Subscribes to open-Completed-import intents (only the main-window Completed
+ * entry should call this).
+ * @param onOpenIntent - Invoked when an open-import intent arrives.
+ * @returns Cleanup that removes the listener and closes the channel.
+ * @example
+ * const cleanup = subscribeToOpenCompletedImport(() => setOpen(true))
+ * cleanup()
+ */
+export const subscribeToOpenCompletedImport = (
+  onOpenIntent: () => void,
+): (() => void) => {
+  const channel = createPasteImportChannel()
+  if (!channel) return () => {}
+
+  const handleMessage = (event: MessageEvent) => {
+    if (isPasteImportIntentMessage(event.data)) onOpenIntent()
+  }
+
+  channel.addEventListener('message', handleMessage)
+  return () => {
+    channel.removeEventListener('message', handleMessage)
+    channel.close()
+  }
+}


### PR DESCRIPTION
## Paste-to-import — PR2 (UI) · Issue #53

Second of two PRs. The paste-import UI: dialog, per-zone entries, bulk undo, copy, responsive, a11y. Built to the approved design (variant **C** structure) + `/plan-design-review` (D2–D7) + eng/devex fold-ins.

**Stacked on #54** (server). Review/merge #54 first; this targets `feat/paste-import-server` and auto-retargets to `main` once #54 merges.

### What's here

- **`PasteImportDialog`** (presentational, Storybook-safe) + **`PasteImport`** (oRPC container): serif title, paste textarea, live preview as a quiet **dense list**, Geist-Mono count (`N tasks · M skipped`, over-cap `… importing the first 1,000`), shared category Select (defaults to the sidebar's selected category) + per-row override (inherited chip → reveals a Select on hover/focus; **no always-on per-row dropdowns**), ghost Cancel + amber confirm. All interaction states (idle/empty/parsing/preview/over-cap/submitting/success/error-offline). `importBatchId` generated once, **reused on retry** (idempotent P2002 no-op), cleared on success.
- **Entry points (D4):** Import by Completed's "Clear all", Import by the Add-todo form, and empty-state discoverability. FloatingNavigator (D7): Import focuses the main window + opens the dialog via the existing `focusMainWindow()` IPC + a BroadcastChannel intent (no new Electron plumbing).
- **Bulk undo (D5):** 10s success toast with Undo + a 60s inline undo banner; Todo-zone batch also offers **Move to Completed** (client-orchestrated `todo.deleteMany` → `completed.createMany` with retained titles + a new id).
- **Copy (D6 + Slice-1 honesty fold-in):** Completed `N added — today's lit` (Slice 1 lands everything on today's cell; the "year" framing is Slice-2's dated import); Todo `N added to your list` + pre-confirm note `these stay open — they'll light the heatmap as you complete them`.
- **a11y:** Radix focus-trap; `aria-live` parse-count announce (`useDeferredValue`); keyboard rows; 44px targets. **Responsive:** mobile full-width sheet, stack, tap-to-override.
- Warm Cathedral tokens only — the candle/vignette from the mockup is **not shipped** (warmth via tokens; whole-app warm-up is tracked separately in `TODOS.md`).

### Verification

- `pnpm typecheck` 0 errors · `pnpm build` succeeds (13/13 pages) · full suite **265 passed** (CI Node 24.13.0) · Storybook **131 passed** incl. 6 PasteImport stories (with a11y) · `pnpm lint` clean.

### Known limitations (v1, by design)

- D7 opens the dialog when the main window has the Completed entry mounted (i.e. on `/home`); other routes focus the window but don't open it. Cocoa window-focus is Linux-xvfb-uncoverable → manual macOS smoke before any tag push (per the repo Electron note).

🤖 Autonomous overnight build. Generated with Claude Code.
