### PR TITLE
fix(electron): route corelive:// deep links to the dev app via unique bundle id

### DIFF
--- a/electron/__tests__/devProtocol.test.ts
+++ b/electron/__tests__/devProtocol.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DEEP_LINK_SCHEME,
+  DEV_BUNDLE_ID,
+  ensureDevProtocolRegistration,
+  plistBuddyCommandPlan,
+} from '../devProtocol'
+
+// The logger shells out to electron-log internals at import time in some
+// environments; stub it so these pure-logic tests stay hermetic.
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+describe('plistBuddyCommandPlan', () => {
+  it('sets a unique bundle id and declares the corelive URL scheme', () => {
+    // Arrange
+    const bundleId = 'com.corelive.app.dev'
+    const scheme = 'corelive'
+
+    // Act
+    const plan = plistBuddyCommandPlan({ bundleId, scheme })
+    const commands = plan.map((step) => step.command)
+
+    // Assert
+    expect(commands).toEqual([
+      'Set :CFBundleIdentifier com.corelive.app.dev',
+      'Delete :CFBundleURLTypes',
+      'Add :CFBundleURLTypes array',
+      'Add :CFBundleURLTypes:0:CFBundleURLName string com.corelive.app.dev',
+      'Add :CFBundleURLTypes:0:CFBundleURLSchemes array',
+      'Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string corelive',
+    ])
+  })
+
+  it('marks only the pre-clear Delete step as error-tolerant so a re-run is safe', () => {
+    // Arrange + Act
+    const plan = plistBuddyCommandPlan({
+      bundleId: DEV_BUNDLE_ID,
+      scheme: DEEP_LINK_SCHEME,
+    })
+
+    // Assert — the lone tolerant step is the Delete (nothing to delete on first run)
+    const tolerantCommands = plan
+      .filter((step) => step.tolerateError)
+      .map((step) => step.command)
+    expect(tolerantCommands).toEqual(['Delete :CFBundleURLTypes'])
+  })
+})
+
+describe('ensureDevProtocolRegistration', () => {
+  it('does nothing on non-macOS platforms because deep links bind by path there', () => {
+    // Arrange
+    const runCommand = vi.fn((_file: string, _args: string[]) => '')
+
+    // Act
+    const result = ensureDevProtocolRegistration({
+      platform: 'linux',
+      electronAppPath: '/any/Electron.app',
+      runCommand,
+      readBundleId: () => 'com.github.Electron',
+    })
+
+    // Assert
+    expect(result).toEqual({ skipped: true, reason: 'not macOS' })
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it('rewrites the shared com.github.Electron bundle id to a unique one on macOS', () => {
+    // Arrange — simulate the buggy starting state: generic shared bundle id
+    const runCommand = vi.fn((_file: string, _args: string[]) => '')
+
+    // Act
+    const result = ensureDevProtocolRegistration({
+      platform: 'darwin',
+      electronAppPath: __dirname, // a real, existing directory so the fs guard passes
+      runCommand,
+      readBundleId: () => 'com.github.Electron',
+    })
+
+    // Assert — it patched, and the very first PlistBuddy call sets the unique id
+    expect(result).toEqual({ skipped: false, reason: 'patched' })
+    const plistBuddyCalls = runCommand.mock.calls.filter(
+      ([file]) => file === '/usr/libexec/PlistBuddy',
+    )
+    expect(plistBuddyCalls[0]?.[1]).toEqual([
+      '-c',
+      'Set :CFBundleIdentifier com.corelive.app.dev',
+      expect.stringContaining('Info.plist'),
+    ])
+  })
+
+  it('skips work when the dev Electron is already stamped with the unique id', () => {
+    // Arrange — idempotency: a second `pnpm electron:dev` must not re-sign
+    const runCommand = vi.fn((_file: string, _args: string[]) => '')
+
+    // Act
+    const result = ensureDevProtocolRegistration({
+      platform: 'darwin',
+      electronAppPath: __dirname,
+      runCommand,
+      readBundleId: () => DEV_BUNDLE_ID,
+    })
+
+    // Assert
+    expect(result).toEqual({ skipped: true, reason: 'already patched' })
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it('skips when the Electron.app path does not exist instead of throwing', () => {
+    // Arrange
+    const runCommand = vi.fn((_file: string, _args: string[]) => '')
+
+    // Act
+    const result = ensureDevProtocolRegistration({
+      platform: 'darwin',
+      electronAppPath: '/nonexistent/path/Electron.app',
+      runCommand,
+      readBundleId: () => 'com.github.Electron',
+    })
+
+    // Assert
+    expect(result.skipped).toBe(true)
+    expect(result.reason).toContain('not found')
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+})

--- a/electron/__tests__/devProtocol.test.ts
+++ b/electron/__tests__/devProtocol.test.ts
@@ -91,6 +91,32 @@ describe('ensureDevProtocolRegistration', () => {
     ])
   })
 
+  it('reports patch failed and skips re-signing when a required PlistBuddy step throws', () => {
+    // Arrange — the bundle-id Set fails (e.g. a read-only plist); without an
+    // honest failure path the function would still claim success.
+    const runCommand = vi.fn((_file: string, args: string[]) => {
+      if (args.includes('Set :CFBundleIdentifier com.corelive.app.dev')) {
+        throw new Error('Permission denied')
+      }
+      return ''
+    })
+
+    // Act
+    const result = ensureDevProtocolRegistration({
+      platform: 'darwin',
+      electronAppPath: __dirname,
+      runCommand,
+      readBundleId: () => 'com.github.Electron',
+    })
+
+    // Assert — honest result, and no codesign attempted after the early bail
+    expect(result).toEqual({ skipped: false, reason: 'patch failed' })
+    const codesignCalls = runCommand.mock.calls.filter(
+      ([file]) => file === '/usr/bin/codesign',
+    )
+    expect(codesignCalls).toHaveLength(0)
+  })
+
   it('skips work when the dev Electron is already stamped with the unique id', () => {
     // Arrange — idempotency: a second `pnpm electron:dev` must not re-sign
     const runCommand = vi.fn((_file: string, _args: string[]) => '')

--- a/electron/dev-runner.ts
+++ b/electron/dev-runner.ts
@@ -29,6 +29,7 @@ import { spawn, type ChildProcess } from 'child_process'
 import http from 'http'
 import path from 'path'
 
+import { ensureDevProtocolRegistration } from './devProtocol'
 import { log } from './logger'
 
 /**
@@ -106,6 +107,24 @@ async function startElectron(): Promise<void> {
     log.info('⏳ Waiting for Next.js dev server...')
     await checkServer('http://localhost:3011')
     log.info('✅ Next.js is ready')
+
+    // macOS only: stamp the unpackaged dev Electron with a unique bundle id so
+    // `corelive://` deep links (Google OAuth return leg) resolve to THIS app and
+    // not an arbitrary other `com.github.Electron` copy on the machine. No-op off
+    // macOS and once already patched. Never block startup if it fails.
+    try {
+      ensureDevProtocolRegistration({
+        electronAppPath: path.join(
+          process.cwd(),
+          'node_modules',
+          'electron',
+          'dist',
+          'Electron.app',
+        ),
+      })
+    } catch (error) {
+      log.warn('Dev deep-link protocol registration skipped:', error)
+    }
 
     // Path to compiled main process (built by electron-vite)
     // dev-runner is executed from project root, so use process.cwd()

--- a/electron/devProtocol.ts
+++ b/electron/devProtocol.ts
@@ -179,6 +179,7 @@ export function ensureDevProtocolRegistration(options: {
   }
 
   // 1. Rewrite bundle id + declare the corelive scheme.
+  let patchFailed = false
   for (const step of plistBuddyCommandPlan({
     bundleId: DEV_BUNDLE_ID,
     scheme: DEEP_LINK_SCHEME,
@@ -187,9 +188,17 @@ export function ensureDevProtocolRegistration(options: {
       runCommand(PLIST_BUDDY, ['-c', step.command, plistPath])
     } catch (error) {
       if (!step.tolerateError) {
+        patchFailed = true
         log.warn(`devProtocol: PlistBuddy "${step.command}" failed:`, error)
       }
     }
+  }
+
+  // If the plist couldn't be rewritten, the identity is unchanged — re-signing,
+  // refreshing LaunchServices, and logging success would all be misleading. Bail
+  // honestly so the caller (and logs) reflect that the binding was NOT fixed.
+  if (patchFailed) {
+    return { skipped: false, reason: 'patch failed' }
   }
 
   // 2. Ad-hoc re-sign so any Electron build that seals Info.plist still launches.

--- a/electron/devProtocol.ts
+++ b/electron/devProtocol.ts
@@ -1,0 +1,225 @@
+/**
+ * @fileoverview Dev-only macOS deep-link protocol registration fix.
+ *
+ * Why this exists:
+ * On macOS, LaunchServices resolves a custom URL scheme (`corelive://`) by an
+ * app's **bundle id**, not its on-disk path. Every *unpackaged* Electron shares
+ * the generic bundle id `com.github.Electron`. A dev machine typically has many
+ * such copies (this app's `node_modules`, plus unrelated Electron projects). So
+ * `app.setAsDefaultProtocolClient('corelive')` from `pnpm electron:dev` binds the
+ * scheme to the ambiguous `com.github.Electron`, and the OS later launches an
+ * *arbitrary* copy (often the highest-versioned one from another project) — which
+ * is the bare Electron welcome window, not our running dev app. This breaks the
+ * browser→app return leg of Google OAuth (`corelive://oauth/callback?token=…`).
+ *
+ * When it triggers:
+ * Called from `electron/dev-runner.ts` once, right before the dev Electron is
+ * spawned (so the new identity is in place at process launch). No-op off macOS
+ * and no-op once already patched (idempotent), so repeated `pnpm electron:dev`
+ * runs stay fast. The packaged app is unaffected — it ships the unique, signed
+ * bundle id `com.corelive.app`.
+ *
+ * What it does:
+ * Rewrites the dev `Electron.app/Contents/Info.plist` to a **unique** bundle id
+ * (`com.corelive.app.dev`, distinct from prod) and declares the `corelive` URL
+ * scheme, ad-hoc re-signs (tolerant), and refreshes the LaunchServices record.
+ * After this, `setAsDefaultProtocolClient('corelive')` registers an unambiguous
+ * handler and `corelive://` resolves to *this* running dev app.
+ *
+ * @module electron/devProtocol
+ */
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { log } from './logger'
+
+/**
+ * Unique bundle id for the unpackaged dev Electron. Deliberately distinct from
+ * the packaged `com.corelive.app` so dev and prod handlers never collide, and
+ * from `com.github.Electron` so other Electron projects can't hijack the scheme.
+ */
+export const DEV_BUNDLE_ID = 'com.corelive.app.dev'
+
+/** Custom URL scheme used for deep links (mirrors electron-builder.json). */
+export const DEEP_LINK_SCHEME = 'corelive'
+
+/** One PlistBuddy mutation; `tolerateError` is true when re-running may have
+ *  already removed/added the entry (Delete on first run has nothing to delete). */
+export interface PlistBuddyStep {
+  command: string
+  tolerateError: boolean
+}
+
+/**
+ * Builds the ordered, idempotent PlistBuddy command plan that rewrites the dev
+ * Electron Info.plist to a unique bundle id and a declared URL scheme. Pure (no
+ * I/O) so it can be unit-tested without a real plist. Delete-before-Add makes a
+ * re-run safe even though Add fails on existing keys.
+ *
+ * @param options.bundleId - The unique bundle id to set.
+ * @param options.scheme - The URL scheme to declare (e.g. `corelive`).
+ * @returns Ordered PlistBuddy steps; the lone Delete tolerates a missing entry.
+ * @example
+ * plistBuddyCommandPlan({ bundleId: 'com.corelive.app.dev', scheme: 'corelive' })
+ * // => [{ command: 'Set :CFBundleIdentifier com.corelive.app.dev', tolerateError: false }, ...]
+ */
+export function plistBuddyCommandPlan(options: {
+  bundleId: string
+  scheme: string
+}): PlistBuddyStep[] {
+  const { bundleId, scheme } = options
+  return [
+    { command: `Set :CFBundleIdentifier ${bundleId}`, tolerateError: false },
+    // Reset the URL-types array first so re-runs don't stack duplicate entries.
+    { command: 'Delete :CFBundleURLTypes', tolerateError: true },
+    { command: 'Add :CFBundleURLTypes array', tolerateError: false },
+    {
+      command: `Add :CFBundleURLTypes:0:CFBundleURLName string ${bundleId}`,
+      tolerateError: false,
+    },
+    {
+      command: 'Add :CFBundleURLTypes:0:CFBundleURLSchemes array',
+      tolerateError: false,
+    },
+    {
+      command: `Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string ${scheme}`,
+      tolerateError: false,
+    },
+  ]
+}
+
+/** Injectable shell runner so the orchestrator can be unit-tested without
+ *  touching PlistBuddy/codesign/lsregister. Returns trimmed stdout. */
+export type CommandRunner = (file: string, args: string[]) => string
+
+/** Default runner backed by `execFileSync` (real shell-outs in dev). */
+const defaultRunCommand: CommandRunner = (file, args) =>
+  execFileSync(file, args, { encoding: 'utf8' }).trim()
+
+const PLIST_BUDDY = '/usr/libexec/PlistBuddy'
+
+/** Known `lsregister` locations across macOS versions; the canonical
+ *  LaunchServices.framework path first, with the legacy shortcut as fallback. */
+const LSREGISTER_CANDIDATES = [
+  '/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister',
+  '/System/Library/Frameworks/CoreServices.framework/Support/lsregister',
+]
+
+/** Resolves the first `lsregister` binary that exists, or null if none do. */
+function resolveLsregister(): string | null {
+  return (
+    LSREGISTER_CANDIDATES.find((candidate) => fs.existsSync(candidate)) ?? null
+  )
+}
+
+export interface EnsureDevProtocolResult {
+  skipped: boolean
+  reason: string
+}
+
+/**
+ * Ensures the dev Electron.app carries a unique bundle id + declared scheme so
+ * macOS routes `corelive://` to it. Safe to call every dev launch: no-op off
+ * macOS, no-op when the app is missing, and no-op once already patched.
+ *
+ * @param options.platform - OS platform (defaults to `process.platform`; inject for tests).
+ * @param options.electronAppPath - Path to the dev `Electron.app` bundle.
+ * @param options.runCommand - Injectable command runner (defaults to execFileSync).
+ * @param options.readBundleId - Injectable reader for the current bundle id (defaults to PlistBuddy Print).
+ * @returns `{ skipped, reason }` — `skipped: true` when nothing was changed.
+ * @example
+ * ensureDevProtocolRegistration({ platform: 'linux' }) // => { skipped: true, reason: 'not macOS' }
+ */
+export function ensureDevProtocolRegistration(options: {
+  electronAppPath: string
+  platform?: NodeJS.Platform
+  runCommand?: CommandRunner
+  readBundleId?: (plistPath: string) => string
+}): EnsureDevProtocolResult {
+  const {
+    electronAppPath,
+    platform = process.platform,
+    runCommand = defaultRunCommand,
+    readBundleId,
+  } = options
+
+  // Deep-link bundle-id collision is macOS-only; other platforms register by path.
+  if (platform !== 'darwin') {
+    return { skipped: true, reason: 'not macOS' }
+  }
+
+  if (!fs.existsSync(electronAppPath)) {
+    return {
+      skipped: true,
+      reason: `Electron.app not found: ${electronAppPath}`,
+    }
+  }
+
+  const plistPath = path.join(electronAppPath, 'Contents', 'Info.plist')
+
+  const readCurrentBundleId =
+    readBundleId ??
+    ((plist: string): string => {
+      try {
+        return runCommand(PLIST_BUDDY, [
+          '-c',
+          'Print :CFBundleIdentifier',
+          plist,
+        ])
+      } catch {
+        return ''
+      }
+    })
+
+  // Idempotent: once we've stamped the unique id, leave it (keeps launches fast).
+  if (readCurrentBundleId(plistPath) === DEV_BUNDLE_ID) {
+    return { skipped: true, reason: 'already patched' }
+  }
+
+  // 1. Rewrite bundle id + declare the corelive scheme.
+  for (const step of plistBuddyCommandPlan({
+    bundleId: DEV_BUNDLE_ID,
+    scheme: DEEP_LINK_SCHEME,
+  })) {
+    try {
+      runCommand(PLIST_BUDDY, ['-c', step.command, plistPath])
+    } catch (error) {
+      if (!step.tolerateError) {
+        log.warn(`devProtocol: PlistBuddy "${step.command}" failed:`, error)
+      }
+    }
+  }
+
+  // 2. Ad-hoc re-sign so any Electron build that seals Info.plist still launches.
+  //    Tolerated: this binary's signature leaves Info.plist unbound, so a failure
+  //    here does not block launch — we just lose the belt-and-suspenders.
+  try {
+    runCommand('/usr/bin/codesign', ['--force', '--sign', '-', electronAppPath])
+  } catch (error) {
+    log.warn('devProtocol: ad-hoc re-sign failed (continuing):', error)
+  }
+
+  // 3. Refresh LaunchServices so the new identity + scheme are known immediately.
+  //    Not fatal: the Electron main process also self-registers via
+  //    setAsDefaultProtocolClient on launch, so a missing lsregister only delays
+  //    the binding until first run.
+  const lsregister = resolveLsregister()
+  if (lsregister) {
+    try {
+      runCommand(lsregister, ['-f', electronAppPath])
+    } catch (error) {
+      log.warn('devProtocol: lsregister refresh failed (continuing):', error)
+    }
+  } else {
+    log.warn(
+      'devProtocol: lsregister not found; relying on runtime registration',
+    )
+  }
+
+  log.info(
+    `devProtocol: dev Electron bundle id set to ${DEV_BUNDLE_ID} for corelive:// deep links`,
+  )
+  return { skipped: false, reason: 'patched' }
+}


### PR DESCRIPTION
## Problem

Running `pnpm dev:electron` on macOS and signing in with Google: the `corelive://` deep-link redirect (the browser→app return leg of OAuth) launched a **bare Electron welcome window from an unrelated project** instead of returning to the running dev app.

## Root cause

macOS LaunchServices resolves a custom URL scheme by an app's **bundle id**, not its on-disk path. Every *unpackaged* Electron shares the generic id `com.github.Electron`, and a dev machine usually has many copies (this repo's `node_modules`, plus other Electron projects). So `setAsDefaultProtocolClient('corelive')` binds the scheme ambiguously and the OS launches an arbitrary copy (often the highest-versioned one from another project).

Confirmed via `lsregister -dump`: 5 bundles / 20 claims fighting over `corelive:`, and many `com.github.Electron` copies across sibling projects.

**Scope: dev-only, macOS-only.** The packaged app uses the unique, signed `com.corelive.app` and is unaffected. Pre-existing; unrelated to recent feature work.

## Fix

Dev-only: before the dev Electron is spawned, stamp its `Electron.app` with a **unique** bundle id (`com.corelive.app.dev` — distinct from both prod and `com.github.Electron`), declare the `corelive` scheme, ad-hoc re-sign (so the arm64 binary still launches), and refresh LaunchServices. After this, `setAsDefaultProtocolClient('corelive')` registers an unambiguous handler.

**No runtime auth / DeepLink logic changes.** Idempotent and a no-op off macOS / when already patched, so it never slows or blocks `pnpm electron:dev`, and it never runs in CI or in packaged builds.

- `electron/devProtocol.ts` — `ensureDevProtocolRegistration()` (+ pure, unit-tested `plistBuddyCommandPlan`)
- `electron/dev-runner.ts` — invoke it after Next is ready, before spawning Electron (failure never blocks startup)
- `electron/__tests__/devProtocol.test.ts` — regression spec

## Verification

Local `pnpm electron:dev` (real stack), go/no-go:

1. **GUI launch** — the patched + re-signed arm64 binary opened real windows (devtools renderer targets: `title: CoreLive`, `…/login`, `/floating-navigator`). No SIGKILL.
2. **Deep-link delivery** — with the app running, `open "corelive://oauth/callback?state=test&token=test"` → the **running** app logged `🔗 [Early] Received open-url event` then `Received OAuth callback deep link`. **No stray/second Electron launched.** Reported symptom cleared.
3. Green: electron 207/207, src 246 pass/21 skip (DB-gated), typecheck, lint, build.

> CI blind spot (called out honestly): `dev-runner` never runs in CI and electron E2E there is Linux/xvfb, so this macOS dev path is gated by local verification only. The change is confined to dev tooling. Real Google round-trip (token exchange) is the one step left to confirm manually with credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS (development): automatic registration of the corelive:// deep-link scheme at app startup for unpackaged/dev builds; non-blocking and logs warnings on failure.

* **Tests**
  * Added hermetic unit tests covering the plist update and registration behaviors, including success, skip, and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/corelive/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->