### PR TITLE
feat: completion feedback + 居残りモード (stay-in-place completed todos)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ _trials/
 .claude/goal-notes.md
 .claude/auto.json
 .claude/auto-notes.md
+.gbrain-source

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -161,22 +161,40 @@ Intentional choreography. Most motion is in the 150–250ms range. The one motio
 
 ### Specific motion choreography
 
-| Action                              | Motion                             | Duration | Easing             |
-| ----------------------------------- | ---------------------------------- | -------- | ------------------ |
-| Task completion → Heatmap cell fill | radial-sweep fill                  | 400ms    | ease-out           |
-| Hover lift (cell, card, button)     | `translateY(-1px)` + `scale(1.04)` | 150ms    | ease-out           |
-| Page transition                     | fade                               | 200ms    | ease-out           |
-| Modal / Dialog                      | `scale(0.96 → 1)` + fade           | 250ms    | celebration easing |
-| Tooltip                             | fade + 4px slide-up                | 100ms    | ease-out           |
-| Theme toggle                        | crossfade (no transition flash)    | n/a      | n/a                |
+| Action                              | Motion                              | Duration | Easing             |
+| ----------------------------------- | ----------------------------------- | -------- | ------------------ |
+| Task completion → Heatmap cell fill | radial-sweep fill                   | 400ms    | ease-out           |
+| Task completion → checkbox fill     | amber fill (checkbox only, NOT row) | ~200ms   | ease-out           |
+| Hover lift (cell, card, button)     | `translateY(-1px)` + `scale(1.04)`  | 150ms    | ease-out           |
+| Page transition                     | fade                                | 200ms    | ease-out           |
+| Modal / Dialog                      | `scale(0.96 → 1)` + fade            | 250ms    | celebration easing |
+| Tooltip                             | fade + 4px slide-up                 | 100ms    | ease-out           |
+| Theme toggle                        | crossfade (no transition flash)     | n/a      | n/a                |
+
+> **Checkbox completion fill (2026-06-04, opt-in-feedback feature).** Checking a
+> task plays a soft amber fill on the CHECKBOX (not the whole row) over ~200ms
+> `ease-out` — short tier, deliberately NOT the heatmap's radial-sweep geometry
+> or celebration easing. The heatmap-cell fill stays the single performative
+> "hero" moment (400ms); the checkbox fill is the quiet, repeatable
+> acknowledgment of the app's most-frequent gesture, and that restraint is what
+> lets it fire on every check without fatigue. Gated behind `motion-safe:` —
+> `prefers-reduced-motion` users get an instant, motionless state change. On an
+> optimistic-update rollback the state snaps back instantly (no reverse-celebration).
 
 ### Forbidden
 
 - Bounce springs (any `cubic-bezier` with overshoot >1.05 except modals)
 - Confetti, particle bursts, screen-flash
-- SFX, haptics
+- SFX, haptics — EXCEPT a single soft, opt-in completion sound (default OFF; see note below)
 - Scroll-driven hero animations
 - Loading spinners that exceed 3s without progress text
+
+> **Opt-in completion sound (2026-06-04).** The one sanctioned exception to the
+> SFX ban: a single soft, warm, non-melodic completion sound (≤~400ms), played
+> ONLY when the user explicitly enables it (default OFF). It is a quiet
+> companion's acknowledgment, never a gamified "level-up" chime, and never plays
+> by default. OS mute is honored by the OS (the app does not detect it). At most
+> one sound is in-flight; a rapid second check cuts/restarts rather than layering.
 
 ## Voice & Microcopy
 
@@ -219,19 +237,20 @@ The full color system maps onto the existing shadcn/ui tokens. Migration is per-
 
 ## Decisions Log
 
-| Date       | Decision                                                                             | Rationale                                                                                                                                                                                                                 |
-| ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-05-10 | DESIGN.md created from `/design-consultation` (dry-run, OpenAI verification pending) | First codified design system; supersedes implicit shadcn/ui defaults                                                                                                                                                      |
-| 2026-05-10 | Aesthetic: Warm Cathedral (vs cold Linear / Things baseline)                         | Aligns with north star "self-affirmation feeling"; differentiates from productivity category convergence                                                                                                                  |
-| 2026-05-10 | Heatmap recolored from green to warm temperature gradient                            | Eureka: temperature carries the "personal pride" signal that green carries "GitHub work" — orthogonal axis to North Star                                                                                                  |
-| 2026-05-10 | Newsreader serif for display (vs Inter / Geist / DM Sans)                            | Productivity apps 100% converge on geometric sans; a serif says "craft" within 0.3s of page load                                                                                                                          |
-| 2026-05-10 | Inter Tight (not Inter) for body                                                     | Inter alone is the AI default; Tight is denser and pairs with Newsreader's character                                                                                                                                      |
-| 2026-05-10 | Geist Mono for data/code (vs JetBrains Mono)                                         | Warmer character, tabular-nums, fewer false-positive associations with terminal/code                                                                                                                                      |
-| 2026-05-10 | Streak counter replaced with "shown-up days this month"                              | Eliminates streak-guilt; empty days = rest, never failure; aligns with "self-affirmation"                                                                                                                                 |
-| 2026-05-10 | Tooltip copy as quiet praise, not raw stats                                          | Each hover delivers a small affirmation moment — north star delivered at the interaction layer                                                                                                                            |
-| 2026-05-10 | Cell size: 12px min / 32px max                                                       | Locked by Heatmap Cathedral eng review D6                                                                                                                                                                                 |
-| 2026-05-10 | OKLCH color space throughout                                                         | Perceptually even gradient steps; current globals.css already uses oklch — alignment, not migration                                                                                                                       |
-| 2026-05-27 | Startup-window settings ("On launch") — Sunrise framing + quiet-companion microcopy  | Choosing the boot window reads as "waking up for me," not "is it broken?"; the last enabled toggle locks with "At least one window opens at launch" — gentle guidance, never an error; north star: control, not KPI guilt |
+| Date       | Decision                                                                                                                           | Rationale                                                                                                                                                                                                                                                                                                                                    |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-10 | DESIGN.md created from `/design-consultation` (dry-run, OpenAI verification pending)                                               | First codified design system; supersedes implicit shadcn/ui defaults                                                                                                                                                                                                                                                                         |
+| 2026-05-10 | Aesthetic: Warm Cathedral (vs cold Linear / Things baseline)                                                                       | Aligns with north star "self-affirmation feeling"; differentiates from productivity category convergence                                                                                                                                                                                                                                     |
+| 2026-05-10 | Heatmap recolored from green to warm temperature gradient                                                                          | Eureka: temperature carries the "personal pride" signal that green carries "GitHub work" — orthogonal axis to North Star                                                                                                                                                                                                                     |
+| 2026-05-10 | Newsreader serif for display (vs Inter / Geist / DM Sans)                                                                          | Productivity apps 100% converge on geometric sans; a serif says "craft" within 0.3s of page load                                                                                                                                                                                                                                             |
+| 2026-05-10 | Inter Tight (not Inter) for body                                                                                                   | Inter alone is the AI default; Tight is denser and pairs with Newsreader's character                                                                                                                                                                                                                                                         |
+| 2026-05-10 | Geist Mono for data/code (vs JetBrains Mono)                                                                                       | Warmer character, tabular-nums, fewer false-positive associations with terminal/code                                                                                                                                                                                                                                                         |
+| 2026-05-10 | Streak counter replaced with "shown-up days this month"                                                                            | Eliminates streak-guilt; empty days = rest, never failure; aligns with "self-affirmation"                                                                                                                                                                                                                                                    |
+| 2026-05-10 | Tooltip copy as quiet praise, not raw stats                                                                                        | Each hover delivers a small affirmation moment — north star delivered at the interaction layer                                                                                                                                                                                                                                               |
+| 2026-05-10 | Cell size: 12px min / 32px max                                                                                                     | Locked by Heatmap Cathedral eng review D6                                                                                                                                                                                                                                                                                                    |
+| 2026-05-10 | OKLCH color space throughout                                                                                                       | Perceptually even gradient steps; current globals.css already uses oklch — alignment, not migration                                                                                                                                                                                                                                          |
+| 2026-05-27 | Startup-window settings ("On launch") — Sunrise framing + quiet-companion microcopy                                                | Choosing the boot window reads as "waking up for me," not "is it broken?"; the last enabled toggle locks with "At least one window opens at launch" — gentle guidance, never an error; north star: control, not KPI guilt                                                                                                                    |
+| 2026-06-04 | Completion feedback: checkbox amber fill (~200ms ease-out, NOT the heatmap hero) always-on + opt-in completion sound (default OFF) | The app's most-repeated gesture returned nothing; a quiet, design-sanctioned fill turns each check into self-affirmation without gamification. Motion stays subordinate to the heatmap hero so it repeats without fatigue; sound is opt-in so it is a deliberate choice, never default SFX (north star: self-affirmation, not dopamine hits) |
 
 ## Implementation Migration Notes
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -110,3 +110,22 @@ function that will pull it off the deferred list.
       Depends on: Part 0 (archive-on-clear) landing first.
       Forcing function: post-ship polish pass on the completion-feedback feature.
       Effort: ~1-2h human / ~20 min CC.
+
+- [ ] **居残りモード切替時の fade トランジション (D8) — deferred polish.**
+      Surfaced in `/plan-design-review` (2026-06-04, D8); built as plan task T10
+      (P2). Toggling 居残りモード ON should make todos completed since the last
+      clear RETROACTIVELY fade INTO the active list (DESIGN.md enter easing,
+      `motion-safe:` gated); toggling OFF should fade them OUT symmetrically, so
+      the "watch your day accumulate" reveal feels gentle, not a jarring pop.
+      DEFERRED from the completion-feedback / 居残りモード ship (PR #60) because a
+      naive `animate-in` on completed-retained rows MISFIRES — it also fires on
+      every in-place check, contradicting D7 ("the check feedback is the checkbox
+      motion, not a row fade"). A correct impl must DISTINGUISH
+      mode-toggle-retroactive-populate from in-place-check (track previous retain
+      state + diff the visible row set), and the fade-OUT needs an unmount
+      animation (framer-motion `AnimatePresence`, not yet wired for this list —
+      or limit to enter-only via the existing `tw-animate-css`). Feature works
+      without it: rows appear / disappear instantly on toggle.
+      Forcing function: a focused motion-polish pass on the completion feature,
+      or whenever `AnimatePresence` lands for any list.
+      Effort: ~1.5-2h human / ~30 min CC.

--- a/TODOS.md
+++ b/TODOS.md
@@ -22,6 +22,22 @@ function that will pull it off the deferred list.
       completion timestamps to avoid streak drift on backdated edits.
       Effort: ~half day human / ~30 min CC.
 
+- [ ] **archiveCompletedTodos is not idempotent — a rapid double-clear inflates the heatmap COUNT.**
+      Surfaced by CodeRabbit on PR #60 (#3). Two clears (or clear + per-item
+      delete) firing in parallel can each archive the same completed Todo before
+      either deletes it, inserting two Completed rows for one completion, so that
+      day's heatmap count is over-stated. NO data or XP loss (the Todo is still
+      removed, NodeAssignment SetNull, the archived:false invariant holds).
+      ACCEPTED as a known limitation (PR #60, user call): it needs a deliberate
+      double-action (and Clear is already confirm-gated) and only affects a
+      display count. Full-fix options when revisited: (a) add `Completed.todoId` + a unique constraint + `skipDuplicates` on the archive insert, or (b) run
+      the archive tx at `Serializable` isolation with P2034 retry. Both touch the
+      LOAD-BEARING archive path (archived:false / SetNull / completedAt ??
+      updatedAt) so they need care + a re-run of the heatmap-survives integration
+      tests.
+      Forcing function: a report of a wrong heatmap count, or the next change to the archive path.
+      Effort: ~1-2h human / ~30 min CC.
+
 - [ ] **User-TZ bucketing.** Heatmap currently uses UTC midnight buckets.
       JST 8:00 completion lands on previous UTC day. Defer until PR3
       requires it (streak calcs need user TZ per CEO §11.4).

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,7 +6,11 @@ function that will pull it off the deferred list.
 
 ## Heatmap / Completion semantics
 
-- [ ] **Migrate Todo heatmap bucket to a stable `completedAt` field.**
+- [x] **Migrate Todo heatmap bucket to a stable `completedAt` field.** ✅ 2026-06-04 (feat/completion-feedback-idokori)
+      Done in the completion-feedback / 居残りモード work: (a) `Todo.completedAt`
+      added in migration `20260603235155_add_todo_completedat`, (b) backfilled
+      from `updatedAt`, (c) `toggleTodo` stamps it on false→true, (d)
+      `fetchCompletedEntries` filters/buckets by `completedAt ?? updatedAt`.
       Today `getHeatmap` and `getDayDetail` bucket Todo rows by
       `updatedAt`, which mutates on every edit and can shift heatmap dots
       forward in time when a user edits a long-completed Todo. Plan:
@@ -60,6 +64,22 @@ function that will pull it off the deferred list.
       tokens were untouched). Left as a follow-up because fixing it darkens the brand
       amber — a taste call that needs the user's eye and a fresh screenshot pass, not a
       drive-by token tweak. Affects primary CTA / button label text on the amber fill.
+- [ ] **a11y: empty/unchecked `<Checkbox>` border is ~1.22:1 on the ivory bg (fails WCAG 1.4.11 — 3:1 for UI-component boundaries).**
+      Surfaced in `/plan-design-review` (2026-06-04, D12). The unchecked shadcn
+      `<Checkbox>` uses `border-input` (`--input` = oklch(0.908 0.022 76)); against the
+      warm-ivory `--background` (oklch(0.975 0.016 80)) that is only ~1.22:1 — well below
+      the 3:1 bar for non-text UI-component boundaries. Pre-existing and app-wide (NOT
+      introduced by the completion-feedback / 居残りモード work), but that feature centers
+      the pending checkbox as the actionable foreground, so it raises the stakes.
+      Tracked HIGH priority (D12). Proper fix = a thin, "papery" warm stroke that still
+      reaches ≥3:1, applied to the GLOBAL `<Checkbox>` (NOT a per-surface override — that
+      would make checkboxes inconsistent across the app). Needs the user's eye (the stroke
+      must stay quiet/papery per DESIGN.md while passing AA). DISTINCT from the
+      `--primary`/`--primary-foreground` 3.75:1 entry above (that is the amber CTA label;
+      this is the unchecked checkbox border).
+      Forcing function: a focused checkbox-component a11y pass, or the next time the
+      pending checkbox is touched (e.g. the 居残りモード build).
+      Effort: ~1h human / ~15 min CC.
 
 ## Tooling / Safety
 
@@ -74,3 +94,19 @@ function that will pull it off the deferred list.
       and assert local in the integration-test setup (extend `describeIfDb`).
       Forcing function: any incident, or the next time dev→Neon is revisited.
       Effort: ~30 min CC.
+
+## Completion feedback / affirmation
+
+- [ ] **Clear-moment affirmation — a quiet acknowledgment when the user clears the completed list.**
+      Surfaced in `/plan-design-review` (2026-06-04, D9). With Part 0 (archive-on-clear),
+      clearing now safely archives completed tasks — but there is no moment of closure;
+      the rows just leave. A quiet, NON-gamified acknowledgment at the clear moment (e.g.
+      a soft "8 things done — good day" / 「今日は8個 — お疲れさま」 microcopy, NOT a
+      celebration, NOT a streak) could honor the north star
+      「些細でも経験値、今日自分頑張ったなと自分を肯定できる感覚」. DEFERRED as a fast-follow
+      (D9: "record, don't build now") to respect the CEO-review HOLD SCOPE — the current
+      feature set (completion feedback + 居残りモード) ships first. Voice must follow
+      DESIGN.md "quiet companion" (no KPI %, no scoreboard).
+      Depends on: Part 0 (archive-on-clear) landing first.
+      Forcing function: post-ship polish pass on the completion-feedback feature.
+      Effort: ~1-2h human / ~20 min CC.

--- a/e2e/web/qa-fixes.spec.ts
+++ b/e2e/web/qa-fixes.spec.ts
@@ -113,12 +113,18 @@ test.describe('QA Fixes Verification', () => {
       await expect(clearButton).toBeVisible()
       await clearButton.click()
 
-      // Assert — confirmation dialog appears with the right copy
+      // Assert — confirmation dialog appears with the right copy. Clearing now
+      // ARCHIVES (the heatmap day survives), so the dialog reassures rather than
+      // warning "cannot be undone" — assert the on-brand "stays counted on your
+      // heatmap" reassurance instead. (Substring match avoids the dynamic count
+      // clause and the curly/straight apostrophe in "doesn't erase the record".)
       const dialog = page.getByRole('alertdialog')
       await expect(dialog).toBeVisible()
       await expect(dialog.getByText('Clear all completed tasks?')).toBeVisible()
       await expect(
-        dialog.getByText('This action cannot be undone'),
+        dialog.getByText('They stay counted on your heatmap', {
+          exact: false,
+        }),
       ).toBeVisible()
 
       // Act 2 — cancel the dialog

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -145,6 +145,7 @@ export default defineConfig([
             'floating-navigator-*',
             // Custom utility classes (defined in globals.css @layer utilities)
             'cathedral-lit',
+            'tap-target-24',
             // Tailwind default color palette (temporary - will migrate to tokens)
             'text-red-*',
             'text-blue-*',

--- a/prisma/migrations/20260603235155_add_todo_completedat/migration.sql
+++ b/prisma/migrations/20260603235155_add_todo_completedat/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "Todo" ADD COLUMN     "completedAt" TIMESTAMP(3);
+
+-- Data migration: backfill completedAt for already-completed todos.
+-- Best-effort: a todo completed-then-edited gets completedAt = its last
+-- updatedAt (the last time the old updatedAt-drift could bite). Incomplete
+-- todos keep completedAt = NULL. This mirrors the Completed.completedAt
+-- backfill (completedAt = createdAt) so existing rows do not shift heatmap days.
+UPDATE "Todo" SET "completedAt" = "updatedAt" WHERE "completed" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,15 @@ model Todo {
   id          Int              @id @default(autoincrement())
   text        String           @db.VarChar(255)
   completed   Boolean          @default(false)
+  // Semantic "when it was completed" timestamp, distinct from updatedAt (which
+  // mutates on every text/notes edit, so a completed todo edited later would
+  // drift its heatmap day). NULLABLE with NO @default: a non-null default would
+  // stamp every historical row with the migration timestamp, jumping all old
+  // rows to migration-day. The migration backfills existing completed rows with
+  // completedAt = updatedAt; toggleTodo writes it on each false→true completion.
+  // The heatmap buckets the Todo half by `completedAt ?? updatedAt` (coalesced
+  // in JS), so a null (un-converted write path) still lands on a day.
+  completedAt DateTime?
   notes       String?          @db.Text
   order       Int?             // Sort order for drag-and-drop reordering (nullable for backwards compatibility)
   user        User             @relation(fields: [userId], references: [id])

--- a/src/app/(main)/home/_components/CompletedTodos.tsx
+++ b/src/app/(main)/home/_components/CompletedTodos.tsx
@@ -276,10 +276,11 @@ export const CompletedTodos = React.memo(function CompletedTodos({
           <AlertDialogHeader>
             <AlertDialogTitle>Clear all completed tasks?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will permanently delete{' '}
-              {data?.pages[0]?.total ?? allTodos.length} completed task
-              {(data?.pages[0]?.total ?? allTodos.length) !== 1 ? 's' : ''}.
-              This action cannot be undone.
+              This clears {data?.pages[0]?.total ?? allTodos.length} completed
+              task
+              {(data?.pages[0]?.total ?? allTodos.length) !== 1 ? 's' : ''} from
+              this list. They stay counted on your heatmap — clearing only
+              tidies the list, it doesn&apos;t erase the record.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/app/(main)/home/_components/TodoItem.stories.tsx
+++ b/src/app/(main)/home/_components/TodoItem.stories.tsx
@@ -1,0 +1,62 @@
+import { configureStore } from '@reduxjs/toolkit'
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { Provider } from 'react-redux'
+
+import preferencesReducer from '@/lib/redux/slices/preferencesSlice'
+
+import { TodoItem } from './TodoItem'
+
+// A minimal store with 居残りモード ON so the completed-in-place treatment renders
+// exactly as it does in retain mode: amber checkbox + taupe strikethrough, no
+// status badge (D16), and no per-row trash on the completed row (D14).
+const retainStore = configureStore({
+  reducer: { preferences: preferencesReducer },
+  preloadedState: {
+    preferences: { completionSound: false, retainCompletedInList: true },
+  },
+})
+
+const noop = (): void => {}
+
+const meta = {
+  title: 'Home/TodoItem',
+  component: TodoItem,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <Provider store={retainStore}>
+        <div className="max-w-md">
+          <Story />
+        </div>
+      </Provider>
+    ),
+  ],
+} satisfies Meta<typeof TodoItem>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const baseTodo = {
+  id: '1',
+  text: 'Draft project brief',
+  completed: false,
+  createdAt: new Date('2026-06-04T09:00:00.000Z'),
+}
+
+/** A pending row — full-contrast ink, empty checkbox, trash present. */
+export const Pending: Story = {
+  args: { todo: baseTodo, onToggleComplete: noop, onDelete: noop },
+}
+
+/**
+ * The 居残りモード completed-in-place state — checked amber checkbox + taupe
+ * strikethrough, staying in the active list. No status badge; no per-row trash
+ * (tidy via Clear). This is the state the feature's Success Criteria calls for.
+ */
+export const CompletedInPlace: Story = {
+  args: {
+    todo: { ...baseTodo, id: '2', text: '30-minute walk', completed: true },
+    onToggleComplete: noop,
+    onDelete: noop,
+  },
+}

--- a/src/app/(main)/home/_components/TodoItem.tsx
+++ b/src/app/(main)/home/_components/TodoItem.tsx
@@ -7,7 +7,6 @@ import {
 } from 'lucide-react'
 import React, { useCallback, useState } from 'react'
 
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -16,7 +15,10 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { Textarea } from '@/components/ui/textarea'
+import { useCompletionFeedback } from '@/hooks/useCompletionFeedback'
 import { getColorDotClass } from '@/lib/category-colors'
+import { useAppSelector } from '@/lib/redux/hooks'
+import { selectRetainCompletedInList } from '@/lib/redux/slices/preferencesSlice'
 
 export interface Todo {
   id: string
@@ -59,9 +61,23 @@ export const TodoItem = React.memo(function TodoItem({
     setIsNotesOpen(open)
   }, [])
 
+  const { checkboxMotionClassName, fire } = useCompletionFeedback()
+
+  // D14: in 居残りモード the per-row trash is hidden on completed-retained rows
+  // (tidy via Clear, which archives + keeps the heatmap); pending rows keep it.
+  // In the non-retain Completed section the trash stays (routed through the
+  // Undo-toast delete). So hide only when this row is completed AND retain is on.
+  const isRetaining = useAppSelector(selectRetainCompletedInList)
+  const showDeleteButton = !todo.completed || !isRetaining
+
   const handleToggleComplete = useCallback(() => {
+    // Fire the opt-in sound only on a real completion (false→true); the CSS
+    // checkbox fill plays on the state change itself. Un-completing is quiet.
+    if (!todo.completed) {
+      fire()
+    }
     onToggleComplete(todo.id)
-  }, [onToggleComplete, todo.id])
+  }, [fire, onToggleComplete, todo.completed, todo.id])
 
   const handleDelete = useCallback(() => {
     onDelete(todo.id)
@@ -101,11 +117,14 @@ export const TodoItem = React.memo(function TodoItem({
             <GripVertical className="h-5 w-5" />
           </button>
         )}
+        {/* Expand the 16px checkbox to a ≥24px hit target (WCAG 2.5.8 AA) with a
+            transparent ::before, without resizing the global Checkbox (D12). */}
         <Checkbox
           checked={todo.completed}
           onCheckedChange={handleToggleComplete}
           id={`todo-${todo.id}`}
           aria-label={todo.text}
+          className={`${checkboxMotionClassName} tap-target-24`}
         />
         <div className="min-w-0 flex-1">
           <div
@@ -132,9 +151,6 @@ export const TodoItem = React.memo(function TodoItem({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <Badge variant={todo.completed ? 'secondary' : 'default'}>
-            {todo.completed ? 'Completed' : 'Pending'}
-          </Badge>
           {onUpdateNotes && (
             <Collapsible
               open={isNotesOpen}
@@ -157,15 +173,17 @@ export const TodoItem = React.memo(function TodoItem({
               </CollapsibleTrigger>
             </Collapsible>
           )}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleDelete}
-            className="hover:bg-destructive/10 text-destructive hover:text-destructive"
-          >
-            <Trash2 className="h-4 w-4" />
-            <span className="sr-only">Delete</span>
-          </Button>
+          {showDeleteButton && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleDelete}
+              className="hover:bg-destructive/10 text-destructive hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4" />
+              <span className="sr-only">Delete</span>
+            </Button>
+          )}
         </div>
       </div>
       {onUpdateNotes && (

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -6,7 +6,18 @@ import { useIsRestoring, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Circle } from 'lucide-react'
 import { memo, Suspense, useCallback, useMemo, useState } from 'react'
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
@@ -22,6 +33,8 @@ import { useStreakNotifications } from '@/hooks/useStreakNotifications'
 import { useTodoMutations } from '@/hooks/useTodoMutations'
 import { todoSortableSensors } from '@/lib/dnd-kit-sensors'
 import { orpc } from '@/lib/orpc/client-query'
+import { useAppSelector } from '@/lib/redux/hooks'
+import { selectRetainCompletedInList } from '@/lib/redux/slices/preferencesSlice'
 import { subscribeToTodoSync } from '@/lib/todo-sync-channel'
 import type { CategoryWithCount } from '@/server/schemas/category'
 
@@ -55,6 +68,9 @@ export const TodoList = memo(function TodoList() {
 
   // Category filter state (persisted to localStorage)
   const [selectedCategoryId] = useSelectedCategory()
+  // 居残りモード (keep completed todos in the active list) — drives the
+  // retain-aware query input + cache keys below.
+  const isRetaining = useAppSelector(selectRetainCompletedInList)
 
   // Mutations with optimistic updates (pass categoryId for correct cache key)
   const {
@@ -64,7 +80,8 @@ export const TodoList = memo(function TodoList() {
     updateMutation,
     clearCompletedMutation,
     reorderMutation,
-  } = useTodoMutations(selectedCategoryId)
+    deleteCompletedWithUndo,
+  } = useTodoMutations(selectedCategoryId, isRetaining)
 
   // Local state for optimistic reordering
   const [localPendingTodos, setLocalPendingTodos] = useState<Todo[]>([])
@@ -86,7 +103,10 @@ export const TodoList = memo(function TodoList() {
   const { data: pendingData, isLoading: pendingLoading } = useQuery({
     ...orpc.todo.list.queryOptions({
       input: {
-        completed: false,
+        // 居残りモード drops the completed:false filter so the active list holds
+        // ALL todos (pending + completed-since-clear); MUST mirror the
+        // retain-aware pendingKey in useTodoMutations or optimistic updates miss.
+        ...(isRetaining ? {} : { completed: false }),
         limit: TODO_QUERY_LIMIT,
         offset: TODO_QUERY_OFFSET,
         ...(selectedCategoryId !== null && { categoryId: selectedCategoryId }),
@@ -173,6 +193,23 @@ export const TodoList = memo(function TodoList() {
   )
 
   /**
+   * Deletes a COMPLETED todo with a 5s Undo toast (D3). The row is removed
+   * optimistically; the server archive-then-delete commits only when the undo
+   * window closes, so the heatmap day is preserved and Undo fully restores it.
+   * @param id - Todo identifier as a string.
+   * @example deleteCompletedTodo('42')
+   */
+  const deleteCompletedTodo = useCallback(
+    (id: string) => {
+      const todoId = parseInt(id, DECIMAL_RADIX)
+      if (!isNaN(todoId)) {
+        deleteCompletedWithUndo(todoId)
+      }
+    },
+    [deleteCompletedWithUndo],
+  )
+
+  /**
    * Updates the notes for a specific todo item.
    * @param id - Todo identifier as a string.
    * @param notes - New notes content.
@@ -201,6 +238,22 @@ export const TodoList = memo(function TodoList() {
   const deleteCompleted = useCallback(() => {
     clearCompletedMutation.mutate({})
   }, [clearCompletedMutation])
+
+  // Retain-mode Clear confirmation: Clear is the ONLY way to remove
+  // completed-retained rows (D14 hides the per-row trash) and it archives the
+  // whole done-list in one click, so it confirms first — matching the safety of
+  // CompletedTodos' clear and the per-item Undo toast (advisor).
+  const [retainClearDialogOpen, setRetainClearDialogOpen] = useState(false)
+  const handleRetainClearClick = useCallback(() => {
+    setRetainClearDialogOpen(true)
+  }, [])
+  const handleRetainClearDialogOpenChange = useCallback((open: boolean) => {
+    setRetainClearDialogOpen(open)
+  }, [])
+  const handleConfirmRetainClear = useCallback(() => {
+    deleteCompleted()
+    setRetainClearDialogOpen(false)
+  }, [deleteCompleted])
 
   // Transform data into Todo component format
   /**
@@ -245,6 +298,13 @@ export const TodoList = memo(function TodoList() {
 
   // Use local state for rendering to enable optimistic reordering
   const pendingTodos = localPendingTodos
+  // In retain mode the active list holds completed todos too; split the counts
+  // so the header reads honestly (pending count) and can surface a quiet
+  // "N done" (D6). In non-retain mode completedInListCount is always 0.
+  const completedInListCount = pendingTodos.filter(
+    (todoRow) => todoRow.completed,
+  ).length
+  const pendingCount = pendingTodos.length - completedInListCount
 
   /**
    * Handles drag end event to reorder todos.
@@ -330,10 +390,28 @@ export const TodoList = memo(function TodoList() {
               <span>Todo List</span>
               <Badge variant="outline" className="flex items-center gap-1">
                 <Circle className="h-3 w-3" />
-                {pendingTodos.length} pending
+                {pendingCount} pending
               </Badge>
             </CardTitle>
             <CardDescription>Manage your tasks efficiently</CardDescription>
+            {/* 居残りモード — quiet "N done" count + Clear (archives completed,
+                keeping them on the heatmap). Hidden entirely when nothing is
+                done (D6); the count is ambient, not an assertive live region. */}
+            {isRetaining && completedInListCount > 0 && (
+              <div className="flex items-center justify-between pt-2">
+                <span className="font-mono text-sm tabular-nums text-muted-foreground">
+                  {completedInListCount} done
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleRetainClearClick}
+                  className="h-auto px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+                >
+                  Clear
+                </Button>
+              </div>
+            )}
           </CardHeader>
           <CardContent className="space-y-4">
             <AddTodoForm
@@ -413,12 +491,44 @@ export const TodoList = memo(function TodoList() {
           dataByDate={heatmapByDate}
           isLoading={heatmapLoading}
         />
-        <CompletedTodos
-          onDelete={deleteTodo}
-          onClearCompleted={deleteCompleted}
-          onToggleComplete={toggleComplete}
-        />
+        {/* In 居残りモード completed todos live in the active list above, so the
+            separate Completed section is suppressed (no double display). */}
+        {!isRetaining && (
+          <CompletedTodos
+            onDelete={deleteCompletedTodo}
+            onClearCompleted={deleteCompleted}
+            onToggleComplete={toggleComplete}
+          />
+        )}
       </div>
+
+      {/* Retain-mode Clear confirmation — Clear is the only path to remove
+          completed-retained rows (D14 hides the per-row trash) and it archives
+          the whole done-list at once, so it confirms first (mirrors the
+          CompletedTodos clear dialog). Archiving keeps every completion on the
+          heatmap. */}
+      <AlertDialog
+        open={retainClearDialogOpen}
+        onOpenChange={handleRetainClearDialogOpenChange}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear finished tasks?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This clears {completedInListCount} finished task
+              {completedInListCount !== 1 ? 's' : ''} from your list. They stay
+              counted on your heatmap — clearing only tidies the list, it
+              doesn&apos;t erase the record.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmRetainClear}>
+              Clear
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 })

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,33 +1,39 @@
 import type { Metadata } from 'next'
 import * as React from 'react'
 import { memo } from 'react'
+
 /**
- * Settings Page (Electron Only)
+ * Settings Page
  *
- * This page displays Electron-specific settings and is only
- * accessible when running in the Electron environment.
- * Web users attempting to access this route will be redirected.
+ * The single settings home across web and Electron (D15). Everyone sees the
+ * shared Preferences section; the Electron window-chrome settings render only
+ * under the desktop app (ElectronSettingsPage returns null on web).
  *
  * @module app/settings/page
  */
-
 import { ElectronSettingsPage } from '@/components/electron/ElectronSettingsPage'
+import { PreferencesSettings } from '@/components/settings/PreferencesSettings'
 
 export const metadata: Metadata = {
   title: 'Settings',
-  description: 'Electron application settings',
+  description: 'CoreLive preferences and desktop application settings',
 }
 
 /**
  * Settings page component.
  *
- * Renders the ElectronSettingsPage component for Electron users.
- * The component itself handles checking for Electron environment.
+ * Renders the web-common Preferences section for all users, followed by the
+ * Electron-only window-chrome settings (which self-gate to the desktop app).
  *
  * @returns Settings page
  */
 const SettingsPage = memo(function SettingsPage(): React.ReactNode {
-  return <ElectronSettingsPage />
+  return (
+    <div className="mx-auto h-full max-w-2xl">
+      <PreferencesSettings />
+      <ElectronSettingsPage />
+    </div>
+  )
 })
 
 export default SettingsPage

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -220,14 +220,15 @@ export const AppSidebar = memo(function AppSidebar() {
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
-                {isElectron && (
-                  <SidebarMenuItem>
-                    <SidebarMenuButton onClick={handleOpenSettings}>
-                      <Settings className="h-4 w-4" />
-                      <span>Settings</span>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                )}
+                {/* Settings is web-reachable (D15): the shared Preferences
+                    section is shown to everyone; Electron window-chrome settings
+                    self-gate to the desktop app. */}
+                <SidebarMenuItem>
+                  <SidebarMenuButton onClick={handleOpenSettings}>
+                    <Settings className="h-4 w-4" />
+                    <span>Settings</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
                 <SidebarMenuItem>
                   <SidebarMenuButton>
                     <Trash2 className="h-4 w-4" />

--- a/src/components/electron/ElectronSettingsPage.tsx
+++ b/src/components/electron/ElectronSettingsPage.tsx
@@ -54,7 +54,7 @@ import {
  * @returns Settings page with toggle switches, or fallback for web users
  */
 export const ElectronSettingsPage = memo(
-  function ElectronSettingsPage(): React.ReactElement {
+  function ElectronSettingsPage(): React.ReactElement | null {
     const dispatch = useAppDispatch()
     const isElectron = useIsElectron() // SSR-safe via useSyncExternalStore
 
@@ -172,22 +172,11 @@ export const ElectronSettingsPage = memo(
       [dispatch],
     )
 
-    // Environment guard: Show fallback for web users
+    // Web users see the shared Preferences section (rendered by the settings
+    // page); the Electron window-chrome settings below are desktop-only, so
+    // render nothing here off-Electron (D15 — one settings home, prefs for all).
     if (!isElectron) {
-      return (
-        <div className="mx-auto max-w-2xl p-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-2xl">Settings</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">
-                These settings are only available in the desktop application.
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-      )
+      return null
     }
 
     return (

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { isFloatingNavigatorEnvironment } from '@/electron/utils/electron-client'
+import { useCompletionFeedback } from '@/hooks/useCompletionFeedback'
 import { COLOR_DOT_CLASSES } from '@/lib/category-colors'
 import { todoSortableSensors } from '@/lib/dnd-kit-sensors'
 import { log } from '@/lib/logger'
@@ -154,9 +155,15 @@ const PendingFloatingTodoRow = React.memo(function PendingFloatingTodoRow({
   onSaveEdit,
   onCancelEdit,
 }: PendingFloatingTodoRowProps): React.ReactNode {
+  const { checkboxMotionClassName, fire } = useCompletionFeedback()
   const handleToggle = useCallback(() => {
+    // Fire the opt-in sound only on a real completion (false→true); the CSS
+    // checkbox fill plays on the state change. Un-completing is quiet.
+    if (!todo.completed) {
+      fire()
+    }
     onToggle(todo.id)
-  }, [onToggle, todo.id])
+  }, [fire, onToggle, todo.completed, todo.id])
   const handleDelete = useCallback(() => {
     onDelete(todo.id)
   }, [onDelete, todo.id])
@@ -187,7 +194,7 @@ const PendingFloatingTodoRow = React.memo(function PendingFloatingTodoRow({
       <Checkbox
         checked={todo.completed}
         onCheckedChange={handleToggle}
-        className="h-4 w-4 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        className={`tap-target-24 h-4 w-4 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${checkboxMotionClassName}`}
         aria-label={`Mark task "${todo.text}" as ${todo.completed ? 'incomplete' : 'complete'}`}
       />
 
@@ -290,6 +297,7 @@ const CompletedFloatingTodoRow = React.memo(function CompletedFloatingTodoRow({
   onToggle,
   onDelete,
 }: CompletedFloatingTodoRowProps): React.ReactNode {
+  const { checkboxMotionClassName } = useCompletionFeedback()
   const handleToggle = useCallback(() => {
     onToggle(todo.id)
   }, [onToggle, todo.id])
@@ -306,7 +314,7 @@ const CompletedFloatingTodoRow = React.memo(function CompletedFloatingTodoRow({
       <Checkbox
         checked={todo.completed}
         onCheckedChange={handleToggle}
-        className="h-4 w-4 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        className={`tap-target-24 h-4 w-4 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${checkboxMotionClassName}`}
         aria-label={`Mark completed task "${todo.text}" as incomplete`}
       />
       <span

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -15,6 +15,8 @@ import {
 import { useTodoMutations } from '@/hooks/useTodoMutations'
 import { subscribeToCategorySync } from '@/lib/category-sync-channel'
 import { orpc } from '@/lib/orpc/client-query'
+import { useAppSelector } from '@/lib/redux/hooks'
+import { selectRetainCompletedInList } from '@/lib/redux/slices/preferencesSlice'
 import { subscribeToTodoSync } from '@/lib/todo-sync-channel'
 import type {
   CategoryColor,
@@ -50,6 +52,9 @@ export const FloatingNavigatorContainer = React.memo(
 
     // Category filter state (shared with main app via localStorage)
     const [selectedCategoryId, setSelectedCategoryId] = useSelectedCategory()
+    // 居残りモード (app-wide pref, D11): keep completed todos visible instead of
+    // letting them vanish on check. Drives the retain-aware query + mutations.
+    const isRetaining = useAppSelector(selectRetainCompletedInList)
 
     // Mutations with optimistic updates (pass categoryId for correct cache key)
     const {
@@ -58,7 +63,7 @@ export const FloatingNavigatorContainer = React.memo(
       deleteMutation,
       updateMutation,
       reorderMutation,
-    } = useTodoMutations(selectedCategoryId)
+    } = useTodoMutations(selectedCategoryId, isRetaining)
 
     // Category CRUD mutations with optimistic updates
     const {
@@ -97,7 +102,10 @@ export const FloatingNavigatorContainer = React.memo(
     const { data, isLoading, error } = useQuery({
       ...orpc.todo.list.queryOptions({
         input: {
-          completed: false,
+          // 居残りモード drops completed:false so completed todos stay in the
+          // result (shown in the Completed section) instead of vanishing on
+          // check; mirrors the retain-aware pendingKey in useTodoMutations.
+          ...(isRetaining ? {} : { completed: false }),
           limit: TODO_QUERY_LIMIT,
           offset: TODO_QUERY_OFFSET,
           ...(selectedCategoryId !== null && {

--- a/src/components/settings/PreferencesSettings.tsx
+++ b/src/components/settings/PreferencesSettings.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { memo, useCallback } from 'react'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { useAppDispatch, useAppSelector } from '@/lib/redux/hooks'
+import {
+  selectCompletionSound,
+  selectRetainCompletedInList,
+  setCompletionSound,
+  setRetainCompletedInList,
+} from '@/lib/redux/slices/preferencesSlice'
+
+/**
+ * Web-common user preferences section (shown to everyone, web + Electron). Houses
+ * the 居残りモード and completion-sound toggles that govern the core todo
+ * experience — distinct from the Electron window-chrome settings, which stay
+ * gated to the desktop app. Writes the `preferences` Redux slice (persisted to
+ * localStorage and synced across windows by the preferences sync middleware).
+ *
+ * @returns The Preferences settings card.
+ * @example
+ * <PreferencesSettings />
+ */
+export const PreferencesSettings = memo(function PreferencesSettings() {
+  const dispatch = useAppDispatch()
+  const completionSound = useAppSelector(selectCompletionSound)
+  const retainCompletedInList = useAppSelector(selectRetainCompletedInList)
+
+  const handleRetainChange = useCallback(
+    (checked: boolean): void => {
+      dispatch(setRetainCompletedInList(checked))
+    },
+    [dispatch],
+  )
+
+  const handleCompletionSoundChange = useCallback(
+    (checked: boolean): void => {
+      dispatch(setCompletionSound(checked))
+    },
+    [dispatch],
+  )
+
+  return (
+    <div className="space-y-4 p-4">
+      <Card className="border-0 bg-transparent shadow-none">
+        <CardHeader className="px-2 pb-2 pt-0">
+          <CardTitle className="text-lg">Preferences</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 px-2">
+          {/* 居残りモード — keep checked tasks in place instead of moving them. */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label
+                htmlFor="retain-completed-in-list"
+                className="text-sm font-medium"
+              >
+                Keep finished tasks in the list
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Checked tasks stay in place with a line through them, so you can
+                watch the day add up — instead of moving to Completed.
+              </p>
+            </div>
+            <Switch
+              id="retain-completed-in-list"
+              checked={retainCompletedInList}
+              onCheckedChange={handleRetainChange}
+            />
+          </div>
+
+          {/* Opt-in completion sound (default OFF) — the DESIGN.md SFX exception. */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="completion-sound" className="text-sm font-medium">
+                Completion sound
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                A soft sound when you check something off. Off by default.
+              </p>
+            </div>
+            <Switch
+              id="completion-sound"
+              checked={completionSound}
+              onCheckedChange={handleCompletionSoundChange}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+})
+
+export default PreferencesSettings

--- a/src/globals.css
+++ b/src/globals.css
@@ -162,4 +162,20 @@
       0 0 0 1px oklch(from var(--primary) l c h / 22%),
       0 0 48px -12px oklch(from var(--primary) l c h / 35%);
   }
+
+  /* Expand a small control's hit area to ≥24px (WCAG 2.5.8 AA) via a transparent
+     ::before, without changing its visual size — used on the 16px todo checkbox
+     so the global Checkbox stays untouched (DESIGN.md D12). */
+  .tap-target-24 {
+    position: relative;
+  }
+  .tap-target-24::before {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    /* Guarantee the ≥24px AA target even if the host control's size changes
+       (inset:-4px alone only reaches 24px when the host is exactly 16px). */
+    min-block-size: 24px;
+    min-inline-size: 24px;
+  }
 }

--- a/src/hooks/useCompletionFeedback.test.tsx
+++ b/src/hooks/useCompletionFeedback.test.tsx
@@ -1,0 +1,57 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { renderHook } from '@testing-library/react'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { describe, expect, it } from 'vitest'
+
+import preferencesReducer from '@/lib/redux/slices/preferencesSlice'
+
+import { useCompletionFeedback } from './useCompletionFeedback'
+
+/**
+ * Renders useCompletionFeedback under a minimal Redux store with the given
+ * completion-sound preference (the hook reads it app-level via useAppSelector).
+ */
+function renderWithSound(completionSound: boolean) {
+  const store = configureStore({
+    reducer: { preferences: preferencesReducer },
+    preloadedState: {
+      preferences: { completionSound, retainCompletedInList: false },
+    },
+  })
+  return renderHook(() => useCompletionFeedback(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    ),
+  })
+}
+
+describe('useCompletionFeedback', () => {
+  it('returns the motion-safe, short-tier checkbox fill className (not celebration easing)', () => {
+    // Act
+    const { result } = renderWithSound(false)
+
+    // Assert — motion-safe gated, 200ms ease-out; NOT the heatmap celebration easing.
+    expect(result.current.checkboxMotionClassName).toContain('motion-safe:')
+    expect(result.current.checkboxMotionClassName).toContain('duration-200')
+    expect(result.current.checkboxMotionClassName).toContain('ease-out')
+    expect(result.current.checkboxMotionClassName).not.toContain('cubic-bezier')
+  })
+
+  it('fire() never throws when the completion sound is OFF (the default — a pure no-op)', () => {
+    // Arrange
+    const { result } = renderWithSound(false)
+
+    // Act / Assert — opt-in default OFF means no audio is created or played.
+    expect(() => result.current.fire()).not.toThrow()
+  })
+
+  it('fire() never throws even when sound is ON in a context without Web Audio (degrades silently)', () => {
+    // Arrange — enabling the preference must never let a missing/blocked
+    // AudioContext break the completion flow; it degrades to silence.
+    const { result } = renderWithSound(true)
+
+    // Act / Assert
+    expect(() => result.current.fire()).not.toThrow()
+  })
+})

--- a/src/hooks/useCompletionFeedback.test.tsx
+++ b/src/hooks/useCompletionFeedback.test.tsx
@@ -35,6 +35,9 @@ function renderWithSound(completionSound: boolean) {
  * stop()ped when a new fire() starts a replacement).
  */
 interface FakeAudioState {
+  // How many times the AudioContext constructor ran — lets a test prove the
+  // module-level singleton builds ONE context across multiple hook instances.
+  constructCount: number
   context: { state: AudioContextState; resumeCount: number; closed: boolean }
   oscillators: Array<{
     started: boolean
@@ -54,6 +57,7 @@ function installFakeAudioContext(): {
   uninstall: () => void
 } {
   const state: FakeAudioState = {
+    constructCount: 0,
     context: { state: 'suspended', resumeCount: 0, closed: false },
     oscillators: [],
   }
@@ -69,6 +73,9 @@ function installFakeAudioContext(): {
 
   class FakeAudioContext {
     currentTime = 0
+    constructor() {
+      state.constructCount += 1
+    }
     get state(): AudioContextState {
       return state.context.state
     }
@@ -209,9 +216,10 @@ describe('useCompletionFeedback', () => {
       first.result.current.fire()
       second.result.current.fire()
 
-      // Assert — both fires shared a single AudioContext (the second oscillator
-      // was cut by being created in the same shared context), proving the audio
-      // state is app-wide rather than per-row.
+      // Assert — exactly ONE AudioContext was constructed across both instances
+      // (the singleton is shared, not per-row), and the first instance's
+      // oscillator was cut when the second fired (one sound in-flight app-wide).
+      expect(state.constructCount).toBe(1)
       expect(state.oscillators).toHaveLength(2)
       const [firstSharedOscillator] = state.oscillators
       expect(firstSharedOscillator?.stopped).toBe(true)

--- a/src/hooks/useCompletionFeedback.test.tsx
+++ b/src/hooks/useCompletionFeedback.test.tsx
@@ -2,11 +2,14 @@ import { configureStore } from '@reduxjs/toolkit'
 import { renderHook } from '@testing-library/react'
 import * as React from 'react'
 import { Provider } from 'react-redux'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import preferencesReducer from '@/lib/redux/slices/preferencesSlice'
 
-import { useCompletionFeedback } from './useCompletionFeedback'
+import {
+  resetCompletionFeedbackAudioForTest,
+  useCompletionFeedback,
+} from './useCompletionFeedback'
 
 /**
  * Renders useCompletionFeedback under a minimal Redux store with the given
@@ -26,7 +29,103 @@ function renderWithSound(completionSound: boolean) {
   })
 }
 
+/**
+ * Records all oscillators a fake AudioContext creates so a test can assert the
+ * "at most one sound in-flight" cut/restart behavior (an earlier oscillator gets
+ * stop()ped when a new fire() starts a replacement).
+ */
+interface FakeAudioState {
+  context: { state: AudioContextState; resumeCount: number; closed: boolean }
+  oscillators: Array<{
+    started: boolean
+    stopped: boolean
+    type: OscillatorType
+  }>
+}
+
+/**
+ * Installs a minimal synchronous globalThis.AudioContext stub so fire() runs its
+ * real sound path (createOscillator → resume → start/stop → in-flight cut)
+ * instead of only the silent-degradation branch. Returns the recorded state plus
+ * an uninstall fn to restore the original constructor.
+ */
+function installFakeAudioContext(): {
+  state: FakeAudioState
+  uninstall: () => void
+} {
+  const state: FakeAudioState = {
+    context: { state: 'suspended', resumeCount: 0, closed: false },
+    oscillators: [],
+  }
+  const gainNodeStub = {
+    gain: {
+      setValueAtTime: vi.fn(),
+      linearRampToValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn(),
+    },
+    connect: vi.fn(() => audioDestinationStub),
+  }
+  const audioDestinationStub = {}
+
+  class FakeAudioContext {
+    currentTime = 0
+    get state(): AudioContextState {
+      return state.context.state
+    }
+    destination = audioDestinationStub
+    async resume(): Promise<void> {
+      state.context.resumeCount += 1
+      state.context.state = 'running'
+    }
+    async close(): Promise<void> {
+      state.context.closed = true
+    }
+    createGain() {
+      return gainNodeStub
+    }
+    createOscillator() {
+      const record = {
+        started: false,
+        stopped: false,
+        type: 'sine' as OscillatorType,
+      }
+      state.oscillators.push(record)
+      return {
+        set type(value: OscillatorType) {
+          record.type = value
+        },
+        frequency: { setValueAtTime: vi.fn() },
+        connect: vi.fn(() => gainNodeStub),
+        start: vi.fn(() => {
+          record.started = true
+        }),
+        stop: vi.fn(() => {
+          record.stopped = true
+        }),
+        addEventListener: vi.fn(),
+      }
+    }
+  }
+
+  const original = globalThis.AudioContext
+  // @ts-expect-error — assigning a test double over the DOM lib type.
+  globalThis.AudioContext = FakeAudioContext
+  return {
+    state,
+    uninstall: () => {
+      globalThis.AudioContext = original
+    },
+  }
+}
+
 describe('useCompletionFeedback', () => {
+  // The shared AudioContext + in-flight oscillator are module-level singletons
+  // (so "one sound in-flight" holds across row surfaces), so reset between tests
+  // or a stub installed in one case would leak into the next.
+  afterEach(() => {
+    resetCompletionFeedbackAudioForTest()
+  })
+
   it('returns the motion-safe, short-tier checkbox fill className (not celebration easing)', () => {
     // Act
     const { result } = renderWithSound(false)
@@ -53,5 +152,71 @@ describe('useCompletionFeedback', () => {
 
     // Act / Assert
     expect(() => result.current.fire()).not.toThrow()
+  })
+
+  it('fire() plays a single sine tone (resumes a suspended context, then starts+stops the oscillator) when sound is ON', () => {
+    // Arrange — a real Web Audio context is available and the preference is ON.
+    const { state, uninstall } = installFakeAudioContext()
+    try {
+      const { result } = renderWithSound(true)
+
+      // Act
+      result.current.fire()
+
+      // Assert — the suspended context is resumed, and exactly one warm sine
+      // oscillator is created, started, and scheduled to stop.
+      expect(state.context.resumeCount).toBe(1)
+      expect(state.oscillators).toHaveLength(1)
+      const [onlyOscillator] = state.oscillators
+      expect(onlyOscillator?.type).toBe('sine')
+      expect(onlyOscillator?.started).toBe(true)
+      expect(onlyOscillator?.stopped).toBe(true)
+    } finally {
+      uninstall()
+    }
+  })
+
+  it('fire() keeps at most one sound in-flight — a rapid second completion cuts the first oscillator instead of layering', () => {
+    // Arrange — sound ON, with a stub that records every oscillator created.
+    const { state, uninstall } = installFakeAudioContext()
+    try {
+      const { result } = renderWithSound(true)
+
+      // Act — two completions in quick succession (e.g. two rows checked fast).
+      result.current.fire()
+      result.current.fire()
+
+      // Assert — the first oscillator is cut (stopped) when the second starts,
+      // so the two cues never layer into a cacophony.
+      expect(state.oscillators).toHaveLength(2)
+      const [firstOscillator, secondOscillator] = state.oscillators
+      expect(firstOscillator?.stopped).toBe(true)
+      expect(secondOscillator?.started).toBe(true)
+    } finally {
+      uninstall()
+    }
+  })
+
+  it('fire() reuses one shared AudioContext across separate hook instances (the per-row surfaces never each open their own)', () => {
+    // Arrange — two independently mounted hook instances stand in for two of the
+    // row surfaces (TodoItem + a Floating row) that mount the hook separately.
+    const { state, uninstall } = installFakeAudioContext()
+    try {
+      const first = renderWithSound(true)
+      const second = renderWithSound(true)
+
+      // Act — each instance fires once.
+      first.result.current.fire()
+      second.result.current.fire()
+
+      // Assert — both fires shared a single AudioContext (the second oscillator
+      // was cut by being created in the same shared context), proving the audio
+      // state is app-wide rather than per-row.
+      expect(state.oscillators).toHaveLength(2)
+      const [firstSharedOscillator] = state.oscillators
+      expect(firstSharedOscillator?.stopped).toBe(true)
+    } finally {
+      uninstall()
+    }
   })
 })

--- a/src/hooks/useCompletionFeedback.ts
+++ b/src/hooks/useCompletionFeedback.ts
@@ -1,0 +1,117 @@
+'use client'
+
+import { useCallback, useRef } from 'react'
+
+import {
+  COMPLETION_SOUND_ATTACK_MS,
+  COMPLETION_SOUND_DURATION_MS,
+  COMPLETION_SOUND_FREQUENCY_HZ,
+  COMPLETION_SOUND_PEAK_GAIN,
+} from '@/lib/constants/completionFeedback'
+import { useAppSelector } from '@/lib/redux/hooks'
+import { selectCompletionSound } from '@/lib/redux/slices/preferencesSlice'
+
+/**
+ * motion-safe gated amber fill for the checkbox (~200ms ease-out, `duration-200`
+ * = CHECKBOX_COMPLETION_FILL_MS). Transitions background + border + box-shadow so
+ * the amber fills in over the short tier; `prefers-reduced-motion` users get an
+ * instant, motionless state change (the motion-safe classes simply don't apply).
+ * Deliberately NOT the heatmap's radial-sweep / celebration easing — the heatmap
+ * stays the single performative hero moment.
+ */
+const CHECKBOX_COMPLETION_MOTION_CLASS =
+  'motion-safe:transition-[background-color,border-color,box-shadow] motion-safe:duration-200 motion-safe:ease-out'
+
+/**
+ * Return shape of useCompletionFeedback.
+ *
+ * @property checkboxMotionClassName - motion-safe class to apply to the checkbox.
+ * @property fire - Plays the opt-in completion sound (no-op unless enabled).
+ */
+export interface CompletionFeedback {
+  checkboxMotionClassName: string
+  fire: () => void
+}
+
+/**
+ * Shared completion-feedback seam for the three row surfaces (TodoItem + the two
+ * Floating rows), which share no row component. Returns the motion-safe checkbox
+ * fill className and a `fire()` that plays the opt-in completion sound. Why a
+ * hook, not a component: the surfaces differ structurally, so the hook is the
+ * shared spot. The sound is opt-in (default OFF), read app-level from Redux, and
+ * synthesized (no bundled asset); at most one sound is in-flight, so a rapid
+ * second check cuts/restarts rather than layering. Call `fire()` only on a
+ * false→true completion (un-completing is quiet).
+ *
+ * @returns The checkbox motion className and the sound `fire` trigger.
+ * @example
+ * const { checkboxMotionClassName, fire } = useCompletionFeedback()
+ * const onCheck = () => { if (!todo.completed) fire(); toggle(todo.id) }
+ * <Checkbox className={checkboxMotionClassName} onCheckedChange={onCheck} />
+ */
+export function useCompletionFeedback(): CompletionFeedback {
+  const isSoundEnabled = useAppSelector(selectCompletionSound)
+  const audioContextRef = useRef<AudioContext | null>(null)
+  const activeOscillatorRef = useRef<OscillatorNode | null>(null)
+
+  const fire = useCallback(() => {
+    // Opt-in only (default OFF) and browser-only — no-op otherwise.
+    if (!isSoundEnabled || typeof window === 'undefined') return
+
+    try {
+      // Lazily create the AudioContext on first real use so users who never
+      // enable sound never pay for one.
+      audioContextRef.current ??= new AudioContext()
+      const audioContext = audioContextRef.current
+      // Browsers suspend audio until a user gesture; a checkbox click is one, so
+      // resume here is the moment playback can legitimately start.
+      if (audioContext.state === 'suspended') void audioContext.resume()
+
+      // At most one in-flight: cut any still-ringing tone so rapid checks never
+      // layer into a cacophony — they restart the single cue instead.
+      if (activeOscillatorRef.current) {
+        try {
+          activeOscillatorRef.current.stop()
+        } catch {
+          // Already stopped — nothing to cut.
+        }
+        activeOscillatorRef.current = null
+      }
+
+      const startTime = audioContext.currentTime
+      const endTime = startTime + COMPLETION_SOUND_DURATION_MS / 1000
+      const oscillator = audioContext.createOscillator()
+      const gainNode = audioContext.createGain()
+
+      // Soft, warm, non-melodic: a single low-mid sine with a fast attack and a
+      // short exponential decay — a paper-soft thud, never a gamified chime.
+      oscillator.type = 'sine'
+      oscillator.frequency.setValueAtTime(
+        COMPLETION_SOUND_FREQUENCY_HZ,
+        startTime,
+      )
+      gainNode.gain.setValueAtTime(0, startTime)
+      gainNode.gain.linearRampToValueAtTime(
+        COMPLETION_SOUND_PEAK_GAIN,
+        startTime + COMPLETION_SOUND_ATTACK_MS / 1000,
+      )
+      // Decay toward (but not to) zero — exponential ramps cannot target 0.
+      gainNode.gain.exponentialRampToValueAtTime(0.0001, endTime)
+
+      oscillator.connect(gainNode).connect(audioContext.destination)
+      oscillator.start(startTime)
+      oscillator.stop(endTime)
+      activeOscillatorRef.current = oscillator
+      oscillator.addEventListener('ended', () => {
+        if (activeOscillatorRef.current === oscillator) {
+          activeOscillatorRef.current = null
+        }
+      })
+    } catch {
+      // AudioContext unavailable / autoplay blocked — silently skip. The sound
+      // is a non-essential opt-in cue; never let it break the completion flow.
+    }
+  }, [isSoundEnabled])
+
+  return { checkboxMotionClassName: CHECKBOX_COMPLETION_MOTION_CLASS, fire }
+}

--- a/src/hooks/useCompletionFeedback.ts
+++ b/src/hooks/useCompletionFeedback.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 
 import {
   COMPLETION_SOUND_ATTACK_MS,
@@ -10,6 +10,17 @@ import {
 } from '@/lib/constants/completionFeedback'
 import { useAppSelector } from '@/lib/redux/hooks'
 import { selectCompletionSound } from '@/lib/redux/slices/preferencesSlice'
+
+// Module-level singletons (NOT per-hook refs): useCompletionFeedback mounts once
+// per row surface (TodoItem + the two Floating rows), so per-instance state would
+// let two rows each open their own AudioContext and play overlapping tones —
+// browsers also cap the number of live AudioContexts, so per-row contexts would
+// eventually be refused. Sharing one context + one in-flight oscillator across
+// all instances is what actually enforces the hook's "at most one sound
+// in-flight" contract app-wide. Per-JS-context (so per Electron window) is the
+// intended scope; we never share audio across windows.
+let sharedAudioContext: AudioContext | null = null
+let sharedActiveOscillator: OscillatorNode | null = null
 
 /**
  * motion-safe gated amber fill for the checkbox (~200ms ease-out, `duration-200`
@@ -51,31 +62,30 @@ export interface CompletionFeedback {
  */
 export function useCompletionFeedback(): CompletionFeedback {
   const isSoundEnabled = useAppSelector(selectCompletionSound)
-  const audioContextRef = useRef<AudioContext | null>(null)
-  const activeOscillatorRef = useRef<OscillatorNode | null>(null)
 
   const fire = useCallback(() => {
     // Opt-in only (default OFF) and browser-only — no-op otherwise.
     if (!isSoundEnabled || typeof window === 'undefined') return
 
     try {
-      // Lazily create the AudioContext on first real use so users who never
-      // enable sound never pay for one.
-      audioContextRef.current ??= new AudioContext()
-      const audioContext = audioContextRef.current
+      // Lazily create the single shared AudioContext on first real use so users
+      // who never enable sound never pay for one.
+      sharedAudioContext ??= new AudioContext()
+      const audioContext = sharedAudioContext
       // Browsers suspend audio until a user gesture; a checkbox click is one, so
       // resume here is the moment playback can legitimately start.
       if (audioContext.state === 'suspended') void audioContext.resume()
 
-      // At most one in-flight: cut any still-ringing tone so rapid checks never
-      // layer into a cacophony — they restart the single cue instead.
-      if (activeOscillatorRef.current) {
+      // At most one in-flight (app-wide via the shared singleton): cut any
+      // still-ringing tone so rapid checks — even across different rows — never
+      // layer into a cacophony; they restart the single cue instead.
+      if (sharedActiveOscillator) {
         try {
-          activeOscillatorRef.current.stop()
+          sharedActiveOscillator.stop()
         } catch {
           // Already stopped — nothing to cut.
         }
-        activeOscillatorRef.current = null
+        sharedActiveOscillator = null
       }
 
       const startTime = audioContext.currentTime
@@ -101,10 +111,10 @@ export function useCompletionFeedback(): CompletionFeedback {
       oscillator.connect(gainNode).connect(audioContext.destination)
       oscillator.start(startTime)
       oscillator.stop(endTime)
-      activeOscillatorRef.current = oscillator
+      sharedActiveOscillator = oscillator
       oscillator.addEventListener('ended', () => {
-        if (activeOscillatorRef.current === oscillator) {
-          activeOscillatorRef.current = null
+        if (sharedActiveOscillator === oscillator) {
+          sharedActiveOscillator = null
         }
       })
     } catch {
@@ -114,4 +124,19 @@ export function useCompletionFeedback(): CompletionFeedback {
   }, [isSoundEnabled])
 
   return { checkboxMotionClassName: CHECKBOX_COMPLETION_MOTION_CLASS, fire }
+}
+
+/**
+ * Test-only reset of the module-level shared audio singletons. Exists because
+ * the AudioContext + in-flight oscillator now live at module scope (so the
+ * "one sound in-flight" contract holds across row surfaces), which means state
+ * leaks between test cases unless explicitly cleared. Call from `afterEach`.
+ *
+ * @returns void
+ * @example
+ * afterEach(() => resetCompletionFeedbackAudioForTest())
+ */
+export function resetCompletionFeedbackAudioForTest(): void {
+  sharedAudioContext = null
+  sharedActiveOscillator = null
 }

--- a/src/hooks/useTodoMutations.ts
+++ b/src/hooks/useTodoMutations.ts
@@ -2,8 +2,11 @@
 
 import type { InfiniteData } from '@tanstack/react-query'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+import { toast } from 'sonner'
 
 import { broadcastCategorySync } from '@/lib/category-sync-channel'
+import { TODO_DELETE_UNDO_WINDOW_MS } from '@/lib/constants/todo'
 import { orpc } from '@/lib/orpc/client-query'
 import { broadcastTodoSync } from '@/lib/todo-sync-channel'
 
@@ -42,6 +45,11 @@ interface TodoResponse {
  * @param categoryId - Currently selected category ID for correct cache key matching.
  *   Must match the categoryId used in the todo list query so optimistic updates
  *   target the right cache entry.
+ * @param isRetaining - 居残りモード on/off. When on, the active list drops the
+ *   completed:false filter (holds ALL todos), so the cache key omits `completed`
+ *   and toggle flips a row IN PLACE instead of moving it to the Completed list.
+ *   Passed in (not read from Redux) so consumers without a ReduxProvider — and
+ *   the hook's own unit tests — stay decoupled from the store.
  * @returns Object containing all todo mutations with optimistic updates
  *
  * @example
@@ -49,17 +57,23 @@ interface TodoResponse {
  * createMutation.mutate({ text: 'New task', categoryId: 5 })
  * toggleMutation.mutate({ id: 42 })
  */
-export function useTodoMutations(categoryId: number | null) {
+export function useTodoMutations(
+  categoryId: number | null,
+  isRetaining = false,
+) {
   const queryClient = useQueryClient()
 
   // Query keys for cache operations
-  // - pendingKey: exact match for useQuery in TodoList (includes categoryId filter)
+  // - pendingKey: exact match for useQuery in TodoList (includes categoryId filter).
+  //   In retain mode (居残りモード) it drops the completed:false filter so the
+  //   active list holds ALL todos; the key MUST match TodoList's query input
+  //   exactly (same omission) or optimistic updates miss the cache.
   // - completedBaseKey: partial match for useInfiniteQuery in CompletedTodos
   //   (infiniteOptions with function input generates unpredictable keys,
   //    so we use partial matching for completed list operations)
   const pendingKey = orpc.todo.list.queryOptions({
     input: {
-      completed: false,
+      ...(isRetaining ? {} : { completed: false }),
       limit: 100,
       offset: 0,
       ...(categoryId !== null && { categoryId }),
@@ -125,6 +139,35 @@ export function useTodoMutations(categoryId: number | null) {
     ...orpc.todo.toggle.mutationOptions({}),
     onMutate: async ({ id }) => {
       await queryClient.cancelQueries({ queryKey: pendingKey })
+
+      // Retain mode (居残りモード): the active list holds ALL todos, so a toggle
+      // flips the row IN PLACE — it keeps its `order` position with the checked
+      // + strikethrough look instead of moving to the Completed section.
+      if (isRetaining) {
+        const previousActive =
+          queryClient.getQueryData<TodoResponse>(pendingKey)
+        queryClient.setQueryData<TodoResponse>(pendingKey, (old) => {
+          if (!old) return old
+          return {
+            ...old,
+            todos: old.todos.map((todoRow) =>
+              todoRow.id === id
+                ? {
+                    ...todoRow,
+                    completed: !todoRow.completed,
+                    updatedAt: new Date(),
+                  }
+                : todoRow,
+            ),
+          }
+        })
+        return {
+          previousActive,
+          previousPending: undefined,
+          previousCompletedQueries: undefined,
+        }
+      }
+
       await queryClient.cancelQueries({ queryKey: completedBaseKey })
 
       const previousPending = queryClient.getQueryData<TodoResponse>(pendingKey)
@@ -219,9 +262,20 @@ export function useTodoMutations(categoryId: number | null) {
         }
       }
 
-      return { previousPending, previousCompletedQueries }
+      return {
+        previousActive: undefined,
+        previousPending,
+        previousCompletedQueries,
+      }
     },
     onError: (_err, _input, context) => {
+      // Retain mode rollback: restore the single active-list snapshot.
+      if (isRetaining) {
+        if (context?.previousActive) {
+          queryClient.setQueryData(pendingKey, context.previousActive)
+        }
+        return
+      }
       if (context?.previousPending) {
         queryClient.setQueryData(pendingKey, context.previousPending)
       }
@@ -422,6 +476,21 @@ export function useTodoMutations(categoryId: number | null) {
     ...orpc.todo.clearCompleted.mutationOptions({}),
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: pendingKey })
+
+      // Retain mode (居残りモード): completed todos live in the active list
+      // (pendingKey), not the suppressed Completed section, so clear removes the
+      // completed rows from there optimistically (the server archives them).
+      if (isRetaining) {
+        const previousActive =
+          queryClient.getQueryData<TodoResponse>(pendingKey)
+        queryClient.setQueryData<TodoResponse>(pendingKey, (old) => {
+          if (!old) return old
+          const remaining = old.todos.filter((todoRow) => !todoRow.completed)
+          return { ...old, todos: remaining, total: remaining.length }
+        })
+        return { previousActive, previousCompletedQueries: undefined }
+      }
+
       await queryClient.cancelQueries({ queryKey: completedBaseKey })
 
       const previousCompletedQueries = queryClient.getQueriesData<
@@ -437,9 +506,16 @@ export function useTodoMutations(categoryId: number | null) {
         }),
       )
 
-      return { previousCompletedQueries }
+      return { previousActive: undefined, previousCompletedQueries }
     },
     onError: (_err, _input, context) => {
+      // Retain mode rollback: restore the active-list snapshot.
+      if (isRetaining) {
+        if (context?.previousActive) {
+          queryClient.setQueryData(pendingKey, context.previousActive)
+        }
+        return
+      }
       if (context?.previousCompletedQueries) {
         for (const [queryKey, data] of context.previousCompletedQueries) {
           if (data) {
@@ -523,6 +599,67 @@ export function useTodoMutations(categoryId: number | null) {
     },
   })
 
+  // ============================================
+  // DELETE-COMPLETED-WITH-UNDO - Deferred-commit per-item delete
+  // ============================================
+  // Used by the Completed section's per-row trash (D3). Optimistically removes
+  // the row at once, shows a Sonner Undo toast, and only commits the real
+  // archive-then-delete (via deleteMutation → the server archives the
+  // completion, so the heatmap day survives) when the undo window closes. Undo
+  // is a pure client-side restore — no server call is made. Separate from
+  // deleteMutation, which is used directly for PENDING rows (no undo needed,
+  // no heatmap day to lose).
+  const deleteCompletedWithUndo = useCallback(
+    (id: number) => {
+      // Snapshot every completed query so Undo can restore the exact prior state.
+      const completedSnapshot = queryClient.getQueriesData<
+        InfiniteData<TodoResponse>
+      >({ queryKey: completedBaseKey })
+
+      // Optimistically remove the row from all completed queries immediately.
+      queryClient.setQueriesData<InfiniteData<TodoResponse>>(
+        { queryKey: completedBaseKey },
+        (old) => {
+          if (!old) return old
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              todos: page.todos.filter((t) => t.id !== id),
+              total: page.total - 1,
+            })),
+          }
+        },
+      )
+
+      // Commit the server-side archive+delete only when the window closes; Undo
+      // flips this guard so the scheduled commit (and its timer) become a no-op.
+      let isCancelled = false
+      const commit = () => {
+        if (isCancelled) return
+        isCancelled = true
+        deleteMutation.mutate({ id })
+      }
+      const undoTimer = setTimeout(commit, TODO_DELETE_UNDO_WINDOW_MS)
+
+      toast('Removed from completed', {
+        duration: TODO_DELETE_UNDO_WINDOW_MS,
+        action: {
+          label: 'Undo',
+          onClick: () => {
+            clearTimeout(undoTimer)
+            isCancelled = true
+            // Restore the snapshot: the completed row reappears in place.
+            for (const [queryKey, data] of completedSnapshot) {
+              if (data) queryClient.setQueryData(queryKey, data)
+            }
+          },
+        },
+      })
+    },
+    [queryClient, completedBaseKey, deleteMutation],
+  )
+
   return {
     createMutation,
     toggleMutation,
@@ -530,5 +667,6 @@ export function useTodoMutations(categoryId: number | null) {
     updateMutation,
     clearCompletedMutation,
     reorderMutation,
+    deleteCompletedWithUndo,
   }
 }

--- a/src/lib/constants/completionFeedback.ts
+++ b/src/lib/constants/completionFeedback.ts
@@ -1,0 +1,24 @@
+/**
+ * Checkbox amber-fill duration on completion — the short tier (150–250ms) from
+ * DESIGN.md, locked to ~200ms (D10). Mirrored by the Tailwind `duration-200`
+ * utility applied to the checkbox in useCompletionFeedback; this constant is the
+ * documented source of truth (Storybook / tests reference it). It is
+ * deliberately NOT the heatmap hero fill (400ms radial-sweep) — the checkbox
+ * fill is the quiet, repeatable acknowledgment, the heatmap stays the single
+ * performative moment.
+ */
+export const CHECKBOX_COMPLETION_FILL_MS = 200
+
+// --- Opt-in completion sound (synthesized; soft / warm / non-melodic) ---
+// Default OFF (DESIGN.md opt-in-sound exception). Synthesized via Web Audio so
+// no asset needs bundling/hosting (the asset choice is an open product question);
+// these values shape a soft, low-mid "paper thud", never a gamified chime.
+
+/** Base frequency of the completion thud — low-mid sine reads as warm, not beepy. */
+export const COMPLETION_SOUND_FREQUENCY_HZ = 180
+/** Peak gain — intentionally low so the cue stays gentle, never a game chime. */
+export const COMPLETION_SOUND_PEAK_GAIN = 0.12
+/** Fast attack to the peak so the onset is soft, not a click. */
+export const COMPLETION_SOUND_ATTACK_MS = 6
+/** Total envelope length; ≤400ms per DESIGN.md's opt-in-sound exception. */
+export const COMPLETION_SOUND_DURATION_MS = 280

--- a/src/lib/constants/preferences.ts
+++ b/src/lib/constants/preferences.ts
@@ -1,0 +1,20 @@
+/**
+ * Default user preferences for the core web/Electron experience. BOTH default
+ * OFF so existing users — and anyone whose pre-existing persisted Redux blob
+ * lacks this slice — keep today's behavior: no completion sound, and completed
+ * todos move to the Completed list rather than staying in place.
+ *
+ * Read preferences through the slice's defensive `?? DEFAULT` selectors: the
+ * persistence middleware's default `shallowMerge` drops any field ADDED to this
+ * slice in a future release for users who already persisted it, so a missing
+ * field must coalesce to its default here (eng-review Finding 5).
+ */
+export const DEFAULT_PREFERENCES = {
+  /** Play a soft sound on completion. Opt-in DESIGN.md exception, default OFF. */
+  completionSound: false,
+  /**
+   * 居残りモード — keep checked todos in the active list (checked + strikethrough)
+   * instead of moving them to the Completed list. Default OFF (today's behavior).
+   */
+  retainCompletedInList: false,
+}

--- a/src/lib/constants/todo.ts
+++ b/src/lib/constants/todo.ts
@@ -1,0 +1,8 @@
+/**
+ * How long the "Removed from completed" Undo toast stays open before the
+ * per-item delete is committed to the server (archive-then-delete). Undo within
+ * this window is a pure client-side cancel — no server call is ever made, so the
+ * completed row simply reappears in place. Kept short (a Gmail-style undo
+ * window) so a real delete is not held back for long.
+ */
+export const TODO_DELETE_UNDO_WINDOW_MS = 5000

--- a/src/lib/preferences-sync-channel.ts
+++ b/src/lib/preferences-sync-channel.ts
@@ -1,0 +1,108 @@
+import type { Middleware } from '@reduxjs/toolkit'
+
+import {
+  hydratePreferences,
+  type PreferencesState,
+} from '@/lib/redux/slices/preferencesSlice'
+
+const PREFERENCES_SYNC_CHANNEL_NAME = 'corelive-preferences-sync'
+const PREFERENCES_SYNC_EVENT_TYPE = 'preferences-sync'
+
+type PreferencesSyncMessage = Readonly<{
+  type: typeof PREFERENCES_SYNC_EVENT_TYPE
+  state: PreferencesState
+}>
+
+// The local, user-initiated toggles that should propagate to other windows.
+// hydratePreferences is deliberately excluded so an applied broadcast never
+// re-broadcasts (the loop guard).
+const BROADCASTABLE_ACTION_TYPES = new Set<string>([
+  'preferences/setCompletionSound',
+  'preferences/setRetainCompletedInList',
+])
+
+/**
+ * True only in a browser runtime that supports BroadcastChannel (not SSR).
+ * @returns Whether cross-window preference sync can run.
+ */
+const isBrowserWithChannel = (): boolean =>
+  typeof window !== 'undefined' && typeof BroadcastChannel !== 'undefined'
+
+/**
+ * Narrows an unknown BroadcastChannel payload to a preferences-sync message.
+ * @param data - The raw `event.data` from the channel.
+ * @returns Whether `data` is a well-formed preferences-sync message.
+ * @example
+ * isPreferencesSyncMessage({ type: 'preferences-sync', state: {...} }) // => true
+ */
+const isPreferencesSyncMessage = (
+  data: unknown,
+): data is PreferencesSyncMessage => {
+  if (typeof data !== 'object' || data === null) return false
+  const message = data as Partial<PreferencesSyncMessage>
+  return (
+    message.type === PREFERENCES_SYNC_EVENT_TYPE &&
+    typeof message.state === 'object' &&
+    message.state !== null
+  )
+}
+
+/**
+ * Creates Redux middleware that mirrors local preference changes to other
+ * windows/tabs over a BroadcastChannel and applies preferences received from
+ * them. Why: each window owns its own Redux store + localStorage, so without
+ * this a toggle in window A would not reach window B (web, Electron, Floating)
+ * until a reload. Loop-free: a received snapshot is applied via
+ * hydratePreferences (NOT a broadcastable action), and only the user-initiated
+ * set* toggles trigger an outgoing broadcast. No-ops on the server / where
+ * BroadcastChannel is unavailable.
+ *
+ * @returns Redux middleware to concat into the store's middleware chain.
+ * @returns
+ * - In a browser: a middleware that broadcasts set* toggles and applies inbound snapshots
+ * - On the server / unsupported runtime: a transparent pass-through middleware
+ * @example
+ * configureStore({
+ *   middleware: (gdm) => gdm().concat(createPreferencesSyncMiddleware()),
+ * })
+ */
+export const createPreferencesSyncMiddleware = (): Middleware => {
+  // No channel on the server (SSR) or in unsupported runtimes — pass through.
+  if (!isBrowserWithChannel()) {
+    return () => (next) => (action) => next(action)
+  }
+
+  const channel = new BroadcastChannel(PREFERENCES_SYNC_CHANNEL_NAME)
+
+  return (store) => {
+    // Apply preferences pushed from another window. hydratePreferences is not a
+    // broadcastable action, so this never bounces back out (no echo loop).
+    channel.addEventListener('message', (event: MessageEvent) => {
+      if (isPreferencesSyncMessage(event.data)) {
+        store.dispatch(hydratePreferences(event.data.state))
+      }
+    })
+
+    return (next) => (action) => {
+      const result = next(action)
+      // Broadcast only the local, user-initiated set* toggles, carrying the
+      // resulting full preferences snapshot so receivers apply an exact copy.
+      if (
+        typeof action === 'object' &&
+        action !== null &&
+        'type' in action &&
+        typeof action.type === 'string' &&
+        BROADCASTABLE_ACTION_TYPES.has(action.type)
+      ) {
+        const { preferences } = store.getState() as {
+          preferences: PreferencesState
+        }
+        channel.postMessage({
+          type: PREFERENCES_SYNC_EVENT_TYPE,
+          state: preferences,
+        } satisfies PreferencesSyncMessage)
+      }
+      return result
+    }
+  }
+}

--- a/src/lib/preferences-sync-channel.ts
+++ b/src/lib/preferences-sync-channel.ts
@@ -40,10 +40,17 @@ const isPreferencesSyncMessage = (
 ): data is PreferencesSyncMessage => {
   if (typeof data !== 'object' || data === null) return false
   const message = data as Partial<PreferencesSyncMessage>
+  if (message.type !== PREFERENCES_SYNC_EVENT_TYPE) return false
+  // Validate the inner preference fields, not just that `state` is an object: a
+  // malformed channel payload (e.g. `completionSound: 'yes'`) would otherwise be
+  // hydrated into Redux and persisted, since the selectors only coalesce
+  // null/undefined and would let non-boolean junk through unchanged.
+  const state = message.state as Partial<PreferencesState> | undefined
   return (
-    message.type === PREFERENCES_SYNC_EVENT_TYPE &&
-    typeof message.state === 'object' &&
-    message.state !== null
+    typeof state === 'object' &&
+    state !== null &&
+    typeof state.completionSound === 'boolean' &&
+    typeof state.retainCompletedInList === 'boolean'
   )
 }
 

--- a/src/lib/redux/slices/preferencesSlice.test.ts
+++ b/src/lib/redux/slices/preferencesSlice.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_PREFERENCES } from '@/lib/constants/preferences'
+
+import type { RootState } from '../store'
+
+import reducer, {
+  hydratePreferences,
+  initialState,
+  resetPreferences,
+  selectCompletionSound,
+  selectPreferences,
+  selectRetainCompletedInList,
+  setCompletionSound,
+  setRetainCompletedInList,
+  type PreferencesState,
+} from './preferencesSlice'
+
+// Build a RootState-shaped object carrying only the preferences slice the
+// selectors read (other slices are irrelevant to these assertions). The cast
+// is deliberate: these tests simulate malformed/partial persisted slices.
+function stateWith(preferences: Partial<PreferencesState>): RootState {
+  return { preferences } as unknown as RootState
+}
+
+describe('preferencesSlice', () => {
+  it('defaults both preferences to OFF so behavior is unchanged for new users', () => {
+    // Assert
+    expect(initialState).toEqual({
+      completionSound: false,
+      retainCompletedInList: false,
+    })
+  })
+
+  it('enables the completion sound when setCompletionSound(true) is dispatched', () => {
+    // Act
+    const next = reducer(initialState, setCompletionSound(true))
+
+    // Assert
+    expect(next.completionSound).toBe(true)
+    expect(next.retainCompletedInList).toBe(false)
+  })
+
+  it('enables 居残りモード when setRetainCompletedInList(true) is dispatched', () => {
+    // Act
+    const next = reducer(initialState, setRetainCompletedInList(true))
+
+    // Assert
+    expect(next.retainCompletedInList).toBe(true)
+    expect(next.completionSound).toBe(false)
+  })
+
+  it('replaces the whole state on hydratePreferences (the cross-window apply path)', () => {
+    // Arrange
+    const incoming: PreferencesState = {
+      completionSound: true,
+      retainCompletedInList: true,
+    }
+
+    // Act
+    const next = reducer(initialState, hydratePreferences(incoming))
+
+    // Assert
+    expect(next).toEqual(incoming)
+  })
+
+  it('restores both defaults on resetPreferences', () => {
+    // Arrange — a fully-enabled state.
+    const enabled: PreferencesState = {
+      completionSound: true,
+      retainCompletedInList: true,
+    }
+
+    // Act
+    const next = reducer(enabled, resetPreferences())
+
+    // Assert
+    expect(next).toEqual({
+      completionSound: false,
+      retainCompletedInList: false,
+    })
+  })
+
+  it('coalesces a field missing from a persisted blob to its default (shallowMerge forward-compat, Finding 5)', () => {
+    // Arrange — an older persisted slice that lacks completionSound, exactly as
+    // shallowMerge would leave it after the field was added in a later release.
+    const legacyState = stateWith({ retainCompletedInList: true })
+
+    // Act / Assert — the selector returns the default, never undefined.
+    expect(selectCompletionSound(legacyState)).toBe(
+      DEFAULT_PREFERENCES.completionSound,
+    )
+    expect(selectRetainCompletedInList(legacyState)).toBe(true)
+  })
+
+  it('selectPreferences returns both fields coalesced to defaults for an empty persisted slice', () => {
+    // Arrange — both fields dropped.
+    const emptyState = stateWith({})
+
+    // Act
+    const preferences = selectPreferences(emptyState)
+
+    // Assert
+    expect(preferences).toEqual({
+      completionSound: false,
+      retainCompletedInList: false,
+    })
+  })
+})

--- a/src/lib/redux/slices/preferencesSlice.ts
+++ b/src/lib/redux/slices/preferencesSlice.ts
@@ -1,0 +1,131 @@
+/**
+ * Preferences Slice
+ *
+ * Redux slice for the core web/Electron user preferences that govern the todo
+ * experience (not Electron window chrome — that lives in electronSettings).
+ * Persisted to localStorage via redux-storage-middleware and synced live across
+ * windows via the preferences BroadcastChannel.
+ *
+ * @module lib/redux/slices/preferencesSlice
+ *
+ * @example
+ * import { useAppSelector, useAppDispatch } from '@/lib/redux/hooks'
+ * import {
+ *   selectRetainCompletedInList,
+ *   setRetainCompletedInList,
+ * } from '@/lib/redux/slices/preferencesSlice'
+ *
+ * const retain = useAppSelector(selectRetainCompletedInList)
+ * const dispatch = useAppDispatch()
+ * dispatch(setRetainCompletedInList(true))
+ */
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+
+import { DEFAULT_PREFERENCES } from '@/lib/constants/preferences'
+
+import type { RootState } from '../store'
+
+/**
+ * Interface for the core user-preferences state.
+ *
+ * @property completionSound - Play a soft sound on completion (opt-in, default OFF).
+ * @property retainCompletedInList - 居残りモード: keep checked todos in the active
+ *   list with strikethrough instead of moving them to Completed (default OFF).
+ */
+export interface PreferencesState {
+  completionSound: boolean
+  retainCompletedInList: boolean
+}
+
+/**
+ * Default preferences state. Used as initial state and for reset; both fields
+ * default OFF so behavior is unchanged for users who never touch the toggles.
+ */
+export const initialState: PreferencesState = {
+  ...DEFAULT_PREFERENCES,
+}
+
+/**
+ * Redux slice for core user preferences (completion sound + 居残りモード).
+ */
+export const preferencesSlice = createSlice({
+  name: 'preferences',
+  initialState,
+  reducers: {
+    /**
+     * Toggles the opt-in completion sound.
+     * @param state - Current state
+     * @param action - Payload containing the new completionSound value
+     */
+    setCompletionSound: (state, action: PayloadAction<boolean>) => {
+      state.completionSound = action.payload
+    },
+
+    /**
+     * Toggles 居残りモード (keep completed todos in the active list).
+     * @param state - Current state
+     * @param action - Payload containing the new retainCompletedInList value
+     */
+    setRetainCompletedInList: (state, action: PayloadAction<boolean>) => {
+      state.retainCompletedInList = action.payload
+    },
+
+    /**
+     * Replaces the whole preferences state. Used by the cross-window sync to
+     * apply preferences received from another window without re-broadcasting.
+     * @param _state - Current state (unused, returns new state)
+     * @param action - Payload containing the full preferences snapshot
+     */
+    hydratePreferences: (_state, action: PayloadAction<PreferencesState>) => {
+      return { ...action.payload }
+    },
+
+    /**
+     * Resets all preferences to their default (OFF) values.
+     * @param _state - Current state (unused, returns new state)
+     */
+    resetPreferences: (_state) => {
+      return { ...initialState }
+    },
+  },
+})
+
+// Export actions
+export const {
+  setCompletionSound,
+  setRetainCompletedInList,
+  hydratePreferences,
+  resetPreferences,
+} = preferencesSlice.actions
+
+// Selectors — read through `?? DEFAULT` so a field dropped by shallowMerge (a
+// field added to this slice AFTER a user persisted it) coalesces to its default
+// instead of surfacing `undefined` (eng-review Finding 5).
+/**
+ * Selects the completion-sound preference.
+ * @param state - Root state
+ * @returns Whether the opt-in completion sound is enabled (default false)
+ */
+export const selectCompletionSound = (state: RootState): boolean =>
+  state.preferences.completionSound ?? DEFAULT_PREFERENCES.completionSound
+
+/**
+ * Selects the 居残りモード (retain-completed-in-list) preference.
+ * @param state - Root state
+ * @returns Whether completed todos stay in the active list (default false)
+ */
+export const selectRetainCompletedInList = (state: RootState): boolean =>
+  state.preferences.retainCompletedInList ??
+  DEFAULT_PREFERENCES.retainCompletedInList
+
+/**
+ * Selects the full preferences state (both fields coalesced to defaults).
+ * @param state - Root state
+ * @returns The complete preferences state
+ */
+export const selectPreferences = (state: RootState): PreferencesState => ({
+  completionSound: selectCompletionSound(state),
+  retainCompletedInList: selectRetainCompletedInList(state),
+})
+
+export default preferencesSlice.reducer

--- a/src/lib/redux/store.ts
+++ b/src/lib/redux/store.ts
@@ -16,7 +16,10 @@
 import { createStorageMiddleware } from '@laststance/redux-storage-middleware'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 
+import { createPreferencesSyncMiddleware } from '../preferences-sync-channel'
+
 import electronSettingsReducer from './slices/electronSettingsSlice'
+import preferencesReducer from './slices/preferencesSlice'
 
 /**
  * Root reducer combining all slice reducers.
@@ -24,6 +27,7 @@ import electronSettingsReducer from './slices/electronSettingsSlice'
  */
 const rootReducer = combineReducers({
   electronSettings: electronSettingsReducer,
+  preferences: preferencesReducer,
 })
 
 /**
@@ -45,7 +49,7 @@ const { middleware: storageMiddleware, reducer: hydratedReducer } =
   createStorageMiddleware({
     rootReducer,
     key: STORAGE_KEY,
-    slices: ['electronSettings'], // Slices to persist to localStorage
+    slices: ['electronSettings', 'preferences'], // Slices to persist to localStorage
   })
 
 /**
@@ -66,7 +70,10 @@ export const store = configureStore({
     getDefaultMiddleware({
       // Disable serializable check for storage middleware compatibility
       serializableCheck: false,
-    }).concat(storageMiddleware),
+    })
+      .concat(storageMiddleware)
+      // Mirror preference toggles across windows (web / Electron / Floating).
+      .concat(createPreferencesSyncMiddleware()),
   devTools: process.env.NODE_ENV !== 'production',
 })
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,6 +5,9 @@ const isProtectedRoute = createRouteMatcher([
   '/home(.*)',
   '/skill-tree(.*)',
   '/braindump(.*)',
+  // /settings is web-reachable (D15) but still requires auth like the rest of
+  // the app — the preferences it edits belong to a signed-in user's experience.
+  '/settings(.*)',
   // Floating Navigator must redirect to /login like the other panels so the
   // Electron main-process nav-watch can detect an unauthenticated cold boot
   // and surface the main window instead of an empty panel.

--- a/src/server/procedures/todo.archive.test.ts
+++ b/src/server/procedures/todo.archive.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment node
+import { randomUUID } from 'node:crypto'
+
+import { call } from '@orpc/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { prisma } from '@/lib/prisma'
+
+import { fetchCompletedEntries } from '../utils/completedAggregation'
+
+import { clearCompleted, createManyTodo, deleteTodo, toggleTodo } from './todo'
+
+// Each case makes several sequential round-trips to the real Postgres (user
+// upsert + category get-or-create + writes), which can exceed the 5s default —
+// give the whole suite a generous ceiling so it never flakes on DB latency.
+vi.setConfig({ testTimeout: 30_000 })
+
+// Real-DB integration suite: runs only when RUN_DB_INTEGRATION_TESTS=1 (the CI
+// `test` job sets it after Postgres is up; set it locally with `docker compose
+// up`). Skips cleanly in DB-less contexts so it never blocks unrelated runs.
+const describeIfDb =
+  process.env.RUN_DB_INTEGRATION_TESTS === '1' ? describe : describe.skip
+
+// A date window wide enough to always contain "now" plus the fixed past day the
+// edit-drift test uses, so fetchCompletedEntries never excludes a row on range.
+const RANGE_START = new Date('2000-01-01T00:00:00.000Z')
+const RANGE_END = new Date('2100-01-01T00:00:00.000Z')
+const PAST_COMPLETION_DAY = new Date('2026-05-01T10:00:00.000Z')
+
+function authContext(clerkId: string) {
+  return {
+    context: {
+      headers: new Headers({ Authorization: `Bearer ${clerkId}` }),
+    },
+  }
+}
+
+const createdClerkIds = new Set<string>()
+
+function freshClerkId(): string {
+  const clerkId = `test_todo_archive_${randomUUID()}`
+  createdClerkIds.add(clerkId)
+  return clerkId
+}
+
+/**
+ * Seeds one INCOMPLETE todo (via the real paste-import procedure, which
+ * get-or-creates the default category) and returns its row. Completing it is
+ * left to toggleTodo so completedAt is stamped through the real write path.
+ */
+async function seedTodo(clerkId: string, title: string) {
+  await call(
+    createManyTodo,
+    { items: [{ title }], importBatchId: randomUUID() },
+    authContext(clerkId),
+  )
+  const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+  const todo = await prisma.todo.findFirstOrThrow({
+    where: { userId: user.id, text: title },
+  })
+  return { user, todo }
+}
+
+afterEach(async () => {
+  for (const clerkId of createdClerkIds) {
+    const user = await prisma.user.findUnique({ where: { clerkId } })
+    if (!user) continue
+    // FK-safe teardown: skill tree cascades node + assignment; todo SetNulls any
+    // surviving assignment; then the leaf tables, then the user.
+    await prisma.skillTree.deleteMany({ where: { userId: user.id } })
+    await prisma.completed.deleteMany({ where: { userId: user.id } })
+    await prisma.todo.deleteMany({ where: { userId: user.id } })
+    await prisma.importBatch.deleteMany({ where: { userId: user.id } })
+    await prisma.category.deleteMany({ where: { userId: user.id } })
+    await prisma.user.delete({ where: { id: user.id } })
+  }
+  createdClerkIds.clear()
+})
+
+describeIfDb('todo archive-on-removal (Part 0)', () => {
+  it('toggleTodo stamps completedAt when a todo is completed', async () => {
+    // Arrange — a fresh incomplete todo (completedAt is null).
+    const clerkId = freshClerkId()
+    const { todo } = await seedTodo(clerkId, 'morning pages')
+    expect(todo.completedAt).toBeNull()
+
+    // Act — complete it through the real toggle path.
+    await call(toggleTodo, { id: todo.id }, authContext(clerkId))
+
+    // Assert — completedAt is now populated (the stable heatmap day).
+    const completed = await prisma.todo.findUniqueOrThrow({
+      where: { id: todo.id },
+    })
+    expect(completed.completed).toBe(true)
+    expect(completed.completedAt).not.toBeNull()
+  })
+
+  it('clearCompleted archives completed todos (archived:false) instead of deleting them, so the heatmap day survives', async () => {
+    // Arrange — one completed todo; capture its pre-clear heatmap presence.
+    const clerkId = freshClerkId()
+    const { user, todo } = await seedTodo(clerkId, 'evening walk')
+    await call(toggleTodo, { id: todo.id }, authContext(clerkId))
+    const entriesBeforeClear = await fetchCompletedEntries(
+      user.id,
+      RANGE_START,
+      RANGE_END,
+    )
+    expect(entriesBeforeClear).toHaveLength(1)
+    expect(entriesBeforeClear[0]?.source).toBe('todo')
+
+    // Act — clear all completed.
+    const result = await call(clearCompleted, {}, authContext(clerkId))
+
+    // Assert — the Todo row is gone, but an archived Completed row preserves it.
+    expect(result).toEqual({ deletedCount: 1 })
+    const remainingTodos = await prisma.todo.count({
+      where: { userId: user.id },
+    })
+    expect(remainingTodos).toBe(0)
+    const archivedRows = await prisma.completed.findMany({
+      where: { userId: user.id },
+    })
+    expect(archivedRows).toHaveLength(1)
+    expect(archivedRows[0]?.archived).toBe(false) // LOAD-BEARING invariant
+    expect(archivedRows[0]?.title).toBe('evening walk')
+    expect(archivedRows[0]?.importBatchId).toBeNull()
+
+    // Assert — the heatmap still counts the day, now from the Completed source.
+    const entriesAfterClear = await fetchCompletedEntries(
+      user.id,
+      RANGE_START,
+      RANGE_END,
+    )
+    expect(entriesAfterClear).toHaveLength(1)
+    expect(entriesAfterClear[0]?.source).toBe('completed')
+  })
+
+  it('clearCompleted copies the stable completedAt, NOT the edit-drifting updatedAt', async () => {
+    // Arrange — a todo completed long ago, then edited today: completedAt holds
+    // the real completion day while updatedAt has drifted to now.
+    const clerkId = freshClerkId()
+    const { user, todo } = await seedTodo(clerkId, 'gym last week')
+    await call(toggleTodo, { id: todo.id }, authContext(clerkId))
+    // Force the completed-long-ago / edited-today split (the @updatedAt column
+    // auto-bumps to now on this write, so it differs from completedAt).
+    await prisma.todo.update({
+      where: { id: todo.id },
+      data: {
+        completedAt: PAST_COMPLETION_DAY,
+        text: 'gym last week (edited)',
+      },
+    })
+
+    // Act — clear it.
+    await call(clearCompleted, {}, authContext(clerkId))
+
+    // Assert — the archived row carries the past completion day, not the edit
+    // day (proves the helper copies completedAt ?? updatedAt, not bare updatedAt).
+    const archived = await prisma.completed.findFirstOrThrow({
+      where: { userId: user.id },
+    })
+    expect(archived.completedAt).toEqual(PAST_COMPLETION_DAY)
+  })
+
+  it('deleting a COMPLETED todo archives it (heatmap survives); deleting a PENDING todo hard-deletes it', async () => {
+    // Arrange — one completed todo and one pending todo.
+    const clerkId = freshClerkId()
+    const { user, todo: completedTodo } = await seedTodo(clerkId, 'read a book')
+    await call(toggleTodo, { id: completedTodo.id }, authContext(clerkId))
+    const { todo: pendingTodo } = await seedTodo(clerkId, 'buy groceries')
+
+    // Act — delete the completed one, then the pending one.
+    await call(deleteTodo, { id: completedTodo.id }, authContext(clerkId))
+    await call(deleteTodo, { id: pendingTodo.id }, authContext(clerkId))
+
+    // Assert — completed delete archived (Completed row, archived:false); pending
+    // delete left no trace; the heatmap still shows the completed day.
+    const archivedRows = await prisma.completed.findMany({
+      where: { userId: user.id },
+    })
+    expect(archivedRows).toHaveLength(1)
+    expect(archivedRows[0]?.archived).toBe(false)
+    expect(archivedRows[0]?.title).toBe('read a book')
+    const entries = await fetchCompletedEntries(user.id, RANGE_START, RANGE_END)
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.source).toBe('completed')
+  })
+
+  it('archive-on-clear preserves earned XP: NodeAssignment survives with todoId→null and the todoText snapshot intact', async () => {
+    // Arrange — complete a todo and assign it to a skill node (earned XP).
+    const clerkId = freshClerkId()
+    const { user, todo } = await seedTodo(clerkId, 'practice piano')
+    await call(toggleTodo, { id: todo.id }, authContext(clerkId))
+    const tree = await prisma.skillTree.create({
+      data: { userId: user.id, name: 'My Tree' },
+    })
+    const node = await prisma.skillNode.create({
+      data: { skillTreeId: tree.id, name: 'Music', x: 0.5, y: 0.5 },
+    })
+    const assignment = await prisma.nodeAssignment.create({
+      data: { nodeId: node.id, todoId: todo.id, todoText: 'practice piano' },
+    })
+
+    // Act — clear completed (archives + deletes the Todo).
+    await call(clearCompleted, {}, authContext(clerkId))
+
+    // Assert — the assignment row survives, orphaned (todoId null) but with its
+    // XP-bearing snapshot intact. Do NOT mirror toggleTodo's deleteMany here.
+    const survived = await prisma.nodeAssignment.findUniqueOrThrow({
+      where: { id: assignment.id },
+    })
+    expect(survived.todoId).toBeNull()
+    expect(survived.todoText).toBe('practice piano')
+  })
+})

--- a/src/server/procedures/todo.ts
+++ b/src/server/procedures/todo.ts
@@ -20,6 +20,7 @@ import {
   TodoResponseSchema,
   ReorderTodosSchema,
 } from '../schemas/todo'
+import { archiveCompletedTodos } from '../utils/archiveCompletedTodos'
 import { resolveImportCategoryIds } from '../utils/resolveImportCategoryIds'
 
 // Fetch todo list
@@ -175,9 +176,20 @@ export const deleteTodo = authMiddleware
       })
     }
 
-    await prisma.todo.delete({
-      where: { id },
-    })
+    if (existingTodo.completed) {
+      // A completed todo feeds the heatmap, so it is ARCHIVED (copied into
+      // Completed with archived:false) before removal rather than hard-deleted —
+      // otherwise deleting one completed item silently erases its heatmap day.
+      // Same shared, heatmap-safe semantic as clearCompleted.
+      await prisma.$transaction(async (tx) =>
+        archiveCompletedTodos({ tx, userId: user.id, todoIds: [id] }),
+      )
+    } else {
+      // Pending todos carry no heatmap day, so a plain delete loses nothing.
+      await prisma.todo.delete({
+        where: { id },
+      })
+    }
 
     return { success: true }
   })
@@ -222,7 +234,15 @@ export const toggleTodo = authMiddleware
       }
       return tx.todo.update({
         where: { id },
-        data: { completed: nextCompleted },
+        // Stamp the stable completion day on every false→true transition so the
+        // heatmap buckets by completedAt, not the edit-drifting updatedAt. Left
+        // untouched on un-complete: nothing reads completedAt on a
+        // completed:false row (the heatmap filters completed:true), and the next
+        // completion overwrites it with a fresh now().
+        data: {
+          completed: nextCompleted,
+          ...(nextCompleted && { completedAt: new Date() }),
+        },
       })
     })
 
@@ -235,14 +255,15 @@ export const clearCompleted = authMiddleware
   .handler(async ({ context }) => {
     const { user } = context
 
-    const result = await prisma.todo.deleteMany({
-      where: {
-        userId: user.id,
-        completed: true,
-      },
-    })
+    // Archive-and-remove instead of hard delete: completed Todo rows feed the
+    // heatmap directly, so deleting them erased their days. The shared helper
+    // copies each completion into Completed (archived:false) before removing the
+    // Todo, inside one transaction, so the heatmap day survives the clear.
+    const deletedCount = await prisma.$transaction(async (tx) =>
+      archiveCompletedTodos({ tx, userId: user.id }),
+    )
 
-    return { deletedCount: result.count }
+    return { deletedCount }
   })
 
 /**

--- a/src/server/procedures/todo.ts
+++ b/src/server/procedures/todo.ts
@@ -165,31 +165,40 @@ export const deleteTodo = authMiddleware
       return { success: true }
     }
 
-    // Permission check
-    const existingTodo = await prisma.todo.findFirst({
-      where: { id, userId: user.id },
-    })
-
-    if (!existingTodo) {
-      throw new ORPCError('NOT_FOUND', {
-        message: 'Todo not found',
+    // Decide archive-vs-delete ATOMICALLY inside one transaction. Reading
+    // `completed` outside the transaction was a TOCTOU race (CodeRabbit #4): if a
+    // todo flipped false→true between the read and the delete, the pending branch
+    // would hard-delete a now-completed todo and erase its heatmap day. Instead
+    // archiveCompletedTodos (which filters completed:true) runs first inside the
+    // tx and returns the count archived; it returns 0 only when the row is
+    // genuinely pending at tx time, the sole case the fallback hard-deletes.
+    await prisma.$transaction(async (tx) => {
+      // Permission check on the same snapshot as the archive/delete below.
+      const existingTodo = await tx.todo.findFirst({
+        where: { id, userId: user.id },
       })
-    }
 
-    if (existingTodo.completed) {
+      if (!existingTodo) {
+        throw new ORPCError('NOT_FOUND', {
+          message: 'Todo not found',
+        })
+      }
+
       // A completed todo feeds the heatmap, so it is ARCHIVED (copied into
-      // Completed with archived:false) before removal rather than hard-deleted —
-      // otherwise deleting one completed item silently erases its heatmap day.
-      // Same shared, heatmap-safe semantic as clearCompleted.
-      await prisma.$transaction(async (tx) =>
-        archiveCompletedTodos({ tx, userId: user.id, todoIds: [id] }),
-      )
-    } else {
-      // Pending todos carry no heatmap day, so a plain delete loses nothing.
-      await prisma.todo.delete({
-        where: { id },
+      // Completed with archived:false) before removal rather than hard-deleted.
+      // archivedCount is 0 only when the row is pending at tx time.
+      const archivedCount = await archiveCompletedTodos({
+        tx,
+        userId: user.id,
+        todoIds: [id],
       })
-    }
+
+      // Fallback: a pending todo carries no heatmap day, so a plain delete loses
+      // nothing. Only reached when nothing was archived (the row is pending now).
+      if (archivedCount === 0) {
+        await tx.todo.delete({ where: { id } })
+      }
+    })
 
     return { success: true }
   })

--- a/src/server/schemas/todo.ts
+++ b/src/server/schemas/todo.ts
@@ -27,10 +27,13 @@ export const CreateTodoSchema = TodoSchema.pick({
   categoryId: true,
 })
 
+// `completed` is intentionally NOT updatable here: completion state flows ONLY
+// through `toggleTodo`, the single seam that also maintains `completedAt` (the
+// stable heatmap day) and the NodeAssignment double-XP exploit guard. Letting
+// `updateTodo` flip `completed` would bypass both.
 export const UpdateTodoSchema = TodoSchema.pick({
   text: true,
   notes: true,
-  completed: true,
   categoryId: true,
 }).partial()
 

--- a/src/server/utils/archiveCompletedTodos.ts
+++ b/src/server/utils/archiveCompletedTodos.ts
@@ -20,6 +20,17 @@ import type { Prisma } from '@prisma/client'
  * would destroy XP). `importBatchId` stays null so archive rows are unreachable
  * by the paste-import bulk-undo (the only undo-safety layer under Approach B).
  *
+ * Concurrency (CodeRabbit #3 — accepted limitation, NOT idempotent): two clears
+ * firing in parallel can each read the same completed Todo before either deletes
+ * it, inserting two Completed rows for one completion and inflating that day's
+ * heatmap COUNT. No data or XP loss (the Todo is still removed, NodeAssignment
+ * still SetNull, archived:false holds). Accepted because it needs a deliberate
+ * double-action (e.g. double-firing Clear, which the confirm dialog already
+ * guards) and only affects a display count. A full fix (a unique Completed.todoId
+ * + skipDuplicates, or Serializable isolation + P2034 retry) was deferred to
+ * avoid touching the load-bearing archive invariants above for a count-only edge
+ * case. Tracked in TODOS.md.
+ *
  * @param tx - An active Prisma transaction client (from `prisma.$transaction`).
  * @param userId - Internal `User.id` whose completed todos to archive.
  * @param todoIds - Optional id subset to archive; omit to archive ALL completed.

--- a/src/server/utils/archiveCompletedTodos.ts
+++ b/src/server/utils/archiveCompletedTodos.ts
@@ -1,0 +1,91 @@
+import type { Prisma } from '@prisma/client'
+
+/**
+ * Archives a user's completed Todo rows into the Completed table, then deletes
+ * the Todo rows — the heatmap-safe replacement for hard-deleting a completed
+ * todo. Why: the heatmap counts completed Todo rows directly, so a bare delete
+ * silently erases their heatmap days; copying the completion into Completed
+ * (which the heatmap also reads) before removal keeps the day. Called by
+ * clearCompleted (archive ALL completed) and deleteTodo (archive a single
+ * completed todo). Runs inside a caller-supplied transaction so copy+delete is
+ * atomic.
+ *
+ * LOAD-BEARING: every Completed row is written archived:false (field omitted →
+ * schema `@default(false)`). fetchCompletedEntries filters `archived:false`, so
+ * an `archived:true` row would silently drop from the heatmap and reintroduce
+ * the exact erasure bug this helper exists to kill — never write `true`.
+ * NodeAssignment is intentionally left to the schema's `onDelete:SetNull` (XP
+ * persists via the `todoText` snapshot); do NOT `deleteMany` it (that is
+ * toggleTodo's un-complete exploit guard, not a teardown step — copying it here
+ * would destroy XP). `importBatchId` stays null so archive rows are unreachable
+ * by the paste-import bulk-undo (the only undo-safety layer under Approach B).
+ *
+ * @param tx - An active Prisma transaction client (from `prisma.$transaction`).
+ * @param userId - Internal `User.id` whose completed todos to archive.
+ * @param todoIds - Optional id subset to archive; omit to archive ALL completed.
+ * @returns The number of todos archived-and-removed (0 when none matched).
+ * @example
+ * // Clear all completed (Part 0):
+ * await prisma.$transaction((tx) => archiveCompletedTodos({ tx, userId: 7 }))
+ * @example
+ * // Archive one completed todo (per-item delete):
+ * await prisma.$transaction((tx) =>
+ *   archiveCompletedTodos({ tx, userId: 7, todoIds: [42] }),
+ * )
+ */
+export async function archiveCompletedTodos({
+  tx,
+  userId,
+  todoIds,
+}: {
+  tx: Prisma.TransactionClient
+  userId: number
+  todoIds?: number[]
+}): Promise<number> {
+  // Read the completed todos in scope (always bounded by userId; optionally
+  // narrowed to an explicit id subset for the per-item delete path).
+  const completedTodos = await tx.todo.findMany({
+    where: {
+      userId,
+      completed: true,
+      ...(todoIds !== undefined && { id: { in: todoIds } }),
+    },
+    select: {
+      id: true,
+      text: true,
+      categoryId: true,
+      completedAt: true,
+      updatedAt: true,
+    },
+  })
+
+  // Nothing to archive — skip the writes so callers can report a 0 count.
+  if (completedTodos.length === 0) {
+    return 0
+  }
+
+  // Copy each completion into Completed BEFORE deleting the Todo so the heatmap
+  // day survives. completedAt = the stable completion day (`completedAt ??
+  // updatedAt` — NOT bare updatedAt, which would drift to the edit date for a
+  // completed-then-edited todo). createdAt defaults to now() (honest insert
+  // time, undo-safe). archived omitted → `@default(false)` [LOAD-BEARING].
+  await tx.completed.createMany({
+    data: completedTodos.map((todo) => ({
+      userId,
+      title: todo.text,
+      categoryId: todo.categoryId,
+      completedAt: todo.completedAt ?? todo.updatedAt,
+    })),
+  })
+
+  // Remove the Todo rows. NodeAssignment rows orphan via onDelete:SetNull
+  // (todoId → null), preserving earned XP through the todoText snapshot.
+  const deleteResult = await tx.todo.deleteMany({
+    where: {
+      userId,
+      id: { in: completedTodos.map((todo) => todo.id) },
+    },
+  })
+
+  return deleteResult.count
+}

--- a/src/server/utils/completedAggregation.test.ts
+++ b/src/server/utils/completedAggregation.test.ts
@@ -31,18 +31,24 @@ describe('fetchCompletedEntries', () => {
     expect(entries).toEqual([])
   })
 
-  it('maps Todo rows with source="todo" using updatedAt as completedAt', async () => {
+  it('maps Todo rows with source="todo" using completedAt as the bucket day', async () => {
+    // Arrange — a completed Todo whose stable completedAt differs from updatedAt
+    // (completed earlier, then edited). The heatmap must use completedAt.
     mockedTodoFindMany.mockResolvedValue([
       {
         id: 12,
         text: 'draft digest',
-        updatedAt: new Date('2026-05-07T10:00:00.000Z'),
+        completedAt: new Date('2026-05-07T10:00:00.000Z'),
+        updatedAt: new Date('2026-05-10T15:00:00.000Z'),
         category: { id: 3, name: 'writing', color: 'blue' },
       },
     ] as never)
     mockedCompletedFindMany.mockResolvedValue([])
 
+    // Act
     const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+
+    // Assert — completedAt (05-07) wins, NOT the edit-day updatedAt (05-10)
     expect(entries).toEqual([
       {
         source: 'todo',
@@ -52,6 +58,29 @@ describe('fetchCompletedEntries', () => {
         category: { id: 3, name: 'writing', color: 'blue' },
       },
     ])
+  })
+
+  it('falls back to updatedAt when a Todo row has a null completedAt', async () => {
+    // Arrange — an unconverted / pre-backfill completed Todo (null completedAt)
+    // must coalesce to updatedAt so it never vanishes from the heatmap.
+    mockedTodoFindMany.mockResolvedValue([
+      {
+        id: 13,
+        text: 'legacy completed todo',
+        completedAt: null,
+        updatedAt: new Date('2026-05-06T12:00:00.000Z'),
+        category: null,
+      },
+    ] as never)
+    mockedCompletedFindMany.mockResolvedValue([])
+
+    // Act
+    const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
+
+    // Assert — bucket date is updatedAt's day, not null
+    expect(entries[0]?.completedAt).toEqual(
+      new Date('2026-05-06T12:00:00.000Z'),
+    )
   })
 
   it('maps Completed rows with source="completed" using createdAt as completedAt', async () => {
@@ -171,7 +200,7 @@ describe('fetchCompletedEntries', () => {
     ])
   })
 
-  it('passes userId, completed=true, and the date range to the Todo query', async () => {
+  it('passes userId, completed=true, and the completedAt-or-updatedAt range to the Todo query', async () => {
     mockedTodoFindMany.mockResolvedValue([])
     mockedCompletedFindMany.mockResolvedValue([])
 
@@ -182,13 +211,19 @@ describe('fetchCompletedEntries', () => {
         where: expect.objectContaining({
           userId: 7,
           completed: true,
-          updatedAt: { gte: RANGE_START, lte: RANGE_END },
+          OR: [
+            { completedAt: { gte: RANGE_START, lte: RANGE_END } },
+            {
+              completedAt: null,
+              updatedAt: { gte: RANGE_START, lte: RANGE_END },
+            },
+          ],
         }),
       }),
     )
   })
 
-  it('filters archived=false on the Completed query (defensive)', async () => {
+  it('filters archived=false and the completedAt-or-createdAt range on the Completed query', async () => {
     mockedTodoFindMany.mockResolvedValue([])
     mockedCompletedFindMany.mockResolvedValue([])
 
@@ -199,7 +234,13 @@ describe('fetchCompletedEntries', () => {
         where: expect.objectContaining({
           userId: 7,
           archived: false,
-          createdAt: { gte: RANGE_START, lte: RANGE_END },
+          OR: [
+            { completedAt: { gte: RANGE_START, lte: RANGE_END } },
+            {
+              completedAt: null,
+              createdAt: { gte: RANGE_START, lte: RANGE_END },
+            },
+          ],
         }),
       }),
     )
@@ -220,22 +261,24 @@ describe('fetchCompletedEntries', () => {
     expect(entries[0]?.category).toBeNull()
   })
 
-  it('uses Todo.updatedAt verbatim as completedAt (drift assertion, see TODOS.md)', async () => {
-    // Locks the documented drift: editing a long-completed Todo bumps the
-    // heatmap bucket to the edit day. The migration to a stable
-    // Todo.completedAt column is tracked in TODOS.md.
-    const recentEdit = new Date('2026-05-10T15:00:00.000Z')
+  it('uses Todo.completedAt over updatedAt so a later edit does NOT drift the heatmap day', async () => {
+    // The migration to a stable Todo.completedAt resolved the old drift: editing
+    // a long-completed Todo used to bump its heatmap bucket to the edit day.
+    // Now completedAt holds the real completion day regardless of later edits.
+    const completionDay = new Date('2026-05-07T09:00:00.000Z')
+    const laterEdit = new Date('2026-05-10T15:00:00.000Z')
     mockedTodoFindMany.mockResolvedValue([
       {
         id: 1,
         text: 'long-completed todo, edited today',
-        updatedAt: recentEdit,
+        completedAt: completionDay,
+        updatedAt: laterEdit,
         category: null,
       },
     ] as never)
     mockedCompletedFindMany.mockResolvedValue([])
 
     const entries = await fetchCompletedEntries(1, RANGE_START, RANGE_END)
-    expect(entries[0]?.completedAt).toEqual(recentEdit)
+    expect(entries[0]?.completedAt).toEqual(completionDay)
   })
 })

--- a/src/server/utils/completedAggregation.ts
+++ b/src/server/utils/completedAggregation.ts
@@ -24,21 +24,23 @@ export type CompletedEntry = {
  * with category join. Single source of truth for the heatmap and day-detail
  * oRPC procedures.
  *
- * Heatmap UNION semantics (locked decision D2=A):
- *   Todo bucket      = updatedAt.toISOString().split('T')[0]            (UTC date)
+ * Heatmap UNION semantics (both halves now key off the stable completion day):
+ *   Todo bucket      = (completedAt ?? updatedAt).toISOString()[0..10]  (UTC date)
  *   Completed bucket = (completedAt ?? createdAt).toISOString()[0..10]  (UTC date)
  *
- * Completed buckets by `completedAt ?? createdAt` (paste-import, Issue #53):
- * completedAt is the semantic completion day; createdAt is the defensive
- * fallback for any row missed by the migration backfill (which set
- * completedAt = createdAt, so existing rows do not shift days). The date-range
- * FILTER still uses createdAt in Slice 1 — see the inline TODO in the query.
+ * Both halves FILTER and BUCKET by `completedAt`, with a null-coalescing
+ * fallback (Todo → updatedAt, Completed → createdAt) for any row whose
+ * completedAt is null. Migration 20260603235155 added Todo.completedAt and
+ * backfilled it from updatedAt; toggleTodo writes it on each false→true
+ * completion. Migration 20260529164052 added Completed.completedAt and
+ * backfilled it from createdAt. Because the filter and the bucket now use the
+ * SAME field, a completion always lands on its real day's range — this fixes
+ * both the dated-import drop and the edit-drift noted below.
  *
- * Known drift: Todo.updatedAt mutates on text/notes edit, so a completed
- * Todo edited later will move dates on the heatmap. Acceptable for now;
- * tracked in TODOS.md → "Migrate Todo heatmap bucket to a stable
- * completedAt column". PR3 (Streak Notifications) is the forcing function
- * for that migration.
+ * Resolved drift: Todo.updatedAt mutates on text/notes edit, so before
+ * completedAt existed a completed Todo edited later moved dates on the heatmap.
+ * Keying off the stable completedAt removes that drift (居残りモード was the
+ * forcing function for the migration).
  *
  * Dedup: Todo and Completed are disjoint surfaces by construction —
  * BrainDump's checkbox-tick bypasses the Todo lifecycle (writes Completed
@@ -69,14 +71,20 @@ export async function fetchCompletedEntries(
       where: {
         userId,
         completed: true,
-        // Drift caveat: this bucket field is `updatedAt`, which mutates on
-        // every edit. Migration to a stable `completedAt` column is tracked
-        // in TODOS.md.
-        updatedAt: { gte: startDate, lte: endDate },
+        // Filter by the stable completion day. `completedAt` is the semantic
+        // completion timestamp (migration 20260603235155); fall back to
+        // `updatedAt` only for rows whose `completedAt` is still null (an
+        // unconverted write path or a pre-backfill row) so they never vanish
+        // from the heatmap.
+        OR: [
+          { completedAt: { gte: startDate, lte: endDate } },
+          { completedAt: null, updatedAt: { gte: startDate, lte: endDate } },
+        ],
       },
       select: {
         id: true,
         text: true,
+        completedAt: true,
         updatedAt: true,
         category: { select: { id: true, name: true, color: true } },
       },
@@ -85,27 +93,26 @@ export async function fetchCompletedEntries(
     prisma.completed.findMany({
       where: {
         userId,
-        // archived rows are excluded from the heatmap surface. Today nothing
-        // sets archived=true, but filtering defensively avoids surprises
-        // when an archive flow eventually lands.
+        // archived rows are excluded from the heatmap surface. The archive flow
+        // (archiveCompletedTodos) writes every row archived:false, so cleared
+        // todos still count; an archived:true row would silently drop its day.
         archived: false,
-        // Slice 1: the date-range filter stays on `createdAt` (the insert
-        // time). Paste-import lands everything on today (`completedAt = now()`),
-        // so createdAt and completedAt coincide and the window is correct.
-        // TODO(Slice 2 — dated import): when date-override ships, a row may have
-        // a past `completedAt` with a today `createdAt`; this filter must then
-        // move to `completedAt` or the row will be dropped from its real day's
-        // range. (See docs/plans/2026-05-29-paste-import-plan.md, Heatmap §.)
-        createdAt: { gte: startDate, lte: endDate },
+        // Filter by the semantic completion day, falling back to `createdAt`
+        // (insert time) only for rows whose `completedAt` is null. This lands
+        // the dated-import case (a row with a past `completedAt` and a today
+        // `createdAt`) on its REAL day, and keeps Slice-1 paste-import correct
+        // (those rows have completedAt = now() = createdAt). The backfill set
+        // completedAt = createdAt, so nulls are not expected — the fallback is
+        // defensive.
+        OR: [
+          { completedAt: { gte: startDate, lte: endDate } },
+          { completedAt: null, createdAt: { gte: startDate, lte: endDate } },
+        ],
       },
       select: {
         id: true,
         title: true,
-        // Select both: bucket by `completedAt ?? createdAt` (coalesced in JS
-        // below). completedAt is the semantic completion day; createdAt is the
-        // defensive fallback for any historical row the migration backfill
-        // missed (it backfilled completedAt = createdAt, so existing rows do
-        // NOT shift days on the heatmap).
+        // Bucket by `completedAt ?? createdAt` (coalesced in JS below).
         completedAt: true,
         createdAt: true,
         category: { select: { id: true, name: true, color: true } },
@@ -118,7 +125,9 @@ export async function fetchCompletedEntries(
     source: 'todo',
     id: row.id,
     title: row.text,
-    completedAt: row.updatedAt,
+    // Bucket by the stable completion day, falling back to updatedAt for any
+    // row whose completedAt is null (defensive — see the where clause).
+    completedAt: row.completedAt ?? row.updatedAt,
     category: row.category,
   }))
 


### PR DESCRIPTION
## Summary

Implements **completion feedback + 居残りモード (stay-in-place completed todos)** — the user's request: checking a task gave zero feedback, and they wanted an option for checked items to stay in the list (checked + strikethrough) instead of vanishing. Built to a fully-reviewed plan (office-hours + CEO + design + eng gates + codex cross-model). 8 bisectable commits.

**Headline bug fix (app-wide, all users) — Part 0**
- `clearCompleted` and per-item deletes of a completed todo previously HARD-DELETED the `Todo` row, which the heatmap counts directly, so **clearing/deleting silently erased heatmap days.** They now ARCHIVE (write a `Completed` row, `archived:false`) before removing, via a shared `archiveCompletedTodos` helper, in one transaction. The heatmap day survives. NodeAssignment XP persists (`onDelete:SetNull`).
- Lands the tracked `Todo.completedAt` migration + backfill so the heatmap buckets by a stable completion day (no drift when a long-completed todo is edited).

**Completion feedback — Part 1**
- Always-on checkbox amber-fill motion (~200ms ease-out, `motion-safe:` gated, NOT the heatmap celebration easing) + opt-in synthesized completion sound (default OFF). Shared `useCompletionFeedback` hook at all three row surfaces.

**居残りモード — Part 2**
- Opt-in: checked todos stay in the active list (checked + strikethrough) instead of moving to Completed. D4-structural: drop the `completed:false` filter, flip-in-place, suppress the Completed section (no double-display). Main app interleaves by `order`. "N done" count + confirm-gated Clear; per-item delete with a 5s Undo toast; per-row status Badge removed (D16); trash hidden on retained rows (D14).

**Preferences + settings — Part 3**
- New `preferences` Redux slice (both toggles default OFF) + persist + cross-window BroadcastChannel sync. `/settings` made web-reachable with a shared Preferences section (was Electron-only).

## Test Coverage

Core logic is unit/DB-covered; interactive/UI paths are E2E-territory (see disclosure below).

- `archiveCompletedTodos` — 5 DB-integration tests (heatmap-survives-clear, `archived:false` invariant, completedAt-not-updatedAt, per-item archive, NodeAssignment XP intact)
- `fetchCompletedEntries` heatmap reader — 12 unit tests
- `toggleTodo`/`clearCompleted`/`deleteTodo` — DB-integration
- `preferencesSlice` — 7 unit tests (defaults, reducers, hydrate, defensive selectors)
- `useCompletionFeedback` — 3 unit tests
- `TodoItem` completed-in-place — Storybook story

**257 unit tests pass** (26 DB-gated skip without the env); **5 archive DB-integration tests pass** with `RUN_DB_INTEGRATION_TESTS=1`. `pnpm validate` (test + lint + build + typecheck) green. +3 new test files.

## Pre-Landing Review

Independent `code-reviewer` re-ran typecheck + 257 unit + 5/5 DB-integration + lint (all clean) and verified all 5 locked invariants from source + execution (archived:false, completedAt-not-updatedAt, NodeAssignment SetNull, retain-aware cache-key matching incl. TanStack `hashKey` sort-invariance, SSR-safe loop-free sync). **P1: none. P2: none. Verdict: SHIP.** One a11y NIT applied (tap target made size-independent).

## Plan Completion

12 of 13 tasks done. **T10 (D8 mode-toggle fade) deferred** as polish: a correct impl must distinguish retroactive-populate-on-toggle from in-place-check (a naive `animate-in` fires on every check, contradicting D7). Fully functional without it — rows appear instantly instead of fading.

## ⚠️ NOT yet runtime-verified — next gate is E2E + manual

Verification so far is **static + unit/DB only.** These interactive behaviors are implemented but NOT runtime-tested:
- Checkbox fill motion + reduced-motion suppression
- 居残り flip-in-place + no-flicker-on-refetch
- Per-item Undo deferred-commit
- Opt-in sound with sound ON
- Cross-window preference sync

**Before merge confidence: `pnpm build` + E2E (web + Electron, both modes) + a manual macOS pass** (plan step 7).

**Known limitation:** in the Floating window, retained completed todos show GROUPED in its Completed section, not interleaved (D5) like the main app — deliberate, to avoid rewriting the bespoke Floating rows. "Stay visible, don't vanish on check" holds; interleave does not.

## TODOS
- ✅ "Migrate Todo heatmap bucket to a stable `completedAt` field" (a–d) — completed by this PR.
- Recorded (deferred): D9 clear-moment affirmation, D12 unchecked-checkbox border contrast.

## Test plan
- [x] `pnpm validate` green (test + lint + build + typecheck)
- [x] Vitest: 257 passed, 26 DB-gated skipped
- [x] DB-integration archive suite: 5/5 (`RUN_DB_INTEGRATION_TESTS=1`)
- [ ] E2E web + Electron (both modes) — NEXT
- [ ] Manual macOS smoke: motion, sound, cross-window sync, Floating — NEXT

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in completion sound (default OFF)
  * 200ms checkbox completion fill animation
  * “Retain completed in list” mode with per-item undo

* **Improvements**
  * Unified settings/preferences UI; Settings always visible
  * Larger touch targets for small controls
  * Preference sync across browser tabs
  * Heatmap now uses stable completion timestamps
  * Clarified “Clear completed” confirmation copy

* **Chores**
  * Database migration adding completion timestamps

* **Documentation**
  * Updated design notes, todos, and decision log regarding motion, sound, and accessibility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->