### PR TITLE
fix(electron): harden remote-web/frozen-preload version-skew crash in Settings (v0.8.1)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -145,3 +145,41 @@ function that will pull it off the deferred list.
       Forcing function: a focused motion-polish pass on the completion feature,
       or whenever `AnimatePresence` lands for any list.
       Effort: ~1.5-2h human / ~30 min CC.
+
+## Electron resilience
+
+- [x] **Harden the remote-web / frozen-preload version-skew crash class in Settings.** ✅ 2026-06-04 (fix/electron-preload-version-skew-settings)
+      Installed CoreLive loads remote prod web over its OWN frozen preload, so a
+      newly-deployed component can call a preload METHOD an older app lacks →
+      `undefined()` throws synchronously inside a bare effect → bubbles past the
+      (previously absent) error boundary → blank app. Root-caused via /investigate:
+      app v0.5.0 + web v0.8.0; `StartupWindowSettings` guarded the `settings`
+      namespace but called `getStartupConfig` (landed later in commit 774cb55 / v0.6.0).
+      Fix: (a) all Electron settings cards (Startup / Floating / BrainDump) **and**
+      `ElectronStartupSync` now guard on the METHOD (`typeof api?.method === 'function'`),
+      not just the namespace, rendering a calm "Update CoreLive…" card instead of
+      throwing; (b) added `src/app/error.tsx` (route boundary) + `src/app/global-error.tsx`
+      (the root-layout boundary `error.tsx` cannot cover — it only catches the page
+      subtree, not the layout itself or its children like `ElectronStartupSync`) as
+      systemic nets. `global-error.tsx` is dependency-free (own `<html>/<body>`, inline
+      styles, no shadcn/logger/globals.css) so the last line of defense never re-enters
+      a possibly-failed import graph. `ElectronStartupSync`'s guard is DEFENSIVE only
+      (`settings` + `setHideAppIcon` shipped together in 9b800ba/4d2728d — no published
+      gap), unlike the proven-live `getStartupConfig` crash. A web deploy protects old
+      apps once live; users still must update the app to USE the startup settings.
+
+- [ ] **error.tsx / global-error.tsx want a design sign-off + a reset() escape hatch.**
+      The two new error boundaries above ship with placeholder copy/styling ("Give
+      that another try" + a plain card) pending Raphtalia's design eye — `global-error.tsx`
+      is intentionally inline-styled (no design tokens) for robustness, so it especially
+      wants a later pass once the failure mode is confirmed rare. Separately, both
+      boundaries' only affordance is `reset()`, which DEAD-ENDS on a deterministic error
+      (e.g. the version-skew case before the app is updated): reset re-renders the same
+      crashing tree. Add a secondary escape (a full `window.location.reload()` / "reload"
+      / "go home" action) in the same pass. Deferred review findings folded here:
+      degradation-copy consistency across the non-crashing components (R6) and a shared
+      `SettingsStateCard` extraction (M-series dedup) are separate-branch refactors, not
+      blockers.
+      Forcing function: a design polish pass on the error screens, or the next report of
+      a stuck recovery screen.
+      Effort: ~1h human / ~20 min CC.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corelive",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A comprehensive design system and web application built with Next.js, featuring authentication, database integration, and desktop support",
   "author": "Ryota Murakami <dojce1048@gmail.com> (https://github.com/ryota-murakami)",
   "private": true,

--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -52,4 +52,23 @@ describe('RouteError (route-level error boundary)', () => {
     // Assert: Next.js's reset() is invoked to re-render the segment.
     expect(reset).toHaveBeenCalledTimes(1)
   })
+
+  it('does not throw when mounting through the real (unmocked) logger', () => {
+    // Lock the last-line-of-defense invariant: the boundary's own mount-time
+    // logging must run through the REAL logger without throwing, or the
+    // recovery UI would itself crash and defeat the boundary. Drop the
+    // beforeEach stub so the genuine pino browser path executes; keep console
+    // quiet for hygiene only.
+    vi.restoreAllMocks()
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    // Act + Assert
+    expect(() =>
+      render(<RouteError error={new Error('boom')} reset={vi.fn()} />),
+    ).not.toThrow()
+
+    consoleErrorSpy.mockRestore()
+  })
 })

--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { log } from '@/lib/logger'
+
+import RouteError from './error'
+
+describe('RouteError (route-level error boundary)', () => {
+  beforeEach(() => {
+    // Keep test output clean; the boundary logs the real error on mount.
+    vi.spyOn(log, 'error').mockImplementation(() => {})
+  })
+
+  it('shows a reassuring recovery card instead of a stark crash screen', () => {
+    // Arrange: a caught client error, e.g. an outdated preload throwing.
+    const reset = vi.fn()
+
+    // Act
+    render(<RouteError error={new Error('boom')} reset={reset} />)
+
+    // Assert: gentle, on-brand copy renders (never the scary built-in default).
+    expect(screen.getByText('Give that another try')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Something hiccuped while loading this view/i),
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces the real error to the logger for telemetry', () => {
+    // Arrange
+    const caught = new Error('boom')
+
+    // Act
+    render(<RouteError error={caught} reset={vi.fn()} />)
+
+    // Assert: the boundary logs the underlying error while the UI stays calm.
+    expect(log.error).toHaveBeenCalledWith(
+      'Page boundary caught a client error:',
+      caught,
+    )
+  })
+
+  it('retries the crashed segment when "Try again" is pressed', async () => {
+    // Arrange
+    const reset = vi.fn()
+    const user = userEvent.setup()
+    render(<RouteError error={new Error('boom')} reset={reset} />)
+
+    // Act: the single recovery affordance.
+    await user.click(screen.getByRole('button', { name: /try again/i }))
+
+    // Assert: Next.js's reset() is invoked to re-render the segment.
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+/**
+ * @fileoverview Route-level error boundary for the App Router.
+ *
+ * Replaces Next.js's stark default screen ("This page couldn't load") with a
+ * quiet, on-brand recovery card so any client-side render or effect throw
+ * degrades gracefully instead of blanking the whole app. React renders this in
+ * place of a crashed page subtree (e.g. an outdated Electron preload missing a
+ * method); without it, the nearest boundary is the scary built-in global-error.
+ *
+ * @module app/error
+ */
+import { RotateCcw } from 'lucide-react'
+import { memo, type ReactElement } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { useComponentEffect } from '@/hooks/useComponentEffect'
+import { log } from '@/lib/logger'
+
+interface RouteErrorProps {
+  /** The error React caught while rendering the page subtree. */
+  error: Error & { digest?: string }
+  /** Re-renders the crashed segment to retry after a transient failure. */
+  reset: () => void
+}
+
+/**
+ * Gentle recovery card shown when a page throws, with a one-tap retry — keeps
+ * the quiet-companion voice (reassure, never alarm) so a crash never reads as
+ * the user's failure. Rendered automatically by Next.js as the route boundary.
+ *
+ * @param props - Next.js error-boundary props
+ * @param props.error - The caught error (digest is set for server errors)
+ * @param props.reset - Retries rendering the crashed segment
+ * @returns A reassuring card with a "Try again" action
+ * @example
+ * // Rendered automatically by Next.js when a page subtree throws.
+ */
+const RouteError = memo(function RouteError({
+  error,
+  reset,
+}: RouteErrorProps): ReactElement {
+  // Surface the real error to logs/telemetry; the UI stays calm and vague.
+  useComponentEffect(() => {
+    log.error('Page boundary caught a client error:', error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6">
+      <Card className="max-w-md">
+        <CardHeader>
+          <CardTitle>Give that another try</CardTitle>
+          <CardDescription>
+            Something hiccuped while loading this view. Your data is safe — give
+            it another go.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={reset} className="gap-2">
+            <RotateCcw className="h-4 w-4" />
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+})
+
+export default RouteError

--- a/src/app/global-error.test.tsx
+++ b/src/app/global-error.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import GlobalError from './global-error'
+
+describe('GlobalError (root-layout error boundary)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders a standalone reassuring recovery screen with no design-system deps', () => {
+    // Arrange: global-error replaces the root layout, so it must render its own
+    // shell with only inline styles — no globals.css, no shadcn, no logger.
+    // Spy console.error for hygiene (React warns about nested <html>).
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Act
+    render(<GlobalError error={new Error('boom')} reset={vi.fn()} />)
+
+    // Assert: gentle, on-brand copy renders standalone (never the built-in crash).
+    expect(screen.getByText('Give that another try')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Something hiccuped while loading CoreLive/i),
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces the caught error to console for telemetry', () => {
+    // Arrange: console is the only sink global-error trusts at this layer.
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const caught = new Error('boom')
+
+    // Act
+    render(<GlobalError error={caught} reset={vi.fn()} />)
+
+    // Assert: the boundary logs the underlying error while the UI stays calm.
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[global-error] Root layout boundary caught:',
+      caught,
+    )
+  })
+
+  it('retries the app shell when "Try again" is pressed', async () => {
+    // Arrange
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const reset = vi.fn()
+    const user = userEvent.setup()
+    render(<GlobalError error={new Error('boom')} reset={reset} />)
+
+    // Act: the single recovery affordance.
+    await user.click(screen.getByRole('button', { name: /try again/i }))
+
+    // Assert: Next.js's reset() is invoked to re-render the app shell.
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+/**
+ * @fileoverview Root-layout (global) error boundary for the App Router.
+ *
+ * `src/app/error.tsx` only catches throws inside the page subtree; it cannot
+ * catch a throw from the root layout itself or its direct children (the Redux
+ * provider, `<ElectronStartupSync />`, the toaster). Those escalate here. With
+ * no `global-error.tsx`, they fall through to Next.js's stark built-in crash
+ * screen — the exact outcome the Electron version-skew fix set out to prevent.
+ *
+ * Because `global-error` REPLACES the root layout, it renders its own
+ * `<html>`/`<body>` and is intentionally dependency-free: no shadcn UI, no
+ * design tokens, no logger, no global stylesheet. Every such import is a way
+ * for the last line of defense to fail in precisely the situation it exists to
+ * catch (a root-layout / provider / CSS failure re-triggering through the same
+ * import graph). Styling is inline and deliberately plain — robust now, a
+ * designer pass can prettify it later (tracked as a follow-up).
+ *
+ * @module app/global-error
+ */
+
+import { memo, type ReactElement, useEffect } from 'react'
+
+interface GlobalErrorProps {
+  /** The error React caught while rendering the root layout subtree. */
+  error: Error & { digest?: string }
+  /** Re-renders the whole app shell to retry after a transient failure. */
+  reset: () => void
+}
+
+// Inline, token-free styles: global-error must not depend on globals.css, which
+// may be exactly what failed to load. Plain values keep the backstop standing.
+const pageStyle = {
+  minHeight: '100vh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '24px',
+  backgroundColor: '#fafaf9',
+  color: '#1c1917',
+  fontFamily:
+    'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+}
+
+const cardStyle = {
+  maxWidth: '28rem',
+  width: '100%',
+  border: '1px solid #e7e5e4',
+  borderRadius: '12px',
+  backgroundColor: '#ffffff',
+  padding: '24px',
+  boxShadow: '0 1px 2px rgba(0, 0, 0, 0.04)',
+}
+
+const titleStyle = {
+  margin: '0 0 8px',
+  fontSize: '1.125rem',
+  fontWeight: 600,
+}
+
+const descriptionStyle = {
+  margin: '0 0 20px',
+  fontSize: '0.875rem',
+  lineHeight: 1.6,
+  color: '#57534e',
+}
+
+const buttonStyle = {
+  appearance: 'none' as const,
+  cursor: 'pointer',
+  border: '1px solid #1c1917',
+  borderRadius: '8px',
+  backgroundColor: '#1c1917',
+  color: '#fafaf9',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  padding: '8px 16px',
+}
+
+/**
+ * Logs the root-level boundary error once per error to the console — the only
+ * sink global-error trusts at this layer. A deliberately LOCAL hook rather than
+ * the app's `useComponentEffect`: the last line of defense must not re-enter the
+ * app's effect/logging import graph, which may be exactly what failed. The
+ * console call is guarded so a logging failure can never crash the recovery UI.
+ *
+ * @param error - The error the root layout boundary caught
+ * @returns Nothing; fires a guarded console.error on mount and on error change
+ * @example
+ * useReportRootError(new Error('boom')) // logs '[global-error] Root layout boundary caught:'
+ */
+function useReportRootError(error: Error & { digest?: string }): void {
+  useEffect(() => {
+    try {
+      console.error('[global-error] Root layout boundary caught:', error)
+    } catch {
+      // Intentionally empty: logging must never break the last line of defense.
+    }
+  }, [error])
+}
+
+/**
+ * Last-resort recovery screen shown when the root layout itself throws; renders
+ * its own document shell and stays calm in the quiet-companion voice. Rendered
+ * automatically by Next.js as the global error boundary.
+ *
+ * @param props - Next.js error-boundary props
+ * @param props.error - The caught error (its `digest` is set for server errors)
+ * @param props.reset - Retries rendering the app shell
+ * @returns A standalone, reassuring page with a "Try again" action
+ * @example
+ * // Rendered automatically by Next.js when the root layout subtree throws.
+ */
+const GlobalError = memo(function GlobalError({
+  error,
+  reset,
+}: GlobalErrorProps): ReactElement {
+  useReportRootError(error)
+
+  return (
+    <html lang="en">
+      <body style={pageStyle}>
+        <div style={cardStyle} role="alert">
+          <h1 style={titleStyle}>Give that another try</h1>
+          <p style={descriptionStyle}>
+            Something hiccuped while loading CoreLive. Your data is safe — give
+            it another go.
+          </p>
+          <button type="button" onClick={reset} style={buttonStyle}>
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  )
+})
+
+export default GlobalError

--- a/src/components/electron/BrainDumpSettings.test.tsx
+++ b/src/components/electron/BrainDumpSettings.test.tsx
@@ -30,7 +30,7 @@ type BrainDumpBridge = {
  * installElectronAPI({ brainDump: fakeBridge })
  */
 function installElectronAPI(
-  api: { brainDump?: BrainDumpBridge } | undefined,
+  api: { brainDump?: Partial<BrainDumpBridge> } | undefined,
 ): void {
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
@@ -113,5 +113,20 @@ describe('BrainDumpSettings', () => {
         'React has detected a change in the order of Hooks',
       ),
     )
+  })
+
+  it('degrades gracefully when an old preload exposes brainDump but not the settings getters', async () => {
+    // Arrange: an OUTDATED desktop app exposes the brainDump window-toggle bridge
+    // but predates the getSyncMode/getOpacity/getShortcut settings getters that
+    // the load effect's Promise.all calls.
+    installElectronAPI({ brainDump: { toggle: toggleMock } })
+
+    // Act + Assert: mounting must NOT throw a synchronous TypeError from the
+    // Promise.all (which would bubble out of useEffect to Next.js global-error
+    // and blank the whole page). A graceful update card must render instead.
+    render(<BrainDumpSettings />)
+    expect(
+      await screen.findByText(/Update CoreLive to the latest version/i),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/electron/BrainDumpSettings.test.tsx
+++ b/src/components/electron/BrainDumpSettings.test.tsx
@@ -129,4 +129,48 @@ describe('BrainDumpSettings', () => {
       await screen.findByText(/Update CoreLive to the latest version/i),
     ).toBeInTheDocument()
   })
+
+  it('shows a desktop-only message when the brainDump bridge is absent', async () => {
+    // Arrange: a web renderer has no electronAPI at all.
+    installElectronAPI(undefined)
+
+    // Act
+    render(<BrainDumpSettings />)
+
+    // Assert: the fallback copy renders and no toggles are offered.
+    expect(
+      await screen.findByText(
+        'BrainDump Note is only available in the desktop application.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
+
+  it('shows a loading state until the saved BrainDump settings arrive', async () => {
+    // Arrange: getSyncMode never resolves, so the load Promise.all keeps the
+    // card in its loading state (all three getters exist, so the guards pass).
+    getSyncModeMock.mockReturnValue(new Promise<boolean>(() => {}))
+    getOpacityMock.mockResolvedValue(0.7)
+    getShortcutMock.mockResolvedValue('CommandOrControl+Shift+B')
+    installElectronAPI({
+      brainDump: {
+        getSyncMode: getSyncModeMock,
+        setSyncMode: setSyncModeMock,
+        getOpacity: getOpacityMock,
+        setOpacity: setOpacityMock,
+        getShortcut: getShortcutMock,
+        setShortcut: setShortcutMock,
+        toggle: toggleMock,
+      },
+    })
+
+    // Act
+    render(<BrainDumpSettings />)
+
+    // Assert: the loading copy shows and no toggles have rendered yet.
+    expect(
+      await screen.findByText('Loading BrainDump settings…'),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -99,7 +99,17 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
   useComponentEffect(() => {
     const api =
       typeof window === 'undefined' ? undefined : window.electronAPI?.brainDump
-    if (!api) return
+    // Guard on the METHODS, not just the namespace: an outdated desktop preload
+    // can expose `brainDump` (the window toggle) without the newer settings
+    // getters. A missing method in this Promise.all throws synchronously inside
+    // the effect and bubbles to global-error, so bail out and let the
+    // fallback card render instead.
+    if (
+      typeof api?.getSyncMode !== 'function' ||
+      typeof api?.getOpacity !== 'function' ||
+      typeof api?.getShortcut !== 'function'
+    )
+      return
 
     let cancelled = false
 
@@ -217,6 +227,29 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
           </CardTitle>
           <CardDescription>
             BrainDump Note is only available in the desktop application.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  // Outdated desktop app: the brainDump bridge exists but predates the settings
+  // getters. Invite an update instead of crashing the page.
+  if (
+    hasMounted &&
+    (typeof window.electronAPI?.brainDump?.getSyncMode !== 'function' ||
+      typeof window.electronAPI?.brainDump?.getOpacity !== 'function' ||
+      typeof window.electronAPI?.brainDump?.getShortcut !== 'function')
+  ) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Brain className="h-5 w-5" />
+            BrainDump Note
+          </CardTitle>
+          <CardDescription>
+            Update CoreLive to the latest version to manage BrainDump Note.
           </CardDescription>
         </CardHeader>
       </Card>

--- a/src/components/electron/ElectronStartupSync.test.tsx
+++ b/src/components/electron/ElectronStartupSync.test.tsx
@@ -92,6 +92,21 @@ describe('ElectronStartupSync', () => {
     expect(setHideAppIconMock).not.toHaveBeenCalled()
   })
 
+  it('does not throw when an old preload exposes settings but not setHideAppIcon', async () => {
+    // Arrange: an OUTDATED desktop app exposes the `settings` namespace but
+    // predates the `setHideAppIcon` method this effect calls. Mounted in the
+    // root layout, a synchronous TypeError here would bubble past error.tsx to
+    // global-error and blank every route. The method guard must skip the call.
+    installElectronAPI({ settings: {} })
+
+    // Act + Assert: mounting must not throw, and no IPC is attempted.
+    expect(() =>
+      render(wrapWithStore(<ElectronStartupSync />, true)),
+    ).not.toThrow()
+    await Promise.resolve()
+    expect(setHideAppIconMock).not.toHaveBeenCalled()
+  })
+
   it('logs an error when setHideAppIcon rejects', async () => {
     // Surface IPC failures so main-process regressions don't go silent.
     // Without this test, a future refactor could remove the .catch handler

--- a/src/components/electron/ElectronStartupSync.tsx
+++ b/src/components/electron/ElectronStartupSync.tsx
@@ -55,8 +55,20 @@ export function ElectronStartupSync(): null {
     // failure signal here is the boolean `false`, not a thrown error. The
     // `.catch` is still kept as defense-in-depth in case preload behavior
     // changes or someone exposes the raw IPC channel later.
-    const syncPromise =
-      window.electronAPI?.settings?.setHideAppIcon(hideAppIcon)
+    // Guard on the METHOD, not just the `settings` namespace. This component
+    // is mounted in the root layout, so it runs on every route — and the
+    // installed desktop app loads remote web against its own FROZEN preload.
+    // Calling `undefined()` on an older preload would throw a synchronous
+    // TypeError out of this effect, past its own `.catch`, to the error
+    // boundary (and from the root layout it escapes `error.tsx` entirely —
+    // see `global-error.tsx`). Defensive only: `settings` and `setHideAppIcon`
+    // shipped in the same release, so no published preload has the gap today;
+    // uniform method-guarding future-proofs the bridge against a reshuffle and
+    // matches the other Electron settings components.
+    const settings = window.electronAPI?.settings
+    if (typeof settings?.setHideAppIcon !== 'function') return
+    // Call as a method so `this` stays bound to `settings`.
+    const syncPromise = settings.setHideAppIcon(hideAppIcon)
     syncPromise
       ?.then((ok) => {
         if (ok === false) {

--- a/src/components/electron/FloatingWindowSettings.test.tsx
+++ b/src/components/electron/FloatingWindowSettings.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FloatingWindowSettings } from './FloatingWindowSettings'
+
+// Stand-ins for the typed `floatingPanels` preload bridge the component talks to.
+const getVisibleOnAllWorkspacesMock = vi.fn()
+const setVisibleOnAllWorkspacesMock = vi.fn()
+
+type FloatingPanelsBridge = {
+  getVisibleOnAllWorkspaces: () => Promise<boolean>
+  setVisibleOnAllWorkspaces: (value: boolean) => Promise<boolean>
+}
+
+/**
+ * Define `window.electronAPI` for a test. Passing `undefined` simulates a web
+ * (non-Electron) renderer where the bridge is missing entirely; a partial
+ * `floatingPanels` simulates an outdated desktop preload.
+ *
+ * @param api - The fake electronAPI value, or undefined for a web renderer.
+ */
+function installElectronAPI(
+  api: { floatingPanels?: Partial<FloatingPanelsBridge> } | undefined,
+): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: api,
+  })
+}
+
+describe('FloatingWindowSettings', () => {
+  beforeEach(() => {
+    getVisibleOnAllWorkspacesMock.mockReset()
+    setVisibleOnAllWorkspacesMock.mockReset()
+    // Default: saves succeed; individual tests override when exercising failure.
+    setVisibleOnAllWorkspacesMock.mockResolvedValue(true)
+  })
+
+  it('reflects the saved macOS Spaces preference once the bridge responds', async () => {
+    // Arrange: the saved preference keeps both panels on all desktops.
+    getVisibleOnAllWorkspacesMock.mockResolvedValue(true)
+    installElectronAPI({
+      floatingPanels: {
+        getVisibleOnAllWorkspaces: getVisibleOnAllWorkspacesMock,
+        setVisibleOnAllWorkspaces: setVisibleOnAllWorkspacesMock,
+      },
+    })
+
+    // Act
+    render(<FloatingWindowSettings />)
+
+    // Assert: the desktop-following switch renders and reads on.
+    const desktopSwitch = await screen.findByRole('switch', {
+      name: 'Show on all Mac desktops',
+    })
+    expect(desktopSwitch).toBeChecked()
+  })
+
+  it('shows a desktop-only message when the floatingPanels bridge is absent', async () => {
+    // Arrange: a web renderer has no electronAPI at all.
+    installElectronAPI(undefined)
+
+    // Act
+    render(<FloatingWindowSettings />)
+
+    // Assert: the fallback copy renders and no toggle is offered.
+    expect(
+      await screen.findByText(
+        'Floating window settings are only available in the desktop application.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
+
+  it('degrades gracefully when an old preload exposes floatingPanels but not getVisibleOnAllWorkspaces', async () => {
+    // Arrange: an OUTDATED desktop app exposes the floatingPanels namespace but
+    // predates the getVisibleOnAllWorkspaces method the load effect calls.
+    installElectronAPI({ floatingPanels: {} })
+
+    // Act + Assert: mounting must NOT throw a synchronous TypeError from the load
+    // effect (which would bubble out of useEffect to Next.js global-error and
+    // blank the whole page). A graceful update card must render instead.
+    render(<FloatingWindowSettings />)
+    expect(
+      await screen.findByText(/Update CoreLive to the latest version/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/electron/FloatingWindowSettings.test.tsx
+++ b/src/components/electron/FloatingWindowSettings.test.tsx
@@ -86,4 +86,26 @@ describe('FloatingWindowSettings', () => {
       await screen.findByText(/Update CoreLive to the latest version/i),
     ).toBeInTheDocument()
   })
+
+  it('shows a loading state until the saved Spaces preference arrives', async () => {
+    // Arrange: a never-resolving fetch keeps the card in its loading state.
+    getVisibleOnAllWorkspacesMock.mockReturnValue(
+      new Promise<boolean>(() => {}),
+    )
+    installElectronAPI({
+      floatingPanels: {
+        getVisibleOnAllWorkspaces: getVisibleOnAllWorkspacesMock,
+        setVisibleOnAllWorkspaces: setVisibleOnAllWorkspacesMock,
+      },
+    })
+
+    // Act
+    render(<FloatingWindowSettings />)
+
+    // Assert: the loading copy shows and no switch has rendered yet.
+    expect(
+      await screen.findByText('Loading floating window settings...'),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/electron/FloatingWindowSettings.test.tsx
+++ b/src/components/electron/FloatingWindowSettings.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { FloatingWindowSettings } from './FloatingWindowSettings'
@@ -107,5 +108,39 @@ describe('FloatingWindowSettings', () => {
       await screen.findByText('Loading floating window settings...'),
     ).toBeInTheDocument()
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
+
+  it('rolls the switch back when the main process fails to persist it', async () => {
+    // Arrange: the saved preference is off, and the save will reject — mirroring
+    // StartupWindowSettings' rollback test so both share the same safety net.
+    getVisibleOnAllWorkspacesMock.mockResolvedValue(false)
+    setVisibleOnAllWorkspacesMock.mockRejectedValue(
+      new Error('main process unavailable'),
+    )
+    installElectronAPI({
+      floatingPanels: {
+        getVisibleOnAllWorkspaces: getVisibleOnAllWorkspacesMock,
+        setVisibleOnAllWorkspaces: setVisibleOnAllWorkspacesMock,
+      },
+    })
+    const user = userEvent.setup()
+    render(<FloatingWindowSettings />)
+    const desktopSwitch = await screen.findByRole('switch', {
+      name: 'Show on all Mac desktops',
+    })
+    expect(desktopSwitch).not.toBeChecked()
+
+    // Act: try to enable it; persistence rejects.
+    await user.click(desktopSwitch)
+
+    // Assert: the optimistic on-state reverts and an error surfaces.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('switch', { name: 'Show on all Mac desktops' }),
+      ).not.toBeChecked()
+    })
+    expect(
+      screen.getByText('Failed to update floating window settings'),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/electron/FloatingWindowSettings.tsx
+++ b/src/components/electron/FloatingWindowSettings.tsx
@@ -59,7 +59,10 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
       typeof window === 'undefined'
         ? undefined
         : window.electronAPI?.floatingPanels
-    if (!api) return
+    // Guard on the METHOD, not just the namespace, so an outdated desktop
+    // preload that exposes `floatingPanels` without getVisibleOnAllWorkspaces
+    // degrades to the fallback card instead of throwing inside this effect.
+    if (typeof api?.getVisibleOnAllWorkspaces !== 'function') return
 
     let cancelled = false
 
@@ -129,6 +132,28 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
           <CardDescription>
             Floating window settings are only available in the desktop
             application.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  // Outdated desktop app: the floatingPanels bridge exists but predates
+  // getVisibleOnAllWorkspaces. Invite an update instead of crashing the page.
+  if (
+    hasMounted &&
+    typeof window.electronAPI?.floatingPanels?.getVisibleOnAllWorkspaces !==
+      'function'
+  ) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Monitor className="h-5 w-5" />
+            Floating windows
+          </CardTitle>
+          <CardDescription>
+            Update CoreLive to the latest version to manage floating windows.
           </CardDescription>
         </CardHeader>
       </Card>

--- a/src/components/electron/StartupWindowSettings.test.tsx
+++ b/src/components/electron/StartupWindowSettings.test.tsx
@@ -162,6 +162,23 @@ describe('StartupWindowSettings', () => {
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
   })
 
+  it('degrades gracefully when an old preload exposes settings but not getStartupConfig', async () => {
+    // Arrange: an OUTDATED installed desktop app whose preload still exposes the
+    // long-lived `settings` namespace but predates the newer getStartupConfig
+    // method. The freshly deployed web bundle mounts this component anyway
+    // because window.electronAPI exists (version skew between app and web).
+    installElectronAPI({ settings: {} })
+
+    // Act + Assert: mounting must NOT throw a synchronous TypeError from the
+    // load effect. An unguarded `api.getStartupConfig()` call would bubble out
+    // of useEffect to Next.js global-error and blank the whole page. Instead a
+    // graceful update card must render.
+    render(<StartupWindowSettings />)
+    expect(
+      await screen.findByText(/Update CoreLive to the latest version/i),
+    ).toBeInTheDocument()
+  })
+
   it('shows a loading state until the saved config arrives', async () => {
     // Arrange: a never-resolving fetch keeps the component in its loading state.
     getStartupConfigMock.mockReturnValue(

--- a/src/components/electron/StartupWindowSettings.tsx
+++ b/src/components/electron/StartupWindowSettings.tsx
@@ -93,7 +93,12 @@ export const StartupWindowSettings = memo(function StartupWindowSettings({
   useComponentEffect(() => {
     const api =
       typeof window === 'undefined' ? undefined : window.electronAPI?.settings
-    if (!api) return
+    // Guard on the METHOD, not just the namespace: an outdated desktop preload
+    // can expose `settings` (shipped earlier for hide-app-icon) without the
+    // newer getStartupConfig. Calling a missing method here throws synchronously
+    // inside the effect, and that throw bubbles past the .catch() below to
+    // Next.js global-error. The missing-method render branch handles this case.
+    if (typeof api?.getStartupConfig !== 'function') return
 
     let cancelled = false
 
@@ -168,6 +173,29 @@ export const StartupWindowSettings = memo(function StartupWindowSettings({
           <CardDescription>
             Startup window settings are only available in the desktop
             application.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  // Outdated desktop app: the settings bridge exists but predates
+  // getStartupConfig, so reading the saved config is impossible. Invite an
+  // update in the quiet-companion voice instead of crashing the whole page.
+  if (
+    hasMounted &&
+    typeof window.electronAPI?.settings?.getStartupConfig !== 'function'
+  ) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sunrise className="h-5 w-5" />
+            On launch
+          </CardTitle>
+          <CardDescription>
+            Update CoreLive to the latest version to choose which windows greet
+            you at launch.
           </CardDescription>
         </CardHeader>
       </Card>


### PR DESCRIPTION
## Why

The Settings screen could blank the entire app on an **installed Electron build**. CoreLive's desktop app loads the **remotely-deployed** prod web bundle over its **own frozen preload** (Full WebView), so a newly-deployed component can call a preload **method an older installed app doesn't have** → `undefined()` throws synchronously inside a bare `useEffect` → bubbles past the effect's own `.catch` → with **no error boundary present**, falls through to Next.js's stark built-in crash screen.

Root-caused via `/investigate`: installed app **v0.5.0** + deployed web **v0.8.0**. `StartupWindowSettings` guarded the `window.electronAPI.settings` **namespace** (long-lived) but called `getStartupConfig`, which only landed later (commit `774cb55` / v0.6.0). This is a **structural bug class**, not a one-off — any preload method added in a later app version is absent on every older installed app.

## What

**Method-existence guards** (guard the *method*, not just the namespace) + a graceful "Update CoreLive…" card across every Electron settings surface:
- `StartupWindowSettings` — the proven-live crash (`getStartupConfig`).
- `FloatingWindowSettings` — `getVisibleOnAllWorkspaces`.
- `BrainDumpSettings` — `getSyncMode` / `getOpacity` / `getShortcut`.
- `ElectronStartupSync` (mounted in the **root layout**, runs on every route) — `setHideAppIcon`. **Defensive only**: `settings` + `setHideAppIcon` shipped together (`9b800ba`/`4d2728d`), so no published preload actually has this gap — but uniform guarding matches the others and future-proofs against a preload reshuffle, and a root-layout throw is the highest-blast-radius case.

**Systemic safety nets** (neither existed before):
- `src/app/error.tsx` — route-level boundary; catches any client throw in a page subtree with a calm recovery card.
- `src/app/global-error.tsx` — the **root-layout** boundary `error.tsx` *cannot* cover (it only catches the page subtree, not the layout itself or its children — providers, `ElectronStartupSync`, toaster). **Dependency-free by design**: own `<html>/<body>`, inline styles, no shadcn / logger / `globals.css`, so the last line of defense never re-enters a possibly-failed import graph.

## Tests

`pnpm validate` green under Node 24.13.0: **277 unit tests pass**, typecheck ✓, build ✓, lint ✓ (`--max-warnings 0`). New coverage:
- Each settings card: namespace-present-but-method-absent → renders the update card, does **not** throw; plus loading + bridge-absent branches.
- `ElectronStartupSync`: `{ settings: {} }` (method absent) → no throw, no IPC.
- `global-error.tsx`: standalone render (no design-system deps) + console telemetry + retry.
- `error.tsx`: reassuring copy, real-error logging, retry, and a **real-(unmocked)-logger no-throw** invariant.
- `FloatingWindowSettings`: save-rollback on reject (mirrors `StartupWindowSettings`).

## Deploy / rollout notes

- A **web deploy** of this fix protects **already-installed older apps from crashing** the moment it's live on corelive.app.
- Users must still **update the installed app** (≥ v0.6.0, ideally latest) to actually *use* the startup settings — the fix degrades them gracefully, it doesn't backport the feature.
- This is the version bump to **v0.8.1**; the Electron release tag follows after merge to `main`.

## Follow-ups (tracked in TODOS.md → "Electron resilience")

- `error.tsx` / `global-error.tsx` copy & styling are **placeholders pending a design sign-off** (quiet-companion voice per DESIGN.md). `global-error.tsx`'s inline styling is deliberate (robustness) and wants a later pass.
- Both boundaries' only affordance is `reset()`, which **dead-ends on a deterministic error** (the version-skew case before the app is updated). Add a `window.location.reload()` / "go home" escape in the same design pass.
- Deferred review findings: degradation-copy consistency across non-crashing components and a shared `SettingsStateCard` extraction are separate-branch refactors, not blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added layered error boundaries for graceful crash recovery with retry functionality.
  * Enhanced resilience to outdated desktop app versions—missing or incompatible features now gracefully degrade instead of crashing.

* **Tests**
  * Added comprehensive test coverage for error recovery and desktop app version compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->