### PR TITLE
fix(electron): prevent packaged-app crash from pino-pretty worker exit

### DIFF
--- a/electron/__tests__/logger.test.ts
+++ b/electron/__tests__/logger.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Simulate a pino-pretty thread-stream worker that has exited: every write
+// method throws "the worker has exited" — the exact failure that bricks a
+// packaged Electron main process (see electron/logger.ts). The factory is
+// self-contained because Vitest hoists vi.mock() above the imports below.
+vi.mock('pino', () => {
+  const makeThrowingLogger = () => {
+    const fail = (): never => {
+      throw new Error('the worker has exited')
+    }
+    const throwingLogger = {
+      info: fail,
+      error: fail,
+      warn: fail,
+      debug: fail,
+      trace: fail,
+      fatal: fail,
+      child: () => throwingLogger,
+    }
+    return throwingLogger
+  }
+  return { default: () => makeThrowingLogger() }
+})
+
+// Imported after the mock so the module-load `pino(...)` resolves to the
+// throwing logger above, making every appLogger.* call fail on write.
+import { computeShouldUsePrettyTransport, log } from '../logger'
+
+describe('log.* is crash-safe when the pino transport has died', () => {
+  // Regression for the v0.8.0 prod crash: a packaged build enabled the
+  // pino-pretty worker, the worker exited inside the asar, and the first
+  // log.info() threw "the worker has exited" — uncaught in the main process,
+  // so Electron showed the fatal "A JavaScript error occurred" dialog and the
+  // window was stranded on about:blank. Logging must never crash the app.
+
+  it('does not throw when info() hits a dead transport', () => {
+    // Arrange: appLogger.info is mocked to throw "the worker has exited".
+    // Act + Assert: the wrapper swallows it instead of propagating.
+    expect(() => log.info('Application started')).not.toThrow()
+  })
+
+  it('keeps every log level crash-safe (error, warn, info, debug, trace)', () => {
+    // Arrange: every appLogger level method throws on write.
+
+    // Act + Assert: none of the public log.* methods propagate the failure.
+    expect(() => log.error('boom')).not.toThrow()
+    expect(() => log.warn('careful')).not.toThrow()
+    expect(() => log.info('fyi')).not.toThrow()
+    expect(() => log.debug('details')).not.toThrow()
+    expect(() => log.trace('verbose')).not.toThrow()
+  })
+
+  it('keeps a catch-then-log error path safe (logging with a context object)', () => {
+    // Arrange: this mirrors settings:setHideAppIcon, whose catch block logs the
+    // caught error — the double-throw that originally defeated try/catch.
+
+    // Act + Assert: logging an error WITH a context object stays non-fatal.
+    expect(() =>
+      log.error('Failed to change dock icon visibility:', new Error('nope')),
+    ).not.toThrow()
+  })
+})
+
+describe('computeShouldUsePrettyTransport (pino-pretty worker gate)', () => {
+  // Guards the root-cause decision: the worker transport may only spawn in the
+  // genuine local-dev main process, never in a packaged build, test, or
+  // renderer — otherwise the worker exits and bricks the app.
+
+  it('enables pretty transport only in the development main process', () => {
+    // Arrange: NODE_ENV=development (set by scripts/dev.js) + main process.
+    const result = computeShouldUsePrettyTransport(
+      { NODE_ENV: 'development' },
+      'browser',
+    )
+
+    // Assert
+    expect(result).toBe(true)
+  })
+
+  it('disables pretty transport in a packaged build where NODE_ENV is unset', () => {
+    // Arrange: packaged Electron leaves NODE_ENV undefined — the exact prod case
+    // that crashed. The old `!== 'production'` gate wrongly returned true here.
+    const result = computeShouldUsePrettyTransport(
+      { NODE_ENV: undefined },
+      'browser',
+    )
+
+    // Assert
+    expect(result).toBe(false)
+  })
+
+  it('disables pretty transport under production and test', () => {
+    // Arrange + Act + Assert: neither explicit non-dev env spawns the worker.
+    expect(
+      computeShouldUsePrettyTransport({ NODE_ENV: 'production' }, 'browser'),
+    ).toBe(false)
+    expect(
+      computeShouldUsePrettyTransport({ NODE_ENV: 'test' }, 'browser'),
+    ).toBe(false)
+  })
+
+  it('disables pretty transport outside the main process (renderer/preload)', () => {
+    // Arrange: dev env but NOT the main process — no SharedArrayBuffer there.
+    expect(
+      computeShouldUsePrettyTransport({ NODE_ENV: 'development' }, 'renderer'),
+    ).toBe(false)
+    expect(
+      computeShouldUsePrettyTransport({ NODE_ENV: 'development' }, undefined),
+    ).toBe(false)
+  })
+
+  it('honors DISABLE_PINO_PRETTY=true as an explicit opt-out', () => {
+    // Arrange: dev main process, but the escape hatch is set.
+    const result = computeShouldUsePrettyTransport(
+      { NODE_ENV: 'development', DISABLE_PINO_PRETTY: 'true' },
+      'browser',
+    )
+
+    // Assert
+    expect(result).toBe(false)
+  })
+})

--- a/electron/logger.ts
+++ b/electron/logger.ts
@@ -1,9 +1,12 @@
 /**
  * @fileoverview Logging utility for Electron main process.
  *
- * Uses pino for structured logging with conditional pretty-printing
- * in development mode. Only the main process uses pretty transport
- * to avoid SharedArrayBuffer issues in preload/renderer contexts.
+ * Uses pino for structured logging with conditional pretty-printing in
+ * local development only. The pino-pretty transport runs on a worker thread
+ * that cannot load from inside a packaged asar (and SharedArrayBuffer is
+ * unavailable in preload/renderer), so it is gated to the dev main process —
+ * see computeShouldUsePrettyTransport. Every log.* call is crash-safe via
+ * safeLog so a dead transport can never take down the main process.
  *
  * @module electron/logger
  * @example
@@ -21,32 +24,46 @@ import pino, { type Logger } from 'pino'
 // Environment Detection
 // ============================================================================
 
-/** Whether running in development mode */
-const isDevelopment = process.env.NODE_ENV !== 'production'
-
-/** Whether running in test environment */
-const isTestEnvironment = process.env.NODE_ENV === 'test'
-
 /**
- * Whether running in Electron main process.
- * In Electron, process.type is 'browser' for main, 'renderer' for renderer.
- */
-const isMainProcess =
-  (process as NodeJS.Process & { type?: string }).type === 'browser'
-
-/**
- * Whether to use pino-pretty transport.
+ * Whether pino should attach the pino-pretty worker-thread transport.
  *
- * Only enabled in main process during development because:
- * - pino-pretty uses thread-stream which requires SharedArrayBuffer
- * - SharedArrayBuffer requires cross-origin isolation headers
- * - Electron preload/renderer don't have these headers
+ * Pure (env + processType are passed in) so it is unit-testable across
+ * environments without relying on module-load side effects.
+ *
+ * CRITICAL — must be true ONLY in the genuine local-dev main process.
+ * pino-pretty runs on a thread-stream worker thread. In a packaged Electron
+ * app that worker cannot load pino-pretty from inside the asar archive and
+ * exits; every subsequent pino write then throws "the worker has exited",
+ * which is uncaught in the main process and shows Electron's fatal
+ * "A JavaScript error occurred" dialog (bricking the app on the first log).
+ * So the gate keys on `NODE_ENV === 'development'` (set by scripts/dev.js for
+ * `pnpm electron:dev`), NOT `!== 'production'`: packaged builds leave NODE_ENV
+ * unset and MUST fall through to plain JSON logging. Tests (NODE_ENV ===
+ * 'test') and the renderer/preload (process.type !== 'browser', where
+ * SharedArrayBuffer is unavailable) are excluded for the same reason.
+ *
+ * @param env - Relevant process env vars (NODE_ENV, DISABLE_PINO_PRETTY)
+ * @param processType - Electron process.type ('browser' in the main process)
+ * @returns true only in the Electron main process during local development
+ * @example
+ * computeShouldUsePrettyTransport({ NODE_ENV: 'development' }, 'browser')  // => true
+ * computeShouldUsePrettyTransport({ NODE_ENV: undefined }, 'browser')      // => false (packaged)
+ * computeShouldUsePrettyTransport({ NODE_ENV: 'test' }, 'browser')         // => false
+ * computeShouldUsePrettyTransport({ NODE_ENV: 'development' }, 'renderer') // => false
  */
-const shouldUsePrettyTransport =
-  isDevelopment &&
-  !isTestEnvironment &&
-  isMainProcess &&
-  process.env.DISABLE_PINO_PRETTY !== 'true'
+export const computeShouldUsePrettyTransport = (
+  env: { NODE_ENV?: string; DISABLE_PINO_PRETTY?: string },
+  processType: string | undefined,
+): boolean =>
+  env.NODE_ENV === 'development' &&
+  processType === 'browser' &&
+  env.DISABLE_PINO_PRETTY !== 'true'
+
+/** Whether this process should use the pino-pretty transport (computed once at load). */
+const shouldUsePrettyTransport = computeShouldUsePrettyTransport(
+  process.env,
+  (process as NodeJS.Process & { type?: string }).type,
+)
 
 // ============================================================================
 // Logger Configuration
@@ -82,6 +99,27 @@ const logger: Logger = pino({
  */
 const appLogger: Logger = logger.child({ component: 'corelive' })
 
+/**
+ * Runs a pino logging call, swallowing any error so logging can NEVER crash the
+ * app. If a pino transport worker has exited, every write throws "the worker has
+ * exited"; unguarded in the Electron main process that throw is fatal (it shows
+ * the "A JavaScript error occurred" dialog and even defeats a caller's
+ * catch-then-log error path). Logging is best-effort telemetry — it must never
+ * take down the process.
+ *
+ * @param write - Thunk performing the actual pino call
+ * @example
+ * safeLog(() => appLogger.info('started')) // logs, or silently no-ops on failure
+ */
+const safeLog = (write: () => void): void => {
+  try {
+    write()
+  } catch {
+    // Intentionally swallowed: there is no safe fallback sink here (the failing
+    // transport may be the only one), and a logging failure must not propagate.
+  }
+}
+
 // ============================================================================
 // Log Interface
 // ============================================================================
@@ -103,11 +141,13 @@ export const log = {
    * @param context - Optional context object
    */
   error: (message: string, context?: unknown): void => {
-    if (context !== undefined) {
-      appLogger.error({ context }, message)
-    } else {
-      appLogger.error(message)
-    }
+    safeLog(() => {
+      if (context !== undefined) {
+        appLogger.error({ context }, message)
+      } else {
+        appLogger.error(message)
+      }
+    })
   },
 
   /**
@@ -116,11 +156,13 @@ export const log = {
    * @param context - Optional context object
    */
   warn: (message: string, context?: unknown): void => {
-    if (context !== undefined) {
-      appLogger.warn({ context }, message)
-    } else {
-      appLogger.warn(message)
-    }
+    safeLog(() => {
+      if (context !== undefined) {
+        appLogger.warn({ context }, message)
+      } else {
+        appLogger.warn(message)
+      }
+    })
   },
 
   /**
@@ -129,11 +171,13 @@ export const log = {
    * @param context - Optional context object
    */
   info: (message: string, context?: unknown): void => {
-    if (context !== undefined) {
-      appLogger.info({ context }, message)
-    } else {
-      appLogger.info(message)
-    }
+    safeLog(() => {
+      if (context !== undefined) {
+        appLogger.info({ context }, message)
+      } else {
+        appLogger.info(message)
+      }
+    })
   },
 
   /**
@@ -142,11 +186,13 @@ export const log = {
    * @param context - Optional context object
    */
   debug: (message: string, context?: unknown): void => {
-    if (context !== undefined) {
-      appLogger.debug({ context }, message)
-    } else {
-      appLogger.debug(message)
-    }
+    safeLog(() => {
+      if (context !== undefined) {
+        appLogger.debug({ context }, message)
+      } else {
+        appLogger.debug(message)
+      }
+    })
   },
 
   /**
@@ -155,11 +201,13 @@ export const log = {
    * @param context - Optional context object
    */
   trace: (message: string, context?: unknown): void => {
-    if (context !== undefined) {
-      appLogger.trace({ context }, message)
-    } else {
-      appLogger.trace(message)
-    }
+    safeLog(() => {
+      if (context !== undefined) {
+        appLogger.trace({ context }, message)
+      } else {
+        appLogger.trace(message)
+      }
+    })
   },
 } as const
 


### PR DESCRIPTION
## Problem

The packaged macOS app (v0.8.x) launched to a **blank `about:blank` window** and **crashed on every Settings operation** with the fatal dialog:

> A JavaScript error occurred in the main process — `Error: the worker has exited`

This made the desktop app unusable: the window never reached `corelive.app`, and toggling any setting killed the app.

## Root cause

`electron/logger.ts` enabled the **pino-pretty thread-stream transport** whenever `NODE_ENV !== 'production'`. In a **packaged build `NODE_ENV` is unset**, so the gate wrongly evaluated to dev and spawned the pretty-print worker thread. That worker **cannot load `pino-pretty` from inside the asar archive and exits**; every subsequent `log.*()` then throws `"the worker has exited"`. Because the Electron main process has no `uncaughtException` net, the throw is fatal.

The **startup hide-app-icon sync** (`settings:setHideAppIcon`) logs on its first line, so it hit this on launch — stranding the window on `about:blank` — and every settings IPC handler logs, so each one crashed too. The handler's `catch` block also logs, so its own `try/catch` double-threw.

Confirmed via the live crash stack:

```
Error: the worker has exited
    at ThreadStream.write (.../app.asar/node_modules/thread-stream/index.js:264:19)
    at Pino.LOG [as info] (.../app.asar/node_modules/pino/lib/tools.js:78:21)
    at Object.info (.../app.asar/dist-electron/main/logger.cjs:57:17)
    at .../app.asar/dist-electron/main/index.cjs:1024:18   ← settings:setHideAppIcon
```

## Fix — two layers, both required

1. **Gate the worker transport on `NODE_ENV === 'development'`** (the value `scripts/dev.js` actually sets for `pnpm electron:dev`), extracted into a pure, unit-testable `computeShouldUsePrettyTransport(env, processType)`. Packaged and test builds leave `NODE_ENV` unset and fall through to plain JSON logging — the worker never spawns.
2. **Wrap every `log.*` call in `safeLog()`** so a dead transport can never throw into a caller. This uniformly protects each handler's catch-then-log path, so logging is best-effort telemetry that can never take down the main process.

Layer 1 keeps logging *working* in prod (sync JSON); layer 2 keeps it from ever *crashing*. A global `uncaughtException` handler was deliberately **left out** of this P0 — it changes app-wide crash semantics and deserves its own deliberate change.

## Regression test

`electron/__tests__/logger.test.ts`:
- **Behavioral (primary):** mocks pino so the underlying logger throws `"the worker has exited"`, asserts `log.*` never propagates it (incl. the catch-then-log `log.error(msg, err)` path).
- **Gate:** pure-function coverage across `development` (main) → true, packaged-unset / `production` / `test` / renderer → false, and the `DISABLE_PINO_PRETTY` opt-out.

Verified it **fails without the fix (8/8) and passes with it (8/8)**.

## Verification (packaged build)

`pnpm validate` green (277 unit + 216 electron tests, build, typecheck, lint). Built an unsigned-dir packaged app (`electron:build:dir`) and confirmed on the real `.app`:

- ✅ Window **loads `corelive.app` on launch** — not blank, no fatal dialog.
- ✅ **Relaunched with Hide App Icon ON** (the original startup crash trigger) → still loads cleanly.
- ✅ **Hide App Icon** toggle (the crash-path handler) operates with no crash, both directions.
- ✅ Completion sound / Start at Login toggles operate and **persist across a full quit + relaunch**.
- ℹ️ "Show in Menu Bar" stays disabled — it's a pre-existing intentional stub (Coming Soon), not a regression.

## Scope

P0 logger crash only. Issue #61 (opt-in DevTools / CDP remote-debug in packaged builds) is a separate follow-up PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression tests ensuring logging functions remain crash-safe when transport failures occur.

* **Bug Fixes**
  * Enhanced logging system robustness with safe error handling, preventing crashes from logging operation failures.
  * Improved pretty-print transport selection logic for better development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->