### PR TITLE
feat(electron): opt-in DevTools + CDP debug port for packaged builds

### DIFF
--- a/docs/ELECTRON_ARCHITECTURE.md
+++ b/docs/ELECTRON_ARCHITECTURE.md
@@ -757,7 +757,7 @@ CORELIVE_DEBUG=1 CORELIVE_REMOTE_DEBUGGING_PORT=9333 \
 起動後の確認：
 
 - **DevTools:** `View → Toggle Developer Tools`（Cmd+Option+I）が各ウィンドウで開けるようになります。
-- **CDP（外部ツール接続）:** Chrome で `chrome://inspect` を開く、または `curl http://localhost:9222/json` でターゲット一覧が返ればポートが開いています。
+- **CDP（外部ツール接続）:** Chrome で `chrome://inspect` を開く、または `curl http://localhost:<PORT>/json`（既定: `9222`、`CORELIVE_REMOTE_DEBUGGING_PORT` 指定時はその値）でターゲット一覧が返ればポートが開いています。
 
 | レバー                            | 何が有効になるか                              | 既定値  | どこで判定                    |
 | --------------------------------- | --------------------------------------------- | ------- | ----------------------------- |

--- a/docs/ELECTRON_ARCHITECTURE.md
+++ b/docs/ELECTRON_ARCHITECTURE.md
@@ -732,14 +732,40 @@ log.debug('Debug info')
 **開発環境:** コンソールにカラー出力  
 **本番環境:** JSON形式でファイル出力
 
-### 7.2 DevTools を開く
+### 7.2 DevTools を開く / パッケージ版をデバッグモードで起動
 
-開発環境では自動的にDevToolsが開きます。本番環境で開くには：
+開発環境（`pnpm electron:dev`）では自動的に DevTools が開きます。
 
-```javascript
-// View → Toggle Developer Tools
-// または Cmd+Option+I (macOS)
+**パッケージ版（署名/公証済みビルド）は secure-by-default です（Issue #61）。** 既定では全ウィンドウ（main / floating / braindump / settings）で DevTools が**無効**で、リモートデバッグポートも開きません。そのため既定状態では `View → Toggle Developer Tools`（Cmd+Option+I）は**何も起きません**（以前の main ウィンドウは常時 `devTools: true` だったため開けましたが、この挙動は変更されました）。
+
+パッケージ版をデバッグするには、起動時にオプトインの環境変数を渡します。これにより **全ウィンドウの DevTools が有効**になり、かつ **Chrome DevTools Protocol（CDP）ポート**が開きます。
+
+```bash
+# DevTools を有効化 + CDP ポート(既定 9222)を開いて起動
+CORELIVE_DEBUG=1 /Applications/CoreLive.app/Contents/MacOS/CoreLive
+
+# dev ビルド(electron:build:dir)の .app をデバッグ起動する場合
+CORELIVE_DEBUG=1 dist/mac-arm64/CoreLive.app/Contents/MacOS/CoreLive
+
+# CDP ポートを変更したい場合(任意・1〜65535)
+CORELIVE_DEBUG=1 CORELIVE_REMOTE_DEBUGGING_PORT=9333 \
+  /Applications/CoreLive.app/Contents/MacOS/CoreLive
 ```
+
+> **Note:** macOS の `open -a CoreLive` は環境変数をアプリへ確実に渡せないため、上記のように **実行バイナリを直接起動**してください。
+
+起動後の確認：
+
+- **DevTools:** `View → Toggle Developer Tools`（Cmd+Option+I）が各ウィンドウで開けるようになります。
+- **CDP（外部ツール接続）:** Chrome で `chrome://inspect` を開く、または `curl http://localhost:9222/json` でターゲット一覧が返ればポートが開いています。
+
+| レバー                            | 何が有効になるか                              | 既定値  | どこで判定                    |
+| --------------------------------- | --------------------------------------------- | ------- | ----------------------------- |
+| `CORELIVE_DEBUG=1`                | 全ウィンドウの DevTools + CDP ポート          | 無効    | `electron/utils/debugMode.ts` |
+| `CORELIVE_REMOTE_DEBUGGING_PORT`  | CDP ポート番号の上書き（要 `CORELIVE_DEBUG`） | `9222`  | `resolveRemoteDebuggingPort`  |
+| `advanced.enableDevTools`（設定） | DevTools のみ（CDP ポートは開かない）         | `false` | `isDevToolsEnabled`           |
+
+> **セキュリティ上の区別:** 永続設定 `advanced.enableDevTools` は DevTools の表示のみを切り替え、**CDP リモートデバッグポートは決して開きません**。常時開放される localhost デバッグポートは攻撃面になり得るため、ポート開放は毎回の起動時オプトイン（`CORELIVE_DEBUG`）を必須にしています。E2E 用の `PLAYWRIGHT_REMOTE_DEBUGGING_PORT` は従来どおり独立して機能します。
 
 ### 7.3 IPCデバッグ
 
@@ -757,12 +783,12 @@ ipcErrorHandler.getStats()
 
 ### 7.4 よくある問題
 
-| 問題               | 原因             | 解決策                             |
-| ------------------ | ---------------- | ---------------------------------- |
-| ウィンドウが白い   | CSP違反          | DevTools Console でエラー確認      |
-| IPC応答なし        | チャンネル未登録 | `ALLOWED_CHANNELS` 確認            |
-| トレイアイコンなし | アイコンパス誤り | `build/icons/` 確認                |
-| Deep Link未動作    | プロトコル未登録 | `app.isDefaultProtocolClient` 確認 |
+| 問題               | 原因             | 解決策                                                              |
+| ------------------ | ---------------- | ------------------------------------------------------------------- |
+| ウィンドウが白い   | CSP違反          | DevTools Console でエラー確認（パッケージ版は §7.2 でデバッグ起動） |
+| IPC応答なし        | チャンネル未登録 | `ALLOWED_CHANNELS` 確認                                             |
+| トレイアイコンなし | アイコンパス誤り | `build/icons/` 確認                                                 |
+| Deep Link未動作    | プロトコル未登録 | `app.isDefaultProtocolClient` 確認                                  |
 
 ---
 

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -30,6 +30,7 @@ import {
 } from './constants'
 import { log } from './logger'
 import { buildStartupPillHtml } from './startup-pill-html'
+import { isDevToolsEnabled } from './utils/debugMode'
 import type {
   WindowStateManager,
   WindowOptions,
@@ -367,7 +368,15 @@ export class WindowManager {
         allowRunningInsecureContent: false,
         sandbox: false,
         spellcheck: false,
-        devTools: true,
+        // Secure-by-default (#61): DevTools is unavailable in a packaged build
+        // unless opted in via the advanced.enableDevTools config or the
+        // CORELIVE_DEBUG launch flag. Previously this was an unconditional
+        // `true`, so the prod main window was always inspectable.
+        devTools: isDevToolsEnabled(
+          this.isDev,
+          this.configManager?.get('advanced.enableDevTools', false) ?? false,
+          process.env,
+        ),
       },
       icon: path.join(__dirname, '../build/icons/icon.icns'),
       show: false,
@@ -488,9 +497,11 @@ export class WindowManager {
         webSecurity: true,
         allowRunningInsecureContent: false,
         sandbox: false,
-        devTools:
-          this.isDev ||
-          (this.configManager?.get('advanced.enableDevTools', false) ?? false),
+        devTools: isDevToolsEnabled(
+          this.isDev,
+          this.configManager?.get('advanced.enableDevTools', false) ?? false,
+          process.env,
+        ),
       },
       frame: floatingConfig.frame,
       alwaysOnTop: floatingConfig.alwaysOnTop,
@@ -620,9 +631,11 @@ export class WindowManager {
         webSecurity: true,
         allowRunningInsecureContent: false,
         sandbox: false,
-        devTools:
-          this.isDev ||
-          (this.configManager?.get('advanced.enableDevTools', false) ?? false),
+        devTools: isDevToolsEnabled(
+          this.isDev,
+          this.configManager?.get('advanced.enableDevTools', false) ?? false,
+          process.env,
+        ),
       },
       frame: false,
       alwaysOnTop: true,
@@ -1277,9 +1290,11 @@ export class WindowManager {
         webSecurity: true,
         allowRunningInsecureContent: false,
         sandbox: false,
-        devTools:
-          this.isDev ||
-          (this.configManager?.get('advanced.enableDevTools', false) ?? false),
+        devTools: isDevToolsEnabled(
+          this.isDev,
+          this.configManager?.get('advanced.enableDevTools', false) ?? false,
+          process.env,
+        ),
       },
       show: false,
     })

--- a/electron/__tests__/debugMode.test.ts
+++ b/electron/__tests__/debugMode.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isCoreliveDebugEnabled,
+  isDevToolsEnabled,
+  resolveRemoteDebuggingPort,
+} from '../utils/debugMode'
+
+describe('isCoreliveDebugEnabled (the CORELIVE_DEBUG launch opt-in)', () => {
+  // The single env predicate behind both debug capabilities. A packaged build
+  // must stay non-debuggable unless this is explicitly turned on.
+
+  it('treats CORELIVE_DEBUG="1" as enabled', () => {
+    // Arrange + Act + Assert
+    expect(isCoreliveDebugEnabled({ CORELIVE_DEBUG: '1' })).toBe(true)
+  })
+
+  it('treats CORELIVE_DEBUG="true" (any case, padded) as enabled', () => {
+    // Arrange + Act + Assert: trimmed + case-insensitive so shell quoting/casing
+    // does not silently disable debugging.
+    expect(isCoreliveDebugEnabled({ CORELIVE_DEBUG: 'true' })).toBe(true)
+    expect(isCoreliveDebugEnabled({ CORELIVE_DEBUG: 'TRUE' })).toBe(true)
+    expect(isCoreliveDebugEnabled({ CORELIVE_DEBUG: '  true  ' })).toBe(true)
+  })
+
+  it('treats "0", "false", "", and unset as disabled (packaged default)', () => {
+    // Arrange + Act + Assert: explicit-off and absent both read as off.
+    expect(isCoreliveDebugEnabled({ CORELIVE_DEBUG: '0' })).toBe(false)
+    expect(isCoreliveDebugEnabled({ CORELIVE_DEBUG: 'false' })).toBe(false)
+    expect(isCoreliveDebugEnabled({ CORELIVE_DEBUG: '' })).toBe(false)
+    expect(isCoreliveDebugEnabled({})).toBe(false)
+  })
+})
+
+describe('isDevToolsEnabled (secure-by-default per-window DevTools gate)', () => {
+  // Shared by every production window (main, floating, braindump, settings).
+  // Regression for Issue #61: a default packaged build must NOT expose DevTools
+  // on any window, but each opt-in path must re-enable it.
+
+  it('enables DevTools in the local-dev main process', () => {
+    // Arrange: NODE_ENV=development → isDev true.
+
+    // Act + Assert
+    expect(isDevToolsEnabled(true, false, {})).toBe(true)
+  })
+
+  it('enables DevTools when the advanced.enableDevTools config is on', () => {
+    // Arrange: packaged (isDev false), no env flag, but the persisted config opt-in.
+
+    // Act + Assert
+    expect(isDevToolsEnabled(false, true, {})).toBe(true)
+  })
+
+  it('enables DevTools under the CORELIVE_DEBUG launch opt-in', () => {
+    // Arrange: packaged, config off, but launched with CORELIVE_DEBUG=1.
+
+    // Act + Assert
+    expect(isDevToolsEnabled(false, false, { CORELIVE_DEBUG: '1' })).toBe(true)
+  })
+
+  it('disables DevTools in a default packaged build (all opt-ins off)', () => {
+    // Arrange: packaged main process, no config opt-in, no env flag — the exact
+    // default a notarized user runs.
+
+    // Act
+    const result = isDevToolsEnabled(false, false, {})
+
+    // Assert: secure-by-default — DevTools cannot be opened on any window.
+    expect(result).toBe(false)
+  })
+
+  it('stays disabled when CORELIVE_DEBUG is explicitly off', () => {
+    // Arrange + Act + Assert: CORELIVE_DEBUG=0 must not enable anything.
+    expect(isDevToolsEnabled(false, false, { CORELIVE_DEBUG: '0' })).toBe(false)
+  })
+})
+
+describe('resolveRemoteDebuggingPort (CDP port — env-only, off by default)', () => {
+  // Drives whether main.ts opens a --remote-debugging-port. The persisted config
+  // can NEVER reach here; only env levers open the port.
+
+  it('passes the Playwright E2E port through unchanged (highest precedence)', () => {
+    // Arrange: the existing E2E lever set by the dev-runner.
+
+    // Act + Assert: preserved verbatim so the Electron E2E suite is unaffected.
+    expect(
+      resolveRemoteDebuggingPort({ PLAYWRIGHT_REMOTE_DEBUGGING_PORT: '9222' }),
+    ).toBe('9222')
+  })
+
+  it('prefers the Playwright port over a CORELIVE_DEBUG override', () => {
+    // Arrange: both levers set; the E2E lever wins.
+
+    // Act + Assert
+    expect(
+      resolveRemoteDebuggingPort({
+        PLAYWRIGHT_REMOTE_DEBUGGING_PORT: '9000',
+        CORELIVE_DEBUG: '1',
+        CORELIVE_REMOTE_DEBUGGING_PORT: '9333',
+      }),
+    ).toBe('9000')
+  })
+
+  it('opens the default port 9222 under CORELIVE_DEBUG=1', () => {
+    // Arrange: prod debug opt-in with no explicit port.
+
+    // Act + Assert
+    expect(resolveRemoteDebuggingPort({ CORELIVE_DEBUG: '1' })).toBe('9222')
+  })
+
+  it('honors CORELIVE_REMOTE_DEBUGGING_PORT as a port override', () => {
+    // Arrange: prod debug opt-in with an explicit custom port.
+
+    // Act + Assert
+    expect(
+      resolveRemoteDebuggingPort({
+        CORELIVE_DEBUG: '1',
+        CORELIVE_REMOTE_DEBUGGING_PORT: '9333',
+      }),
+    ).toBe('9333')
+  })
+
+  it('opens no port in a default packaged build', () => {
+    // Arrange: no debug lever of any kind — the notarized default.
+
+    // Act
+    const result = resolveRemoteDebuggingPort({})
+
+    // Assert: secure-by-default — the prod app exposes no CDP surface.
+    expect(result).toBeNull()
+  })
+
+  it('does not open a port from CORELIVE_REMOTE_DEBUGGING_PORT alone', () => {
+    // Arrange: a port is set but the CORELIVE_DEBUG opt-in is NOT — the port
+    // override is inert without the deliberate debug opt-in.
+
+    // Act + Assert
+    expect(
+      resolveRemoteDebuggingPort({ CORELIVE_REMOTE_DEBUGGING_PORT: '9333' }),
+    ).toBeNull()
+  })
+
+  it('throws on an out-of-range custom port', () => {
+    // Arrange: CORELIVE_DEBUG on, but the override is above the TCP max.
+
+    // Act + Assert: surfaced loudly (mirrors the strict ELECTRON_RENDERER_URL guard).
+    expect(() =>
+      resolveRemoteDebuggingPort({
+        CORELIVE_DEBUG: '1',
+        CORELIVE_REMOTE_DEBUGGING_PORT: '70000',
+      }),
+    ).toThrow(/CORELIVE_REMOTE_DEBUGGING_PORT/)
+  })
+
+  it('throws on a non-integer custom port', () => {
+    // Arrange: CORELIVE_DEBUG on, but the override is not a plain integer.
+
+    // Act + Assert
+    expect(() =>
+      resolveRemoteDebuggingPort({
+        CORELIVE_DEBUG: '1',
+        CORELIVE_REMOTE_DEBUGGING_PORT: '9e3',
+      }),
+    ).toThrow(/CORELIVE_REMOTE_DEBUGGING_PORT/)
+  })
+})

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -63,3 +63,20 @@ export const STARTUP_PILL_WIDTH_PX = 260
 
 /** Startup-pill window height (transparent; the visible pill is centered). */
 export const STARTUP_PILL_HEIGHT_PX = 76
+
+// ============================================================================
+// Opt-in debug mode (Issue #61 — DevTools / CDP in packaged builds)
+// ============================================================================
+
+/**
+ * Chrome DevTools Protocol port opened when `CORELIVE_DEBUG` is set without an
+ * explicit `CORELIVE_REMOTE_DEBUGGING_PORT`. 9222 is Chromium's conventional
+ * remote-debugging port — the one `chrome://inspect` probes by default.
+ */
+export const DEFAULT_REMOTE_DEBUGGING_PORT = 9222
+
+/** Lowest valid TCP port — lower bound when validating a user-supplied debug port. */
+export const MIN_TCP_PORT = 1
+
+/** Highest valid TCP port (16-bit unsigned max) — upper bound for the debug port. */
+export const MAX_TCP_PORT = 65535

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -50,6 +50,7 @@ import {
   type AuthUserPayload,
   type WindowBounds,
 } from './types/ipc'
+import { resolveRemoteDebuggingPort } from './utils/debugMode'
 import { WindowManager } from './WindowManager'
 import {
   WindowStateManager,
@@ -84,19 +85,23 @@ function toWindowType(value: unknown): WindowType {
 }
 
 // ============================================================================
-// Remote Debugging for Playwright
+// Remote Debugging (Playwright E2E + opt-in prod debug — Issue #61)
 // ============================================================================
 
 /**
- * Enable remote debugging for automated testing with Playwright.
- * This allows Playwright to connect to the Electron app via Chrome DevTools Protocol.
- * Only enabled when the environment variable is set to prevent security risks in production.
+ * Open a Chrome DevTools Protocol port only when a debug opt-in is set.
+ *
+ * Two independent levers, both resolved by `resolveRemoteDebuggingPort`:
+ * - `PLAYWRIGHT_REMOTE_DEBUGGING_PORT` — the E2E suite's lever (unchanged).
+ * - `CORELIVE_DEBUG=1` — the prod debug opt-in; opens the default port (9222)
+ *   unless `CORELIVE_REMOTE_DEBUGGING_PORT` overrides it.
+ * A default packaged build sets neither, so no port is opened — the production
+ * app exposes no remote-debugging surface unless deliberately launched in debug
+ * mode. (DevTools availability is gated separately in WindowManager.)
  */
-if (process.env.PLAYWRIGHT_REMOTE_DEBUGGING_PORT) {
-  app.commandLine.appendSwitch(
-    'remote-debugging-port',
-    process.env.PLAYWRIGHT_REMOTE_DEBUGGING_PORT,
-  )
+const remoteDebuggingPort = resolveRemoteDebuggingPort(process.env)
+if (remoteDebuggingPort) {
+  app.commandLine.appendSwitch('remote-debugging-port', remoteDebuggingPort)
 }
 
 /**

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -99,7 +99,26 @@ function toWindowType(value: unknown): WindowType {
  * app exposes no remote-debugging surface unless deliberately launched in debug
  * mode. (DevTools availability is gated separately in WindowManager.)
  */
-const remoteDebuggingPort = resolveRemoteDebuggingPort(process.env)
+// Must run at module scope: Chromium reads `remote-debugging-port` during
+// browser-process init (before `app.whenReady()` resolves), so appending it
+// inside `whenReady` would be a no-op and the CDP port would never open.
+// `resolveRemoteDebuggingPort` throws on a bad `CORELIVE_REMOTE_DEBUGGING_PORT`,
+// but here — before the `app.whenReady().catch(...)` boot backstop — an
+// uncaught throw would crash startup outside the friendly fatal-error path.
+// Since this is an opt-in *debug* lever, fail soft: warn loudly (the debug user
+// who set the var needs to know it was rejected) and boot without the CDP port.
+// (The `ELECTRON_RENDERER_URL` block below also throws at module scope but is
+// left fail-loud on purpose: it's an E2E-only knob, so a typo there should abort
+// the test run rather than silently load production.)
+let remoteDebuggingPort: string | null = null
+try {
+  remoteDebuggingPort = resolveRemoteDebuggingPort(process.env)
+} catch (error) {
+  log.warn(
+    '⚠️ Ignoring invalid CORELIVE_REMOTE_DEBUGGING_PORT — no CDP port opened.',
+    error,
+  )
+}
 if (remoteDebuggingPort) {
   app.commandLine.appendSwitch('remote-debugging-port', remoteDebuggingPort)
 }

--- a/electron/utils/debugMode.ts
+++ b/electron/utils/debugMode.ts
@@ -1,0 +1,158 @@
+/**
+ * @fileoverview Debug-mode resolution for the packaged Electron app (Issue #61).
+ *
+ * Exists so a notarized production build is debuggable on demand without ever
+ * being debuggable by default. A default packaged build ships with DevTools off
+ * on every window and no remote-debugging port (secure-by-default); launching
+ * with `CORELIVE_DEBUG=1` turns DevTools on for all windows AND opens a Chrome
+ * DevTools Protocol port. Called by WindowManager (per-window
+ * `webPreferences.devTools`) and main.ts (the `remote-debugging-port` switch).
+ *
+ * Two capabilities, deliberately split so the sensitive one needs an extra step:
+ * - DevTools availability — local dev (NODE_ENV=development), the persisted
+ *   `advanced.enableDevTools` config, OR the `CORELIVE_DEBUG` launch opt-in.
+ * - CDP remote-debugging port — env-only. The persisted config can NEVER open
+ *   it: an always-open localhost debug port is the genuinely risky surface, so
+ *   it must require a deliberate per-launch env var, not a sticky setting.
+ *
+ * @module electron/utils/debugMode
+ */
+
+import {
+  DEFAULT_REMOTE_DEBUGGING_PORT,
+  MAX_TCP_PORT,
+  MIN_TCP_PORT,
+} from '../constants'
+
+/**
+ * Read-only, `process.env`-shaped string map.
+ *
+ * Typed loosely on purpose — NOT the project's augmented `NodeJS.ProcessEnv`
+ * (which requires `NODE_ENV`) — so these pure helpers accept both the real
+ * `process.env` at the call sites AND minimal `{ CORELIVE_DEBUG: '1' }` literals
+ * in unit tests, without `NODE_ENV` noise polluting every test case.
+ */
+type ProcessEnvLike = Readonly<Record<string, string | undefined>>
+
+/**
+ * Whether the `CORELIVE_DEBUG` launch opt-in is enabled — the single env
+ * predicate behind both debug capabilities; triggers when a packaged build is
+ * launched with the flag set.
+ *
+ * Accepts `'1'` or `'true'` (case-insensitive, trimmed) so `CORELIVE_DEBUG=0`,
+ * `false`, empty, and unset all read as off — a packaged build stays
+ * non-debuggable unless explicitly opted in.
+ *
+ * @param env - Process env (the main-process launch environment)
+ * @returns
+ * - true: `CORELIVE_DEBUG` is `'1'` or `'true'`
+ * - false: any other value, including unset (the packaged default)
+ * @example
+ * isCoreliveDebugEnabled({ CORELIVE_DEBUG: '1' })    // => true
+ * isCoreliveDebugEnabled({ CORELIVE_DEBUG: 'true' }) // => true
+ * isCoreliveDebugEnabled({ CORELIVE_DEBUG: '0' })    // => false
+ * isCoreliveDebugEnabled({})                         // => false (packaged default)
+ */
+export const isCoreliveDebugEnabled = (env: ProcessEnvLike): boolean => {
+  const flag = env.CORELIVE_DEBUG?.trim().toLowerCase()
+  return flag === '1' || flag === 'true'
+}
+
+/**
+ * Whether a BrowserWindow should be created with DevTools available — the shared
+ * gate for every production window (main, floating, braindump, settings) so they
+ * are uniformly debuggable or uniformly locked.
+ *
+ * True in local dev, when the persisted `advanced.enableDevTools` config is on,
+ * or under the `CORELIVE_DEBUG` launch opt-in. In a default packaged build all
+ * three are false, so DevTools cannot be opened on any window — the
+ * secure-by-default posture Issue #61 asks for.
+ *
+ * @param isDev - NODE_ENV === 'development' (the local-dev main process)
+ * @param isDevToolsConfigEnabled - Persisted `advanced.enableDevTools` value
+ * @param env - Process env (read for the `CORELIVE_DEBUG` opt-in)
+ * @returns
+ * - true: dev, config-enabled, or `CORELIVE_DEBUG` opt-in set
+ * - false: default packaged build (all three off)
+ * @example
+ * isDevToolsEnabled(true, false, {})                       // => true  (local dev)
+ * isDevToolsEnabled(false, true, {})                       // => true  (config opt-in)
+ * isDevToolsEnabled(false, false, { CORELIVE_DEBUG: '1' }) // => true  (env opt-in)
+ * isDevToolsEnabled(false, false, {})                      // => false (packaged default)
+ */
+export const isDevToolsEnabled = (
+  isDev: boolean,
+  isDevToolsConfigEnabled: boolean,
+  env: ProcessEnvLike,
+): boolean => isDev || isDevToolsConfigEnabled || isCoreliveDebugEnabled(env)
+
+/**
+ * Validate a Chrome DevTools Protocol port string: an integer in the TCP range.
+ * @param value - Raw env string (e.g. CORELIVE_REMOTE_DEBUGGING_PORT)
+ * @returns true only for an integer in [MIN_TCP_PORT, MAX_TCP_PORT]
+ * @example
+ * isValidRemoteDebuggingPort('9222')  // => true
+ * isValidRemoteDebuggingPort('70000') // => false (above 65535)
+ * isValidRemoteDebuggingPort('9e3')   // => false (not a plain integer)
+ */
+const isValidRemoteDebuggingPort = (value: string): boolean => {
+  // Plain-integer only: reject '9e3', '92.22', '-1', ' 9222 ' before Number().
+  if (!/^\d+$/.test(value)) {
+    return false
+  }
+  const port = Number(value)
+  return Number.isInteger(port) && port >= MIN_TCP_PORT && port <= MAX_TCP_PORT
+}
+
+/**
+ * Resolve the Chrome DevTools Protocol `remote-debugging-port` to open, or null
+ * — drives main.ts's decision to expose a CDP port at launch.
+ *
+ * Precedence:
+ * 1. `PLAYWRIGHT_REMOTE_DEBUGGING_PORT` — the existing E2E lever, passed through
+ *    unchanged (the dev-runner always sets a valid port), so E2E is unaffected.
+ * 2. `CORELIVE_DEBUG` opt-in — opens the default port
+ *    (`DEFAULT_REMOTE_DEBUGGING_PORT`) unless `CORELIVE_REMOTE_DEBUGGING_PORT`
+ *    overrides it.
+ * Otherwise null: a default packaged build opens no port (Issue #61).
+ *
+ * @param env - Process env (the main-process launch environment)
+ * @returns
+ * - port string: the CDP port to pass to `--remote-debugging-port`
+ * - null: no debug opt-in set — open no port (the packaged default)
+ * @throws Error if `CORELIVE_REMOTE_DEBUGGING_PORT` is set but is not a valid
+ *   integer in [MIN_TCP_PORT, MAX_TCP_PORT] (mirrors the strict
+ *   ELECTRON_RENDERER_URL guard — surface the typo loudly instead of silently
+ *   opening the wrong/no port)
+ * @example
+ * resolveRemoteDebuggingPort({ PLAYWRIGHT_REMOTE_DEBUGGING_PORT: '9222' }) // => '9222'
+ * resolveRemoteDebuggingPort({ CORELIVE_DEBUG: '1' })                      // => '9222'
+ * resolveRemoteDebuggingPort({ CORELIVE_DEBUG: '1', CORELIVE_REMOTE_DEBUGGING_PORT: '9333' }) // => '9333'
+ * resolveRemoteDebuggingPort({})                                          // => null (packaged default)
+ */
+export const resolveRemoteDebuggingPort = (
+  env: ProcessEnvLike,
+): string | null => {
+  // Existing E2E lever: preserve verbatim, highest precedence, zero behavior
+  // change for the Playwright Electron suite.
+  if (env.PLAYWRIGHT_REMOTE_DEBUGGING_PORT) {
+    return env.PLAYWRIGHT_REMOTE_DEBUGGING_PORT
+  }
+  // Prod debug opt-in: CORELIVE_DEBUG opens the CDP port on the default port,
+  // overridable with CORELIVE_REMOTE_DEBUGGING_PORT.
+  if (isCoreliveDebugEnabled(env)) {
+    const customPort = env.CORELIVE_REMOTE_DEBUGGING_PORT
+    if (customPort !== undefined && customPort !== '') {
+      if (!isValidRemoteDebuggingPort(customPort)) {
+        throw new Error(
+          `CORELIVE_REMOTE_DEBUGGING_PORT must be an integer in ` +
+            `${MIN_TCP_PORT}-${MAX_TCP_PORT} — got "${customPort}".`,
+        )
+      }
+      return customPort
+    }
+    return String(DEFAULT_REMOTE_DEBUGGING_PORT)
+  }
+  // No debug opt-in: a default packaged build exposes no remote-debugging port.
+  return null
+}


### PR DESCRIPTION
## Problem

A packaged / notarized CoreLive build had no controlled way to debug it:

- **DevTools** was off in prod for the floating / braindump / settings windows, but the **main window was `devTools: true` unconditionally** — an inconsistency the issue's Background didn't account for (it assumed every window was gated on `isDev || enableDevTools`).
- The **CDP remote-debugging port** only opened for `PLAYWRIGHT_REMOTE_DEBUGGING_PORT` (wired for the E2E suite), so there was no general prod debug entry point.

## What this adds — a single, secure-by-default debug opt-in

`CORELIVE_DEBUG=1` at launch turns on DevTools for **every** window and opens a CDP `remote-debugging-port`. Unset (the default), a packaged build ships with DevTools off everywhere and no open port.

Two capabilities, deliberately split so the sensitive one needs the explicit step:

| Lever | Enables | Default | Opens CDP port? |
| --- | --- | --- | --- |
| `CORELIVE_DEBUG=1` (env) | DevTools on all windows + CDP port | off | ✅ |
| `CORELIVE_REMOTE_DEBUGGING_PORT=<port>` (env) | overrides the CDP port (needs `CORELIVE_DEBUG`) | `9222` | — |
| `advanced.enableDevTools` (persisted config) | DevTools only | `false` | ❌ never |

The persisted config can flip DevTools but can **never** open the CDP port — an always-open localhost debug port is the genuinely risky surface, so it requires a per-launch env var, mirroring the existing `PLAYWRIGHT_REMOTE_DEBUGGING_PORT` guard ("Only enabled when the environment variable is set to prevent security risks in production").

## ⚠️ Behavior change (disclosed)

The main window was `devTools: true` **unconditionally**, so a prod build could always open DevTools on it via `View → Toggle Developer Tools`. It is **now gated** like the other windows, so a default packaged build can no longer open DevTools on any window unless launched in debug mode.

This is the issue's explicit secure-by-default intent (AC #1: *"cannot [open DevTools] when [the opt-in] is unset (default)"*), and the issue's own Background already assumed the main window was gated. To debug the main window now, launch with `CORELIVE_DEBUG=1` (one env var) — see docs §7.2.

## Implementation

- **`electron/utils/debugMode.ts`** (new) — three pure, unit-tested helpers:
  - `isDevToolsEnabled(isDev, configEnabled, env)` — shared per-window gate.
  - `resolveRemoteDebuggingPort(env)` — the CDP port string to open, or `null` (validates a custom port to 1–65535, throwing on garbage like the `ELECTRON_RENDERER_URL` guard does).
  - `isCoreliveDebugEnabled(env)` — the `CORELIVE_DEBUG` predicate.
- **`electron/WindowManager.ts`** — all four production windows (main, floating, braindump, settings) call `isDevToolsEnabled`. The startup-pill stays `devTools: false` (a transient ~1s window with no debugging value).
- **`electron/main.ts`** — opens `--remote-debugging-port` via `resolveRemoteDebuggingPort(process.env)`. The Playwright path is unchanged (highest precedence).
- **`electron/constants.ts`** — `DEFAULT_REMOTE_DEBUGGING_PORT` (9222), `MIN_TCP_PORT`, `MAX_TCP_PORT`.
- **`docs/ELECTRON_ARCHITECTURE.md` §7.2** — rewritten launch recipe (`CORELIVE_DEBUG=1` + direct-binary example) and corrects the now-false "Toggle Developer Tools works in prod by default" note.

## Acceptance criteria

- [x] **A prod build can open DevTools when the opt-in is set, and cannot when unset (default).** — `isDevToolsEnabled` gate; verified on a packaged build below.
- [x] **A prod build exposes a CDP port only when the opt-in is set.** — `resolveRemoteDebuggingPort` returns `null` by default; verified by curl below.
- [x] **Default packaged behavior is secure-by-default (DevTools closed, no open debug port).** — main window brought in line; no port by default.
- [x] **Documented how to launch in debug mode (flag/env name + example).** — §7.2.
- [x] **All production windows honor the flag (main, floating navigator, braindump, + settings).** — unified gate; identical call at all four sites.

## Tests

`electron/__tests__/debugMode.test.ts` (16): the secure-by-default invariants (`isDevToolsEnabled(false, false, {}) === false`, `resolveRemoteDebuggingPort({}) === null`), each opt-in path, Playwright-port precedence, the custom-port override, and the invalid-port throw.

`pnpm validate` green (277 web unit + 232 electron tests, build, typecheck, lint).

## Verification (packaged, **signed + notarized** `electron:build:dir`)

Same build, same action — opposite results gated purely by the env opt-in:

| Check | Default launch | `CORELIVE_DEBUG=1` launch |
| --- | --- | --- |
| `curl localhost:9222/json/version` | ❌ connection refused (curl exit 7, no listener on 9222) | ✅ `Chrome/148… Electron/42.0.1 corelive/0.8.1` + `webSocketDebuggerUrl`, `lsof` shows `127.0.0.1:9222 (LISTEN)` |
| ⌥⌘I on main window | no-op — no DevTools panel | ✅ DevTools panel opens (Console attached) |

The app loads `corelive.app/home` on launch in both modes (no `about:blank`, no crash — the PR #63 logger fix is in this build too). The CDP port binds to `127.0.0.1` only.

## Scope

Issue #61 only. The PR1 logger crash fix (#63) is already merged.

Closes #61

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in debug mode for packaged apps via environment variables and a configurable remote debugging port.

* **Security**
  * Packaged builds disable developer tools and remote debugging by default to improve security.

* **Documentation**
  * Updated architecture guide with setup, verification steps, comparison table, and a rewritten troubleshooting table.

* **Tests**
  * Added tests covering debug-mode enablement and remote-debugging port resolution and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->