### PR TITLE
fix(electron): bundle ms into asar to restore broken auto-update (v0.8.2)

### DIFF
--- a/electron/__tests__/packaged-runtime-deps.test.ts
+++ b/electron/__tests__/packaged-runtime-deps.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Regression guard for the v0.8.0/v0.8.1 packaging bug: electron-builder + pnpm
+ * (nodeLinker: hoisted) silently drops LEAF transitive packages from the
+ * production app.asar even though they are installed locally. The fix is to
+ * promote each needed leaf to a DIRECT dependency in package.json, which forces
+ * electron-builder's dependency walk to bundle it.
+ *
+ * This is a TEST, not just a comment, because `ms`/`wrappy` are never imported
+ * directly in our source — a routine `depcheck`/`knip`/manual cleanup would flag
+ * them as "unused" and remove them, silently reintroducing the bug. Removing
+ * either must fail loudly in CI (test.yml runs `pnpm test:electron`) instead of
+ * shipping a broken desktop build that only fails at runtime on a user's Mac.
+ */
+
+// Arrange (shared): read the real package.json from the repo root. vitest runs
+// with cwd = project root, so this resolves the same file electron-builder reads.
+const packageJson = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'package.json'), 'utf8'),
+) as { dependencies?: Record<string, string> }
+const dependencies = packageJson.dependencies ?? {}
+
+describe('packaged Electron bundles the leaf deps electron-builder+pnpm would drop', () => {
+  // `ms` is REQUIRED at runtime: debug/src/common.js calls require('ms'), and
+  // the chain is debug <- builder-util-runtime <- electron-updater. With `ms`
+  // absent from the asar, electron-updater throws MODULE_NOT_FOUND at load time,
+  // so the WHOLE auto-update mechanism dies — silently, because the failure is
+  // caught and the app keeps running but can never update itself again.
+  it('keeps "ms" as a direct dependency so packaged electron-updater can load and auto-update stays alive', () => {
+    // Act
+    const declaredMsRange = dependencies.ms
+
+    // Assert: present as a non-empty semver range (version is free to bump; the
+    // invariant is only that ms remains a declared direct dependency).
+    expect(typeof declaredMsRange).toBe('string')
+    expect(declaredMsRange).toBeTruthy()
+  })
+
+  // `wrappy` is DEFENSIVE only — it is NOT in electron-updater's require closure.
+  // It was reachable solely via the pino-pretty crash path (pino-pretty -> pump
+  // -> once -> wrappy), which the logger gate (computeShouldUsePrettyTransport)
+  // already neutralizes in packaged builds. It is pinned as belt-and-suspenders
+  // so that path can never crash on a missing leaf if the gate ever regresses.
+  it('keeps "wrappy" as a direct dependency to harden the pino-pretty crash path against the leaf drop', () => {
+    // Act
+    const declaredWrappyRange = dependencies.wrappy
+
+    // Assert
+    expect(typeof declaredWrappyRange).toBe('string')
+    expect(declaredWrappyRange).toBeTruthy()
+  })
+})

--- a/next.config.js
+++ b/next.config.js
@@ -38,6 +38,11 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  // Hide the Next.js dev tools indicator (the floating "N" logo overlay shown
+  // only in `next dev`). It otherwise floats over the app UI during local web
+  // and Electron development. Compile/runtime errors are still surfaced, and
+  // this setting has no effect on production builds.
+  devIndicators: false,
   // Turbopack configuration (Next.js 16+)
   // code-inspector-plugin enables Alt+click to jump to source code in IDE
   // Next dev evaluates this config before it sets NODE_ENV=development, so we

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corelive",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A comprehensive design system and web application built with Next.js, featuring authentication, database integration, and desktop support",
   "author": "Ryota Murakami <dojce1048@gmail.com> (https://github.com/ryota-murakami)",
   "private": true,
@@ -114,6 +114,7 @@
     "html-to-image": "^1.11.13",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.14.0",
+    "ms": "^2.1.3",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "pino": "^10.3.1",
@@ -133,6 +134,7 @@
     "thread-stream": "^4.1.0",
     "ts-pattern": "^5.9.0",
     "vaul": "^1.1.2",
+    "wrappy": "^1.0.2",
     "zod": "^4.4.3"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.6)
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -233,6 +236,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      wrappy:
+        specifier: ^1.0.2
+        version: 1.0.2
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Summary

Fixes the production Electron crash reported on v0.8.0 **and** a second defect found during investigation: auto-update has been silently dead since v0.8.0.

## Root cause (two coupled defects)

**A — `wrappy` crash (the reported dialog).** The pino-pretty gate used `NODE_ENV !== 'production'`; packaged builds leave `NODE_ENV` unset, so it read as dev, attached the pino-pretty worker-thread transport, and the worker couldn't load `wrappy` from inside the asar → async uncaught exception → fatal dialog. **Already fixed on main** by 79cf175 (gate → `=== 'development'`), but unreleased.

**B — `ms` missing → auto-update dead (this PR).** electron-builder + pnpm (`nodeLinker: hoisted`) silently drops leaf transitive deps from the production app.asar. `ms` was absent, so the chain `debug ← builder-util-runtime ← electron-updater` threw `MODULE_NOT_FOUND` at load time → the whole auto-update mechanism was dead (the failure is caught, so the app ran but never self-updated).

## Fix

- Promote `ms` (required by electron-updater's `debug`) and `wrappy` (defensive only — the pino-pretty path is already neutralized by the logger gate) to **direct dependencies** so electron-builder's dependency walk bundles them into the asar.
- Add an electron-suite **regression test** (`electron/__tests__/packaged-runtime-deps.test.ts`) so a future `depcheck`/`knip` cleanup can't strip them as "unused" and silently reintroduce the bug.
- Bump version to **0.8.2**.

## Verification (runtime, not just source reading)

Rebuilt the signed + notarized packaged app and launched it with `NODE_ENV` unset (the production condition):

- `ms` / `wrappy` now present in `app.asar` (were missing pre-fix).
- MenuManager loads clean — was `❌ Failed to lazy load MenuManager` + `MODULE_NOT_FOUND`.
- electron-updater now runs: `Checking for update...`.
- All main-process logs are plain JSON → pino-pretty not loaded → re-confirms the Defect-A gate fix in the same run.
- The residual `app-update.yml` ENOENT is a `--dir`-build-only artifact; the real installed v0.8.0 release **contains** that file (electron-builder emits it only for publish targets), so the dmg release auto-updates correctly.

`pnpm validate` green (test 277 passed, build compiled, lint + typecheck clean); full `pnpm test:electron` green (234 tests, incl. the 2 new).

## Release note

v0.8.0's auto-update is dead (verified), so users must **download v0.8.2 manually once** from GitHub Releases; auto-update then works for every release after this one.

v0.8.2 also carries the unreleased pino-pretty crash fix (79cf175) and the opt-in DevTools/CDP debug port (inactive unless `CORELIVE_DEBUG` is set).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the development tools indicator from local development environments for a cleaner interface.

* **Chores**
  * Version bumped to 0.8.2.
  * Added regression test coverage for dependency packaging verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->