### PR TITLE
fix(e2e): await server-assigned todo id before delete to fix flaky web E2E

### DIFF
--- a/e2e/web/todo-app.spec.ts
+++ b/e2e/web/todo-app.spec.ts
@@ -94,6 +94,14 @@ test.describe('TODO App E2E Tests', () => {
     await page.getByRole('button', { name: 'Add', exact: true }).click()
     const todoCheckbox = page.getByRole('checkbox', { name: todoText })
     await expect(todoCheckbox).toBeVisible()
+    // Wait for the create mutation to settle with a positive server ID before
+    // deleting. Optimistic create assigns a temporary negative id ("todo--<ts>");
+    // deleting then targets that phantom id, the server no-ops, and create's
+    // refetch brings the real row back — leaving the checkbox visible and the
+    // assertion failing. Matches the toggle/uncheck tests' positive-id guard.
+    await expect(todoCheckbox).toHaveAttribute('id', /^todo-[^-]/, {
+      timeout: 5000,
+    })
 
     // Act — click the per-row Delete button (sr-only labelled)
     const todoItem = page.locator('.rounded-lg.border').filter({


### PR DESCRIPTION
## What

The **E2E Tests (Web) / E2E Web (todo-app)** job failed on the `main`-push run after merging #65 (run [27190763402](https://github.com/laststance/corelive/actions/runs/27190763402)). The same suite **passed** on #65's `pull_request` run — a classic timing-dependent flake.

## Root cause

`should delete a TODO item` races with the optimistic create:

1. `createMutation.onMutate` inserts a temp row with a **negative id** (`-Date.now()`) → the checkbox briefly carries `id="todo--<ts>"` (`src/hooks/useTodoMutations.ts:97`).
2. The test asserted only `toBeVisible()` and then clicked **Delete** — targeting that phantom negative id **before** the create mutation settled.
3. The server delete no-ops on the nonexistent negative id; create's `onSettled` refetch then brings the **real** row (`todo-13`) back → checkbox stays visible → `.not.toBeVisible()` fails.
4. `resetDatabase` is `beforeAll` (not `beforeEach`), so each CI retry re-seeded another `"Delete TODO test"` row, escalating into **strict-mode violations** (2 → 3 matches) — exactly what the logs show.

## Fix

Wait for a positive server id before deleting:

```ts
await expect(todoCheckbox).toHaveAttribute('id', /^todo-[^-]/, { timeout: 5000 })
```

This mirrors the **toggle / uncheck / checkbox-only** sibling tests in the same file, which already guard the same way (and are green in CI). The delete now targets the reconciled real row, making the assertion deterministic. Removes the race rather than masking it.

## Test plan

- [x] `eslint` clean on the changed file
- [ ] CI **E2E Web (todo-app)** goes green (authoritative — local web E2E is blocked by a machine-specific Playwright `webServer`/loopback issue, unrelated to this change)

> Note (non-blocking, optional follow-up): the same race is a latent *product* bug — a real user who clicks Add then Delete within the create round-trip hits the negative id, the server no-ops, and the row reappears. Rare; out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved E2E test reliability for todo deletion scenarios by enhancing test sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->