### PR TITLE
feat(electron): enable Show in Menu Bar toggle with restart-truthful persistence

### DIFF
--- a/electron/SystemTrayManager.ts
+++ b/electron/SystemTrayManager.ts
@@ -69,6 +69,16 @@ export class SystemTrayManager {
    */
   async createTray(): Promise<Tray | null> {
     try {
+      // Idempotent: this method is reached from two paths that can interleave —
+      // boot (SystemIntegrationErrorHandler.initializeTrayWithErrorHandling) and
+      // the live "Show in Menu Bar" toggle / ElectronStartupSync re-push (via
+      // setMenuBarVisible). A second call while a tray already exists would
+      // overwrite `this.tray` and orphan the previous native Tray (a leaked
+      // menu-bar icon), so short-circuit and return the live one.
+      if (this.hasTray()) {
+        return this.tray
+      }
+
       if (!this.isSystemTraySupported()) {
         log.warn('System tray is not supported on this platform')
         this.tray = null
@@ -683,8 +693,9 @@ export class SystemTrayManager {
     if (!this.isSystemTraySupported()) {
       return true
     }
-    // Already visible: createTray() is not idempotent (it would leak a second
-    // Tray), so short-circuit when one is already on screen.
+    // Already visible: short-circuit to keep the existing tray. createTray() is
+    // now idempotent on its own, but returning early also skips the redundant
+    // icon/menu rebuild and just re-asserts the close-to-tray routing below.
     if (this.hasTray()) {
       // A live tray exists, so close should hide-to-tray, not minimize.
       this.setFallbackMode(false)

--- a/electron/SystemTrayManager.ts
+++ b/electron/SystemTrayManager.ts
@@ -45,6 +45,13 @@ export class SystemTrayManager {
   /** Tray instance */
   private tray: Tray | null
 
+  /**
+   * In-flight createTray() promise, memoized so concurrent callers share one
+   * native Tray instead of each constructing their own during the async window
+   * between the hasTray() guard and the this.tray assignment.
+   */
+  private trayCreationPromise: Promise<Tray | null> | null
+
   /** Flag to distinguish quit vs minimize */
   private isQuitting: boolean
 
@@ -57,24 +64,52 @@ export class SystemTrayManager {
   constructor(windowManager: WindowManager) {
     this.windowManager = windowManager
     this.tray = null
+    this.trayCreationPromise = null
     this.isQuitting = false
     this.fallbackMode = false
     this.hasShownTrayNotification = false
   }
 
   /**
-   * Creates the system tray with icon and context menu.
+   * Creates the system tray, idempotent under both sequential and concurrent
+   * calls. Reached from two paths that can interleave — boot
+   * (SystemIntegrationErrorHandler.initializeTrayWithErrorHandling) and the live
+   * "Show in Menu Bar" toggle / ElectronStartupSync re-push (via
+   * setMenuBarVisible). The synchronous hasTray() guard alone does not cover the
+   * await inside createTrayInternal(), so a second caller could slip in before
+   * this.tray is assigned and build a duplicate native Tray (orphaning a menu-bar
+   * icon); memoizing the in-flight promise makes concurrent callers share one.
    *
-   * @returns The tray instance or null if failed
+   * @returns The tray instance or null if creation failed.
    */
   async createTray(): Promise<Tray | null> {
+    // A creation is already running: share its promise so concurrent callers
+    // receive the same tray instead of racing to build a second one.
+    if (this.trayCreationPromise) {
+      return this.trayCreationPromise
+    }
+    this.trayCreationPromise = this.createTrayInternal()
     try {
-      // Idempotent: this method is reached from two paths that can interleave —
-      // boot (SystemIntegrationErrorHandler.initializeTrayWithErrorHandling) and
-      // the live "Show in Menu Bar" toggle / ElectronStartupSync re-push (via
-      // setMenuBarVisible). A second call while a tray already exists would
-      // overwrite `this.tray` and orphan the previous native Tray (a leaked
-      // menu-bar icon), so short-circuit and return the live one.
+      return await this.trayCreationPromise
+    } finally {
+      // Clear so a later call (re-show after a hide/destroy, or retry after a
+      // failed attempt that returned null) can create the tray again.
+      this.trayCreationPromise = null
+    }
+  }
+
+  /**
+   * Actual tray creation logic, serialized by createTray()'s in-flight guard.
+   * Returns null (never throws) on any failure so createTray()'s finally always
+   * clears the memoized promise and a subsequent call may retry.
+   *
+   * @returns The tray instance or null if creation failed.
+   */
+  private async createTrayInternal(): Promise<Tray | null> {
+    try {
+      // Sequential idempotency: a tray already exists (e.g. boot created it
+      // before a toggle re-push), so return it rather than overwriting and
+      // orphaning the previous native Tray.
       if (this.hasTray()) {
         return this.tray
       }

--- a/electron/__tests__/SystemTrayManager.menu-bar.test.ts
+++ b/electron/__tests__/SystemTrayManager.menu-bar.test.ts
@@ -151,4 +151,22 @@ describe('SystemTrayManager.setMenuBarVisible (Show in Menu Bar toggle)', () => 
     // Assert: the UI must NOT persist "shown" when no tray actually appeared.
     expect(didApply).toBe(false)
   })
+
+  it('createTray() keeps the existing tray instead of leaking a second one', async () => {
+    // Arrange: a tray is already on screen. createTray() is reached from BOTH
+    // boot (SystemIntegrationErrorHandler) and the live toggle / startup sync,
+    // and those paths can interleave — a second build would overwrite this.tray
+    // and orphan the first native Tray (a leaked menu-bar icon).
+    const { manager } = createManager()
+    primeExistingTray(manager)
+    const supportedSpy = vi.spyOn(manager, 'isSystemTraySupported')
+
+    // Act
+    const result = await manager.createTray()
+
+    // Assert: the live tray is returned and the whole build path is skipped
+    // (the idempotency guard short-circuits before the platform check).
+    expect(result).toBe(fakeTray)
+    expect(supportedSpy).not.toHaveBeenCalled()
+  })
 })

--- a/electron/__tests__/SystemTrayManager.menu-bar.test.ts
+++ b/electron/__tests__/SystemTrayManager.menu-bar.test.ts
@@ -169,4 +169,42 @@ describe('SystemTrayManager.setMenuBarVisible (Show in Menu Bar toggle)', () => 
     expect(result).toBe(fakeTray)
     expect(supportedSpy).not.toHaveBeenCalled()
   })
+
+  it('createTray() builds only one native tray when two creations race in flight', async () => {
+    // Arrange: NO tray exists yet, so the sync hasTray() guard does not apply.
+    // Let createTray run for real (the other tests prime a tray or mock it
+    // wholesale) and make createTrayWithRetry yield once before returning — that
+    // await is the interleave window where, without the in-flight promise guard,
+    // a second concurrent caller slips past hasTray() and builds a second tray.
+    const { manager } = createManager()
+    vi.spyOn(manager, 'isSystemTraySupported').mockReturnValue(true)
+    // createTrayIcon reads the filesystem; a truthy stub gets past its null check
+    // (returning null would short-circuit before the race point).
+    vi.spyOn(manager, 'createTrayIcon').mockReturnValue(
+      {} as unknown as ReturnType<SystemTrayManager['createTrayIcon']>,
+    )
+    const createTrayWithRetrySpy = vi
+      .spyOn(manager, 'createTrayWithRetry')
+      .mockImplementation(async () => {
+        // Yield so the second createTray() call runs before this.tray is set.
+        await Promise.resolve()
+        return fakeTray
+      })
+    // Post-construction steps touch the native tray; stub them to no-ops.
+    vi.spyOn(manager, 'setTrayTooltipSafely').mockReturnValue(true)
+    vi.spyOn(manager, 'setupTrayMenuSafely').mockReturnValue(true)
+    vi.spyOn(manager, 'setupTrayEventsSafely').mockReturnValue(true)
+
+    // Act: fire two creations concurrently.
+    const [first, second] = await Promise.all([
+      manager.createTray(),
+      manager.createTray(),
+    ])
+
+    // Assert: the native tray is constructed exactly once and both callers get
+    // that same instance — no orphaned, leaked menu-bar icon.
+    expect(createTrayWithRetrySpy).toHaveBeenCalledTimes(1)
+    expect(first).toBe(fakeTray)
+    expect(second).toBe(fakeTray)
+  })
 })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1783,10 +1783,12 @@ function setupIPCHandlers(): void {
     }
   })
 
-  // Show in Menu Bar IPC handler — toggles the tray (menu-bar) icon live.
-  // Note: live-only by design (T11 scope). The tray is re-created at the next
-  // launch regardless of this setting; restart-persistence would be a separate
-  // settings-mirror feature. See SystemTrayManager.setMenuBarVisible.
+  // Show in Menu Bar IPC handler — shows/hides the tray (menu-bar) icon. Boot
+  // always (re)creates the tray (SystemIntegrationErrorHandler), but the
+  // renderer's ElectronStartupSync re-pushes the persisted Redux/localStorage
+  // value at every launch, so an "off" choice survives restarts: the tray
+  // appears at boot, then the startup sync hides it (the same correct-after-
+  // boot pattern as setHideAppIcon). See SystemTrayManager.setMenuBarVisible.
   typedHandle('settings:setShowInMenuBar', async (_event, show) => {
     try {
       if (!systemTrayManager) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1558,7 +1558,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
 
     /**
-     * Set show in menu bar - not yet implemented.
+     * Show or hide the macOS menu-bar (tray) icon — bridges to
+     * `settings:setShowInMenuBar`, which calls SystemTrayManager.setMenuBarVisible.
+     * @param show - true creates/keeps the tray icon, false tears it down.
+     * @returns Promise<boolean> success; false on a thrown error or when the
+     *   handler could not apply the change (e.g. tray creation failed).
      */
     setShowInMenuBar: async (show: boolean): Promise<boolean> => {
       if (typeof show !== 'boolean') {

--- a/electron/types/ipc.ts
+++ b/electron/types/ipc.ts
@@ -740,7 +740,7 @@ export interface IPCChannels {
     request: boolean
     response: boolean
   }
-  /** Placeholder for future SystemTrayManager integration. */
+  /** macOS: show/hide the tray (menu-bar) icon via `SystemTrayManager.setMenuBarVisible`. */
   'settings:setShowInMenuBar': {
     request: boolean
     response: boolean

--- a/src/components/electron/ElectronSettingsPage.tsx
+++ b/src/components/electron/ElectronSettingsPage.tsx
@@ -117,9 +117,14 @@ export const ElectronSettingsPage = memo(
             if (success) {
               dispatch(setShowInMenuBar(checked))
             } else {
-              // IPC call failed (feature not implemented) - log but don't update state
+              // IPC returned false: the tray could not be created (e.g.
+              // createTray failed), so don't persist a "shown" state that
+              // never actually appeared. ElectronStartupSync re-pushes the
+              // persisted value at next launch, keeping the toggle truthful.
               if (process.env.NODE_ENV === 'development') {
-                console.warn('Menu bar visibility change not yet implemented')
+                console.error(
+                  'Failed to update menu bar visibility: IPC returned false',
+                )
               }
             }
           } catch (error) {
@@ -207,25 +212,19 @@ export const ElectronSettingsPage = memo(
             </div>
 
             {/*
-              Show in Menu Bar — stays disabled until `showInMenuBar` moves into
-              the main-process ConfigManager so the boot-time tray creation
-              (SystemIntegrationErrorHandler, which always creates the tray) can
-              read it. The IPC handler is live and truthful (T11 wired
-              SystemTrayManager.setMenuBarVisible), but it only toggles the tray
-              for the current session; persisting "hidden" across restarts is a
-              separate change. Un-gating before then would let the toggle lie
-              (off persists, yet the tray reappears at next launch).
+              Show in Menu Bar — the IPC handler shows/hides the tray live
+              (SystemTrayManager.setMenuBarVisible), and ElectronStartupSync
+              re-pushes the persisted value at every launch so an "off" choice
+              survives restarts (boot creates the tray, then the startup sync
+              hides it — same correct-after-boot pattern as Hide App Icon).
             */}
-            <div className="flex items-center justify-between opacity-60">
+            <div className="flex items-center justify-between">
               <div className="space-y-0.5">
                 <Label
                   htmlFor="show-in-menu-bar"
                   className="text-sm font-medium"
                 >
-                  Show in Menu Bar{' '}
-                  <span className="text-xs text-muted-foreground">
-                    (Coming Soon)
-                  </span>
+                  Show in Menu Bar
                 </Label>
                 <p className="text-xs text-muted-foreground">
                   Display CoreLive in the system menu bar
@@ -235,7 +234,6 @@ export const ElectronSettingsPage = memo(
                 id="show-in-menu-bar"
                 checked={showInMenuBar}
                 onCheckedChange={handleShowInMenuBarChange}
-                disabled
               />
             </div>
 

--- a/src/components/electron/ElectronStartupSync.test.tsx
+++ b/src/components/electron/ElectronStartupSync.test.tsx
@@ -6,11 +6,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import electronSettingsReducer, {
   setHideAppIcon,
+  setShowInMenuBar,
 } from '@/lib/redux/slices/electronSettingsSlice'
 
 import { ElectronStartupSync } from './ElectronStartupSync'
 
 const setHideAppIconMock = vi.fn().mockResolvedValue(true)
+const setShowInMenuBarMock = vi.fn().mockResolvedValue(true)
 
 // Toggle for the mocked Electron environment detector. Tests flip this
 // before rendering to exercise both Electron and web code paths.
@@ -20,7 +22,7 @@ vi.mock('../../../electron/utils/electron-client', () => ({
   isElectronEnvironment: () => isElectronMock.value,
 }))
 
-const buildStore = (hideAppIcon: boolean) =>
+const buildStore = (hideAppIcon: boolean, showInMenuBar = true) =>
   configureStore({
     reducer: {
       electronSettings: electronSettingsReducer,
@@ -28,19 +30,28 @@ const buildStore = (hideAppIcon: boolean) =>
     preloadedState: {
       electronSettings: {
         hideAppIcon,
-        showInMenuBar: true,
+        showInMenuBar,
         startAtLogin: false,
       },
     },
   })
 
-const wrapWithStore = (children: ReactNode, hideAppIcon: boolean) => (
-  <Provider store={buildStore(hideAppIcon)}>{children}</Provider>
+const wrapWithStore = (
+  children: ReactNode,
+  hideAppIcon: boolean,
+  showInMenuBar = true,
+) => (
+  <Provider store={buildStore(hideAppIcon, showInMenuBar)}>{children}</Provider>
 )
 
 const installElectronAPI = (
   api:
-    | { settings?: { setHideAppIcon?: typeof setHideAppIconMock } }
+    | {
+        settings?: {
+          setHideAppIcon?: typeof setHideAppIconMock
+          setShowInMenuBar?: typeof setShowInMenuBarMock
+        }
+      }
     | undefined,
 ): void => {
   Object.defineProperty(window, 'electronAPI', {
@@ -53,10 +64,12 @@ const installElectronAPI = (
 describe('ElectronStartupSync', () => {
   beforeEach(() => {
     setHideAppIconMock.mockClear()
+    setShowInMenuBarMock.mockClear()
     isElectronMock.value = true
     installElectronAPI({
       settings: {
         setHideAppIcon: setHideAppIconMock,
+        setShowInMenuBar: setShowInMenuBarMock,
       },
     })
   })
@@ -69,6 +82,24 @@ describe('ElectronStartupSync', () => {
       await waitFor(() => {
         expect(setHideAppIconMock).toHaveBeenCalledWith(hideAppIcon)
       })
+      // Cross-check the OTHER setting got its own distinct literal (the store's
+      // showInMenuBar default is true), so a selector/value swap between the two
+      // independent effects can never silently pass this case.
+      expect(setShowInMenuBarMock).toHaveBeenCalledWith(true)
+    },
+  )
+
+  it.each([true, false])(
+    'forwards persisted showInMenuBar=%s to the main process on mount',
+    async (showInMenuBar) => {
+      render(wrapWithStore(<ElectronStartupSync />, false, showInMenuBar))
+
+      await waitFor(() => {
+        expect(setShowInMenuBarMock).toHaveBeenCalledWith(showInMenuBar)
+      })
+      // Cross-check the dock-icon effect sent its own distinct literal (false),
+      // guarding against a swap where one effect forwards the other's value.
+      expect(setHideAppIconMock).toHaveBeenCalledWith(false)
     },
   )
 
@@ -80,6 +111,7 @@ describe('ElectronStartupSync', () => {
     // Yield once so any pending effect would have flushed.
     await Promise.resolve()
     expect(setHideAppIconMock).not.toHaveBeenCalled()
+    expect(setShowInMenuBarMock).not.toHaveBeenCalled()
   })
 
   it('does not throw when window.electronAPI is undefined', async () => {
@@ -90,21 +122,43 @@ describe('ElectronStartupSync', () => {
     ).not.toThrow()
     await Promise.resolve()
     expect(setHideAppIconMock).not.toHaveBeenCalled()
+    expect(setShowInMenuBarMock).not.toHaveBeenCalled()
   })
 
   it('does not throw when an old preload exposes settings but not setHideAppIcon', async () => {
     // Arrange: an OUTDATED desktop app exposes the `settings` namespace but
     // predates the `setHideAppIcon` method this effect calls. Mounted in the
     // root layout, a synchronous TypeError here would bubble past error.tsx to
-    // global-error and blank every route. The method guard must skip the call.
-    installElectronAPI({ settings: {} })
+    // global-error and blank every route. The method guard must skip the call —
+    // and crucially, the still-present setShowInMenuBar sync must run anyway.
+    installElectronAPI({ settings: { setShowInMenuBar: setShowInMenuBarMock } })
 
-    // Act + Assert: mounting must not throw, and no IPC is attempted.
+    // Act + Assert: mounting must not throw; the missing method is skipped while
+    // the independent menu-bar sync still fires (guards are per-method).
     expect(() =>
       render(wrapWithStore(<ElectronStartupSync />, true)),
     ).not.toThrow()
-    await Promise.resolve()
+    await waitFor(() => {
+      expect(setShowInMenuBarMock).toHaveBeenCalledWith(true)
+    })
     expect(setHideAppIconMock).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when an old preload exposes settings but not setShowInMenuBar', async () => {
+    // Arrange: the mirror case — an OUTDATED preload has setHideAppIcon but not
+    // the newer setShowInMenuBar. The menu-bar guard must skip its call without
+    // suppressing the hideAppIcon sync (independent per-method guards).
+    installElectronAPI({ settings: { setHideAppIcon: setHideAppIconMock } })
+
+    // Act + Assert: no throw; the present method still syncs, the missing one is
+    // skipped.
+    expect(() =>
+      render(wrapWithStore(<ElectronStartupSync />, true)),
+    ).not.toThrow()
+    await waitFor(() => {
+      expect(setHideAppIconMock).toHaveBeenCalledWith(true)
+    })
+    expect(setShowInMenuBarMock).not.toHaveBeenCalled()
   })
 
   it('logs an error when setHideAppIcon rejects', async () => {
@@ -122,6 +176,28 @@ describe('ElectronStartupSync', () => {
     await waitFor(() => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         '[ElectronStartupSync] Failed to sync hideAppIcon:',
+        ipcError,
+      )
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('logs an error when setShowInMenuBar rejects', async () => {
+    // Mirror of the hideAppIcon failure path: a rejected menu-bar sync must be
+    // surfaced under its own label so the two settings' failures are
+    // distinguishable in logs.
+    const ipcError = new Error('tray unavailable')
+    setShowInMenuBarMock.mockRejectedValueOnce(ipcError)
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    render(wrapWithStore(<ElectronStartupSync />, false, true))
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[ElectronStartupSync] Failed to sync showInMenuBar:',
         ipcError,
       )
     })
@@ -150,6 +226,25 @@ describe('ElectronStartupSync', () => {
     consoleErrorSpy.mockRestore()
   })
 
+  it('logs an error when setShowInMenuBar resolves to false', async () => {
+    // Same false-return contract as hideAppIcon: a `false` resolution means the
+    // tray never appeared, so it must be reported (not silently treated as ok).
+    setShowInMenuBarMock.mockResolvedValueOnce(false)
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    render(wrapWithStore(<ElectronStartupSync />, false, true))
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[ElectronStartupSync] Failed to sync showInMenuBar: IPC returned false',
+      )
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
+
   it('does not log an error when setHideAppIcon resolves to true', async () => {
     // Guard against false-positive logging: the success path must stay quiet.
     // If someone flipped the boolean check (`ok === true` instead of `ok === false`),
@@ -163,6 +258,27 @@ describe('ElectronStartupSync', () => {
 
     await waitFor(() => {
       expect(setHideAppIconMock).toHaveBeenCalledWith(true)
+    })
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('does not log an error when setShowInMenuBar resolves to true', async () => {
+    // Mirror of the hideAppIcon success-quiet test, but for the tray-OFF success
+    // path (showInMenuBar=false persisted, sync succeeds). The shared
+    // reportSyncFailure helper only runs through the hideAppIcon quiet test with
+    // showInMenuBar=true, so a spurious-success log gated to the menu-bar OFF
+    // branch would otherwise ship green.
+    setShowInMenuBarMock.mockResolvedValueOnce(true)
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    render(wrapWithStore(<ElectronStartupSync />, false, false))
+
+    await waitFor(() => {
+      expect(setShowInMenuBarMock).toHaveBeenCalledWith(false)
     })
     expect(consoleErrorSpy).not.toHaveBeenCalled()
 
@@ -201,5 +317,41 @@ describe('ElectronStartupSync', () => {
       expect(setHideAppIconMock).toHaveBeenCalledWith(true)
     })
     expect(setHideAppIconMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-syncs when showInMenuBar changes after mount', async () => {
+    // Mirror dep-lock for the menu-bar effect: a [showInMenuBar] → [] regression
+    // would strand the tray out of sync after a runtime toggle. Also confirms
+    // the menu-bar effect is independent of hideAppIcon — toggling the menu bar
+    // must NOT re-fire the dock-icon sync.
+    const store = configureStore({
+      reducer: { electronSettings: electronSettingsReducer },
+      preloadedState: {
+        electronSettings: {
+          hideAppIcon: false,
+          showInMenuBar: true,
+          startAtLogin: false,
+        },
+      },
+    })
+
+    render(
+      <Provider store={store}>
+        <ElectronStartupSync />
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(setShowInMenuBarMock).toHaveBeenCalledWith(true)
+    })
+
+    store.dispatch(setShowInMenuBar(false))
+
+    await waitFor(() => {
+      expect(setShowInMenuBarMock).toHaveBeenCalledWith(false)
+    })
+    expect(setShowInMenuBarMock).toHaveBeenCalledTimes(2)
+    // Independence: the dock-icon sync fired only once (mount), not again.
+    expect(setHideAppIconMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/electron/ElectronStartupSync.tsx
+++ b/src/components/electron/ElectronStartupSync.tsx
@@ -3,12 +3,16 @@
 /**
  * Electron Startup Sync
  *
- * Forwards persisted Electron settings from renderer-side localStorage
- * to the main process at startup. The hideAppIcon preference is stored
- * by redux-storage-middleware in localStorage, but the macOS dock policy
- * (`app.setActivationPolicy`) is runtime-only and resets to 'regular' on
- * every launch. Without this sync, the Settings UI shows the toggle as ON
- * while the dock icon remains visible until the user toggles it again.
+ * Forwards persisted Electron settings from renderer-side localStorage to the
+ * main process at startup. Both the `hideAppIcon` (dock policy) and
+ * `showInMenuBar` (tray icon) preferences live in localStorage via
+ * redux-storage-middleware, but their main-process effects are runtime-only and
+ * reset on every launch: the macOS dock policy (`app.setActivationPolicy`)
+ * resets to 'regular', and the tray is always (re)created at boot by
+ * SystemIntegrationErrorHandler regardless of the saved choice. Without this
+ * sync, the Settings UI would show a toggle as OFF while the dock icon /
+ * menu-bar icon stayed visible until the user toggled it again — i.e. the toggle
+ * would "lie" across restarts.
  *
  * Renders nothing. Mount once near the top of the React tree, inside
  * `<ReduxProvider>`.
@@ -18,20 +22,62 @@
 
 import { useComponentEffect } from '@/hooks/useComponentEffect'
 import { useAppSelector } from '@/lib/redux/hooks'
-import { selectHideAppIcon } from '@/lib/redux/slices/electronSettingsSlice'
+import {
+  selectHideAppIcon,
+  selectShowInMenuBar,
+} from '@/lib/redux/slices/electronSettingsSlice'
 
 import { isElectronEnvironment } from '../../../electron/utils/electron-client'
 
 /**
- * Pushes the persisted `hideAppIcon` value to the main process via IPC
- * after Redux hydrates from localStorage. The IPC handler in main.ts is
- * idempotent (re-applying the same activation policy is a no-op), so
- * firing on every selector change is safe.
+ * Reports an IPC settings-sync failure to the console without ever throwing.
  *
- * Uses `isElectronEnvironment()` directly inside the effect rather than
- * the `useIsElectron` hook: avoids importing the heavy auth-form module
- * (and its Clerk hooks) into the root layout chunk for web users, while
- * staying SSR-safe because effects only run in the browser.
+ * The preload bridge (electron/preload.ts) wraps `typedInvoke` in a try/catch
+ * and returns `false` instead of rejecting, so the meaningful failure signal is
+ * the boolean `false`, not a thrown error. The `.catch` is kept as
+ * defense-in-depth in case preload behavior changes or someone exposes the raw
+ * IPC channel later (which is also why `syncPromise` is treated as possibly
+ * undefined). Swallowing failures silently would mask main-process regressions
+ * during startup sync.
+ *
+ * @param syncPromise - The pending IPC call, or undefined if the bridge returned nothing.
+ * @param label - Setting name used in the failure message (e.g. 'hideAppIcon').
+ * @returns void; logs to `console.error` on a `false` resolution or rejection.
+ * @example
+ * reportSyncFailure(settings.setHideAppIcon(true), 'hideAppIcon')
+ */
+function reportSyncFailure(
+  syncPromise: Promise<boolean> | undefined,
+  label: string,
+): void {
+  syncPromise
+    ?.then((ok) => {
+      if (ok === false) {
+        console.error(
+          `[ElectronStartupSync] Failed to sync ${label}: IPC returned false`,
+        )
+      }
+    })
+    ?.catch((error: unknown) => {
+      console.error(`[ElectronStartupSync] Failed to sync ${label}:`, error)
+    })
+}
+
+/**
+ * Pushes the persisted `hideAppIcon` and `showInMenuBar` values to the main
+ * process via IPC after Redux hydrates from localStorage. The IPC handlers in
+ * main.ts are idempotent (re-applying the same activation policy is a no-op;
+ * `setMenuBarVisible` skips creating a second tray), so firing on every selector
+ * change is safe.
+ *
+ * Each setting syncs in its OWN effect with its OWN method guard so they stay
+ * independent: a re-render that only changes one setting re-syncs only that one,
+ * and an older preload missing one method never suppresses the other's sync.
+ *
+ * Uses `isElectronEnvironment()` directly inside each effect rather than the
+ * `useIsElectron` hook: avoids importing the heavy auth-form module (and its
+ * Clerk hooks) into the root layout chunk for web users, while staying SSR-safe
+ * because effects only run in the browser.
  *
  * @returns Always null; this component renders nothing.
  *
@@ -44,46 +90,34 @@ import { isElectronEnvironment } from '../../../electron/utils/electron-client'
  */
 export function ElectronStartupSync(): null {
   const hideAppIcon = useAppSelector(selectHideAppIcon)
+  const showInMenuBar = useAppSelector(selectShowInMenuBar)
 
+  // Sync the dock-icon policy. Guard on the METHOD, not just the `settings`
+  // namespace. This component is mounted in the root layout, so it runs on every
+  // route — and the installed desktop app loads remote web against its own
+  // FROZEN preload. Calling `undefined()` on an older preload would throw a
+  // synchronous TypeError out of this effect, past its own `.catch`, to the
+  // error boundary (and from the root layout it escapes `error.tsx` entirely —
+  // see `global-error.tsx`). Uniform method-guarding future-proofs the bridge
+  // against a reshuffle and matches the other Electron settings components.
   useComponentEffect(() => {
     if (!isElectronEnvironment()) return
-    // Surface IPC failures to the console; swallowing them silently would
-    // mask main-process regressions during startup sync.
-    //
-    // The preload bridge (electron/preload.ts) wraps `typedInvoke` in a
-    // try/catch and returns `false` instead of rejecting, so the meaningful
-    // failure signal here is the boolean `false`, not a thrown error. The
-    // `.catch` is still kept as defense-in-depth in case preload behavior
-    // changes or someone exposes the raw IPC channel later.
-    // Guard on the METHOD, not just the `settings` namespace. This component
-    // is mounted in the root layout, so it runs on every route — and the
-    // installed desktop app loads remote web against its own FROZEN preload.
-    // Calling `undefined()` on an older preload would throw a synchronous
-    // TypeError out of this effect, past its own `.catch`, to the error
-    // boundary (and from the root layout it escapes `error.tsx` entirely —
-    // see `global-error.tsx`). Defensive only: `settings` and `setHideAppIcon`
-    // shipped in the same release, so no published preload has the gap today;
-    // uniform method-guarding future-proofs the bridge against a reshuffle and
-    // matches the other Electron settings components.
     const settings = window.electronAPI?.settings
     if (typeof settings?.setHideAppIcon !== 'function') return
     // Call as a method so `this` stays bound to `settings`.
-    const syncPromise = settings.setHideAppIcon(hideAppIcon)
-    syncPromise
-      ?.then((ok) => {
-        if (ok === false) {
-          console.error(
-            '[ElectronStartupSync] Failed to sync hideAppIcon: IPC returned false',
-          )
-        }
-      })
-      ?.catch((error: unknown) => {
-        console.error(
-          '[ElectronStartupSync] Failed to sync hideAppIcon:',
-          error,
-        )
-      })
+    reportSyncFailure(settings.setHideAppIcon(hideAppIcon), 'hideAppIcon')
   }, [hideAppIcon])
+
+  // Sync the menu-bar (tray) visibility. Independent method guard for the same
+  // frozen-preload reason as above; an old preload that lacks `setShowInMenuBar`
+  // is skipped rather than crashing every route.
+  useComponentEffect(() => {
+    if (!isElectronEnvironment()) return
+    const settings = window.electronAPI?.settings
+    if (typeof settings?.setShowInMenuBar !== 'function') return
+    // Call as a method so `this` stays bound to `settings`.
+    reportSyncFailure(settings.setShowInMenuBar(showInMenuBar), 'showInMenuBar')
+  }, [showInMenuBar])
 
   return null
 }


### PR DESCRIPTION
## Summary

The **Show in Menu Bar** row in Electron Settings was gated behind a `(Coming Soon)` label, an `opacity-60` wrapper, and a `disabled` Switch. The menu-bar feature is actually complete, so this un-gates the row.

While un-gating, I found the toggle was a **"lying toggle"**: the live IPC toggle worked, but the persisted value was never re-applied at launch — boot always recreated the tray unconditionally, so turning it **OFF silently reverted on the next start**. This PR un-gates the row *and* wires the persistence so the toggle stays truthful across restarts.

## Changes

- **`ElectronSettingsPage.tsx`** — remove the `(Coming Soon)` span, `opacity-60` wrapper, and `disabled` prop; fix the stale failure-handler comment.
- **`ElectronStartupSync.tsx`** — add a second, independent effect that re-pushes `showInMenuBar` at boot (mirrors `hideAppIcon`), each guarded per-method against frozen-preload version skew; extract a `reportSyncFailure` helper.
- **`SystemTrayManager.createTray()`** — make idempotent (early-return the live tray) so the boot path and the live toggle / startup re-push can no longer interleave into a second native `Tray` (a leaked menu-bar icon).
- **`main.ts` / `preload.ts` / `types/ipc.ts`** — correct three now-stale comments (`"live-only"`, `"not yet implemented"`, `"Placeholder for future"`).
- **Tests** — +8 startup-sync cases (mount-forward both values, old-preload guard independence in both directions, reject/false logging, re-sync dep-lock, success-quiet, swap-guarding cross-assertions) and a tray idempotency regression test.

Persistence is localStorage/Redux only, matching `hideAppIcon` parity — no server change needed.

## Verification

- ✅ Production build
- ✅ Web unit tests (289, +1)
- ✅ Electron tests (235, +1)
- ✅ typecheck
- ✅ lint
- Adversarial multi-lens review (correctness / sweep / test rigor / standards) — all confirmed findings folded in.

## ⚠️ Manual macOS smoke still required

Tray paths are Cocoa-specific and **not** covered by Linux/xvfb CI, so before release please verify on a real macOS build:

1. Toggle **Show in Menu Bar OFF** → **quit** → **relaunch** → tray stays hidden.
2. Heads-up: in the OFF case the tray **appears then hides** at each launch (boot creates it; the remote page must load + hydrate before the sync hides it — same tradeoff as the dock icon for Hide App Icon). Confirm this is acceptable UX for the menu bar.
3. ON case does **not** double-create the tray (exercises the new idempotency guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Show in Menu Bar" toggle is now active, reliably persists across restarts, and syncs at startup alongside the existing dock/hide setting.

* **Bug Fixes**
  * Prevented duplicate tray/menu-bar icons via concurrency-safe, idempotent tray creation.
  * Improved error handling and clearer logging when showing/hiding the menu bar fails.

* **Tests**
  * Expanded tests including a concurrency/race scenario to verify a single tray is created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->