### PR TITLE
feat(settings): add a Back button to the standalone Settings page

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -13,6 +13,7 @@ import { memo } from 'react'
  */
 import { ElectronSettingsPage } from '@/components/electron/ElectronSettingsPage'
 import { PreferencesSettings } from '@/components/settings/PreferencesSettings'
+import { SettingsBackButton } from '@/components/settings/SettingsBackButton'
 
 export const metadata: Metadata = {
   title: 'Settings',
@@ -30,6 +31,9 @@ export const metadata: Metadata = {
 const SettingsPage = memo(function SettingsPage(): React.ReactNode {
   return (
     <div className="mx-auto h-full max-w-2xl">
+      {/* Standalone /settings has no sidebar; this is the only way back
+          (essential in Electron, which has no browser chrome). */}
+      <SettingsBackButton />
       <PreferencesSettings />
       <ElectronSettingsPage />
     </div>

--- a/src/components/settings/SettingsBackButton.test.tsx
+++ b/src/components/settings/SettingsBackButton.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SettingsBackButton } from './SettingsBackButton'
+
+// useRouter is the only navigation API this component touches; back() is the
+// observable effect we assert on.
+const backMock = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    back: backMock,
+  }),
+}))
+
+/**
+ * Force `window.history.length` to a fixed value so a test can choose whether
+ * the page looks like an in-app arrival (length > 1) or a fresh load (length 1),
+ * which is the single input that decides whether the Back button renders.
+ *
+ * @param length - The history length to report until the test cleans up.
+ */
+function setHistoryLength(length: number): void {
+  Object.defineProperty(window.history, 'length', {
+    configurable: true,
+    value: length,
+  })
+}
+
+describe('SettingsBackButton', () => {
+  afterEach(() => {
+    backMock.mockReset()
+    // Drop the per-test override so the real history.length is restored.
+    delete (window.history as unknown as { length?: number }).length
+  })
+
+  it('returns to the previous screen when Settings was opened from the sidebar', async () => {
+    // Arrange: reached via in-app navigation, so a prior history entry exists.
+    setHistoryLength(2)
+    const user = userEvent.setup()
+    render(<SettingsBackButton />)
+
+    // Act
+    await user.click(await screen.findByRole('button', { name: /back/i }))
+
+    // Assert: it steps back to wherever the user came from (e.g. /home),
+    // never force-pushing a fixed route.
+    expect(backMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders nothing in the tray popover, where there is no screen to go back to', () => {
+    // Arrange: a fresh loadURL of /settings (the frameless tray popover) leaves
+    // history.length at 1 — back() would be a no-op.
+    setHistoryLength(1)
+
+    // Act
+    render(<SettingsBackButton />)
+
+    // Assert: no dead button is shown; the popover is dismissed by blur instead.
+    expect(screen.queryByRole('button', { name: /back/i })).toBeNull()
+  })
+})

--- a/src/components/settings/SettingsBackButton.tsx
+++ b/src/components/settings/SettingsBackButton.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { ArrowLeft } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { memo, useCallback, useSyncExternalStore } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+/**
+ * Re-renders once after hydration so the client reads the real
+ * `window.history.length` (the server snapshot is always `false`). History
+ * length only changes on navigation, which unmounts this page, so there is
+ * nothing to keep subscribed to afterwards.
+ *
+ * @param callback - React-supplied store-changed notifier.
+ * @returns A no-op unsubscribe.
+ */
+function subscribeToHistory(callback: () => void): () => void {
+  if (typeof window !== 'undefined') {
+    queueMicrotask(callback)
+  }
+  return () => {}
+}
+
+/**
+ * Whether `/settings` was reached via in-app navigation — i.e. there is a prior
+ * history entry that `router.back()` can actually return to.
+ *
+ * @returns
+ * - `true` when a previous history entry exists (sidebar → /settings)
+ * - `false` on the server, or for a fresh load (tray popover / deep-link)
+ * @example
+ * getHasBackTargetSnapshot() // => true  (after sidebar push)
+ * getHasBackTargetSnapshot() // => false (popover loadURL, history.length === 1)
+ */
+function getHasBackTargetSnapshot(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.history.length > 1
+}
+
+/**
+ * SSR snapshot — there is never history to go back to on the server, so the
+ * button is absent until hydration reads the real value (no hydration flash of
+ * a wrong state).
+ *
+ * @returns Always `false`.
+ */
+function getServerSnapshot(): boolean {
+  return false
+}
+
+/**
+ * Back affordance for the standalone `/settings` route. Exists because
+ * `/settings` renders outside the `(main)` sidebar layout and the Electron main
+ * window has no browser chrome, so reaching Settings from the sidebar was a
+ * dead end. Gated on history (not platform) so it appears for every in-app
+ * arrival — web and Electron alike — yet stays hidden in the frameless tray
+ * Settings popover (a fresh `loadURL`, dismissed on blur) and on direct web
+ * deep-links, where `back()` has no target.
+ *
+ * @returns The ghost "Back" button, or `null` when there is nothing to go back to.
+ * @example
+ * // Top of the settings page, above the settings sections:
+ * <SettingsBackButton />
+ */
+export const SettingsBackButton = memo(function SettingsBackButton() {
+  const router = useRouter()
+  const hasBackTarget = useSyncExternalStore(
+    subscribeToHistory,
+    getHasBackTargetSnapshot,
+    getServerSnapshot,
+  )
+
+  const handleBack = useCallback((): void => {
+    router.back()
+  }, [router])
+
+  // Nothing to return to (tray popover / deep-link): `back()` would no-op, so
+  // render nothing rather than a dead button.
+  if (!hasBackTarget) return null
+
+  return (
+    <div className="p-4 pb-0">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="-ml-2.5 text-muted-foreground hover:text-foreground"
+        onClick={handleBack}
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back
+      </Button>
+    </div>
+  )
+})
+
+export default SettingsBackButton


### PR DESCRIPTION
## Why

Opening **Settings** from the sidebar was a dead end. `/settings` lives *outside* the `(main)` route group (D15 — a focused, full-width settings home), so it renders with **no sidebar** and therefore no back navigation. On the web you can still use the browser's back button, but **Electron's main window has no browser chrome**, so reaching Settings left the user stranded with no way back.

## What

Adds `SettingsBackButton`, a ghost "Back" affordance rendered at the top of the standalone `/settings` page.

| Decision | Rationale |
| --- | --- |
| Gate on **history**, not platform (`window.history.length > 1`) | Shows for every *in-app* arrival — web **and** Electron sidebar push — yet stays hidden where there's nothing to return to. |
| `router.back()` on click (no fixed `/home` push) | `back()` is a safe no-op when there's no history. A fixed `/home` push would be *harmful* inside the frameless tray Settings popover. |
| `useSyncExternalStore` + `getServerSnapshot → false` | SSR-safe, no hydration flash; mirrors the repo's existing `useIsElectron` pattern. |

## Where it shows / hides

- **Shows**: sidebar → `/settings` (web and Electron main window) — there's a prior entry to return to.
- **Hidden**: the frameless **tray Settings popover** (a fresh `loadURL` → `history.length === 1`, dismissed on blur) and direct web deep-links (the browser's own back is available). Even if it somehow rendered, `back()` would no-op rather than misbehave.

## Verification

- New unit tests (2): returns to the previous screen when opened from the sidebar; renders nothing in the tray-popover case.
- `typecheck` + `lint` clean; full suite **284 passed / 26 skipped**.
- **Renderer-only** change — ships via the web deploy and reaches the installed Electron app after corelive.app updates. No packaged macOS build required; verifiable in a browser (`sidebar → Settings → Back`).

## Note (verified vs assumed)

The main-window Back button is the verified win (browser click-through). The tray-popover *hidden* behavior rests on the popover's `/settings` load yielding `history.length === 1`. `proxy.ts` gates `/settings` with a **server-side** auth redirect (`NextResponse.redirect`), which browsers follow transparently **without** adding a history entry — so an authed popover should stay at length 1. Final confirmation still wants a one-time **macOS smoke**: open tray → Settings popover → confirm **no** Back button and that it still dismisses on blur. If a Back button ever appears there, the escalation is a popover-specific marker (e.g. `WindowManager` loads `/settings?chrome=none`, button reads `useSearchParams`) — intentionally not pre-built here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Back button to the settings page for improved navigation. The button intelligently appears when you navigate to settings from within the app, enabling you to return to the previous screen with a single click. When opening settings directly or from a standalone context, the button is hidden to keep the interface clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->