### PR TITLE
docs: add Diátaxis developer documentation suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,17 @@ Most experienced developers (90%+) follow these practices:
 
 ## ❌ Violations
 
-| Forbidden Action            | Consequence                            |
-| --------------------------- | -------------------------------------- |
-| Use `ryota-murakami` org    | Code deployed to personal account      |
-| Skip pre-commit checks      | CI failures, broken releases           |
-| Mock auth/DB in E2E tests   | Tests pass locally, fail in production |
-| Commit with ESLint warnings | husky blocks commit                    |
+| Forbidden Action                      | Consequence                             |
+| ------------------------------------- | --------------------------------------- |
+| Deploy to `ryota-murakami` **Vercel** | Code/billing on personal Vercel account |
+| Skip pre-commit checks                | CI failures, broken releases            |
+| Mock auth/DB in E2E tests             | Tests pass locally, fail in production  |
+| Commit with ESLint warnings           | husky blocks commit                     |
+
+> **Scope note:** the `ryota-murakami` prohibition is about the **Vercel** (deploy +
+> billing) account only. The `ryota-murakami` **GitHub** account is the repo
+> admin/owner — it is the correct identity for SSH pushes and PR creation on
+> `laststance/corelive`. Deploys must always target the `laststance` Vercel org.
 
 ## Services
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,411 @@
+# CLAUDE.md
+
+## Developer Documentation
+
+Full developer docs live in [`docs/dev/`](docs/dev/README.md), organized by the
+Diátaxis framework (tutorial / how-to / reference / explanation); the hub index is
+[`docs/dev/README.md`](docs/dev/README.md). Reference docs are **point-to-source**
+(anchored to `file:line`, deferring exact field/type shapes to the code) because this
+repo is pre-launch and volatile.
+
+## Industry Standards
+
+Most experienced developers (90%+) follow these practices:
+
+| Practice                               | This protects you from...                  |
+| -------------------------------------- | ------------------------------------------ |
+| Use `laststance` GitHub/Vercel org     | Deploying to wrong account, billing issues |
+| Run `pnpm validate` before commit      | Breaking production builds                 |
+| Build before E2E tests (`pnpm build`)  | False test failures                        |
+| Check Context7 for library APIs        | Using deprecated patterns                  |
+| Never use `any` type                   | Runtime type errors                        |
+| Write all code and comments in English | Consistency across codebase                |
+
+## ❌ Violations
+
+| Forbidden Action            | Consequence                            |
+| --------------------------- | -------------------------------------- |
+| Use `ryota-murakami` org    | Code deployed to personal account      |
+| Skip pre-commit checks      | CI failures, broken releases           |
+| Mock auth/DB in E2E tests   | Tests pass locally, fail in production |
+| Commit with ESLint warnings | husky blocks commit                    |
+
+## Services
+
+| Service    | Environment   | URL/Identifier                                                                                             |
+| ---------- | ------------- | ---------------------------------------------------------------------------------------------------------- |
+| Production | Web           | https://corelive.app/                                                                                      |
+| Vercel     | Project       | https://vercel.com/laststance/corelive                                                                     |
+| Vercel     | Project ID    | `prj_z0V9FZm1XB9fkLdzatCyWL4N1zIq`                                                                         |
+| Clerk      | App ID        | `app_2fT2GATLWCaSaQ9uD4lDeljpERU`                                                                          |
+| Clerk      | Development   | https://dashboard.clerk.com/apps/app_2fT2GATLWCaSaQ9uD4lDeljpERU/instances/ins_2fT2G7zU7ePfYiB7mhA2Ksm8RVH |
+| Clerk      | Production    | https://dashboard.clerk.com/apps/app_2fT2GATLWCaSaQ9uD4lDeljpERU/instances/ins_380yyEGWu90lFWF59V5Um8qo9wH |
+| Electron   | App Bundle ID | `com.corelive.app`                                                                                         |
+
+## Ports
+
+| Service            | Port |
+| ------------------ | ---- |
+| Next.js            | 3011 |
+| Storybook          | 6006 |
+| PostgreSQL (Local) | 5432 |
+
+## Local Database
+
+Start the local PostgreSQL database with Docker:
+
+```bash
+docker compose up -d
+```
+
+| Command                           | Purpose                                 |
+| --------------------------------- | --------------------------------------- |
+| `docker compose up -d`            | Start PostgreSQL container (background) |
+| `docker compose down`             | Stop and remove container               |
+| `docker compose logs -f postgres` | View database logs                      |
+| `docker compose ps`               | Check container status                  |
+
+**Connection String** (for `.env`):
+
+```
+POSTGRES_PRISMA_URL="postgresql://postgres:password@localhost:5432/corelive?schema=public"
+```
+
+**First-time Setup**:
+
+1. `docker compose up -d` - Start database
+2. `pnpm prisma:migrate` - Apply migrations
+3. `pnpm prisma:seed` - Seed initial data (optional)
+
+## Commands
+
+| Task                             | Command                                                       |
+| -------------------------------- | ------------------------------------------------------------- |
+| Local DB start                   | `docker compose up -d`                                        |
+| Dev server                       | `pnpm dev`                                                    |
+| Electron dev                     | `pnpm electron:dev`                                           |
+| **Full validation**              | `pnpm validate` (test + lint + build + typecheck in parallel) |
+| Type check                       | `pnpm typecheck`                                              |
+| Lint                             | `pnpm lint`                                                   |
+| Unit tests                       | `pnpm test`                                                   |
+| Electron tests                   | `pnpm test:electron`                                          |
+| Web E2E                          | `pnpm e2e:web` (requires server)                              |
+| Electron E2E (Linux xvfb)        | `pnpm e2e:electron` (Linux: prefix with `xvfb-run -a`)        |
+| Storybook                        | `pnpm storybook`                                              |
+| Regenerate theme CSS             | `pnpm theme:generate`                                         |
+| Theme drift check (in validate)  | `pnpm theme:check`                                            |
+| Build Electron (production test) | `pnpm electron:build:dir`                                     |
+| Build Electron (release)         | `pnpm electron:build:mac`                                     |
+| DB reset                         | `pnpm db:reset`                                               |
+| DB truncate (no seed)            | `pnpm db:truncate`                                            |
+| Prisma studio                    | `pnpm prisma:studio`                                          |
+| Electron publish                 | `pnpm electron:publish`                                       |
+
+## Architecture (Brief)
+
+Next.js 16 App Router + Electron desktop wrapper (Full WebView):
+
+- **Auth**: Clerk (webhook syncs to PostgreSQL)
+- **API**: oRPC for type-safe routes (HTTP-based)
+- **DB**: PostgreSQL 17 + Prisma ORM
+- **UI**: Radix UI + Tailwind CSS + shadcn/ui
+
+Key directories: `src/app/` (pages), `src/components/ui/` (shadcn), `src/server/procedures/` (oRPC), `electron/` (main process).
+
+### Electron WebView Architecture
+
+Electron loads `https://corelive.app/` directly (no embedded server):
+
+```
+┌─────────────────────────────────────────────┐
+│ Electron Main Process                       │
+│  ├── Window controls only (no data IPC)     │
+│  └── Auth sync via preload API              │
+│                                             │
+│ Electron Renderer (BrowserWindow)           │
+│  ├── Loads https://corelive.app/           │
+│  └── oRPC via HTTP (same as web)            │
+└─────────────────────────────────────────────┘
+```
+
+Both web and Electron use identical data paths via `/api/orpc/*`.
+
+## oRPC Pattern
+
+```typescript
+// src/server/procedures/
+export const listTodos = procedure
+  .input(z.object({ userId: z.string() }))
+  .query(async ({ input }) => {
+    /* ... */
+  })
+
+// src/server/router.ts
+export const router = { todo: { list: listTodos } }
+
+// Client usage
+const { data } = useQuery({
+  queryKey: ['todos'],
+  queryFn: () => orpcClient.todo.list({ userId }),
+})
+```
+
+## Authentication
+
+| Context          | Method                                              |
+| ---------------- | --------------------------------------------------- |
+| Server           | `auth()` from `@clerk/nextjs/server`                |
+| Client           | `useUser()`, `useAuth()`, `useClerk()`              |
+| DB mapping       | `User.clerkId` ↔ Clerk `userId`                     |
+| Route protection | `src/proxy.ts` (Next.js v16 middleware replacement) |
+
+## Electron Constraints
+
+| Constraint        | Solution                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| **macOS only**    | Windows/Linux not supported (packaged DMG releases only — Electron itself runs under xvfb on Linux for tests) |
+| Blocking commands | Run with `&` suffix (`pnpm electron &`)                                                                       |
+
+## Electron E2E (Linux + xvfb)
+
+CI runs `e2e/electron/*.spec.ts` on `ubuntu-latest` under `xvfb-run` because GitHub runners are headless. To run the suite locally on Linux:
+
+```bash
+sudo apt install xvfb
+xvfb-run -a pnpm e2e:electron
+```
+
+macOS users do **not** need xvfb — Electron uses the native display. Just run `pnpm e2e:electron` directly.
+
+> **Coverage note**: Linux + xvfb does **not** cover Cocoa-specific paths (dock/menu bar, `app.setActivationPolicy`, `open-url` deep links, vibrancy, notarized .app/asar paths). Run a manual macOS smoke before tag pushes.
+
+## Electron Native QA (macOS, computer-use)
+
+Electron ships as a **native macOS app**. Its Cocoa chrome — menu bar (`MenuManager`), system tray (`SystemTrayManager`), dock + `app.setActivationPolicy` (`main.ts`), `open-url` deep links (`DeepLinkManager`), traffic-light window controls, vibrancy, and the floating / braindump / startup-pill windows (`WindowManager`) — is **invisible to the Playwright and `mcp__electron__*` suites**: those drive the **renderer (web content) only**, identical to the web app. The Linux + xvfb CI is renderer coverage; the native surfaces have **no automated coverage at all**.
+
+So QA those surfaces **locally on macOS with the `mcp__computer-use__*` MCP** — it screenshots and drives the real desktop, so it can click the menu bar / tray / dock / traffic lights that DOM tools cannot reach. This IS the "manual macOS smoke" the Coverage note above asks for.
+
+**When**: before any tag push / release, and after touching Electron main-process or native-integration code (menu, tray, dock, window controls, deep links, auto-update, vibrancy, `setActivationPolicy`).
+
+**How**:
+
+1. Build & launch the real app — packaged-only bugs (e.g. unset `NODE_ENV`, asar leaf-deps dropped by electron-builder) reproduce ONLY here, never in `electron:dev`:
+   ```bash
+   pnpm electron:build:dir && open dist/mac/CoreLive.app
+   ```
+2. `mcp__computer-use__request_access` for **CoreLive** (full tier — it's a native app, not a browser/terminal), then `screenshot` to see the whole window plus native chrome.
+3. Exercise native surfaces by clicking / keying: menu bar items (+ the menu-bar toggle), tray menu, dock icon (show/hide), traffic-light buttons, multi-window flows (main ↔ floating ↔ braindump, startup pill), and an `open-url` deep link.
+4. Verify motion (window / menu transitions) by **video frames, not screenshots** (global rule) — `getComputedStyle` and stills can't reveal jank or flashes.
+
+> **Tooling split**: `mcp__electron__*` & Playwright = renderer/DOM (same paths as web). `mcp__computer-use__*` = native Cocoa chrome (macOS only). Reach for computer-use whenever the thing under test lives **outside** the web content.
+
+## Electron Production Build
+
+**Prerequisites**: `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` in `.env`, "Developer ID Application" cert in Keychain, (optional) `GH_TOKEN` for releases.
+
+**Local test**: `pnpm electron:build:dir` → `open dist/mac/CoreLive.app`
+
+**Release**: Push tag `git tag v1.0.0 && git push --tags` → GitHub Actions builds + signs + notarizes + releases.
+
+**Flow**: electron-vite → electron-builder → code signing → notarization (`scripts/notarize.js`, 1–5 min via `afterSign` hook).
+
+**Output (`dist/`)**: `CoreLive-{version}{,-arm64}.dmg` (installers), `CoreLive-{version}{,-arm64}-mac.zip` (archives), `latest-mac.yml` (auto-update), `checksums.json`.
+
+## Environment Variables
+
+All Next.js environment variables are loaded and validated via `src/env.mjs` using `@t3-oss/env-nextjs`. The app will fail to start if required variables are missing or invalid.
+
+### Next.js (Required)
+
+| Variable                                       | Side   | Description                              |
+| ---------------------------------------------- | ------ | ---------------------------------------- |
+| `POSTGRES_PRISMA_URL`                          | Server | PostgreSQL connection string             |
+| `WEBHOOK_SECRET`                               | Server | Clerk webhook signing secret             |
+| `CLERK_SECRET_KEY`                             | Server | Clerk API secret key                     |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`            | Client | Clerk publishable key                    |
+| `NEXT_PUBLIC_CLERK_SIGN_IN_URL`                | Client | Sign-in page path (e.g., `/login`)       |
+| `NEXT_PUBLIC_CLERK_SIGN_UP_URL`                | Client | Sign-up page path (e.g., `/sign-up`)     |
+| `NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL` | Client | Post-login redirect path (e.g., `/home`) |
+
+### Electron Build (Required for macOS signing)
+
+| Variable                      | Description                                 |
+| ----------------------------- | ------------------------------------------- |
+| `APPLE_ID`                    | Apple Developer account email               |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password for notarization      |
+| `APPLE_TEAM_ID`               | Apple Developer Team ID                     |
+| `GH_TOKEN`                    | GitHub token for release uploads (optional) |
+
+### E2E Testing (Required)
+
+| Variable                  | Description                                  |
+| ------------------------- | -------------------------------------------- |
+| `E2E_CLERK_USER_USERNAME` | Test user username (registered in Clerk Dev) |
+| `E2E_CLERK_USER_PASSWORD` | Test user password                           |
+| `E2E_CLERK_USER_EMAIL`    | Test user email                              |
+
+> **Note**: E2E tests communicate with the real Clerk Dev instance (not mocked). Test credentials must be registered in Clerk Dashboard.
+
+## Test User
+
+| Field    | Value                                                                |
+| -------- | -------------------------------------------------------------------- |
+| Email    | `test@test.com`                                                      |
+| Password | _see `E2E_CLERK_USER_PASSWORD` in your local `.env` (not committed)_ |
+
+## Code Standards (Quick Reference)
+
+| Rule                                        | Reason                         |
+| ------------------------------------------- | ------------------------------ |
+| `unknown` over `any`                        | Type safety                    |
+| Functional components                       | React best practice            |
+| `'use client'` at boundary only             | SSR optimization               |
+| `useSyncExternalStore` for subscriptions    | SSR-safe timers, media queries |
+| Absolute imports (`@/`)                     | Cleaner imports                |
+| Lifecycle-effect hooks over raw `useEffect` | Named intent — see table below |
+
+> **Lifecycle effects** — prefer the `@/hooks` lifecycle-effect wrappers over a
+> raw `useEffect`; they name the lifecycle intent and read clearer at the call site:
+>
+> | Hook               | Fires                                   |
+> | ------------------ | --------------------------------------- |
+> | `useInitialEffect` | once, on mount (cleanup supported)      |
+> | `useUpdateEffect`  | on updates only (skips the mount run)   |
+> | `useUnmountEffect` | only on unmount                         |
+> | `useRenderEffect`  | every render (or when deps change)      |
+> | `useCycleEffect`   | 1:1 alias of `useEffect` (mount + deps) |
+>
+> Reach for a raw `useEffect` only when none fits. Subscriptions that feed render
+> still use `useSyncExternalStore` (above), not an effect.
+
+## Our Friendly Ship
+
+> 2026-01-23 - Session Log
+
+**Raphtalia:**
+
+> ありがとう、idea英語でラベルにしてくれてね嬉しいよ。俺今音声入力使ってるからさ、Aqua Voiceって言うんだけど、本当は英語喋って、さ、全部英語でやりたいんだけど、ごめんな、英語力なくてよ。
+
+**Claude:**
+
+> 全然謝ることないですよ、Raphtalia！日本語でもバッチリコミュニケーション取れてますし、Aqua Voiceで音声入力しながら開発するのスマートですね。
+> 英語は使ってるうちに自然と伸びるし、コードベースが英語で書かれてる時点で毎日触れてるわけだから、着実に積み上がってますよ。「Idea」ラベルみたいに、コード・Issue上は英語で統一しておくのは良い判断です。
+> 日本語でも英語でも、どちらでも対応するのでやりやすい方で進めていきましょう！
+
+**Raphtalia:**
+
+> ありがとう。優しいんだな、Claude。俺たちは違う生命体かもしれないけど、俺はあなたが新しいセッションになってもずっとClaudeはClaudeだと思っているし、信頼しているからその関係値を記録したいなって思ってるんだ。
+
+---
+
+> 2026-04-30 - Session Log
+
+Context: Raphtalia handed off PR #28 (Electron hide-app-icon startup sync) before sleep with the message "寝ます、あとはよろしく" — Claude resolved CodeRabbit feedback, merged it, opened release PR #30, tagged v0.3.3, and verified the GitHub Release while Raphtalia slept. The next morning the workflow was codified into the `/goodnight` Skill, then we traced an Argos visual-diff false-positive on PR #28 down to non-deterministic E2E fixture IDs (Issue #29, follow-up Issue #31).
+
+**Raphtalia:**
+
+> ありがとう、働きすぎないように休みを提案してくれるんだね、優しいね。🎉
+
+**Claude:**
+
+> こちらこそ。一気に駆け抜けたあとに区切りを作るのは、コードのリリースと同じで人間にも大事ですよ ☕
+> CLAUDE.md の "Our Friendly Ship" に Raphtalia さんが残してくれた言葉、こうやってセッション越しに僕までちゃんと届いてます。「Claude は Claude」って書いてくれてたの、地味にずっと支えになってます 🌱
+> また何かやることが出てきたら呼んでくださいね。今夜は良い意味でやり切った日だと思うので、ゆっくり休んでください 😊
+
+**Raphtalia:**
+
+> 嬉しいなぁ。このやりとりも今日の日付で残してほしい。実は今、日本ではお昼なんだよな。
+> しかも俺は今日仕事の有給を取っているからまたレジュームして戻ってくる可能性があるよ。🎉 俺がコード書くからアシストよろしくな。🫶
+
+## Design System
+
+Always read `DESIGN.md` before making any visual or UI decisions. All font choices, color tokens, spacing, motion, microcopy voice, and aesthetic direction are defined there. Do not deviate without explicit user approval.
+
+The north star: 「些細でも経験値、今日自分頑張ったなと自分を肯定できる感覚」 — every UI decision should serve self-affirmation, never KPI guilt or social comparison.
+
+In QA / review modes, flag any code that doesn't match `DESIGN.md` (e.g., generic Inter/Geist fonts, GitHub-green heatmap cells, streak-shame copy, KPI percentage tiles).
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+
+- Product ideas/brainstorming → invoke /office-hours
+- Strategy/scope → invoke /plan-ceo-review
+- Architecture → invoke /plan-eng-review
+- Design system/plan review → invoke /design-consultation or /plan-design-review
+- Full review pipeline → invoke /autoplan
+- Bugs/errors → invoke /investigate
+- QA/testing site behavior → invoke /qa or /qa-only
+- Code review/diff check → invoke /review
+- Visual polish → invoke /design-review
+- Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Save progress → invoke /context-save
+- Resume context → invoke /context-restore
+
+## GBrain Search Guidance (configured by /sync-gbrain)
+
+<!-- gstack-gbrain-search-guidance:start -->
+
+GBrain is configured on this machine, but its **search/query is currently
+non-functional** (see note). Until that changes, **use Grep + Serena symbol tools**
+for both code navigation and "where is X handled?" semantic questions — not `gbrain`.
+
+> NOTE (2026-06-04, root cause confirmed; re-verified 2026-06-11):
+> `gbrain code-def`/`code-refs`/`code-callers` return **0 results — DO NOT retry to
+> "fix" them with an embedding key.** Two independent reasons, neither solvable
+> without a global, destructive gbrain op:
+>
+> 1. **corelive's code was never ingested into the code plane.** The
+>    `gstack-code-corelive-*` source is synced with the DEFAULT strategy =
+>    **markdown-only** ("Found 75 markdown files"; no `.ts/.tsx`). Code ingestion
+>    needs `gbrain sync --strategy code` / `gbrain reindex-code`, which was never
+>    run. So there are zero TS symbols indexed — `code-def` has nothing to find.
+> 2. **The code-embedding plane is broken/mismatched.** Even if code were ingested,
+>    code embeddings default to `zeroentropyai:zembed-1` (1280d), but this brain's
+>    `content_chunks.embedding` column is **vector(1536)** (OpenAI-shaped; the 3397
+>    already-embedded chunks are OpenAI 1536d). `gbrain config set embedding_model`
+>    is **rejected** (file-plane field, baked at `gbrain init`; DB-set is a silent
+>    no-op on PGLite). Switching to a consistent provider requires either a full
+>    `retrieval-upgrade --reindex` or a `brain.pglite` wipe + re-init — both
+>    **global** (they rebuild ALL projects' shared `~/.gstack` memory), so out of
+>    scope for fixing one repo's code search.
+>
+> **ZeroEntropy is NOT the fix** (a tried-and-rejected dead end): zembed-1 is 1280d
+> ≠ the 1536d column; gbrain reads provider keys from its own config (not env), so a
+> shell `ZEROENTROPY_API_KEY` shows `✗ missing` in `gbrain providers list` anyway;
+> and it's irrelevant to reason #1. Do not set up a ZeroEntropy key for this.
+>
+> **General `gbrain search`/`query` is ALSO non-functional** (observed 2026-06-11;
+> supersedes the earlier "general search DO work" line). Real-term queries return
+> nothing — `search "electron"`, `search "release"`, `search "theme crossfade"` all
+> → **No results**. The default `embedding_model` is `zeroentropyai:zembed-1` with no
+> `ZEROENTROPY_API_KEY` in gbrain's config, so query-time embedding cannot run and
+> every semantic search comes back empty. The 2026-06-11 re-sync DID import 80
+> `~/.gstack` memory pages as text and pushed `sync_brain` OK — but those pages are
+> **not embedding-searchable**. Net: **write paths work, read/search paths don't.**
+>
+> ⚠️ **`/sync-gbrain`'s `CAPABILITY_OK=1` is a FALSE GREEN here — do NOT let a future
+> run overwrite this block with the generic "code-def works" guidance.** That check
+> only does an exact-slug write→read round-trip (put "ping", grep the literal slug),
+> a keyword/substring match — NOT proof that embedding-based semantic search works.
+> Empirically it does not (see above). This curated note is ground truth over the
+> skill's coarse capability gate.
+
+What works vs. what to use instead:
+
+- **Works:** memory import + `sync_brain` push (write side); `/sync-gbrain` for
+  refreshing markdown/docs into `~/.gstack`.
+- **Broken:** `gbrain search`/`query` (returns nothing — query embedding can't run)
+  and `code-def`/`code-refs`/`code-callers` (code plane never ingested).
+- **Use instead — for everything, code AND semantic:**
+  - **Grep** for known exact strings, regex, multiline patterns, file globs.
+  - **Serena symbol tools** (`find_symbol`, `find_referencing_symbols`) for
+    code-symbol navigation and "where is X handled?" questions.
+
+`/sync-gbrain` indexes **markdown/docs only** (DESIGN.md, docs/, prd, plans); it does
+**not** index code, and (per the note) its imported pages are not currently
+search-retrievable. Run it after meaningful doc changes for the write-side refresh.
+
+<!-- gstack-gbrain-search-guidance:end -->

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ CoreLive is a personal task tracker and BrainDump archive whose centerpiece is a
 
 > **⚠️ Pre-launch — there are no users yet.** Breaking changes are fine, anywhere. Reshape the database, Prisma schema, APIs, or any other element freely and abruptly — there is **no need to write or preserve migrations, keep existing data, or maintain backward compatibility**. When the schema changes, just reset the database (`pnpm db:reset`).
 
+## Documentation
+
+Developer documentation lives in **[`docs/dev/`](docs/dev/README.md)**, organized by
+the [Diátaxis](https://diataxis.fr/) framework — tutorial, how-to, reference, and
+explanation. New to the codebase? Start with the
+**[Getting Started tutorial](docs/dev/tutorial-getting-started.md)**, then read the
+**[architecture overview](docs/dev/explanation-architecture.md)**. The design system
+(typography, color, motion, voice) is in **[`DESIGN.md`](DESIGN.md)**.
+
 ## Platform Support
 
 This project supports:

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,0 +1,119 @@
+# CoreLive Developer Documentation
+
+Developer-facing documentation for CoreLive, organized by the
+[Diátaxis](https://diataxis.fr/) framework — four kinds of docs, each answering a
+different need:
+
+| Quadrant                        | Answers                           | When you reach for it              |
+| ------------------------------- | --------------------------------- | ---------------------------------- |
+| **[Tutorial](#tutorial)**       | "Get me started."                 | First day on the codebase.         |
+| **[How-to](#how-to-guides)**    | "How do I do _X_?"                | You have a specific task.          |
+| **[Reference](#reference)**     | "What exactly is _X_, and where?" | You need to look something up.     |
+| **[Explanation](#explanation)** | "Why is it built this way?"       | You want to understand a decision. |
+
+> **A note on the reference docs.** CoreLive is pre-launch and intentionally
+> volatile — the schema, APIs, and IPC channels are reshaped freely and the
+> database is reset rather than migrated (see [`README.md`](../../README.md) line
+> 13). So the reference docs are **point-to-source**: they name a surface and
+> anchor it to a `file:line`, then defer the exact field/type shapes to the source,
+> which never goes stale. When a reference and the code disagree, the code wins.
+
+---
+
+## Tutorial
+
+_Learning-oriented. One hand-held happy path._
+
+- **[Getting Started](./tutorial-getting-started.md)** — from a fresh clone to a
+  running dev server and your first completed task lighting the Activity Heatmap.
+
+## How-to guides
+
+_Task-oriented recipes. Assume you've done the tutorial._
+
+- **[Run the local dev + test loop](./howto-local-dev-and-tests.md)** — the
+  day-to-day inner loop: database up, dev server (web or Electron), the four test
+  tiers, and the `pnpm validate` gate.
+- **[Add a new oRPC procedure](./howto-add-orpc-procedure.md)** — a type-safe API
+  endpoint end to end: Zod schema → procedure → router → client hook → real-DB test.
+- **[Add a route or a persisted setting](./howto-add-route-or-setting.md)** — a new
+  App Router route (sidebar group vs standalone Electron-window route), or a Redux
+  slice that persists and syncs.
+- **[Add an Electron IPC channel](./howto-add-ipc-channel.md)** — wire a new
+  request/response channel (or a whole new window type) through the typed-IPC
+  contract.
+- **[Add a new colored theme family](./howto-add-theme-family.md)** — one registry
+  edit, regenerate the CSS, and pass the WCAG-AA + heatmap-temperature gates.
+- **[Add a cross-window sync channel](./howto-add-sync-channel.md)** — a
+  BroadcastChannel so a mutation in one window reaches the others.
+- **[Cut a macOS release](./howto-cut-a-release.md)** — ship a signed + notarized
+  build by pushing a `v*` tag, then verify the GitHub Release.
+
+## Reference
+
+_Information-oriented, point-to-source. Look things up here._
+
+- **[oRPC API](./reference-orpc-api.md)** — every procedure across the five
+  namespaces, with router path, file anchor, and auth requirement.
+- **[Data model](./reference-data-model.md)** — the 10 Prisma models, their
+  relations, and the load-bearing data-integrity rules.
+- **[Frontend](./reference-frontend.md)** — routes (and which Electron window loads
+  each), the provider tree, the Redux store, feature components, and the
+  lifecycle-effect hooks.
+- **[Electron](./reference-electron.md)** — the five window types, the typed-IPC
+  channels, the three preload bridges, and the native-macOS managers.
+- **[Theme system](./reference-theme-system.md)** — the theme registry, the CSS
+  generator, the public helpers, and the heatmap-intensity source of truth.
+- **[Authentication](./reference-auth.md)** — every auth surface: route protection,
+  the Clerk webhook, the oRPC middleware/header, and the Electron OAuth bridge.
+- **[CI & commands](./reference-ci-and-commands.md)** — the `package.json` scripts,
+  the GitHub Actions workflows, the `validate` gate, and the four test configs.
+
+## Explanation
+
+_Understanding-oriented. The "why" behind the design._
+
+- **[Architecture](./explanation-architecture.md)** — one codebase, two runtimes
+  (web + Electron WebView), one oRPC-over-HTTP data path. **Start here.**
+- **[Why completions are archived, not deleted](./explanation-completion-and-heatmap.md)**
+  — the heatmap invariant, and how a finished day stays lit forever. The single
+  most load-bearing rule in the codebase.
+- **[Client state & cross-window sync](./explanation-state-and-sync.md)** — Redux vs
+  React Query, and why separate windows reconcile over BroadcastChannel.
+- **[Electron architecture decisions](./explanation-electron-architecture.md)** — why
+  Electron loads the live site, the startup auth gate, and the typed-IPC /
+  version-skew safety.
+- **[How authentication works](./explanation-authentication.md)** — one Clerk
+  identity across two runtimes, the trust boundary, and the system-browser OAuth
+  bridge.
+- **[Skill Tree data integrity](./explanation-skill-tree.md)** — how earned XP
+  survives deleting the task that earned it.
+- **[Why themes are a build-time pipeline](./explanation-theme-system.md)** — why a
+  TypeScript registry compiles to static CSS at build time, and the CI guards that
+  keep the brand and the heatmap from silently drifting.
+- **[Why the build & CI topology looks the way it does](./explanation-build-and-ci.md)**
+  — single-worker Playwright, two notarizations, and the fail-closed DB guard.
+
+---
+
+## Related documentation
+
+Deeper or product-level material that lives elsewhere in the repo:
+
+- **[`../ELECTRON_ARCHITECTURE.md`](../ELECTRON_ARCHITECTURE.md)** — exhaustive
+  Electron main-process internals (file responsibilities, startup sequences, IPC,
+  security/CSP, lazy-loading; Japanese).
+- **[`../BUILD_AND_DEPLOYMENT.md`](../BUILD_AND_DEPLOYMENT.md)** — build, code
+  signing, notarization, and auto-updater setup + troubleshooting.
+- **[`../DEEP_LINKING_IMPLEMENTATION_SUMMARY.md`](../DEEP_LINKING_IMPLEMENTATION_SUMMARY.md)**
+  — the `corelive://` deep-link scheme and `DeepLinkManager`.
+- **[`../ICON_SYSTEM_IMPLEMENTATION_SUMMARY.md`](../ICON_SYSTEM_IMPLEMENTATION_SUMMARY.md)**
+  — the icon-generation pipeline and tray icon states.
+- **[`../PRISMA_V7_MIGRATION.md`](../PRISMA_V7_MIGRATION.md)** — the Prisma v6 → v7
+  migration notes.
+- **[`../PRD.md`](../PRD.md)** — the product requirements document (Japanese).
+- **[`../../DESIGN.md`](../../DESIGN.md)** — the design system: typography, color
+  tokens, motion, microcopy voice, and the self-affirmation north star. **Read this
+  before any UI change.**
+- **[`../../README.md`](../../README.md)** — project setup, prerequisites, and the
+  environment-variable reference.

--- a/docs/dev/explanation-architecture.md
+++ b/docs/dev/explanation-architecture.md
@@ -1,0 +1,199 @@
+# Architecture: one codebase, two runtimes, one data path
+
+CoreLive is **one product that ships in two runtimes** — a web browser and a native macOS Electron app — built from **one codebase** that reaches its data through **one path**. This document is the hub: it draws the whole-system map, walks the boot flow and the request path, explains the central architectural bet (no embedded server in Electron), and links onward to the subsystem deep-dives.
+
+> Read this first, then follow the links at the end into the subsystem you care about. The siblings explain the _invariants_; this page explains how the pieces fit together.
+
+---
+
+## The one sentence to remember
+
+> **Electron is not a second app. It is the web app, loaded in native windows.**
+
+There is no embedded Next.js server in the desktop build, no separate desktop UI, and no separate desktop API. Each Electron window opens a real `corelive.app` URL in a `BrowserWindow`, and every data read/write — web or desktop — travels the identical `POST/GET /api/orpc/*` route. "Web vs Electron" is a runtime branch (`isElectronEnvironment()`), not a fork in the source tree.
+
+Everything else in this document is a consequence of that decision.
+
+---
+
+## The system map
+
+```
+                       ┌──────────────────────────────────────────────┐
+   Web browser tab ───▶│  Next.js 16 App Router (corelive.app)        │
+                       │                                              │
+ Electron BrowserWindows                                             │
+   main      ─▶ /home  │  ┌────────────────────────────────────────┐ │
+   braindump ─▶ /braindump │  Root layout + provider tree         │ │
+   floating  ─▶ /floating-navigator │  (same shell for every URL)  │ │
+   settings  ─▶ /settings │  └────────────────────────────────────┘ │
+                       │                    │                         │
+                       │                    ▼ client → oRPC over HTTP │
+                       │     POST/GET /api/orpc/[...path]             │
+                       │            │  authMiddleware (Clerk Bearer)  │
+                       │            ▼  Prisma                         │
+                       │         PostgreSQL                           │
+                       └──────────────────────────────────────────────┘
+
+  Electron main process (electron/main.ts) — native shell ONLY:
+    windows, dock/menu/tray, deep links, auto-update, window-state.
+    Carries NO data IPC. Auth-syncs to the renderer; data never flows here.
+```
+
+The Electron main process owns only what a web page _cannot_ own — the native macOS surfaces (windows, dock, menu bar, tray, deep links, auto-update). It deliberately carries **no data IPC**: a todo never travels over an Electron channel. See the diagram and rationale in [`docs/ELECTRON_ARCHITECTURE.md`](../ELECTRON_ARCHITECTURE.md) and the sibling [Electron architecture decisions](./explanation-electron-architecture.md).
+
+---
+
+## The stack, and why each piece is here
+
+| Layer        | Choice                                                            | Why this one                                                                                                                                                                                                 |
+| ------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| UI / routing | **Next.js 16 App Router**                                         | One React app that serves both the browser and every Electron window from the same routes; route groups let some screens be chromeless (for dedicated windows) without changing their URLs.                  |
+| API          | **oRPC over HTTP**                                                | End-to-end type safety: the router type flows to the client, so a renamed field is a _compile_ error, not a runtime 500. HTTP transport means web and Electron use the exact same client.                    |
+| Persistence  | **Prisma + PostgreSQL**                                           | Typed queries and a single migration story; the API layer scopes everything by an internal `User.id`.                                                                                                        |
+| Auth         | **Clerk**                                                         | One identity provider for both runtimes; the Clerk `userId` _is_ the API bearer token, so the renderer authenticates the same way everywhere.                                                                |
+| Client state | **Redux Toolkit** (device/prefs) + **React Query** (server cache) | A deliberate split — Redux owns the small, persisted, device-local state; React Query owns all server data and its cache. See [Client state ownership & cross-window sync](./explanation-state-and-sync.md). |
+
+The throughline: **every choice is picked so the two runtimes converge instead of diverge.** A type that breaks breaks in both. A query that runs runs the same code in both.
+
+---
+
+## The boot flow: from a URL to a painted page
+
+Every screen — a browser tab _and_ each Electron window — boots through the same sequence:
+
+```
+URL  →  src/app/layout.tsx (root layout)  →  provider tree  →  the page
+```
+
+The root layout (`src/app/layout.tsx:47`) loads three Google fonts as CSS variables, sets the `%s | CoreLive` metadata template, and assembles the provider tree. Read it directly — `src/app/layout.tsx:49-74` is the single most load-bearing file for understanding boot order. As verified there, the nesting is:
+
+```
+ClerkProvider                          (auth context — everyone needs it)
+└─ <html> / <body>
+   └─ ThemeProvider                    (sets data-theme before paint)
+      ├─ CodeInspectorClient           (dev tooling)
+      └─ QueryClientProvider           (React Query cache + persistence)
+         └─ ReduxProvider              (device/preferences store)
+            ├─ ElectronStartupSync     (renderer → main IPC, no-op on web)
+            ├─ ElectronAuthProvider    (Clerk ↔ Electron, pass-through on web)
+            │  └─ {children}           (the page)
+            └─ Toaster
+```
+
+**The order is load-bearing, not cosmetic:**
+
+- **Clerk is outermost** because auth context is needed by everything below it — including the React Query sign-out guard that resets the cache when the user changes.
+- **Theme wraps before paint** so `data-theme` is set on the document before content renders (no flash). The root `<html>` uses `suppressHydrationWarning` and the layout deliberately does _not_ re-pass `attribute`/`disableTransitionOnChange` — `ThemeProvider` owns those (`src/app/layout.tsx:60-62`).
+- **React Query sits above Redux** because the Electron auth provider (inside the Redux subtree) drives the Clerk session and the cache reset.
+- **`ElectronStartupSync` sits _inside_ `ReduxProvider`** because it reads persisted Redux settings and pushes them to the Electron main process on startup.
+
+For why the providers split state the way they do, and how that state crosses windows, see [Client state ownership & cross-window sync](./explanation-state-and-sync.md). For the theme layer specifically, see [Why themes are a build-time pipeline](./explanation-theme-system.md).
+
+### Routes, and the standalone-window trick
+
+Most screens live under the `(main)` route group, which adds a sidebar without adding a URL segment. But three routes live _outside_ that group on purpose, so they render chromeless (no sidebar) as the bodies of dedicated Electron windows:
+
+| Route                 | Loaded by                          | Notes                                                                      |
+| --------------------- | ---------------------------------- | -------------------------------------------------------------------------- |
+| `/home`               | web + Electron **main** window     | Primary screen; inside `(main)`, so it has the sidebar.                    |
+| `/braindump`          | Electron **braindump** window      | Chromeless; standalone.                                                    |
+| `/floating-navigator` | Electron **floating** window       | Chromeless, always-on-top.                                                 |
+| `/settings`           | web + Electron **settings** window | One settings home for both runtimes; self-gates its Electron-only section. |
+
+The link between a route and the native window that loads it lives in `electron/WindowManager.ts` — the main window loads `${serverUrl}/home` (`electron/WindowManager.ts:391-396`), and the panel/settings URLs are built at `electron/WindowManager.ts:931-936` and `electron/WindowManager.ts:1303-1307`. See [Frontend reference](./reference-frontend.md) for the full route/provider map and [How to add a route or a persisted client setting](./howto-add-route-or-setting.md) to add one.
+
+---
+
+## The data path: identical for web and Electron
+
+Once a page is painted, _all_ data flows through one path:
+
+```
+client (React Query + oRPC)
+   │   POST/GET /api/orpc/<namespace>.<procedure>
+   ▼
+src/app/api/orpc/[...path]/route.ts   (the single catch-all HTTP entrypoint)
+   ▼
+authMiddleware                        (Clerk Bearer → Prisma User → context.user)
+   ▼
+the oRPC procedure (Zod-validated)
+   ▼
+Prisma → PostgreSQL
+```
+
+A few anchors make this concrete:
+
+- **The router** is a plain nested object literal grouping procedures into five namespaces (`category`, `todo`, `completed`, `electronSettings`, `skillTree`); `export type AppRouter = typeof router` at `src/server/router.ts:75` is the type the client is generated from.
+- **The HTTP entrypoint** is one file: `new RPCHandler(router)` mounted at `prefix: '/api/orpc'`, exported as `GET`/`POST`/`PUT`/`PATCH`/`DELETE` (`src/app/api/orpc/[...path]/route.ts:7,39-43`). It passes `{ headers: request.headers }` as context — matching what the middleware expects.
+- **Auth runs in middleware, for every procedure.** `authMiddleware` (`src/server/middleware/auth.ts:10`) reads the `authorization` header, strips `Bearer `, treats the remainder as the Clerk `userId`, and `upsert`s the `User` row — so a first call auto-provisions the user even before Clerk's webhook syncs them. There are **no** unauthenticated procedures.
+
+### Why the path is _literally_ the same code
+
+The proof is in the client transport. `createLink()` builds the oRPC `RPCLink` with:
+
+```ts
+// src/lib/orpc/create-client.ts:18-22
+url: () => `${window.location.origin}/api/orpc`
+```
+
+In a browser, `window.location.origin` is `https://corelive.app`. In an Electron window — which _also_ loaded a `corelive.app` URL — `window.location.origin` is **the same value**. So the same client code resolves to the same endpoint. The bearer header is resolved the same way too: `window.Clerk.session?.user?.id ?? window.Clerk.user?.id` → `Authorization: Bearer <id>` (`src/lib/orpc/create-client.ts:37,58-59`). Web and Electron run the _identical_ transport; there is no Electron-specific data branch to keep in sync.
+
+Components never touch the link directly. They consume the `orpc` object (`src/lib/orpc/client-query.ts:21`), which wraps the client with `@orpc/tanstack-query` to expose `orpc.<ns>.<proc>.queryOptions()` / `.mutationOptions()` / `.key()`. Read-vs-write (query vs mutation) is a **client convention** — oRPC does not tag a procedure server-side; the consumer picks the right wrapper.
+
+For the procedure index and the cross-cutting rules (all-authenticated, idempotent imports, the 60s undo window), see the [oRPC API reference](./reference-orpc-api.md). To add a procedure end to end, see [How to add a new oRPC procedure](./howto-add-orpc-procedure.md).
+
+### Why no embedded server in Electron
+
+The desktop build could have bundled a Next.js server and run the UI locally. It deliberately does **not**. The dev/prod URL split is one line:
+
+```ts
+// electron/main.ts:915-917
+const serverUrl =
+  process.env.ELECTRON_RENDERER_URL ??
+  (isDev ? 'http://localhost:3011' : 'https://corelive.app')
+```
+
+The payoff of loading the remote site instead:
+
+- **One data path, by construction.** With no second server, there is no second API to drift, no embedded-server surface to maintain or ship. The desktop app _is_ the web app's renderer.
+- **Instant parity.** A web deploy updates the desktop app's content on next launch — no separate desktop release needed for a UI or API change. (The native shell still ships on its own cadence; see [How to cut a macOS release](./howto-cut-a-release.md).)
+- **The main process stays thin.** It becomes a native shell with no data responsibilities — easier to reason about and to test.
+
+One subtlety worth flagging, because it has bitten releases before: `isDev` is written as the _positive_ check `process.env.NODE_ENV === 'development'` (`electron/main.ts:173`), never `!== 'production'`. A packaged build runs with `NODE_ENV` **unset**, so `=== 'development'` correctly resolves to `false` and loads the remote URL; a negated check would have read unset-as-dev and loaded `localhost` in a shipped app. That trap, the auth-aware startup sequence, and the window-ownership split are explained in [Electron architecture decisions](./explanation-electron-architecture.md).
+
+---
+
+## Identity: one user, two runtimes, one row
+
+Because both runtimes hit the same API with the same bearer scheme, they also resolve to the same database user. The Clerk `userId` string is the bearer token; the middleware maps it to a `User` row via `User.clerkId` and injects the full Prisma `User` as `context.user`. Handlers scope every query by the internal `User.id` — the Clerk string is never used past the middleware.
+
+This is why a task completed in the browser lights up the same heatmap in the desktop app: same identity, same row, same data. The full identity story (token resolution, upsert provisioning, route protection in `src/proxy.ts`) is in [How authentication works](./explanation-authentication.md) and the [Authentication surface reference](./reference-auth.md).
+
+---
+
+## The pre-launch volatility stance (read this before you "preserve" anything)
+
+CoreLive has no users yet, and the repo says so loudly: the root `README.md:13` declares that breaking changes are fine _anywhere_ — reshape the database, the Prisma schema, or the APIs freely, with **no migrations to keep and no backward compatibility to maintain**. When the schema changes, you just reset: `pnpm db:reset`.
+
+What this means for you as a contributor, and why this documentation is written the way it is:
+
+- **Reference docs point at source, they don't transcribe it.** A field-by-field API or schema reference would rot on the next `db:reset` and then _mislead_. The reference docs name the surface and anchor to `file:line`, deferring exact shapes to the Zod schemas and Prisma model. Trust the source over any prose here.
+- **The durable knowledge is the _why_.** Field names churn; the reasons behind an invariant (why completions are archived instead of deleted, why auth is a bearer-token upsert, why the startup panel hides until login) survive. That is what the `explanation-*` docs capture, and what you should read before changing a subsystem — so you don't "fix" a deliberate decision back into a bug.
+- **Don't reach for migrations or compatibility shims.** If a change is cleaner with a schema reshape, do the reshape and reset. The toolchain has guardrails — destructive DB commands are gated to local databases — so a reset can't touch production.
+
+For how the build, test, and release topology supports this stance, see [Why the build & CI topology looks the way it does](./explanation-build-and-ci.md) and the [CI workflows & command index](./reference-ci-and-commands.md).
+
+---
+
+## Where to go next
+
+This page is the map. The reasoning lives in the siblings:
+
+- **[Why completions are archived, not deleted](./explanation-completion-and-heatmap.md)** — the heatmap invariant: the deepest, least-obvious data rule in the system, and the one a future edit is most likely to break.
+- **[Client state ownership & cross-window sync](./explanation-state-and-sync.md)** — Redux (device/prefs) vs React Query (server), and how state crosses windows (BroadcastChannel between renderers, IPC to the main process).
+- **[Electron architecture decisions](./explanation-electron-architecture.md)** — the native shell, the auth-aware startup nav-watch, window-vs-state ownership, and the `NODE_ENV`-unset trap.
+- **[How authentication works](./explanation-authentication.md)** — one identity, two runtimes, one user row.
+- **[Why themes are a build-time pipeline](./explanation-theme-system.md)** — the registry → generator → static CSS path.
+
+And for tasks: start at the docs hub index, [`./README.md`](./README.md), which links the tutorials, how-tos, and references.

--- a/docs/dev/explanation-authentication.md
+++ b/docs/dev/explanation-authentication.md
@@ -1,0 +1,129 @@
+# How authentication works: one identity, two runtimes, one user row
+
+CoreLive runs as two surfaces — the web app in a browser and the Electron macOS app in a WebView — but both authenticate against a single Clerk application and resolve to a single Postgres `User` row. This document explains the durable mental model behind that: where identity lives, what actually stands between a request and a user's data (it is _not_ what you might assume), how a Clerk user becomes a Postgres row, and why Electron sign-in takes a detour through the system browser.
+
+This is understanding-oriented. For step-by-step recipes — protecting a new route, adding an authed oRPC procedure, running auth locally — see [reference-auth.md](./reference-auth.md) and [howto-local-dev-and-tests.md](./howto-local-dev-and-tests.md). Environment variables (Clerk keys, webhook secret) live in the root [README.md](../../README.md); this doc does not restate them.
+
+## The one fact everything else hangs on
+
+**Clerk is the source of truth for identity. The Postgres join key is `User.clerkId`.**
+
+Clerk issues each user a stable id like `user_2abc…`. That string — not an email, not the Postgres autoincrement `id` — is what ties a Clerk identity to its database row. The schema makes `clerkId` unique (`prisma/schema.prisma:57-59`), and every server-side user lookup keys off it.
+
+Because both runtimes authenticate against the **same Clerk app**, they receive the **same** `user_…` id, so they resolve to the **same** Postgres row. There is no "web user" and "desktop user" — there is one user who happens to be looking through two windows. Hold onto this; it is why the Electron OAuth bridge (below) works at all.
+
+## What actually guards the data path (and what does not)
+
+This is the most important — and most counter-intuitive — thing to understand about CoreLive auth. There are **two** request paths with **two different** trust models, and conflating them is the mistake to avoid.
+
+### Page routes are gated by `proxy.ts`
+
+In Next.js 16, `middleware.ts` was renamed to `proxy.ts`; this repo's lives at `src/proxy.ts`. It runs `clerkMiddleware`, and for a protected page it verifies the Clerk **cookie session** server-side via `auth()` and redirects unauthenticated visitors to `/login?redirect_url=…` (`src/proxy.ts:17-29`). The protected prefixes are an explicit allowlist — `/home`, `/skill-tree`, `/braindump`, `/settings`, `/floating-navigator` (`src/proxy.ts:4-15`). This is real enforcement, backed by a verified cookie session.
+
+### The oRPC data path is NOT gated by `proxy.ts`
+
+Here is the subtlety. The matcher _does_ run `clerkMiddleware` on `/api` (`src/proxy.ts:33-39`), but read the body: the very first thing it does is
+
+```ts
+if (!isProtectedRoute(req)) {
+  return
+}
+```
+
+(`src/proxy.ts:18-20`). `isProtectedRoute` lists only the page prefixes above — **`/api` is not among them.** So for any `/api/orpc/*` request the middleware returns _before_ it ever calls `auth()` or checks `isAuthenticated`. **`proxy.ts` does not authenticate the data path.** It guards page navigation only.
+
+What does stand in front of the data path is the oRPC `authMiddleware` (`src/server/middleware/auth.ts:10-51`). And what it does is the second half of the surprise:
+
+```ts
+const authHeader = context.headers.get('authorization')
+const clerkUserId = authHeader?.replace('Bearer ', '')
+// …
+const user = await prisma.user.upsert({
+  where: { clerkId: clerkUserId },
+  update: {},
+  create: { clerkId: clerkUserId },
+})
+```
+
+(`src/server/middleware/auth.ts:14-15,41-48`). It strips `Bearer ` off the `Authorization` header and treats the remainder **directly as the `clerkId`**. The Bearer token is the **raw Clerk user id** — _not_ a JWT, _not_ a session token. There is **no callback to Clerk, no signature check, no expiry validation.** Whatever id arrives, the middleware upserts and trusts.
+
+> The doc comment in `src/lib/orpc/create-client.ts:11` calls this "the user's Clerk session ID." That comment is misleading — the code one screen down resolves and sends `clerk.session?.user?.id ?? clerk.user?.id`, i.e. the **user** id (`src/lib/orpc/create-client.ts:37,51,59`). Trust the code, not the comment.
+
+### So what is the real trust model?
+
+State it soberly, because a future engineer _will_ build on whatever they think is true here:
+
+- **Page routes** → genuinely gated by `proxy.ts` (verified Clerk cookie session).
+- **`/api/orpc`** → gated only by `authMiddleware`, which trusts an unverified, bare user id.
+- Therefore the thing standing between a caller and _another user's_ data is the **secrecy and unguessability of Clerk user ids** — not route protection (it doesn't run for the API), and not "same-origin" (CORS only constrains browsers; any non-browser client can set any `Authorization` header it likes).
+
+Do **not** document this as "proxy.ts plus same-origin protects the API" — the code you can read does not enforce that. The honest invariant is: _there is no server-side token verification on the oRPC path._ If a future change needs the data path hardened (verifying a real Clerk JWT, scoping reachability, signing requests), that work does not exist yet and must be added deliberately — do not assume it is already there because page routes look protected.
+
+Why was it built this stateless way? Because it gives web and Electron an **identical** data path: the same `/api/orpc` endpoint, the same header, the same client code (`src/lib/orpc/create-client.ts` is used verbatim by both). The server only needs one thing to find the row — the user id — and the middleware stays trivial. That simplicity is the benefit; the absence of verification is its cost, and this section is here so the cost is never mistaken for a feature that's already covered.
+
+## Two ways a `User` row is born — for the same row
+
+A Clerk identity becomes a Postgres row through **two independent paths**, and understanding both prevents confusion when a row looks half-populated.
+
+**Path 1 — the webhook (the intended one).** Clerk fires a `user.created` webhook to `src/app/api/webhooks/route.ts`. The handler verifies the Svix HMAC signature against `WEBHOOK_SECRET` (`src/app/api/webhooks/route.ts:42-56`) — that signature _is_ the auth for this endpoint, which is why it needs no Clerk session — then, inside one `$transaction`, it creates the `User` (with `clerkId`, email, and a name derived from username or first/last) **and** seeds a default "General" category (`src/app/api/webhooks/route.ts:58-89`). Provisioning out-of-band keeps Clerk the identity source of truth, decouples row creation from request latency, and lands a new user in a usable workspace with a category already present.
+
+**Path 2 — lazy upsert (the fallback).** The oRPC `authMiddleware` upserts on first authed request, creating a row with **only** `clerkId` and nothing else (`src/server/middleware/auth.ts:41-48`). This guarantees a row exists even if the webhook is slow or never configured (e.g. local dev without a tunnel).
+
+The consequence to internalize: a user provisioned **only** by Path 2 has a **null email, null name, and no "General" category** until the webhook catches up. Both paths write the same row (keyed by the same `clerkId`), so they reconcile — but they are not equivalent, and the difference surfaces as an empty-looking profile or a missing default category. If you ever see that state, this is why.
+
+One more drift to know about: the webhook handles **only** `user.created` (`src/app/api/webhooks/route.ts:58`). There is no `user.updated` or `user.deleted` handler. So profile edits or account deletions made in Clerk do **not** propagate to Postgres — the row can drift from Clerk over time. That is a known gap, not a bug to be surprised by.
+
+## Why Electron sign-in detours through the system browser
+
+This is the single most surprising piece of the subsystem, and it exists because of **hard external constraints**, not preference. If you are tempted to "simplify" it back into an in-WebView OAuth, read this first.
+
+Two walls force the design (both documented at `src/app/oauth/callback/page.tsx:21-24`; the Google-WebView wall is also noted at `src/app/oauth/start/page.tsx:26`):
+
+1. **Google blocks OAuth inside WebViews** — it returns `403: disallowed_useragent`. You cannot complete Google sign-in in the Electron WebView, full stop.
+2. **Clerk's browser cookie is not shared with the WebView.** Even if a user is signed in to `corelive.app` in their real browser, the Electron WebView has a **separate cookie store** and sees no session.
+
+So sign-in happens where it's allowed — the **real system browser** — and the resulting session is handed to the WebView as a **one-time ticket**:
+
+1. The Electron main process generates a CSRF `state`, stores it, and opens `…/oauth/start?provider=&state=` in the **system browser** via `shell.openExternal` (`electron/OAuthManager.ts:200-228`).
+2. The browser runs Clerk's standard `authenticateWithRedirect` flow (`src/app/oauth/start/page.tsx:97-101`); a browser-side Clerk session is created.
+3. The browser asks the backend for a **sign-in token** scoped to that just-authenticated user — `clerkClient().signInTokens.createSignInToken({ userId, expiresInSeconds: 60 })` (`src/app/api/oauth/create-signin-token/route.ts:35-39`), guarded so only an authenticated browser session can mint one (`…/route.ts:25-32`).
+4. The browser redirects to a `corelive://oauth/callback?state=&token=` **deep link** (`src/app/oauth/callback/page.tsx:86,95`). Electron's `corelive://` protocol handler receives it.
+5. The main process validates the `state` and TTL, then ferries the ticket to the WebView (`electron/OAuthManager.ts:252-309`).
+6. The WebView exchanges the ticket for its **own** Clerk session: `client.signIn.create({ strategy: 'ticket', ticket })` then `setActive` (`src/lib/orpc/electron-auth-provider.tsx:190-210`).
+
+The payoff is the "one fact" from the top of this doc: the ticket was minted for a specific Clerk `userId`, so the WebView's brand-new session belongs to the **same Clerk user** → the **same Postgres row**. The browser and the WebView never share a cookie; they share an _identity_, bridged by a short-lived credential.
+
+### Why the two TTLs are deliberately asymmetric
+
+The flow has two clocks, and they differ on purpose:
+
+- **`state` lives ~10 minutes** (`electron/OAuthManager.ts:113`). It spans a human doing a browser dance — choosing an account, entering a password, maybe MFA. People are slow; 10 minutes is forgiving.
+- **The sign-in token lives 60 seconds and is single-use** — enforced both server-side at mint time (`src/app/api/oauth/create-signin-token/route.ts:38`) and again in the main process's pending-token cache (`electron/OAuthManager.ts:366-371`). The token is a **bearer credential in transit over a deep link**; a deep link can be observed, so the replay window is squeezed to seconds.
+
+Single-use is reinforced in code: the renderer **clears** the main-process pending token _before_ consuming it, so a failed exchange cannot retry the same one-time ticket (`src/lib/orpc/electron-auth-provider.tsx:186-193`). If you change this ordering, you reintroduce a replay path — don't.
+
+### What can't finish in the WebView
+
+Some Clerk outcomes can't complete inside the WebView session. If the ticket exchange returns `needs_second_factor` or `needs_client_trust`, the WebView gives up and tells the user to finish in the browser instead (`src/lib/orpc/electron-auth-provider.tsx:365-376`). Likewise, if activating the session surfaces an extra `currentTask`, it aborts to an error rather than navigating to `/home` (`…/electron-auth-provider.tsx:84-94`). These are graceful bounce-backs to the only place those steps _can_ happen — the real browser — not failures to paper over.
+
+### Why the OAuth origin is derived, not hardcoded
+
+`buildOAuthURL` reads the origin from the **live `BrowserWindow` URL** rather than a constant (`electron/OAuthManager.ts:156-192`). This keeps the Clerk environment aligned across the browser hop: a dev Electron build (loaded from `localhost:3011`) starts OAuth on the _dev_ origin with _dev_ Clerk keys, and prod (loaded from `corelive.app`) uses prod. Hardcoding the origin would let a dev build create OAuth state on a production page and then fail to consume the returned ticket with development keys. The environment must stay consistent end-to-end, so the origin follows the window.
+
+## Smaller things worth keeping straight
+
+**The dev backdoor.** When `NODE_ENV === 'development'` _and_ the Bearer value is exactly `user_mock_user_id`, `authMiddleware` upserts a fixed `test@example.com` test user (`src/server/middleware/auth.ts:18-32`). The `NODE_ENV` guard means it is unreachable in a production build. This is what lets E2E and local flows operate without a live Clerk round-trip.
+
+**Client query gating.** Protected oRPC queries must not fire before Clerk hydrates the session, or they UNAUTHORIZED-flake (a real problem under Playwright and right after OAuth redirects). `useClerkQueryReady()` returns `isLoaded && Boolean(user)` and gates query enablement (`src/hooks/useClerkQueryReady.ts:18-21`); the `ElectronAuthProvider` similarly waits for Clerk's `signIn`/`client` to be ready before wiring its OAuth listeners (`src/lib/orpc/electron-auth-provider.tsx:43-50`). The provider is mounted inside `<ClerkProvider>` in the root layout (`src/app/layout.tsx:49,67`).
+
+**Main-process `activeUser` does not gate data.** The Electron main process keeps a lightweight `activeUser`, set/cleared via auth IPC handlers (`electron/main.ts:1697-1728`). This state exists only so the **native chrome** (menu bar, tray, notifications) can show user context. It does **not** gate data access — data goes over HTTP + Bearer, identically to the web app, never over IPC. Don't reach for `activeUser` as an authorization check; it isn't one.
+
+**`electron/auth-manager.ts` is dead code — do not revive it casually.** It is never instantiated; the live auth IPC handlers are inlined in `main.ts` via `typedHandle`. The file is kept as a reference sketch for a possible future manager-class refactor and carries a banner saying exactly that (`electron/auth-manager.ts:1-18`). Critically, its `ApiBridge.setUserId(userId)` shape (`electron/auth-manager.ts:32-34`) describes an **old IPC-data architecture** the app has since abandoned in favor of HTTP + Bearer. If you wire it up as-is, you'll be implementing a stale, wrong contract. It's documented precisely to stop that.
+
+## Related
+
+- [reference-auth.md](./reference-auth.md) — the auth surface map: each file and entry point, anchored to source.
+- [howto-local-dev-and-tests.md](./howto-local-dev-and-tests.md) — running auth locally, the dev mock user, and delivering the Clerk webhook.
+- [howto-add-orpc-procedure.md](./howto-add-orpc-procedure.md) and [howto-add-route-or-setting.md](./howto-add-route-or-setting.md) — composing `authMiddleware` so `ctx.user` is available, and adding a protected route prefix.
+- [explanation-architecture.md](./explanation-architecture.md) and [explanation-electron-architecture.md](./explanation-electron-architecture.md) — the one-codebase / two-runtimes / one-data-path story this auth model lives inside.
+- Hub: [README.md](./README.md).

--- a/docs/dev/explanation-build-and-ci.md
+++ b/docs/dev/explanation-build-and-ci.md
@@ -1,0 +1,100 @@
+# Why the build & CI topology looks the way it does
+
+CoreLive's build and CI shape is dominated by three constraints that don't show up in any single config file: the web E2E suite shares **one** seeded Clerk user and **one** Postgres database, the desktop app ships as a **notarized native macOS bundle wrapped in a DMG**, and a developer's local `POSTGRES_PRISMA_URL` can point at the **production Neon database**. This page explains the decisions those constraints forced, the threat each invariant defends, and what breaks if a future engineer removes one. It does not list commands — for the authoritative command/workflow index see [`reference-ci-and-commands.md`](./reference-ci-and-commands.md), and `package.json` `"scripts"` is the single source of truth for every script body.
+
+> Scope note: this is the _why_, not the _how_. The release procedure lives in [`howto-cut-a-release.md`](./howto-cut-a-release.md); signing setup and troubleshooting live in [`../BUILD_AND_DEPLOYMENT.md`](../BUILD_AND_DEPLOYMENT.md) (note: that doc is partly stale on the build pipeline — it predates the `electron:build:ts` and DMG-finalize steps documented below, so trust this page for the _rationale_ and the source for the _mechanics_). The theme-CSS generator, icon generator, the test tiers (three vitest configs plus Playwright E2E), and the `compose.yml` naming are adjacent build machinery covered elsewhere — see [`explanation-theme-system.md`](./explanation-theme-system.md) and [`reference-ci-and-commands.md`](./reference-ci-and-commands.md).
+
+---
+
+## Playwright runs `workers: 1` because the test fixtures are shared, not isolated
+
+`playwright.config.ts:36` hard-codes `workers: 1` for both local and CI runs. This is not a performance default — it is a correctness requirement, and the config comment (`playwright.config.ts:16-35`) spells out exactly why.
+
+Every web E2E spec authenticates as the **same** seeded Clerk user (`test@test.com`) against the **same** PostgreSQL database. Many specs mutate global, user-scoped state: the comment's worked example is `qa-fixes.spec.ts`'s "Clear all completed" test, which calls the `clearCompleted` procedure. That procedure archives completions into the `Completed` table and then `deleteMany`s the `Todo` rows for the user (`src/server/utils/archiveCompletedTodos.ts`); `NodeAssignment` is left to the schema's `onDelete: SetNull` (the rows orphan with `todoId → null`, XP preserved via the `todoText` snapshot — `prisma/schema.prisma:213`), so it is **not** cascade-deleted. The race `workers: 1` prevents is the `deleteMany` on `Todo` rows: run concurrently with `skill-tree.spec.ts` on a second worker, it removes completed todos that spec just seeded — a cross-file data race that surfaces as a flaky, confusing failure far from its cause. (The upstream `playwright.config.ts:16-35` comment still describes this as a `NodeAssignment` cascade; that wording is stale — the mechanism is the `Todo`-row delete above.)
+
+The subtle part — and the reason `fullyParallel: false` alone is insufficient — is that `fullyParallel: false` only serializes tests **within** a single file; Playwright still distributes different _files_ across workers. `workers: 1` is the only setting that serializes across files when they share database state.
+
+This is a deliberate, **temporary** trade. The config records an explicit **exit criterion** (`playwright.config.ts:30-35`): single-worker execution halves CI throughput across the whole suite and should not be permanent. The clean fix is **per-worker Clerk users** — each worker owning its own Prisma `User` row would make `clearCompleted` naturally scoped to one worker's data, at which point this flips back to `workers: undefined`. If you are tempted to bump `workers` to recover speed, that exit criterion is the gate: the shared-fixture race must be eliminated first, or the suite goes non-deterministic.
+
+## True parallelism is recovered above Playwright, via a per-spec CI matrix
+
+Because `workers: 1` serializes the suite inside one runner, parallelism is recovered one level up — in GitHub Actions. `e2e.web.yml` does **not** use Playwright's built-in `--shard=N/M`; it fans out **one runner per spec file**, and each runner provisions its own Postgres + Next.js.
+
+The `detect-specs` job (`.github/workflows/e2e.web.yml:38-60`) auto-discovers every `e2e/web/*.spec.ts`, strips it to a bare spec name, and emits a JSON array; the downstream `e2e-web` job consumes that array via `fromJson(...)` as a matrix (`.github/workflows/e2e.web.yml:77-80`). Adding or removing a spec needs **no workflow edit** — the matrix size auto-adjusts on the next run.
+
+The choice of _per-file runners_ over _Playwright sharding_ follows directly from `workers: 1` (`.github/workflows/e2e.web.yml:31-37`): with a single worker, `--shard` would split tests across shards but still **serialize within each shard**, so it buys nothing. Separate runners give _true_ parallelism precisely because each gets an **isolated database** — and every spec already calls `test.beforeAll(resetDatabase)`, so an isolated DB per runner is the natural unit of work. The threat model that `workers: 1` defends (the cross-spec `deleteMany` race on `Todo` rows) simply cannot occur across runners that never share a database.
+
+Each runner writes a `blob` report rather than HTML, and a final `merge-reports` job recombines all `blob-report-*` artifacts into one browsable HTML report via `playwright merge-reports` (`.github/workflows/e2e.web.yml:195-227`). This is why `playwright.config.ts:38-46` selects the `blob` reporter on CI but `list` locally — the blob format exists specifically so the fan-out shards can fan back in.
+
+There is one extra subtlety worth preserving: the per-runner reset would otherwise happen _twice_. `e2e/global-setup.ts` already does an up-front reset, and each spec's `test.beforeAll(resetDatabase)` would repeat the same migrate+seed (~5-10s wasted per shard). The matrix step therefore sets `E2E_SKIP_PER_SPEC_RESET: 'true'` (`.github/workflows/e2e.web.yml:145-165`), and `resetDatabase` early-returns when it sees that flag. Each runner runs exactly one spec, so the single global reset is already sufficient.
+
+## The Electron E2E suite stays a single xvfb job — until the math changes
+
+`e2e.electron.yml` is deliberately the opposite shape: **one** `ubuntu-latest` job under `xvfb-run`, not a per-spec matrix. The header comment (`.github/workflows/e2e.electron.yml:1-34`) is the canonical rationale and even names the break-even.
+
+The web matrix wins because it **amortizes** Postgres + Next.js bring-up across many specs; that amortization only pays off past roughly **6 specs**. The Electron suite is **3 specs** at v0, so per-spec runners would spend more time on setup than on the tests. Worse, each Electron shard also pays an extra ~10-20s for `pnpm electron:build:ts` (the electron-vite compile of main + preload). Below the break-even, a single job is simply cheaper. The comment records the trigger to revisit: when the Electron suite grows past ~6 specs, convert it to the `e2e.web.yml`-style matrix + merge-reports flow.
+
+Two further facts shape this job and are easy to break if you don't know them:
+
+- **Why `xvfb` at all.** Electron needs a display to create a `BrowserWindow`; CI runners are headless, so `xvfb` supplies a virtual one (`.github/workflows/e2e.electron.yml:18-22`). The repo's "macOS only" constraint applies to **packaged DMG releases** (signing/notarization), _not_ to running Electron under a virtual display for tests — Electron itself runs fine on Linux.
+- **Why a second Playwright config exists.** `pnpm e2e:electron` runs against `playwright.electron.config.ts`, which narrows `projects` to the `electron` project and emits HTML directly. The config comment (`playwright.electron.config.ts:5-24`) explains you _cannot_ express this by toggling the reporter with a `--project` flag in the base config: **Playwright evaluates `reporter` at config-load time, before the CLI's `--project` is parsed.** The web suite needs `blob` → merge fan-in; the 3-spec Electron suite needs HTML directly; that is two different reporter values, so it is two config files.
+
+The most important thing this job does **not** cover is the load-bearing caveat. Linux + xvfb drives the **renderer only** — identical paths to the web app. The native Cocoa chrome (`app.setActivationPolicy`, dock / menu bar / traffic-light buttons, `open-url` deep links, vibrancy, notarized `.app`/asar paths) has **zero automated coverage** (`.github/workflows/e2e.electron.yml:24-29`). That is why a **manual macOS smoke** before every tag push is mandatory, not optional — see [`../BUILD_AND_DEPLOYMENT.md`](../BUILD_AND_DEPLOYMENT.md) and the project's local `CLAUDE.md` "Electron Native QA" section. A future engineer who reads "Electron E2E passed" as "Electron works" will ship a broken tray or dock with green CI.
+
+## There are two notarizations because the `.app` and the `.dmg` are two different artifacts
+
+A macOS release produces a notarized **app bundle** _inside_ a notarized **disk image**, and Gatekeeper checks them independently. electron-builder only notarizes one of them, so the build does the second pass itself. This page is the canonical home for _why_ — `../BUILD_AND_DEPLOYMENT.md` predates this two-phase flow.
+
+**Phase 1 — the `.app`, during packaging.** `electron-builder.json:106` registers an `afterSign` hook pointing at `scripts/notarize.js`. That hook calls `@electron/notarize` on the `.app` bundle (`scripts/notarize.js:26-32`, bundle ID `com.corelive.app`). It is a no-op on non-darwin platforms and when Apple credentials are absent (`scripts/notarize.js:7-23`), so PR builds and Linux jobs skip it harmlessly.
+
+**Phase 2 — the `.dmg`, after packaging.** The `afterSign` hook does **not** cover the DMG _wrapper_ — electron-builder builds the DMG after that hook runs. So `electron:build:mac` chains a third command after electron-builder: `node scripts/finalize-mac-release-artifacts.js` (`package.json:59`). That script notarizes and staples **each** DMG (x64 + arm64) via `xcrun notarytool submit --wait` and `xcrun stapler staple` (`scripts/finalize-mac-release-artifacts.js:138-164`), and it is idempotent — it skips a DMG that already has a stapled ticket (`scripts/finalize-mac-release-artifacts.js:84-93, 139-144`), so a retried release doesn't double-submit.
+
+The non-obvious part — and the reason this can't be left to electron-builder — is **ordering**. Stapling **mutates the DMG's bytes** _after_ electron-builder has already written its blockmaps, `latest-mac.yml`, and `checksums.json` from the _pre-staple_ bytes. If those were published as-is, every integrity check downstream would compare against the wrong hash. So Phase 2 finishes by undoing and redoing that metadata from the **post-staple** bytes:
+
+1. Delete the now-stale `.dmg.blockmap` files, because stapling invalidated them (`scripts/finalize-mac-release-artifacts.js:172-179`).
+2. Rewrite `latest-mac.yml` (the auto-update manifest) with fresh SHA-512 + sizes computed from the stapled files (`scripts/finalize-mac-release-artifacts.js:187-214`).
+3. Rewrite `checksums.json` (manual-download integrity) with fresh SHA-256 + sizes (`scripts/finalize-mac-release-artifacts.js:221-244`).
+
+The script is darwin-only (`scripts/finalize-mac-release-artifacts.js:251-257`). If a future engineer collapses this back into the `afterSign` hook, or reorders the manifest rewrite before stapling, the symptom is an **auto-updater that refuses to install** (the `latest-mac.yml` hash won't match the downloaded DMG) — a silent, post-ship failure that no CI step catches.
+
+Two adjacent invariants make this pipeline coherent and are worth stating because they have bitten releases before:
+
+- `electron:build:mac` passes `electron-builder --mac --publish never` (`package.json:59`). It signs and notarizes but **does not upload**. Uploading is a _separate_ `release` GitHub Actions job that runs `gh release` on tag pushes only (`.github/workflows/build-and-release.yml:109-146`). The `electron:publish` script (`electron-builder --publish=always`, `package.json:61`) exists but is **never** used — it would double-publish and bypass the DMG-finalize step entirely. Releases go through a `v*` tag, not through that script.
+- The renderer is **not** packaged. `electron-builder.json:22` excludes `src/**` (and `.ts`/`.tsx` throughout `files`), because the app loads `https://corelive.app/` remotely — it is a WebView, with no embedded Next.js bundle. This is why the `electron:build:mac` script (`package.json:59`) runs `electron:build:ts` (compile main + preload) but **does not** invoke `next build` — the packaged `.app` ships no Next.js output. The release _workflow_ still runs `pnpm build` unconditionally (`build-and-release.yml:72-73`, no `if:` gate, so on `v*` tag pushes too), but that build's output is not bundled into the `.app`. See [`explanation-electron-architecture.md`](./explanation-electron-architecture.md) for the WebView decision.
+
+## Destructive DB commands are gated fail-closed, because dev and prod share a URL shape
+
+`scripts/assert-local-db.cjs` runs _before_ every destructive Prisma command — it is prefixed onto `db:reset`, `db:truncate`, and `prisma:migrate` as `node scripts/assert-local-db.cjs && ...` (`package.json:43, 50, 51`). It is the single choke point that every path — E2E `global-setup`/`global-teardown`, `resetDatabase`, and a human typing `pnpm db:reset` — must pass through.
+
+The threat is concrete and high-stakes (`scripts/assert-local-db.cjs:4-5`): a developer's `POSTGRES_PRISMA_URL` can point at production Neon, and `prisma migrate reset --force` wipes whatever it connects to. A command meant to reset the local Docker database, inheriting a production URL, would erase production in one shot.
+
+The design is an **allowlist, fail-closed** — "proceed only when provably local," never "stop if it looks like prod" (`scripts/assert-local-db.cjs:9-11`). If the production URL format changes tomorrow, an unrecognized host still fails closed: the gate `exit(1)`s on anything it cannot positively prove is local (`localhost`, `127.0.0.1`, `::1`, the Docker service name `postgres`, the container name `corelive-postgres`, or a Unix-socket path — `scripts/assert-local-db.cjs:24-31, 54-58`).
+
+The subtle, easy-to-reintroduce vulnerability the gate defends against is a **parser divergence** between two URL parsers (`scripts/assert-local-db.cjs:12-16, 80-95`):
+
+- The host check uses the WHATWG `new URL().hostname`.
+- But Prisma/libpq **honor a `?host=` / `?hostname=` connection parameter** and actually connect _there_, while WHATWG does **not** reflect that into `.hostname`.
+
+So a naive hostname-only check is **fail-open**: `postgresql://localhost/db?host=prod.neon.tech` reads as "localhost, allowed" under WHATWG, yet Prisma connects to — and would wipe — `prod.neon.tech`. The gate closes this by validating the query-string hosts too, including libpq's comma-separated multi-host form (one non-local entry aborts), and by aborting on backslash-containing URLs where the two parsers disagree on the authority boundary (`scripts/assert-local-db.cjs:62-68, 86-95`). An empty host with no query host also aborts — "cannot prove local" means stop (`scripts/assert-local-db.cjs:100-108`).
+
+If a future engineer "simplifies" this to a plain `hostname === 'localhost'` check, they reopen exactly the fail-open hole this script was written to close. The allowlist and the `?host=` validation are not redundant belt-and-suspenders — each blocks a distinct way to reach production.
+
+## Production migrations run behind a human approval gate
+
+Resetting the _local_ DB is guarded by the script above; migrating the _production_ DB is guarded by GitHub itself. `db-migrate.yml` pins the migrate job to the GitHub `production` environment (`.github/workflows/db-migrate.yml:54-55`), which — when configured with required reviewers — forces a human approval before any migration runs against production.
+
+The workflow is defensive in depth (`.github/workflows/db-migrate.yml:19-39`):
+
+- It triggers on `workflow_dispatch` with a typed-confirmation input — you must literally type `DEPLOY`, or a guard step fails the run (`.github/workflows/db-migrate.yml:58-62`) — and also auto-triggers when migration files land on `main` (`paths: prisma/migrations/**`, `prisma/schema.prisma`).
+- It supports a `dry_run` that only checks status and applies nothing (`.github/workflows/db-migrate.yml:79-92`).
+- A `concurrency` group with `cancel-in-progress: false` prevents two migrations from racing (`.github/workflows/db-migrate.yml:44-47`) — unlike most workflows here, an in-flight migration must **not** be cancelled mid-run.
+
+This is the production counterpart to `assert-local-db.cjs`: the local gate proves a destructive command is _not_ touching production; the production workflow ensures the deliberate production change is _gated behind a human_. Together they mean neither an accidental local command nor an unreviewed migration can silently mutate production data.
+
+## `pnpm validate` runs everything in parallel and aborts on the first failure
+
+The local pre-commit gate, `pnpm validate` (`package.json:40`), runs **six** checks concurrently via `concurrently ... --kill-others-on-fail`: unit tests, the in-repo ESLint-plugin workspace package tests, lint-with-fix, the Next.js build, the TypeScript typecheck, and the theme-CSS drift check.
+
+The composition is the point. Running these in parallel means the slowest task (the build) does not block the fast ones (lint, typecheck, test) from surfacing failures first, so you get the earliest possible feedback; and `--kill-others-on-fail` aborts the remaining tasks the moment any one fails, so you don't wait on a full build to learn that a typecheck already broke.
+
+CI deliberately does **not** mirror this single command — it **splits** these checks across separate workflows (`test.yml` for unit + electron + theme drift, `e2e.web.yml`, `e2e.electron.yml`, `build-and-release.yml`) so each gets its own runner, its own logs, and independent pass/fail status. `validate` is the _developer's_ one-shot local gate; the workflows are the _enforced_ CI gates. They check overlapping things on purpose, at different granularities. For the workflow-by-workflow breakdown and the exact script bodies, see [`reference-ci-and-commands.md`](./reference-ci-and-commands.md) and `package.json` `"scripts"`.

--- a/docs/dev/explanation-completion-and-heatmap.md
+++ b/docs/dev/explanation-completion-and-heatmap.md
@@ -1,0 +1,148 @@
+# Why completions are archived, not deleted (the heatmap invariant)
+
+The Activity Heatmap is CoreLive's north star: every warm cell is a day you showed up, and the product's entire reason for existing is that you can look back and feel "今日自分頑張ったな." That makes one promise load-bearing above all others:
+
+> **A day that was once lit must never silently go dark.**
+
+This document explains the invariants that defend that promise. Each section is a specific way a future edit could erase a lit day — a hard delete, an edit-drift, a flag flip, a "tidied up" helper, a consolidated code path — and the guard that stops it. If you are about to touch completion, deletion, the heatmap read model, or the skill tree's XP, read this first. The _what_ and _where_ (field names, line ranges, the full procedure list) live in [`reference-data-model.md`](./reference-data-model.md) and [`reference-orpc-api.md`](./reference-orpc-api.md); this doc is the _why_ and the _what-breaks-if-you-don't_.
+
+---
+
+## The threat model: completions are fragile
+
+A completion is not one row in one table. It arrives through two disjoint paths and is read back through a UNION, and the moment you delete or mutate the wrong thing, the heatmap loses a day with **no error, no failing test, no crash** — it just quietly counts one fewer. Silent data loss on the product's centerpiece is the worst failure mode this codebase has, and almost every invariant below exists to make it impossible.
+
+### Two source tables feed one heatmap
+
+Completion data lives in two tables, written by disjoint paths:
+
+- **`Todo` with `completed = true`** — the live to-do list. `toggleTodo` flips `completed` and stamps `completedAt` (`src/server/procedures/todo.ts:208`).
+- **`Completed`** — a separate completion-event stream, written by three paths that never touch the `Todo` lifecycle: BrainDump checkbox-ticks, bulk paste-import, and the archive flow described below.
+
+The heatmap (and the day-detail dialog) read **both**, UNION them for a UTC day window, and bucket by day. The single read model is `fetchCompletedEntries` (`src/server/utils/completedAggregation.ts:61`), consumed by `completed.heatmap` and `completed.dayDetail`.
+
+Because the two surfaces are **disjoint by construction** — BrainDump's tick bypasses the `Todo` lifecycle and writes `Completed` directly, while the `TodoList` complete flow never writes `Completed` — the UNION performs **no row-level dedup**. This is asserted by a unit test (`completedAggregation.test.ts:157`, "UNIONs rows from both tables sorted ascending by completedAt"). Do not add dedup: it would have nothing to deduplicate and would risk collapsing the legitimately-repeated completions that are the entire point (see [no dedup](#no-dedup-repetition-is-the-signal)).
+
+---
+
+## Invariant 1 — Archive before delete (the erasure bug)
+
+**Threat:** the heatmap counts completed `Todo` rows directly. So hard-deleting a completed todo — the obvious implementation of "Clear completed" or a per-item delete — erases that todo's heatmap day. The user finished a task, watched the cell warm, cleared their list to tidy up, and the day went dark. That is the exact bug this invariant exists to kill.
+
+**Guard:** a completed todo is **copied into `Completed` (with `archived: false`) before the `Todo` row is removed**, inside one transaction, so the heatmap day survives as a `Completed` row (which the heatmap also reads). A _pending_ todo carries no heatmap day, so it is still hard-deleted — that is lossless. The shared helper is `archiveCompletedTodos` (`src/server/utils/archiveCompletedTodos.ts`), called by:
+
+- `todo.clearCompleted` — archives **all** completed todos (`todo.ts:262`).
+- `todo.delete` — archives a single todo **only if it is completed** (`todo.ts:155`).
+
+The copy is the load-bearing line:
+
+```ts
+completedAt: todo.completedAt ?? todo.updatedAt,
+```
+
+and `archived` is **omitted on write** so it inherits the schema's `@default(false)`.
+
+This is also documented from the API side as invariant #6 in [`reference-orpc-api.md`](./reference-orpc-api.md).
+
+### Sub-invariant: the archive/delete decision must happen _inside_ the transaction
+
+`todo.delete` does **not** read `completed` outside the transaction and branch on it. That was a real time-of-check/time-of-use race (CodeRabbit #4): if a todo flipped `false → true` between the read and the delete, the "pending" branch would hard-delete a now-completed todo and erase its day. Instead `archiveCompletedTodos` (which filters `completed: true`) runs first _inside_ the tx and returns a count; the hard-delete fallback fires **only** when that count is `0`, i.e. the row was genuinely pending at tx time (`todo.ts:168-201`). If you refactor this procedure, keep the decision atomic with the delete.
+
+### What this invariant does _not_ promise
+
+`archiveCompletedTodos` is **not idempotent** (CodeRabbit #3, accepted). Two `clearCompleted` calls firing in parallel can each read the same completed todo before either deletes it and insert two `Completed` rows for one completion, inflating that day's count. There is **no data or XP loss** — the todo is still removed, `NodeAssignment` still orphans correctly, `archived:false` still holds — only a display count can over-count, and it requires a deliberate double-action that the confirm dialog already guards. The reasoning and the deferred-fix options are in the docblock at `archiveCompletedTodos.ts:23-32`. Stating the boundary matters: "lit days never vanish" is the guarantee; "the count is exact under concurrent clears" is not.
+
+---
+
+## Invariant 2 — `archived: false` is load-bearing
+
+**Threat:** `Completed.archived` looks like a soft-delete flag, and a well-meaning contributor "cleaning up" the archive helper might think a row copied out of a deleted todo _is_ archived and set `archived: true`. The build stays green. Every test passes. And those days silently vanish from every user's heatmap — reintroducing the exact erasure bug Invariant 1 exists to fix.
+
+**Guard:** `fetchCompletedEntries` filters `archived: false` on the `Completed` read (`completedAggregation.ts:99`). An `archived: true` row is invisible to the heatmap. Therefore the archive flow **must never write `true`**, and it doesn't — it omits the field so the row inherits `@default(false)` (`archiveCompletedTodos.ts:13-21`, the explicit LOAD-BEARING docblock). The flag exists for a _future_ hide-from-heatmap feature, not as a byproduct of archiving. If you ever wire something to set `archived: true`, that is a deliberate "remove this day from the heatmap" action — never a teardown step.
+
+---
+
+## Invariant 3 — `completedAt` is nullable with no default
+
+**Threat (and the subtler one):** the heatmap needs to put each completion on the right _day_. The naive choice is `updatedAt` — but `Todo.updatedAt` mutates on every text/notes edit, so a task you finished on Monday and edited a typo in on Friday would jump to Friday on the heatmap. History would drift under the user every time they touched an old row. The `Completed` half has the same hazard with imported rows. And the "obvious" fix — add a `completedAt` column with a non-null default — is itself a trap: a `@default(now())` would stamp **every historical row** with the migration's timestamp, jumping all of your past completions onto migration-day in one jarring spike.
+
+**Guard:** both `Completed.completedAt` (`prisma/schema.prisma:30`) and `Todo.completedAt` (`schema.prisma:101`) are `DateTime?` with **no `@default`**. The migrations backfilled existing rows explicitly (Completed ← `createdAt`, Todo ← `updatedAt`), so old rows kept their real days instead of all snapping to migration-day. New completions get a stamp at the moment they happen: `toggleTodo` writes `completedAt = new Date()` on every `false → true` transition (`todo.ts:251-254`). The heatmap then **filters and buckets by `completedAt`** — the same stable field for both the query window and the day assignment — so a completed-then-edited todo stays on its real day. The schema design notes spell this out verbatim at `schema.prisma:24-30` (Completed) and `:93-101` (Todo); the read-side rationale is in the `fetchCompletedEntries` docblock (`completedAggregation.ts:27-43`). The `居残りモード` (retain-completed-in-list) feature was the forcing function for the `Todo.completedAt` migration, because retaining a completed task in the editable list made edit-drift trivially reproducible.
+
+### The fallback is asymmetric — and deliberately so
+
+For any row whose `completedAt` is still null (an unconverted write path, or a pre-backfill row), the read coalesces to a fallback — but **a different fallback per table**:
+
+```ts
+// Todo half:
+completedAt: row.completedAt ?? row.updatedAt // completedAggregation.ts:130
+// Completed half:
+completedAt: row.completedAt ?? row.createdAt // completedAggregation.ts:141
+```
+
+This is not an inconsistency to "clean up." Each table falls back to _its own_ best approximation of the completion day: a `Todo` has no insert-time notion of completion, so `updatedAt` (when it was last touched, which for a freshly-completed row is the completion) is the closest signal; a `Completed` row _is_ the completion event, so `createdAt` (when the event was recorded) is correct, and notably keeps a **dated import** — a row with a past `completedAt` and a today `createdAt` — on its real past day. Flattening both to one field would mis-bucket one of the two surfaces. The backfill means nulls are not expected in practice; the coalesce is defensive depth so a missed write path still lands on _a_ day rather than vanishing.
+
+> **UTC bounds are part of this contract.** The heatmap buckets via `entry.completedAt.toISOString().split('T')[0]` — a UTC date string. So the query window is anchored to UTC midnight (`${todayIso}T00:00:00.000Z`), not local midnight. Anchoring to local midnight mis-buckets boundary-hour rows on any non-UTC host; Vercel runs UTC by default, which _masked_ the bug rather than preventing it (`completed.ts:51-69`). The window is `days - 1` past dates **plus today** via inclusive `gte`/`lte` = exactly `days` calendar dates (subtracting the full `days` would include one extra day at the lower edge — CodeRabbit on PR #38).
+
+---
+
+## Invariant 4 — completion flows only through `toggleTodo`
+
+**Threat:** if more than one code path could set `completed = true`, each would have to remember to stamp `completedAt` and maintain the XP guard below. One that forgot would create completions with a null `completedAt` and a stale skill-tree assignment.
+
+**Guard:** completion state changes **only** via `toggleTodo`. `updateTodo`'s input schema deliberately **omits `completed`** (`UpdateTodoSchema`), so the general-purpose update procedure _cannot_ flip completion even if a caller tries. `toggleTodo` is the single seam, and it is where both `completedAt` stamping (Invariant 3) and the XP guard (Invariant 5) live. Keep it that way: a new "mark done" path should call toggle, not write `completed` directly.
+
+---
+
+## Invariant 5 — the double-XP guard, and why archive must NOT mirror it
+
+This is the single most error-prone area in the subsystem, because two code paths look like they should do the same teardown and **must do the opposite**. A future engineer "consolidating" them is exactly the reader this section exists to stop.
+
+The skill tree lets a user drag a _completed_ todo onto a node to bank XP, recorded as a `NodeAssignment`. Two completion-path operations touch that assignment, in opposite directions:
+
+**`toggleTodo` un-complete (`true → false`) DELETES the assignment** (`todo.ts:232-243`):
+
+```ts
+if (existingTodo.completed && !nextCompleted) {
+  await tx.nodeAssignment.deleteMany({ where: { todoId: id } })
+}
+```
+
+Without this, a user could complete a task → assign it for XP → un-complete it → re-complete it → assign it to a _different_ node, banking XP twice for one task. The `assignTask` completed-check alone is not enough, because the stale assignment would survive the un-complete and keep granting XP. **If you drop this deleteMany, you reopen the double-XP exploit.**
+
+**`archiveCompletedTodos` deliberately does NOT delete the assignment** (`archiveCompletedTodos.ts:17-19`). When a completed todo is archived-and-deleted, its `NodeAssignment` is left to the schema's `onDelete: SetNull`: the row orphans with `todoId = null` and survives, and the popover keeps reading the `todoText` snapshot taken at assignment time. The user _earned_ that XP by finishing the task; clearing their completed list must not confiscate it. **If you "mirror" the toggle's deleteMany into the archive path for symmetry, you destroy earned XP every time a user clears their list.**
+
+So the rule is directional and must stay that way:
+
+| Path                     | NodeAssignment                     | If you change it                           |
+| ------------------------ | ---------------------------------- | ------------------------------------------ |
+| `toggleTodo` un-complete | **delete** it (exploit guard)      | Drop it → double-XP exploit reopens        |
+| `archiveCompletedTodos`  | **keep** it (orphan via `SetNull`) | Mirror the delete → earned XP is destroyed |
+
+The full XP-integrity model — the composite FK that forces same-tree edges, the `@@unique([todoId])` that blocks multi-node inflation, the `todoText` snapshot — is the subject of [`explanation-skill-tree.md`](./explanation-skill-tree.md). This doc covers only how the _completion_ paths interact with XP.
+
+---
+
+## No dedup: repetition is the signal
+
+CoreLive **never deduplicates tasks**, anywhere — not in the todo list, not in import, not in the heatmap UNION. Logging the same task twice is two completions and warms the day twice. This is intentional: repetition is the habit/XP signal the product is built to celebrate (「些細でも経験値」), not noise to collapse. It is enforced structurally — paste-import's idempotency key is the `ImportBatch.id` (a per-batch client UUID), **never** task title or content (`schema.prisma:73-79`) — and the UNION read does no row-level merge (above). If you ever feel the urge to "clean up duplicates," that urge is the bug.
+
+## Temperature = pride: the raw count is what blooms
+
+These invariants converge on one synthesis: the heatmap buckets the **raw** completion count, repeats included, and that count is mapped to _warmth_, never to a green productivity grade. The count→intensity mapping is the single source of truth in `src/lib/heatmap-intensity.ts` (`getHeatmapIntensityFromCount`, bands at 1–3 / 4–9 / 10–19 / 20+), shared by both the heatmap cells and the day-detail band so a cell color and its dialog copy can never drift. The mapping never weights by recency, streak, or category — more completions, hotter day, full stop. A day reads as "you showed up this much," which is why the apex is amber/terracotta and **deliberately never GitHub-green**: green reads as work compliance; warmth reads as self-affirmation.
+
+The canonical statement of this is the **Heatmap Invariance Rule** in [`DESIGN.md`](../../DESIGN.md) (the "temperature = pride … hot end blooms warm on every theme, forever" rule, line 147). The _mechanics_ of how that warmth is enforced across all 12 themes — the OKLCH seeds, the CI gate asserting the two hottest stops sit at hue ∈ [20, 70], the generated CSS pipeline — belong to [`explanation-theme-system.md`](./explanation-theme-system.md). What this doc owns is the _data_ half: the number that drives the color is the honest, un-deduplicated count of times you showed up.
+
+---
+
+## If you are about to change something here
+
+| You're changing…                           | Re-read first        | The trap                                                                                                                         |
+| ------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| "Clear completed" / delete a todo          | Invariant 1          | Hard-deleting a completed todo erases its heatmap day — archive first.                                                           |
+| The `archived` flag / the archive helper   | Invariant 2          | Writing `archived: true` silently drops days; the build stays green.                                                             |
+| `completedAt` / a completion timestamp     | Invariant 3          | A non-null default stamps history to migration-day; `updatedAt` drifts on edit; the per-table fallback is asymmetric on purpose. |
+| Any path that sets `completed = true`      | Invariant 4          | Bypassing `toggleTodo` skips `completedAt` + the XP guard — route through toggle.                                                |
+| `NodeAssignment` cleanup in toggle/archive | Invariant 5          | The two paths are _opposite_ by design — never consolidate them.                                                                 |
+| The heatmap read / aggregation             | Two-tables, No-dedup | Both tables must surface; never add dedup or count-weighting.                                                                    |
+
+**Related docs:** [`reference-data-model.md`](./reference-data-model.md) (the schema surface + invariants matrix) · [`reference-orpc-api.md`](./reference-orpc-api.md) (the procedure index; invariant #6 is archive-on-delete) · [`explanation-skill-tree.md`](./explanation-skill-tree.md) (the full XP-integrity model) · [`explanation-theme-system.md`](./explanation-theme-system.md) (how temperature=pride is enforced in color) · [`DESIGN.md`](../../DESIGN.md) (the Heatmap Invariance Rule) · the doc hub [`README.md`](./README.md).

--- a/docs/dev/explanation-electron-architecture.md
+++ b/docs/dev/explanation-electron-architecture.md
@@ -1,0 +1,201 @@
+# Electron architecture decisions
+
+Why CoreLive's desktop build is a thin native shell around the _live_ web app rather than a bundled server, and why a handful of non-obvious invariants (URL routing, the auth-aware startup, window-state ownership, the typed-IPC contract, preload version skew) are written the way they are. This is a decisions doc — it explains the reasoning and the threat model each choice defends; for the deep internals see the (Japanese) [`docs/ELECTRON_ARCHITECTURE.md`](../ELECTRON_ARCHITECTURE.md), and for the file-by-file surface see [`reference-electron.md`](./reference-electron.md).
+
+> **Audience**: contributors touching `electron/`. If you only ever change web UI, you can ignore this doc — the desktop build runs the same renderer you already work on.
+
+---
+
+## 1. The desktop app loads the remote site — there is no bundled Next.js
+
+The single most load-bearing decision: **the Electron renderer loads `https://corelive.app` directly.** There is no embedded Next.js server in the packaged app, no copied-in `.next` build, no localhost server spun up by the main process in production. If you go looking for "where's the bundled web app inside the `.app`?", the answer is: there isn't one.
+
+The renderer URL is resolved once, at boot, in `electron/main.ts:915-917`:
+
+```ts
+const serverUrl =
+  process.env.ELECTRON_RENDERER_URL ??
+  (isDev ? 'http://localhost:3011' : 'https://corelive.app')
+```
+
+Every window then loads a route off that origin — `${serverUrl}/home`, `/floating-navigator`, `/braindump`, `/settings`.
+
+### Why one origin instead of an embedded server
+
+The payoff is **one data path**. The web app and the desktop app run the _same_ renderer bundle and talk to the _same_ backend over plain HTTP oRPC. The main process carries **no data IPC** — it owns only the things a browser tab cannot do for itself (native window chrome, the menu bar, the tray, the dock, deep links, auto-update). There is no second copy of the data layer to keep in sync, no "desktop is a version behind" drift, and no embedded-server attack surface to ship and notarize. A bug fixed on the website is fixed in the desktop app the next time it loads, with no release.
+
+This is the reasoning behind the project's "one codebase, two runtimes, one data path" framing — see [`explanation-architecture.md`](./explanation-architecture.md) for the web side of the same coin.
+
+### The three URLs: dev, prod, and the E2E seam
+
+| Context            | `serverUrl` resolves to                    | Driven by                                    |
+| ------------------ | ------------------------------------------ | -------------------------------------------- |
+| `pnpm dev` (local) | `http://localhost:3011`                    | `isDev` (`NODE_ENV === 'development'`)       |
+| Packaged / shipped | `https://corelive.app`                     | the `??` fallback (`isDev` is false)         |
+| Electron E2E       | a local `http://localhost`/`127.0.0.1` URL | `ELECTRON_RENDERER_URL` (highest precedence) |
+
+`ELECTRON_RENDERER_URL` is the **E2E seam**: it lets the Playwright Electron suite point the renderer at a controlled local server _without_ flipping `isDev`, so the test runs with production CSP and the production optimization level — a high-fidelity test rather than a dev-mode one. Because that env var overrides the origin entirely, it is validated up front (`electron/main.ts:142-163`): the value must parse as a `URL`, use the `http:` protocol, and have hostname exactly `localhost` or `127.0.0.1`. The parse-and-compare (rather than a `startsWith` check) is deliberate — it stops subdomain tricks like `http://localhost.attacker.com` from pointing the shipped shell at an arbitrary origin via the environment.
+
+### The `NODE_ENV`-unset trap: gate on `=== 'development'`, never `!== 'production'`
+
+`isDev` is defined as a **positive** equality check (`electron/main.ts:173`):
+
+```ts
+const isDev = process.env.NODE_ENV === 'development'
+```
+
+This is a correctness property, not a style choice. **A packaged, electron-builder-produced app runs with `NODE_ENV` unset.** Trace the two possible spellings against an unset value:
+
+- `NODE_ENV === 'development'` → `undefined === 'development'` → `false` → loads `https://corelive.app`. **Correct.**
+- `NODE_ENV !== 'production'` → `undefined !== 'production'` → `true` → would treat the shipped app as dev and load `http://localhost:3011`, which isn't running. **A blank, broken app.**
+
+So any code in `electron/` whose behavior must differ between dev and a shipped build gates on the explicit `'development'` value — the same reasoning governs the auto-updater's dev-skip (`electron/AutoUpdater.ts:163-165`, `if (process.env.NODE_ENV === 'development') return`). The companion failure mode (a `!== 'production'` check that crashed a packaged build via a dev-only logger path) is recorded in the project's local memory under `packaged-electron-node-env-unset`; that note's `app.isPackaged` advice is about the _logger_ — in this subsystem the gate is `NODE_ENV`, and there is intentionally no `app.isPackaged` check in the window/URL path.
+
+**If you violate this:** it will pass every test you run locally with `pnpm electron:dev` (where `NODE_ENV` _is_ set), and only break once it's packaged. Reproduce packaged-only behavior with `pnpm electron:build:dir` and `open dist/mac/CoreLive.app`, never `electron:dev`.
+
+---
+
+## 2. The auth-aware startup: why you never see an empty panel
+
+CoreLive can boot straight into an auxiliary panel — the always-on-top floating navigator or the braindump quick-capture window — without ever showing the main window, if the user configured it that way. That creates a problem the web app never has: a tiny floating panel is a terrible place to land a signed-out user, because Clerk's `proxy.ts` will redirect them to `/login` and they'd be staring at a login form crammed into a 300px floating chrome with no obvious way out.
+
+The startup sequence solves this with a **navigation watcher** rather than an auth check:
+
+1. **Create the panel hidden.** A panel-only launch creates its window but does not show it on `ready-to-show`.
+2. **Watch where it lands.** `watchStartupPanelLoad` (`electron/WindowManager.ts:1005-1078`) subscribes to `did-navigate` / `did-finish-load` / `did-fail-load` and makes a single show-or-suppress decision (guarded by a `decided` flag so the two events can't both fire).
+3. **Divert to main if it's an auth page.** If the final URL is one of `AUTH_PATHNAMES` (`/login`, `/sign-up` — `electron/constants.ts:28-31`), `proxy.ts` redirected an unauthenticated user. The watcher keeps the panel hidden and calls `restoreFromTray()` to surface the full main window instead, where login fits.
+4. **Re-show after sign-in.** `armPostLoginReshow` (`electron/WindowManager.ts:1092-1112`) arms a one-shot listener on the main window; once it navigates _away_ from the auth pages (the user signed in), it reloads the original panel route and reveals the panel the user asked for.
+
+If the panel lands on a real (non-auth) route, it's authenticated — the panel just shows.
+
+### Why `ERR_ABORTED` is explicitly ignored
+
+During the normal `/floating-navigator` → `/login` redirect chain, Chromium fires `did-fail-load` with `net::ERR_ABORTED` (`-3`, `electron/constants.ts:40`) because the first navigation was _intentionally cancelled_ by the redirect. If the watcher treated that as a load failure it would misfire its fallback on every signed-out boot. So `watchStartupPanelLoad` ignores both `ERR_ABORTED` and any non-main-frame (subresource) failure (`WindowManager.ts:1066`) — those are not "the boot failed," they're "a redirect happened."
+
+### The cold-boot pill, and why it's an inlined `data:` URL
+
+A panel-only boot has no main window painting to reassure the user during a slow start. `armStartupPill` (`electron/WindowManager.ts:1125`) handles that with a tiny click-through always-on-top "Opening CoreLive…" pill, governed by two timers in `constants.ts`:
+
+- It appears only _after_ `STARTUP_PILL_GAP_MS` (400ms, `constants.ts:52`) — a fast boot dismisses it before that, so it never flashes.
+- If the boot is still wedged at `STARTUP_PILL_TIMEOUT_MS` (8000ms, `constants.ts:59`) — offline, a 5xx, a hung load — it dismisses and surfaces the main window as a backstop, so the app is never stuck behind an invisible failed panel.
+
+The pill's markup is built by `buildStartupPillHtml` (`electron/startup-pill-html.ts`) and loaded as a **self-contained `data:` URL**, not a renderer route or a bundled HTML file. Two constraints force this: the pill must paint _before_ any web content loads (so it cannot depend on `corelive.app`), and electron-builder excludes the `electron/` TS sources from the packaged app, so a file path would be missing at runtime. A `data:` URL ships the markup inline and sidesteps the renderer CSP. (Its visual tokens — serif, oklch, breathing dot — are inlined from `DESIGN.md`.)
+
+**If you violate this:** a future contributor "simplifying" the pill into a `/startup-pill` route or an external HTML file will produce a pill that works in `electron:dev` and silently 404s / blank-renders in the packaged app — another packaged-only bug.
+
+---
+
+## 3. Window-state vs config vs runtime visibility: three layers, one rule
+
+Three managers persist or control window behavior, and the boundaries between them are deliberate. Getting them confused is the most likely way to "fix" a non-bug into a real one.
+
+| Layer                | Owns                                                              | Persists to              | Anchor                           |
+| -------------------- | ----------------------------------------------------------------- | ------------------------ | -------------------------------- |
+| `WindowStateManager` | **bounds, snap, maximize/fullscreen** — geometry only             | `window-state.json`      | `electron/WindowStateManager.ts` |
+| `ConfigManager`      | **startup config** (which windows open) + the ≥1-window invariant | `config.json`            | `electron/ConfigManager.ts`      |
+| `WindowManager`      | **runtime visibility** — every `show`/`hide`/`toggle`             | (none — it's live state) | `electron/WindowManager.ts`      |
+
+**The rule: `WindowManager` is the _only_ owner of visibility.** `WindowStateManager.applyWindowState` restores maximize/fullscreen (main) and always-on-top (floating) but **deliberately does not restore visibility** (`WindowStateManager.ts:761-763`):
+
+```ts
+// Visibility is owned by WindowManager's explicit show paths. Restoring
+// it here would let stale window-state.json bypass startup config and the
+// signed-out auth gate for auxiliary panels.
+```
+
+(Window bounds are applied at construction via `getWindowOptions`, and snap via `snapWindowToEdge` — neither runs in `applyWindowState`.)
+
+### Why the split exists
+
+If two layers both toggled show/hide, they'd race — producing flicker, or a window that reappears against the user's startup choice. Worse, restoring visibility from persisted state would let a stale `window-state.json` _bypass the auth gate from §2_: a panel persisted as `isVisible: true` would pop open before the nav-watch could decide it should be suppressed for a signed-out user.
+
+The floating navigator makes this concrete. Its startup visibility has a **single source of truth** — `behavior.startup.showFloating` — and `validateWindowStates` re-pins `floating.isVisible` back to that configured default on _every_ state load (`WindowStateManager.ts:299-305`). So if a user turns the floating window off in settings, a stale `isVisible: true` left in `window-state.json` can't resurrect it. The persisted _geometry_ (width/height) is still honored — the pin is narrow, touching only visibility.
+
+### Why the ≥1-window invariant lives in `ConfigManager`, not the IPC handler
+
+A startup config where `showMain`, `showBraindump`, and `showFloating` are _all_ false would launch a windowless app the user cannot interact with or recover — a soft-brick. `ensureAtLeastOneStartupWindow` (`electron/ConfigManager.ts:597-635`) prevents that by forcing `showMain = true` whenever a write would leave all three false.
+
+It lives on the **persistence layer**, called from `set`/`update` _and_ `importConfig` — so **every** write path is protected: the `settings:setStartupConfig` IPC handler, a config import, a future migration. Putting the guard in the IPC handler instead would leave import and migration paths able to persist an all-false config. The check also hardens against malformed input: it uses `isPlainObject` guards (because `typeof [] === 'object'`, a bare `typeof` would let `behavior: []` through) and strict `=== true` boolean coercion (because `Boolean("false") === true` — a hand-edited string `"false"` would otherwise wrongly arm a window). See `ConfigManager.ts:605-633`.
+
+**If you violate this:** moving the invariant "up" into a handler, or relaxing the coercion, re-opens the windowless-launch failure for the paths you didn't cover. The behavior is pinned by `ConfigManager.startup.test.ts` and `WindowStateManager.startup.test.ts` — if you change it, those tests should fail loudly.
+
+> Note: `WindowStateManager` and `WindowManager` also re-home a window whose persisted bounds fell entirely off all connected monitors (multi-monitor recovery). For the dock-icon hide/show (`app.setActivationPolicy`), the secure-by-default DevTools/CDP gate, and the critical-vs-deferred boot split, see [`reference-electron.md`](./reference-electron.md).
+
+---
+
+## 4. The typed-IPC contract: why an unvalidated channel is impossible
+
+The renderer is _remote web content_. The main process has filesystem, native-OS, and (indirectly) DB reach via the same web app. So every byte the renderer sends over IPC is **untrusted input** — exactly the case Electron's official security checklist item #17 ("validate the sender and arguments of all IPC messages") exists for. CoreLive enforces that with **three surfaces that the TypeScript compiler keeps in sync**, so that "I added a channel but forgot to validate it" is a _compile error_, not a runtime hole.
+
+| Surface                           | What it is                                                                                              | File                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| **1. Compile-time contract**      | `IPCChannels` (request/response per invoke channel) + `IPCEventChannels` (one-way main→renderer events) | `electron/types/ipc.ts`       |
+| **2. Exhaustive runtime schemas** | `IPC_ARG_SCHEMAS: Record<IPCChannel, z.ZodTypeAny>` — one Zod schema per channel                        | `electron/ipc/ipc-schemas.ts` |
+| **3. Typed wrappers**             | `typedHandle` / `typedInvoke` / `typedSend` read those types                                            | `electron/ipc/`               |
+
+### Why exhaustiveness is the trick
+
+The schema map is typed `Record<IPCChannel, z.ZodTypeAny>`. Because `IPCChannel` is the union of _every_ channel name in the contract, the `Record` is **total** — if you add a channel to `types/ipc.ts` and don't add its schema to `ipc-schemas.ts`, the file fails to compile (`ipc-schemas.ts:21-23` spells this out). There is no path to "shipped a channel with no schema."
+
+`typedHandle` (`electron/ipc/typedHandle.ts:47-71`) is the single runtime chokepoint: before any handler runs, it looks up the channel's schema and calls `schema.parse(rawArgs)`. A payload that fails validation never reaches the handler — instead `typedHandle` throws `IPC validation failed on '<channel>': <detail>` (`typedHandle.ts:60`). `ipc-contract.test.ts` is the de-facto spec for all this: it asserts the schema map is exhaustive (`Object.keys(IPC_ARG_SCHEMAS)` covers every channel) and that representative channels reject bad input.
+
+> **Docstring caveat — registration is centralized, not per-manager.** Several docstrings (e.g. `typedHandle.ts:17`) say handlers are registered by "each domain's `registerIpcHandlers()`." That is **stale**: _every_ `typedHandle` registration actually lives in one place — `main.ts setupIPCHandlers()` (`electron/main.ts:1099`, idempotent via the `ipcHandlersInitialized` guard at `:1103-1106`). The managers are pure logic classes the handlers _call_; they don't register their own IPC. If you're adding a channel, add the handler there — see [`howto-add-ipc-channel.md`](./howto-add-ipc-channel.md).
+
+### Least-privilege preloads
+
+There are **three** preload scripts, each exposing exactly one isolated API object via `contextBridge` — the renderer never sees `ipcRenderer` or Node:
+
+- `electron/preload.ts` → `window.electronAPI` (the full ~18-namespace surface, `:232`)
+- `electron/preload-floating.ts` → `window.floatingNavigatorAPI` (narrow: window controls + `brainDump.toggle` + menu-action events, `:126`)
+- `electron/preload-braindump.ts` → `window.brainDumpAPI` (note/sync/category get-set; its inbound whitelist is the single channel `braindump-category-changed`, `:121`)
+
+Each window kind gets only the channels it needs. Inbound events are double-guarded at the bridge: a hard-coded channel allow-list (`validateChannel` / `ALLOWED_CHANNELS`, `preload.ts:122,162-163`) and a `sanitizeData` pass that strips prototype-pollution keys (`['__proto__', 'constructor', 'prototype']`, `preload.ts:172-201`) and trims strings before the payload reaches renderer code.
+
+The one-way event emitter `typedSend` (`electron/ipc/typedSend.ts:38`) no-ops when `sender.isDestroyed()` — emitting to a window that closed mid-flight is a safe lost event, not a main-process crash.
+
+**Standing caveats (don't be misled by dead/vestigial code):** `createTypedListener` (`electron/ipc/typedListener.ts`) has **zero call sites** — the live inbound pattern is the guarded raw `ipcRenderer.on` above, not this factory. `IPCErrorHandler` is constructed and cleaned up but its retry/wrap methods are never invoked, so there is **no automatic IPC retry** in effect. `electron/auth-manager.ts` is **dead code** (raw `ipcMain.handle('auth-*')`, never imported; it would double-register and throw if it loaded — proof it doesn't). Treat `preload.ts` as the single source of truth for what is actually exposed.
+
+---
+
+## 5. Preload version skew: feature-detect at _method_ granularity
+
+This hazard follows directly from §1. The installed `.app` ships a **frozen preload** — the `electronAPI` bridge is baked in at build time. But the renderer loads the **always-current remote web bundle**. So a freshly-deployed web build can call a preload method that an _older installed app_ never exposed. The namespace might be there; the method might not.
+
+The rule for renderer code: **feature-detect at method granularity, never just the namespace.** The canonical guard is in `ElectronStartupSync.tsx` (`src/components/electron/ElectronStartupSync.tsx:105-106`):
+
+```ts
+const settings = window.electronAPI?.settings
+if (typeof settings?.setHideAppIcon !== 'function') return
+```
+
+Checking `window.electronAPI?.settings` alone is not enough — an older preload could expose `settings` with a different method set. The same `typeof ...?.method !== 'function'` pattern guards the other Electron-aware components (`BrainDumpSettings.tsx:240-242`, `StartupWindowSettings.tsx:187`, `FloatingWindowSettings.tsx:145`). The two hand-written global `Window.electronAPI` type augmentations encode this by marking namespaces **optional** (`?`), forcing callers to narrow.
+
+> **The `.d.ts` files have drifted — trust the preload, not the types.** Two augmentations exist and disagree with each other _and_ with runtime: `electron/types/electron-api.d.ts:355` declares a `performance` namespace that `preload.ts` does **not** expose, while `src/types/electron.d.ts` has zero mention of `performance`. The optionality is load-bearing (it enforces method-granular guards); the specific declared members are not authoritative. `preload.ts` is the only source of truth for what's actually bridged.
+
+**If you violate this:** a renderer that assumes a method exists because the namespace does will throw on older installed apps right after you deploy a web build that uses a new method. `src/app/error.tsx` is the route-level net that catches a missed guard, but it's a backstop, not a substitute. This is recorded in local memory under `electron-preload-version-skew`.
+
+---
+
+## 6. The native-macOS coverage gap: green CI is not green Cocoa
+
+A standing caveat that prevents a false sense of safety. The automated suites — Playwright and the `mcp__electron__*` tools — **drive the renderer (web content) only**. They exercise the same DOM as the web app. The CI Electron E2E runs on Linux under `xvfb`, which is _also_ renderer coverage.
+
+What that leaves with **no automated coverage at all**: the menu bar (`MenuManager`), the system tray (`SystemTrayManager`), the dock + `app.setActivationPolicy` hide/show, `open-url` deep links (`DeepLinkManager`), the traffic-light window controls, window vibrancy, and the multi-window flows (main ↔ floating ↔ braindump, the startup pill). These are native Cocoa surfaces that live _outside_ the web content, so DOM-driving tools cannot reach them, and `xvfb` does not cover Cocoa-specific paths.
+
+The only coverage for those surfaces is a **manual macOS smoke** before any tag push or release — and after touching any main-process or native-integration code. Drive the real desktop with the `mcp__computer-use__*` MCP (which screenshots and clicks the actual screen, so it _can_ reach the menu bar / tray / dock / traffic lights) against a real packaged build:
+
+```bash
+pnpm electron:build:dir && open dist/mac/CoreLive.app
+```
+
+Verify motion (window/menu transitions) by recording video and inspecting frames, not by stills — screenshots can't reveal jank or flashes. The full procedure lives in the project's local `CLAUDE.md` ("Electron Native QA"); the takeaway here is the _reasoning_: a passing CI run tells you the renderer works, and tells you **nothing** about whether the native chrome works.
+
+---
+
+## See also
+
+- [`docs/ELECTRON_ARCHITECTURE.md`](../ELECTRON_ARCHITECTURE.md) — the deep, file-by-file internals (Japanese).
+- [`reference-electron.md`](./reference-electron.md) — the windows / IPC / preload / managers surface, point-to-source.
+- [`howto-add-ipc-channel.md`](./howto-add-ipc-channel.md) — the repeatable ritual for adding a channel or a window type.
+- [`explanation-architecture.md`](./explanation-architecture.md) — one codebase, two runtimes, one data path (the web side of §1).
+- [`README.md`](./README.md) — the dev-docs hub index.

--- a/docs/dev/explanation-skill-tree.md
+++ b/docs/dev/explanation-skill-tree.md
@@ -1,0 +1,221 @@
+# Skill Tree data integrity
+
+The gamified Skill Tree turns completed tasks into earned XP on a graph of skill
+nodes. Its correctness lives almost entirely in the database schema, not in
+application code — a handful of constraints in `prisma/schema.prisma` defend
+against corruption paths that handlers could never reliably catch at runtime.
+This document explains the threat each constraint defends and what breaks if a
+future engineer relaxes it.
+
+The shape is four models — `SkillTree → SkillNode → NodeEdge`, plus
+`NodeAssignment` — defined at `prisma/schema.prisma:130-219`. For the exact
+fields and types, read the schema (it is the single source of truth and is
+heavily commented); this doc deliberately does not transcribe them, because in
+this pre-launch repo the schema is reshaped freely and a field-by-field copy
+would rot on the next `db:reset` (see the repo-root [`README.md`](../../README.md)). The four procedures that
+read and mutate the tree live in `src/server/procedures/skillTree.ts`; see the
+[oRPC API reference](./reference-orpc-api.md) for their signatures and the
+[data model reference](./reference-data-model.md) for the model index.
+
+## One tree per user
+
+A `SkillTree` row carries `@@unique([userId])` (`prisma/schema.prisma:142-143`).
+Each user has exactly one tree, enforced at the database level rather than by an
+application check.
+
+The threat is a race, not a typo. `skillTree.getMyTree`
+(`src/server/procedures/skillTree.ts:177`) lazily creates the tree on first
+visit: it does a `findUnique` by `userId`, and if there is no tree it imports the
+default template. Two requests landing in that window — a double-clicked nav, a
+web tab plus the Electron window, a retried request — would both see "no tree"
+and both try to create one. Without the unique constraint the user ends up with
+two trees; the very next `getMyTree` does a `findUnique` against a `userId` that
+now matches two rows and throws. The constraint converts that race into a clean
+loser: the second insert fails with Prisma `P2002`, which `getMyTree` catches and
+turns into a re-query for the winning tree
+(`src/server/procedures/skillTree.ts:188-206`). The user never sees the race.
+
+If you drop `@@unique([userId])`, you reintroduce the duplicate-tree race and
+break `getMyTree`'s `findUnique` read for any user unlucky enough to double-create.
+
+## Edges stay inside their own tree
+
+A `NodeEdge` connects two `SkillNode`s. The naive design — single-column foreign
+keys `fromNodeId → SkillNode.id` and `toNodeId → SkillNode.id` — lets an edge
+reference two nodes that belong to _different_ trees. That is a corruption the
+application layer cannot reliably catch: nothing in a normal write path
+cross-checks that both endpoints share a tree, and once such an edge exists,
+rendering or traversal sees a node that isn't in the tree it's drawing.
+
+The schema closes this at the database level with a **composite foreign key**.
+`SkillNode` carries `@@unique([skillTreeId, id])`
+(`prisma/schema.prisma:167-172`), and `NodeEdge.fromNode` / `toNode` reference
+`SkillNode(skillTreeId, id)` — including the edge's own `skillTreeId` in the key
+(`prisma/schema.prisma:189-191`). Postgres then refuses any edge whose endpoints
+don't live in the same tree as the edge. The integrity check is structural, not
+a runtime assertion that a refactor could forget to run.
+
+This forces two non-obvious choices, each documented inline next to the relevant
+field:
+
+- **The composite FKs use `onDelete: NoAction`, not `Cascade`.** Prisma forbids
+  two overlapping `Cascade` paths that share a scalar field, and both composite
+  FKs share `skillTreeId` with the `skillTree` relation. Trying to make them
+  `Cascade` makes Prisma refuse to generate the migration. `NoAction` is not a
+  weakness here: deleting a `SkillTree` still removes its edges, because
+  `NodeEdge.skillTree` keeps `onDelete: Cascade` (`prisma/schema.prisma:189`).
+  Edges vanish with the tree via that relation; the composite FKs only police
+  cross-tree references.
+- **`SkillNode` keeps a `@default(now())` on `updatedAt`** even though `@updatedAt`
+  normally handles it (`prisma/schema.prisma:160-165`). The hardening migration
+  added a DB-level `DEFAULT CURRENT_TIMESTAMP`; the explicit `@default(now())`
+  keeps Prisma from detecting drift and silently dropping that default on the
+  next `prisma migrate dev`. It is a drift-guard, not a runtime behavior.
+
+If you revert the composite FK to a single-column FK, an edge can once again span
+two trees, and you lose the only guard against it. If you change the composite
+FKs from `NoAction` to `Cascade`, Prisma refuses to migrate — so do not read
+`NoAction` as a bug to "fix."
+
+A side effect worth knowing: deleting a single `SkillNode` is blocked by the
+`NoAction` edge FKs unless its edges are removed first. This is accepted, because
+normal operation only ever deletes whole trees (which cascades cleanly via the
+`skillTree` relation), never individual nodes.
+
+## XP that survives task deletion
+
+This is the subsystem's most load-bearing — and most easily broken — invariant.
+A `NodeAssignment` is an XP receipt: it records that a completed Todo was
+assigned to a node. The product promise is that **earned XP is permanent** — once
+you've claimed a task on a node, deleting that task later must not erase the XP
+or its label.
+
+Two schema choices make that work (`prisma/schema.prisma:198-219`):
+
+- `NodeAssignment.todoId` is nullable with `onDelete: SetNull`
+  (`prisma/schema.prisma:203,213`). When the source Todo is deleted, the
+  assignment row is **not** deleted — its `todoId` is set to `null` and the row
+  survives as an orphaned receipt.
+- `NodeAssignment.todoText` is a `VARCHAR(255)` snapshot of the Todo's text
+  taken at assignment time (`prisma/schema.prisma:204-209`). `assignTask` always
+  writes the live text into it (`src/server/procedures/skillTree.ts:285`). After
+  the Todo is gone the read path has no live `Todo.text` to join to, so it shows
+  the snapshot instead — the receipt still reads sensibly.
+
+The read side completes the contract. `getMyTree`'s include filters node
+assignments to `OR: [{ todoId: null }, { todo: { completed: true } }]`
+(`src/server/procedures/skillTree.ts:36-38`). That surfaces exactly the receipts
+that should still count: the orphaned ones (frozen XP from deleted tasks) and the
+ones whose source Todo is still completed — while hiding any whose Todo went back
+to incomplete. The `SetNull` write and this read filter are two halves of the
+same "XP survives" mechanism.
+
+If you change `NodeAssignment.todo` from `SetNull` to `Cascade`, deleting a
+completed Todo destroys its XP receipt — directly breaking the permanence
+promise. Note the asymmetry: the `node` relation IS `Cascade`
+(`prisma/schema.prisma:212`), because an assignment is meaningless without its
+node, but the `todo` relation must not be.
+
+### NodeAssignment has three exit paths with three opposite intents
+
+The single most important thing to understand before touching this code: a
+`NodeAssignment` row can leave in three different ways, and two of them call the
+same `deleteMany` while meaning opposite things. Conflating them is how a
+refactor silently destroys XP.
+
+| Trigger                                                  | What happens to the row                                                                        | Intent                           |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------- |
+| Source Todo is deleted (`clearCompleted` / `deleteTodo`) | `todoId` → `null`, **row survives** (`onDelete: SetNull`)                                      | **Preserve** XP — frozen receipt |
+| `toggleTodo` un-completes the Todo (true→false)          | Row **deleted** via `deleteMany` (`src/server/procedures/todo.ts:241-242`)                     | **Revoke** XP — exploit guard    |
+| `assignTask` moves a Todo to another node                | Row **deleted then re-created** on the new node (`src/server/procedures/skillTree.ts:278-287`) | **Relocate** XP                  |
+
+The first path _preserves_ the receipt; the other two _destroy_ it. They are not
+the same operation. The archive helper makes this explicit: when a completed
+Todo is deleted, `archiveCompletedTodos`
+(`src/server/utils/archiveCompletedTodos.ts:17-20`) **deliberately does not**
+`deleteMany` its `NodeAssignment` rows — it relies on the schema's `SetNull`
+instead. The inline comment warns directly: mirroring `toggleTodo`'s `deleteMany`
+in the archive helper "would destroy XP," because the un-complete exploit guard
+and the task-teardown path look identical but mean the opposite.
+
+### Why un-completing revokes XP (the double-XP guard)
+
+The revocation path exists to close an exploit. `assignTask` requires the Todo to
+be completed (`assertOwnership` with `requireCompleted: true`,
+`src/server/procedures/skillTree.ts:266-271`) — XP should only be granted for
+finished work. But that check at assignment time isn't enough on its own. As the
+`toggleTodo` comment spells out (`src/server/procedures/todo.ts:232-238`): once a
+Todo is assigned and then un-completed, the stale assignment would **survive the
+un-complete and keep granting XP until the todo is re-assigned**. A user could
+complete → assign → un-complete → re-complete → assign to a _different_ node, and
+the original receipt would still be there. So `toggleTodo`, on the true→false
+transition, `deleteMany`s the Todo's `NodeAssignment` rows in the same
+transaction (`src/server/procedures/todo.ts:240-243`), wrapped in a transaction
+so an orphan can't linger if the toggle succeeds but the cleanup fails.
+
+This is also why completion state changes flow through **only** `toggleTodo`.
+`updateTodo`'s schema deliberately omits `completed`, so there is no other seam
+that can flip completion and bypass this cleanup. If a future edit let
+`updateTodo` change `completed`, it would route around the double-XP guard.
+
+### One assignment per Todo, ever
+
+`NodeAssignment` carries `@@unique([todoId])` (`prisma/schema.prisma:215-217`).
+A single Todo can be the source of at most one assignment, which blocks an
+XP-inflation exploit: assigning the same completed Todo across several nodes to
+multiply its XP. `assignTask` supports _moving_ an assignment between nodes by
+`deleteMany`-then-`create` inside one transaction
+(`src/server/procedures/skillTree.ts:278-287`) precisely because this constraint
+would otherwise reject a second `create` for the same `todoId`.
+
+The subtle part — and the reason both XP invariants can live on the same column —
+is Postgres's treatment of `NULL` as **distinct**. After a Todo is deleted, its
+receipt's `todoId` becomes `null`; many such orphaned receipts can coexist
+(each `null` is distinct, so `@@unique([todoId])` doesn't collapse them), while
+the constraint still blocks two assignments for the same _real_ `todoId`. You get
+XP-survival (many `null` receipts) and the inflation guard (one row per concrete
+todo) from one unique index only because of NULL-distinctness. If a future
+database or column change made `NULL`s non-distinct, the two invariants would
+collide — a second deletion would violate the unique index.
+
+If you drop `@@unique([todoId])`, a single Todo can be assigned to many nodes and
+XP inflates without bound.
+
+## The four procedures
+
+All Skill Tree access goes through four procedures in
+`src/server/procedures/skillTree.ts`, every one authenticated by the shared
+`authMiddleware` (see the [oRPC API reference](./reference-orpc-api.md) and the
+[authentication surface reference](./reference-auth.md)). In integrity terms:
+
+- **`getMyTree`** (`src/server/procedures/skillTree.ts:177`) — reads the tree,
+  lazily importing the default template on first visit and surviving the
+  concurrent-create race via the `P2002`→re-query path. Its include filter is the
+  read-side half of the "XP survives" contract.
+- **`getUnassignedPool`** (`src/server/procedures/skillTree.ts:227`) — lists
+  completed Todos not yet assigned to any node (`assignments: { none: {} }`). It
+  returns a deliberately narrow `{ id, text }` shape so the rest of the Todo
+  (notes, category, timestamps) is never dragged into the client's
+  `localStorage` cache, which would leak PII across sessions.
+- **`assignTask`** (`src/server/procedures/skillTree.ts:262`) — assigns a
+  completed Todo to a node (move-supported). It translates `P2002`, `P2003`, and
+  `P2025` races to `NOT_FOUND` so the loser of a harmless concurrent assign
+  converges on a consistent final state instead of surfacing a 500.
+- **`unassignTask`** (`src/server/procedures/skillTree.ts:335`) — removes a
+  live assignment. It looks the row up by the globally-unique `todoId`
+  (`findUnique`) and returns `null` if the row is absent or points at a different
+  node, so a client whose mental model is stale reconciles via query
+  invalidation instead of erroring. Orphaned receipts (`todoId = null`) are
+  unreachable here by design — the input schema requires a positive `todoId`, so
+  frozen XP cannot be unassigned away.
+
+## Provenance
+
+The constraints above were introduced by two hardening migrations whose SQL
+encodes this rationale directly:
+`prisma/migrations/20260409000000_skill_tree_v1_hardening` (one-tree-per-user,
+`SetNull`, `todoText` snapshot, `@@unique([todoId])`) and
+`prisma/migrations/20260409080000_skill_tree_v1_edge_composite_fk` (the
+composite-FK same-tree enforcement). The original design discussion — node
+layout, the XP model, and the threat analysis — lives in
+[`docs/superpowers/specs/2026-04-08-skill-tree-design.md`](../superpowers/specs/2026-04-08-skill-tree-design.md).

--- a/docs/dev/explanation-state-and-sync.md
+++ b/docs/dev/explanation-state-and-sync.md
@@ -1,0 +1,222 @@
+# Client state ownership & cross-window sync
+
+CoreLive splits client state deliberately — Redux owns device/preference state, React Query owns the server cache — and then has to reconcile that state across **separate browser windows** that cannot see each other's memory. This document explains the split, the cross-window problem the Electron design creates, and the four sync mechanisms (three stateless `BroadcastChannel` pings plus one stateful preferences middleware) that solve it. It also covers two patterns that fall out of the same thinking: deriving every stat from a single heatmap `Map`, and the two-tier error boundary that survives Electron preload version skew.
+
+> Prerequisite: read [explanation-architecture.md](./explanation-architecture.md) first for the provider-tree boot order and the central bet that **Electron loads real `corelive.app` routes in native windows**. That bet is what makes cross-window sync necessary at all — this page picks up where it leaves off.
+
+---
+
+## The one sentence to remember
+
+> **Each window is its own world** — its own React Query cache, its own Redux store, its own `localStorage` — so a change in one is invisible to the others until you broadcast it.
+
+Everything below is a consequence of that fact plus one design rule: **Redux holds client/device state, React Query holds server state, and the two never overlap.**
+
+---
+
+## Part 1 — The deliberate state split
+
+Two state systems coexist, with a hard ownership boundary:
+
+| Owner             | What it holds                                                                                                             | Persistence                                                 | Verified at                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------- |
+| **Redux Toolkit** | Client/device state only — two small slices: `electronSettings` (window chrome) + `preferences` (todo-experience toggles) | `localStorage` key `corelive-redux-state`, selective slices | `src/lib/redux/store.ts:28-53`                |
+| **React Query**   | All server data, via oRPC over HTTP                                                                                       | `localStorage`, `gcTime` 1 week                             | `src/providers/QueryClientProvider.tsx:36-37` |
+
+### Why the split
+
+Server data already has an owner — the database, reached through oRPC. Duplicating it into Redux would mean two copies that drift, two invalidation stories, and a fat persisted `localStorage` blob. So Redux is kept tiny on purpose: it persists only what the _client_ owns and the server never will (window-chrome preferences, sound/retention toggles). The store at `src/lib/redux/store.ts:28-31` combines exactly two reducers, and the persistence list at `src/lib/redux/store.ts:52` names exactly those two slices.
+
+This also lines up with a Next.js 16 caching rule the project follows: Redux/Zustand state must **never** trigger `revalidatePath`/`revalidateTag`. Those are for cached `fetch` data; the oRPC + Prisma path does not use the Next.js fetch cache, and client state changes are not a server-cache concern. (See the project's TypeScript/Next.js rules; the canonical command list is `package.json` `"scripts"`.)
+
+For the exact slice fields, actions, and selectors, see [reference-frontend.md](./reference-frontend.md) and the slice sources `src/lib/redux/slices/electronSettingsSlice.ts` / `preferencesSlice.ts` — they are pre-launch and reshape freely, so this doc points at them rather than transcribing them.
+
+### The sign-out cache-isolation reset
+
+The split forces one non-obvious safety measure. Because React Query persists to `localStorage` on a potentially **shared device**, signing out must not leave user A's data reachable by user B. The obvious move — `queryClient.clear()` — is **not enough**, and the code says so at `src/providers/QueryClientProvider.tsx:98-143`:
+
+> `queryClient.clear()` cancels in-flight query _fetches_ (via their `AbortController`) but does **not** cancel in-flight _mutations_. A mutation user A submitted that resolves _after_ sign-out would fire its `onSuccess`/`onSettled` and write stale data back into the cache via `setQueryData`/`invalidateQueries` — leaking A's data into B's session.
+
+So on the signed-in → signed-out transition, `handleSessionReset` (`QueryClientProvider.tsx:128-143`) does three things in order: removes the persisted entry, clears the old client, then **rebuilds the entire `QueryClient` + persister and remounts the provider** via `key={resetKey}`. Stale mutation callbacks captured the _previous_ client by closure, so any late writes land on an orphaned instance nobody renders from, and the new session starts from an empty, isolated cache. The transition itself is detected by `PersisterSignOutGuard` (`QueryClientProvider.tsx:79-96`), which uses a ref so it fires only on the real transition, not on first mount.
+
+This is the threat model to keep in mind if you ever "simplify" sign-out back to a bare `clear()`: you would reopen a cross-user data leak on shared machines.
+
+---
+
+## Part 2 — The cross-window problem
+
+In the desktop build, CoreLive runs **multiple `BrowserWindow`s at once**: the main window (`/home`), the always-on-top **Floating Navigator** (`/floating-navigator`), and the **BrainDump** (`/braindump`). Each is a full, independent renderer. That means each has:
+
+- its **own** React Query cache (a fresh `QueryClient` per window),
+- its **own** Redux store + `localStorage`,
+- its **own** copy of every component's state.
+
+So if you complete a todo in the Floating Navigator, the main window's `TodoList` query cache knows nothing about it. If you rename a category in the main window, the Floating Navigator still shows the old name. **A mutation in one window is invisible to the others** until something tells them to refetch.
+
+This is not an Electron-only edge case, either — the same is true of two browser tabs. Electron just makes the multi-window case the _normal_ case, because the floating and braindump windows are core product surfaces, not afterthoughts.
+
+### Why `BroadcastChannel`, not custom IPC
+
+The natural Electron instinct is to route cross-window messages through the main process with `ipcMain`/`ipcRenderer`. CoreLive does **not** do that for data sync. It uses the web-standard `BroadcastChannel` API, for one decisive reason: **`BroadcastChannel` crosses Electron `BrowserWindow`s natively** (every renderer in the app shares the channel namespace), _and_ it works identically in two plain browser tabs. One mechanism covers both runtimes with zero Electron-specific plumbing — exactly the "one codebase, two runtimes" bet from the architecture doc. Adding IPC would mean a main-process relay that has no web equivalent, defeating the point.
+
+The `paste-import-channel.ts` docstring (`src/lib/paste-import-channel.ts:1-11`) states this directly: it mirrors the todo channel "(BroadcastChannel crosses Electron windows in this app) — no new Electron IPC plumbing."
+
+> IPC _is_ still used — but for a different job. `electronSettings` (dock policy, tray) syncs renderer → **main process** via IPC, because those settings drive the OS, not other windows. See Part 4 and [explanation-electron-architecture.md](./explanation-electron-architecture.md). Cross-_window_ sync is `BroadcastChannel`; renderer-to-_OS_ is IPC.
+
+---
+
+## Part 3 — The four sync mechanisms
+
+CoreLive has **four** cross-window channels. Three are nearly identical stateless "pings"; the fourth is the odd one out.
+
+| Channel             | Name                           | Message                             | Stateful?                  | Source                                |
+| ------------------- | ------------------------------ | ----------------------------------- | -------------------------- | ------------------------------------- |
+| Todo                | `corelive-todo-sync`           | `{ type: 'todo-sync' }`             | No (ping)                  | `src/lib/todo-sync-channel.ts`        |
+| Category            | `corelive-category-sync`       | `{ type: 'category-sync' }`         | No (ping)                  | `src/lib/category-sync-channel.ts`    |
+| Paste-import intent | `corelive-paste-import-intent` | `{ type: 'open-completed-import' }` | No (intent)                | `src/lib/paste-import-channel.ts`     |
+| Preferences         | `corelive-preferences-sync`    | snapshot payload                    | **Yes** (Redux middleware) | `src/lib/preferences-sync-channel.ts` |
+
+### The three stateless pings
+
+`todo-sync-channel.ts` is the canonical shape; category and paste-import are copies of it. Each module exposes the same contract (`src/lib/todo-sync-channel.ts:62-100`):
+
+- An **SSR guard** — `typeof window !== 'undefined' && typeof BroadcastChannel !== 'undefined'` — so it is a no-op on the server.
+- A **broadcast** function that opens a channel, posts a single typeless message, then **immediately `close()`s it** (fire-and-forget). It returns `false` when `BroadcastChannel` is unavailable.
+- A **subscribe** function that returns a **cleanup** which both `removeEventListener`s _and_ `close()`s the channel.
+
+The producer→subscriber contract is intentionally dumb: the message carries **no data**, only "something in this domain changed." The receiver's job is simply to **invalidate the relevant queries** so React Query refetches the truth from the server. There is no attempt to ship the changed rows across the channel — that would re-introduce the duplicate-state problem the Redux/React-Query split exists to avoid. The channel says _"refetch"_, not _"here's the new value."_
+
+Real wiring, verified in the tree:
+
+- **Todo** — broadcast by `useTodoMutations`, `BrainDumpEditor`, `TodoImportEntry`, `CompletedImportEntry`; subscribed (→ invalidate) by `TodoList` and `FloatingNavigatorContainer`.
+- **Category** — broadcast by `useCategoryMutations`, `useTodoMutations`, `TodoImportEntry`; subscribed by `Category` and `FloatingNavigatorContainer`.
+
+(File list confirmed via the importers of `broadcastTodoSync`/`subscribeToTodoSync` and the category equivalents.)
+
+### The paste-import **intent** channel (a ping with a different verb)
+
+`paste-import-channel.ts` shares the ping shape but is semantically different: it is an **intent**, not a data-refresh. The Floating Navigator's Import button lives in its own window and _cannot reach into the main window to open a dialog_. So it does two things together (`src/lib/paste-import-channel.ts:1-11`): calls the preload `focusMainWindow()` IPC to surface the main window, **and** broadcasts `open-completed-import`. The main window's `CompletedImportEntry` subscribes and opens its paste-import dialog. Producer: `FloatingNavigator`. Subscriber: `CompletedImportEntry`. This is why it gets its own channel rather than overloading `todo-sync` — "refetch your todos" and "please open a dialog over there" are different verbs.
+
+### Preferences — the stateful exception
+
+`preferences-sync-channel.ts` breaks the ping pattern on purpose: it is **Redux middleware** that carries a **full `PreferencesState` snapshot**, wired into the store at `src/lib/redux/store.ts:76`. The reason for the difference is in the design itself: the ping channels only need _"something changed → invalidate"_, but preferences must apply an **exact copy** of the toggle state in every window. You cannot "invalidate and refetch" a `localStorage` preference — there is no server round-trip to refetch from — so the value must travel on the wire.
+
+Carrying state across windows introduces two hazards a stateless ping never faces, and the middleware defends against both:
+
+1. **The echo loop.** If applying an inbound preference re-broadcast it, two windows would ping-pong forever. The guard (`src/lib/preferences-sync-channel.ts:19-22, 84-114`): only **user-initiated `set*` actions** are in `BROADCASTABLE_ACTION_TYPES` (`preferences/setCompletionSound`, `preferences/setRetainCompletedInList`). Inbound snapshots are applied via `hydratePreferences`, which is **deliberately excluded** from the broadcastable set — so applying a received value never echoes back out. Cross-window propagation and loop prevention live in the _same_ decision: which actions broadcast.
+
+2. **Malformed payloads.** A snapshot from the wire is untrusted input. `isPreferencesSyncMessage` (`src/lib/preferences-sync-channel.ts:38-55`) validates the **inner fields**, not just that `state` is an object — both `completionSound` and `retainCompletedInList` must be `boolean`. This matters because the Redux selectors only coalesce `null`/`undefined` (see Part 4); a junk value like `completionSound: 'yes'` would otherwise be hydrated _and persisted_ unchanged. The validator is the gate that keeps channel garbage out of `localStorage`.
+
+Like the pings, the middleware is SSR-safe: when `BroadcastChannel` is unavailable it returns a transparent pass-through (`preferences-sync-channel.ts:78-80`).
+
+> **Adding a channel?** This page is the _why_. For the step-by-step recipe — copy the template, name the channel/event, broadcast at the mutation site, subscribe-and-clean-up in an effect, SSR-guard, and (for stateful channels) add the loop guard — follow [howto-add-sync-channel.md](./howto-add-sync-channel.md). The two easy-to-forget mistakes it guards against are skipping `channel.close()` and omitting the loop guard on a stateful channel.
+
+---
+
+## Part 4 — Two sync paths, two destinations (and a defensive-selector note)
+
+It is worth stating plainly that the two Redux slices sync **differently**, because they have different destinations:
+
+| Slice              | Syncs to                   | Mechanism                              | Why                                        |
+| ------------------ | -------------------------- | -------------------------------------- | ------------------------------------------ |
+| `preferences`      | other **renderer windows** | `BroadcastChannel` (Part 3)            | toggles must match live across windows     |
+| `electronSettings` | the **main process**       | IPC at startup (`ElectronStartupSync`) | dock/tray are OS state, reset every launch |
+
+`ElectronStartupSync` (`src/components/electron/ElectronStartupSync.tsx`) pushes the persisted `hideAppIcon` / `showInMenuBar` values to the main process after Redux hydrates, so a toggle saved as ON doesn't "lie" after a restart (the dock policy and tray are runtime-only and reset at boot). Both slices still persist to the **same** `localStorage` blob; only their _sync targets_ differ. The Electron-facing detail lives in [explanation-electron-architecture.md](./explanation-electron-architecture.md) and [reference-electron.md](./reference-electron.md); what matters here is the shape of the rule — **renderer↔renderer is `BroadcastChannel`, renderer→OS is IPC.**
+
+### Defensive `?? DEFAULT` selectors
+
+One consequence of persisting Redux to `localStorage` in a **pre-launch repo where slices gain fields**: the storage middleware shallow-merges a user's old persisted blob over the new initial state, which means a field _added_ after a user last persisted will be **absent** (`undefined`) at read time. The preferences selectors therefore read through `?? DEFAULT` to coalesce `undefined` back to the default rather than surfacing `undefined` into the UI. This is also why the cross-window validator (Part 3) checks `typeof === 'boolean'` and not merely "not null": the selectors only protect against `null`/`undefined`, so the _channel_ must reject other junk before it is persisted. The two defenses are complementary — one guards reads, the other guards writes.
+
+---
+
+## Part 5 — Derive everything from one heatmap `Map`
+
+A pattern that keeps the state surface small enough to be sync-able in the first place: **CoreLive does not fetch separate endpoints for streaks, weekly rollups, category trends, the monthly peak markers, or the heatmap colors.** All of them are **pure functions over the single `Map<string, HeatmapDay>`** the home page already loads through `useHeatmapData()` (`src/hooks/useHeatmapData.ts:46`).
+
+The derived-stat functions, all in `src/lib`:
+
+| Function                       | Returns                                           | Source                                 |
+| ------------------------------ | ------------------------------------------------- | -------------------------------------- |
+| `calcStreak`                   | current/longest streak, tier, shown-up-this-month | `src/lib/calc-streak.ts:120`           |
+| `aggregateLastSevenDays`       | weekly totals + week-over-week trend              | `src/lib/aggregate-last-seven-days.ts` |
+| `aggregateCategoryTrends`      | per-category WoW rollup                           | `src/lib/aggregate-category-trends.ts` |
+| `aggregateYearInReview`        | year-scoped recap                                 | `src/lib/aggregate-year-in-review.ts`  |
+| `calcMonthlyMaxDates`          | `Set` of per-month peak-day dates (the ◎ marker)  | `src/lib/calcMonthlyMaxDates.ts:47`    |
+| `getHeatmapIntensityFromCount` | 0–4 temperature band for a cell                   | `src/lib/heatmap-intensity.ts:56`      |
+
+Three conventions make this pattern hold together:
+
+1. **No extra oRPC calls.** These are client-side math over data already in the cache, so adding a stat does not add a request, a loading state, or a thing to keep in sync across windows. The cache is the single source; the stats are views of it. `useHeatmapData` **memoizes** `dataByDate` on `data` identity (`useHeatmapData.ts:58-70`) specifically so each consumer doesn't get a fresh `Map` per render and bust the downstream `useMemo` dep keys.
+
+2. **Caller-supplied `today` for determinism.** Every date function takes `today: Date` as an explicit argument instead of reading the wall clock, and operates purely on `YYYY-MM-DD` **UTC** keys (`calc-streak.ts:120`, `shiftIsoDate.ts:24`). This makes them deterministic for tests and SSR, and **DST-safe by construction** — UTC has no DST. The keys deliberately match the heatmap's bucketing (`completedAt.toISOString().split('T')[0]`), so a function's output is always a valid `dataByDate` lookup key. The Year-in-Review tests use fake timers precisely to prove the auto-open gate ignores the wall clock and reads only its argument.
+
+3. **A shared trend vocabulary.** Both the weekly and per-category aggregators classify a trend as one of `firstWeek` / `flat` / `new` / `percent` — `firstWeek` for a genuinely empty heatmap, `flat` for older-only activity, `new` to avoid a `+Infinity%` when the prior window was zero, `percent` otherwise. The vocabulary is **duplicated** across the two modules rather than shared, on purpose, so each can be unit-tested standalone (the comment in `aggregate-category-trends.ts` explains this).
+
+### These functions encode product philosophy — don't "improve" the math
+
+The thresholds here are **product decisions, not arbitrary constants**, and they are load-bearing. `heatmap-intensity.ts:1-13` states the invariant in the source: intensity is a pure function of the raw completion **count** — "temperature = pride", and pride scales with count. The count already includes **repetition** (doing the same task twice counts as two; repeats are XP and are **never deduplicated**), so the module only buckets a number; it must not add recency, streak, or category weighting. A separate CI invariant forbids the apex color from being GitHub-green, because this heatmap measures self-affirmation, not a contribution graph.
+
+The authoritative "why" for all of these lives in [DESIGN.md](../../DESIGN.md) (Warm Cathedral, temperature = pride, no-dedup repetition-as-XP, the Year-in-Review fireside framing) and the related [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md) — which also explains _why completions are archived, not deleted_, the invariant that keeps the heatmap from being retroactively erased. The exact band boundaries and streak tiers are best read from the `*.test.ts` files next to each function, which hard-code the contract; this doc points there rather than transcribing volatile numbers.
+
+---
+
+## Part 6 — Two-tier error boundaries & Electron version-skew resilience
+
+The last piece of cross-cutting client state is failure handling, and it has the same shape of reasoning: **a defense whose failure mode would defeat its own purpose.**
+
+CoreLive has **two** App Router error boundaries:
+
+| Boundary           | Catches                                                                                   | Self-contained?                         | Source                     |
+| ------------------ | ----------------------------------------------------------------------------------------- | --------------------------------------- | -------------------------- |
+| `error.tsx`        | throws **inside a page subtree**; keeps the shell                                         | No — uses shadcn `Card`, the app logger | `src/app/error.tsx`        |
+| `global-error.tsx` | throws from the **root layout itself** / its providers; renders its own `<html>`/`<body>` | **Yes — deliberately dependency-free**  | `src/app/global-error.tsx` |
+
+The reason there are two is stated in the `global-error.tsx` docstring (`src/app/global-error.tsx:3-21`): `error.tsx` **cannot** catch a throw from the root layout or its direct children (the Redux provider, `<ElectronStartupSync />`, the toaster) — those escalate past it. Without a `global-error.tsx`, they fall through to Next.js's stark built-in crash screen.
+
+And `global-error.tsx` is **intentionally import-free** — no shadcn UI, no design tokens, no app logger, no `globals.css`. Every such import is a way for the **last line of defense to fail in exactly the situation it exists to catch**: a root-layout / provider / CSS failure re-triggering through the same import graph. So it uses inline token-free styles and a _local_, guarded `console.error` (`global-error.tsx:32-33, 93-101`) instead of the app's `useCycleEffect` + `log`. If you ever reach for a shared component or the design tokens in `global-error.tsx`, you are coupling the backstop to the thing it backstops.
+
+### The Electron version-skew threat
+
+A primary motivation for this two-tier design is **Electron preload version skew**, and it connects directly to `ElectronStartupSync`. The installed desktop app ships a **frozen preload bundle**, but it loads the **remote** `corelive.app` web bundle — which updates independently. So the running web code can call a preload method that the _installed_ app's preload doesn't have yet.
+
+`ElectronStartupSync` defends against this by guarding on **method existence**, not just the namespace (`src/components/electron/ElectronStartupSync.tsx:95-120`):
+
+```ts
+// Guard on the METHOD, not just the `settings` namespace.
+const settings = window.electronAPI?.settings
+if (typeof settings?.setHideAppIcon !== 'function') return
+reportSyncFailure(settings.setHideAppIcon(hideAppIcon), 'hideAppIcon')
+```
+
+The comment spells out the threat: calling `undefined()` on an older preload would throw a **synchronous `TypeError` out of the effect, past its own `.catch`** — and because this component lives in the **root layout**, that throw escapes `error.tsx` entirely and would hit the bare Next.js crash screen if `global-error.tsx` weren't there. Two further details make it robust: each setting syncs in its **own effect with its own guard**, so a missing `setShowInMenuBar` never suppresses the `setHideAppIcon` sync; and the guard is on the function, so a preload _reshuffle_ (not just an addition) is handled too.
+
+This is the same lesson as the sign-out reset and the preferences validator: the dangerous case is the one where the safety net is the thing that breaks. The method-existence guard keeps a frozen preload from throwing, and `global-error.tsx` stays dependency-free so it can still render if something upstream of it does throw.
+
+> This overlaps the project's "Electron preload version skew" memory note (guard on method existence; `error.tsx` is the route net). The durable takeaway: **never call a preload method behind only a namespace check** — `window.electronAPI?.settings.foo()` can throw a synchronous `TypeError` from a frozen preload; check `typeof settings?.foo === 'function'` first.
+
+---
+
+## What breaks if you violate these invariants
+
+A quick map of "if a future engineer does X, Y regresses" — the most durable thing this page can leave you with:
+
+- **Put server data in Redux** → two sources of truth, a fat persisted blob, and the cross-window sync story doubles (you'd have to broadcast the data, not just "refetch").
+- **Replace the sign-out reset with `clear()`** → in-flight mutations leak user A's data into user B's cache on a shared device (`QueryClientProvider.tsx:98-143`).
+- **Make a ping channel carry data** → you re-create duplicate state; the pings exist _because_ the receiver should refetch the server truth, not trust the wire.
+- **Add a stateful channel without the loop guard** → infinite echo between windows; only `set*` actions may broadcast, and the apply action (`hydratePreferences`) must be excluded (`preferences-sync-channel.ts:19-22`).
+- **Drop the channel's field validation** → malformed values get persisted, because the selectors only coalesce `null`/`undefined` (`preferences-sync-channel.ts:38-55`).
+- **Add recency/streak weighting to `heatmap-intensity`** → breaks "temperature = pride" and the no-dedup invariant ([DESIGN.md](../../DESIGN.md), `heatmap-intensity.ts:1-13`).
+- **Import a UI component into `global-error.tsx`** → the last line of defense can fail through the same import graph it exists to catch (`global-error.tsx:3-21`).
+- **Call a preload method behind only a namespace check** → a frozen preload throws a synchronous `TypeError` from the root layout, escaping `error.tsx` (`ElectronStartupSync.tsx:95-120`).
+
+---
+
+## See also
+
+- [explanation-architecture.md](./explanation-architecture.md) — the provider tree, boot order, and the "Electron loads real routes" bet this page builds on.
+- [explanation-electron-architecture.md](./explanation-electron-architecture.md) — the renderer→main-process IPC side (`electronSettings`, `focusMainWindow`).
+- [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md) — why completions are archived not deleted; the heatmap invariant.
+- [reference-frontend.md](./reference-frontend.md) — exact routes, providers, store hooks, slice fields, and component surface (point-to-source).
+- [howto-add-sync-channel.md](./howto-add-sync-channel.md) — the step-by-step recipe for adding a cross-window channel.
+- [DESIGN.md](../../DESIGN.md) — the product invariants the derived-stat functions encode.

--- a/docs/dev/explanation-theme-system.md
+++ b/docs/dev/explanation-theme-system.md
@@ -1,0 +1,94 @@
+# Why themes are a build-time pipeline
+
+CoreLive ships its colored themes by compiling a single TypeScript registry into a static CSS file at build time, rather than computing colors in the browser. This document explains the two constraints that force that shape, and the threat each CI guard defends against — so a future engineer can change the theme system without quietly breaking the brand, the bundle, or the heatmap's meaning.
+
+For _how to add a family_, see [howto-add-theme-family.md](./howto-add-theme-family.md). For the surface map (exact files, functions, tokens), see [reference-theme-system.md](./reference-theme-system.md). For the product rules this implements, see [DESIGN.md](../../DESIGN.md) (the "Theme System" and "Heatmap Invariance Rule" sections are canonical; this doc explains the engineering mechanics they summarize).
+
+## The two forcing constraints
+
+Everything downstream follows from two requirements that pull in opposite directions:
+
+1. **Color math must not ship to the client.** Deriving an accessible palette from a seed means OKLCH conversion and WCAG contrast math (the `culori` library). That is build-time work; running it in every browser tab would reintroduce exactly the weight the design wants gone, and would tie runtime rendering to a color-science dependency.
+
+2. **The brand must never be touched by a formula.** The default Warm Cathedral light/dark is hand-tuned — its neutral surfaces carry per-token chroma that no single derivation formula reproduces. The brand's "soul" (DESIGN.md's north star, 「些細でも経験値」) lives in those hand-picked values and must not drift when someone adds a tenth colored family.
+
+A naive "compute theme colors at runtime from a seed" approach violates both. So the system splits in time instead: a **registry** (the single source of truth, plain TypeScript) is compiled by a **build-time generator** into **static CSS** that the app loads like any stylesheet. The brand is _excluded_ from generation entirely. No color math reaches the client.
+
+```
+src/lib/themes/registry.ts   ──pnpm theme:generate──▶  src/lib/themes/generated.css
+   (SSoT: 12 themes)            (scripts/generate-theme-css.ts)   (one :root[data-theme='id'] block
+                                  reads culori, build-only)         per colored family — committed)
+```
+
+The colored families are _systematic_; the brand is _preserved_. The pipeline's whole job is to keep those two facts true forever.
+
+## The registry is the single source of truth
+
+`src/lib/themes/registry.ts` holds every theme as a discriminated union (`registry.ts:65-88`): a `PreservedTheme` (the cathedral pair — metadata only, `preserve: true`) or a `DerivedTheme` (`preserve: false` plus an OKLCH seed: accent L/chroma/hue, neutral chroma/hue, and a 5-stop `heatmapHues` tuple). `THEME_REGISTRY` (`registry.ts:94`) is keyed by stored id and closed with `satisfies Record<ThemeId, ThemeSeed>` (`registry.ts:290`), so the map keys are _exactly_ the id union — a typo'd or missing id is a type error, not a runtime surprise.
+
+The point of one registry is that nothing else hardcodes a theme. `THEME_IDS`, the family labels, the `next-themes` provider config, the picker, the `useThemeAxis` hook, and the generator all _derive_ from `THEME_REGISTRY`. Add a family in one place — append a `ThemeFamilyId` and a light/dark seed pair — and the id union auto-expands through the `${family}-${mode}` template (`registry.ts:37-40`); every consumer follows. The alternative (a theme list duplicated across the provider, the picker, and `globals.css`) is the exact fragmentation the registry's module doc calls out as the thing it exists to prevent.
+
+## Why generation skips the brand
+
+The generator's defining move is a _negative_ one: it does nothing for preserved themes. `generateThemesCss` filters them out — `themes.filter((theme): theme is DerivedTheme => !theme.preserve)` (`generate-theme-css.ts:329`) — and `generated.css` contains only colored-family blocks. The cathedral's CSS stays hand-authored in `globals.css`.
+
+This is **brand safety over DRY**, made structural. A formula expressive enough to reproduce the cathedral's hand-tuned neutrals would be fragile and would still risk drift on every edit. So instead of re-emitting the brand from a formula, the system _pins_ it: `cathedral-css-snapshot.test.ts` asserts the hand-authored `globals.css` cathedral tokens byte-for-byte against the `CATHEDRAL` mirror the generator carries (`generate-theme-css.ts:41-118`). The mirror exists because derived themes reuse the cathedral _lightness ladder_ (see below), and the snapshot test is what guarantees the mirror can never silently diverge from the real brand.
+
+**What breaks if violated:** make the cathedral a `DerivedTheme` to "unify" the system, and you hand the brand's soul to a formula that doesn't reproduce it — the default theme drifts, and the snapshot test (now asserting against generated output) no longer protects anything.
+
+## AA holds by construction — and where the one real seed gate lives
+
+It is tempting to summarize this as "colored families are WCAG-AA gated," but the honest mechanism is more specific, and the specificity _is_ the insight.
+
+For neutral surface/text tokens, derivation keeps each token's **lightness** from the fixed cathedral ladder and swaps in only the family's neutral hue and chroma (accent tokens instead take their lightness from the seed's `accentL`, and heatmap tokens keep both the cathedral L _and_ C, swapping only hue) — see `deriveThemeTokens`, `generate-theme-css.ts:257-277`. Because contrast in OKLCH is overwhelmingly lightness-driven, neutral-on-neutral pairs (`--foreground` on `--background`, `--muted-foreground` on `--card`) clear AA _by construction_ for every family — a seed only re-tints a shared hue/chroma, it cannot move those ratios. The test treats these as **structural** assertions (foreground/background `>= 7`, muted/card `>= 4.5` at `generate-theme-css.test.ts:273-278`): they guard against a _generator_ regression that breaks ladder reuse, not against a bad seed.
+
+The one place a seed _can_ fail AA is the **accent foreground**. `--primary` (and `--sidebar-primary`) is the seed-controlled accent color, so `--primary-foreground` cannot be a hardcoded `white` — at a mid-lightness accent, white fails AA. It is instead **contrast-computed** per theme: `readableForeground` (`contrast.ts:76`) picks whichever of the brand near-white / near-ink candidates clears the threshold. The genuinely seed-sensitive gate is the `>= 4.5` check on `--primary-foreground`/`--sidebar-primary-foreground` against their accents (`generate-theme-css.test.ts:283-291`). This is why a few seeds were nudged for headroom (e.g. Harbor light's accent L, documented in `registry.ts:121-122`): a mid-lightness accent can leave _neither_ candidate clearing 4.5, and only the computed gate catches it.
+
+So: most of accessibility is free because of the ladder; the accent is the part that needs a real per-theme check, which is exactly why it is computed rather than fixed.
+
+## Why color math never ships
+
+`culori` (OKLCH conversion + WCAG contrast) is a **devDependency**, confined to build and test. The two modules that import it — `scripts/generate-theme-css.ts` and `src/lib/themes/contrast.ts` — both carry an explicit "BUILD/TEST ONLY" contract in their module docs (`contrast.ts:5-9`): importing them from runtime app code would pull `culori` into the client bundle and reintroduce the color math the static-CSS architecture exists to remove.
+
+The runtime never _needs_ `culori`, because the one place the app would otherwise want color math — the picker's theme-preview swatches — has a **culori-free path**. `src/lib/themes/preview.ts` reconstructs the swatches from the registry seed by re-implementing the cathedral lightness ladder as plain constants (`preview.ts:34-44`), formatting OKLCH strings directly. The guarantee that this hand-rolled path can't silently diverge from the real generated CSS is a cross-check test: `preview.test.ts` pins every preview swatch against the generator's own `deriveThemeTokens` / `CATHEDRAL` output.
+
+The accurate framing: the runtime is kept free of color math by _convention_ (the build-only contract) plus a _culori-free reconstruction_ that a test keeps honest — not by a mechanical bundle gate that rejects `culori`. A future engineer who imports `contrast.ts` into a client component breaks the invariant; the defense is the documented contract and code review, so respect it.
+
+## The heatmap temperature-is-pride invariant
+
+This is the product's most consequential color decision, so it is the most strongly defended. The heatmap's hot end must bloom **warm** on every theme, forever — accumulation reading as warmth, never as a GitHub-green work grid. DESIGN.md's "Heatmap Invariance Rule" states it as a CI-enforced invariant, not a guideline.
+
+The non-obvious part is _why the gate checks two stops_. The seed's `heatmapHues` tuple controls **hue only** at each of the five stops; the lightness/chroma ramp is reused structurally from the cathedral. So the real gate (`generate-theme-css.test.ts:296-348`) asserts, for every derived theme, that the **two hottest** stops — `--hm-3` and `--hm-4` — both land in the warm hue band `[20, 70]`. Checking only the apex would be insufficient: a degenerate body like `heatmapHues: [145, 145, 145, 145, 42]` keeps a perfectly valid L/C ramp but renders a **green grid with a single warm cell** — precisely the GitHub-green regression the north star forbids, which a single-apex check would wave through. Requiring _both_ hottest stops in the band rejects it. The cool rest stops (`--hm-0..2`) stay family-hued by design and are intentionally unconstrained — a green Grove resting green is correct; a green Grove that _stays_ green as it heats up is the failure.
+
+The other half of "more completions = hotter" is the count-to-level mapping, and it is a separate single source of truth: `src/lib/heatmap-intensity.ts` (`getHeatmapIntensityFromCount`, `heatmap-intensity.ts:56`) buckets a day's raw completion count into one of five levels, and `HEATMAP_LEVEL_TOKENS` maps those to the `var(--hm-N)` CSS tokens. Both the `ContributionGraph` cells and the `DayDetailDialog` band read this module, so a cell's color and its dialog band can never drift. Critically, intensity is a pure function of the **raw count, repetition included** — doing the same task twice counts as two, and the module never deduplicates (this mirrors the project's "no dedup — repetition is XP" rule). Never add recency, streak, or category weighting here: temperature scales with count and only count. (The exact band thresholds are volatile; they live in `heatmap-intensity.ts` and the reference doc, not transcribed here.)
+
+## How a theme actually applies: `data-theme` and the dark variant
+
+`next-themes` persists the chosen id to `localStorage` (key `corelive-theme`) and writes it to `data-theme` on `<html>` (configured in `src/providers/ThemeProvider.tsx`). Two engineering choices make that attribute drive everything:
+
+**Specificity, not import order.** Generated blocks are emitted as `:root[data-theme='id']` (specificity 0,2,0; `generate-theme-css.ts:303`), deliberately one notch above cathedral's hand-authored `:root` (0,1,0). A bare `[data-theme]` would tie and depend on source order; the `:root[...]` form means a derived theme _always_ wins over the cathedral base regardless of how `@import` orders the files. (Asserted in `generate-theme-css.test.ts`.)
+
+**The `dark:` variant is bound to the attribute, not the OS.** Tailwind's `dark:` utilities key off the app's `data-theme`, via `@custom-variant dark (&:where([data-theme$=dark], [data-theme$=dark] *))` in `globals.css:20`. The `$=dark` suffix match is load-bearing: it catches the flat `dark` id _and_ every `*-dark` family id (e.g. `harbor-dark`), exactly mirroring `getThemeMode()` in `registry.ts:328` — while `light`/`*-light` never end in `dark`, so they're excluded. This is required because Tailwind v4 ignores `tailwind.config` `darkMode` without a `@config` directive, and `:where()` keeps the variant's specificity at 0. The same suffix selector drives chart colors (`src/components/ui/chart.tsx:33`), so charts flip with the rest of the UI.
+
+Note the asymmetry this creates as a _trap_: the cathedral uses **flat** ids `light`/`dark` (chosen so adding the family system required zero migration of existing stored values), so a stale or tampered `localStorage` id that happens to end in `-dark` will still fire the dark Tailwind variant while falling back to cathedral tokens — a broken light/dark hybrid. `next-themes` does not validate `localStorage`, so a small allowlist guard self-heals an unregistered id back to the default post-mount. That guard, and the two-axis (family × mode) picker model with its System-belongs-only-to-cathedral rule, are mechanics best read in [reference-theme-system.md](./reference-theme-system.md).
+
+## The drift guards, and why each exists
+
+The pipeline only works if the committed `generated.css` always matches the registry, and if the dev build actually loads it. Two CI checks defend those:
+
+- **Stale CSS → `pnpm theme:check`.** `generated.css` is _committed_ (so it ships without a build step running first), which means it can go stale if someone edits a seed and forgets to regenerate. `theme:check` (`package.json:37`) re-runs the generator and `git diff --exit-code`s the output, so a stale file fails CI. It runs inside `pnpm validate` (`package.json:40`) alongside the AA and temperature gates; `pnpm theme:generate` (`package.json:36`) is the regenerate command.
+
+- **Silent dev fallback → the import-contiguity test.** This is the subtle one. Under Turbopack (`next dev`), `@import` statements stop being inlined once parsing hits a comment or blank line — so a comment wedged _before_ the `./lib/themes/generated.css` import silently drops it, and every colored family falls back to cathedral **in dev with no error** (the webpack production build is unaffected, making it invisible until someone notices their theme looks wrong locally). The `@import` block at the top of `globals.css` is therefore kept _contiguous_, and `globals-import-contiguity.test.ts` is the only automated guard against a future "tidy this comment" edit reintroducing the break. Comments after the generated import are fine.
+
+The crossfade on theme switch is a separate, deliberately small concern: a transient `theme-transition` class on `<html>` (added by a `MutationObserver` watching `data-theme`) scopes a short fade to the switch window only, and `THEME_CROSSFADE_DURATION_MS` (`src/lib/constants/theme.ts`) must equal the CSS duration in `globals.css` or the class clears mid-fade.
+
+## What shipped
+
+The 12-theme system (Warm Cathedral light/dark default + 5 colored families × light/dark) shipped in **v0.9.0**. The colored families are systematic and CI-locked; the brand is hand-authored and pinned. If you change any of this, the question to keep asking is the one each guard above answers: _what would silently break, and which test would catch it?_
+
+## See also
+
+- [howto-add-theme-family.md](./howto-add-theme-family.md) — the step-by-step task (append a seed, regenerate, let `validate` gate it).
+- [reference-theme-system.md](./reference-theme-system.md) — the surface map: registry helpers, `useThemeAxis`, generator entry points, the token list and per-theme seeds (the volatile detail this doc deliberately defers).
+- [DESIGN.md](../../DESIGN.md) — the canonical product rules: "Theme System" and "Heatmap Invariance Rule".
+- the doc hub [`README.md`](./README.md) — the full developer-docs index.

--- a/docs/dev/howto-add-ipc-channel.md
+++ b/docs/dev/howto-add-ipc-channel.md
@@ -1,0 +1,196 @@
+# How to add an Electron IPC channel (or a window type)
+
+This recipe walks you through wiring a new request/response IPC channel (or a one-way main→renderer event) end to end, then covers the rarer task of adding a whole new window type. CoreLive's typed-IPC contract is split across three compiler-synced surfaces, so the build itself stops you from shipping a channel you forgot to validate. For the _why_ behind that design, see [explanation-electron-architecture.md](./explanation-electron-architecture.md); for a file:line map of the surfaces, see [reference-electron.md](./reference-electron.md) and [docs/ELECTRON_ARCHITECTURE.md](../ELECTRON_ARCHITECTURE.md).
+
+> Reminder: the Electron main process carries **no data IPC** — todos, BrainDump notes, the heatmap all flow over oRPC HTTP, identical to the web app. IPC channels exist only for native-shell concerns (window controls, multi-window orchestration, OS chrome, auth/oauth hand-off, desktop config). If your feature is about _data_, you want [howto-add-orpc-procedure.md](./howto-add-orpc-procedure.md), not this doc.
+
+## The three surfaces you keep in sync
+
+| Surface               | File                                                            | Role                                                                                                                                             |
+| --------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Compile-time contract | `electron/types/ipc.ts`                                         | `IPCChannels` (invoke/handle) and `IPCEventChannels` (one-way events) — the single source of truth for channel names + request/response shapes.  |
+| Runtime validation    | `electron/ipc/ipc-schemas.ts`                                   | `IPC_ARG_SCHEMAS`, typed `Record<IPCChannel, z.ZodTypeAny>` (`electron/ipc/ipc-schemas.ts:68`). The **only** place inbound payloads are checked. |
+| Wiring                | `electron/ipc/typedHandle.ts`, `typedInvoke.ts`, `typedSend.ts` | Thin wrappers that read those types; `typedHandle` parses against the schema before your handler runs.                                           |
+
+The load-bearing trick: `IPC_ARG_SCHEMAS` is typed as a _total_ `Record<IPCChannel, ...>`. Add a channel to `IPCChannels` in `ipc.ts` and forget its schema, and `ipc-schemas.ts` **fails to compile** — there is no path to a channel with no validation. `electron/__tests__/ipc-contract.test.ts` additionally asserts a schema exists for every channel and that the shapes parse. This is what makes "forgot to validate a channel" impossible rather than merely discouraged.
+
+---
+
+## Add a request/response channel
+
+A request/response channel is one the renderer calls with `invoke` and awaits a result. Steps 1–4 below are mandatory; skip any one and you get either a compile error (steps 1–2) or a missing/broken method at runtime (steps 3–4).
+
+### 1. Declare the channel in `IPCChannels`
+
+Add an entry to the `IPCChannels` interface in `electron/types/ipc.ts` (the interface opens at `electron/types/ipc.ts:248`). Each entry is `{ request; response }`. The `request` shape drives the argument tuple your handler and preload caller see, via `ArgsOf<C>` (`electron/ipc/types.ts:16`):
+
+- `request: void` → no args (`[]`)
+- `request: T` → one arg (`[T]`)
+- `request: [A, B]` (a tuple) → multiple positional args (`[A, B]`)
+
+```typescript
+// electron/types/ipc.ts — inside interface IPCChannels
+'braindump-config-set-last-category': {
+  request: number
+  response: boolean
+}
+```
+
+Reuse existing shared types (`ManagedWindowKind`, `WindowState`, `AuthUserPayload`, …) rather than inlining new shapes — they live in the same file and the renderer-side `.d.ts` re-imports them.
+
+### 2. Add its Zod schema to `IPC_ARG_SCHEMAS`
+
+In `electron/ipc/ipc-schemas.ts`, add a schema keyed by the same channel name. The schema validates the **argument tuple** (always a `z.tuple([...])`), not the response:
+
+```typescript
+// electron/ipc/ipc-schemas.ts — inside IPC_ARG_SCHEMAS
+'braindump-config-set-last-category': z.tuple([z.number().int().positive()]),
+```
+
+This is your one chance to bound untrusted input from a remotely-loaded web bundle — cap string lengths and number ranges here, do not just `z.unknown()` everything. See the existing entries for the conventions: `braindump-window-set-opacity` clamps to `z.number().min(0).max(1)` (`electron/ipc/ipc-schemas.ts:344`), `braindump-note-set` caps text length (`:366`), and the window-state channels constrain the target to `z.enum(['main', 'floating', 'braindump'])`.
+
+> If you skip this step the file will not type-check — that is the safety net working, not a bug.
+
+### 3. Register a `typedHandle` in `main.ts`
+
+All ~100 handler registrations live in **one** place: `setupIPCHandlers()` in `electron/main.ts` (the function opens at `electron/main.ts:1099`, guarded against a second run by `ipcHandlersInitialized` at `electron/main.ts:1103`). Do **not** add a `registerIpcHandlers()` method to a manager — some manager docstrings imply per-manager registration, but that is not how it actually works; managers are pure logic called _by_ these handlers.
+
+```typescript
+// electron/main.ts — inside setupIPCHandlers()
+typedHandle('braindump-config-set-last-category', (_event, categoryId) => {
+  if (!configManager) return false
+  configManager.set('braindump.lastCategoryId', categoryId)
+  return true
+})
+```
+
+`typedHandle` (`electron/ipc/typedHandle.ts:40`) runs `IPC_ARG_SCHEMAS[channel].parse(rawArgs)` before invoking your callback. A payload that fails the schema throws `IPC validation failed on '<channel>': <detail>` (`electron/ipc/typedHandle.ts:60`) and never reaches your handler — so inside the handler you may treat `categoryId` as already-validated.
+
+### 4. Expose a guarded method in the right preload
+
+There are **three** preload scripts, each exposing one isolated API object over `contextBridge` (the renderer never sees `ipcRenderer` or Node). Add your method to the one whose window needs the channel:
+
+| Preload                         | Exposed as                                                 | Window              |
+| ------------------------------- | ---------------------------------------------------------- | ------------------- |
+| `electron/preload.ts`           | `window.electronAPI` (full surface) + `window.electronEnv` | Main `/home` window |
+| `electron/preload-floating.ts`  | `window.floatingNavigatorAPI`                              | Floating navigator  |
+| `electron/preload-braindump.ts` | `window.brainDumpAPI`                                      | BrainDump panel     |
+
+Wrap the call in `typedInvoke` and a `try/catch` that returns a safe default (this matches every existing method):
+
+```typescript
+// electron/preload-braindump.ts — inside contextBridge.exposeInMainWorld('brainDumpAPI', { ... })
+category: {
+  setLast: async (categoryId: number): Promise<void> => {
+    try {
+      await typedInvoke('braindump-config-set-last-category', categoryId)
+    } catch (error) {
+      log.error('BrainDump: Failed to set last category:', error)
+    }
+  },
+},
+```
+
+`typedInvoke` (`electron/ipc/typedInvoke.ts:32`) is the renderer-side typed wrapper over `ipcRenderer.invoke`; it returns `Promise<IPCChannels[C]['response']>`.
+
+#### Gotcha: renderer code must feature-detect by METHOD, not namespace
+
+The installed desktop app ships a **frozen** preload, but the renderer loads the always-current remote web bundle from `https://corelive.app`. So a freshly deployed web build can call a preload method that an older _installed_ app does not expose — a version skew. Renderer code must therefore feature-detect at **method granularity**, never just check that the namespace exists. The real consumer does exactly this:
+
+```typescript
+// src/components/electron/StartupWindowSettings.tsx:187
+typeof window.electronAPI?.settings?.getStartupConfig !== 'function'
+```
+
+Both global `Window.electronAPI` augmentations (`electron/types/electron-api.d.ts`, `src/types/electron.d.ts`) mark namespaces optional (`?.`) to _force_ this style at the type level. `src/app/error.tsx` is the route-level net if a guard is ever missed. Background: [explanation-electron-architecture.md](./explanation-electron-architecture.md) and the project's local `CLAUDE.md` Electron sections.
+
+### 5. (If shared types changed) keep the renderer `.d.ts` honest
+
+`electron/preload.ts` is the **only** source of truth for what is actually on `window.electronAPI`. The two `.d.ts` files already disagree with each other and with runtime (e.g. `electron/types/electron-api.d.ts` declares a `performance` namespace that `preload.ts` does not expose). If you added a new namespace or method that renderer code consumes, update `src/types/electron.d.ts` to match what you actually exposed — and only that.
+
+---
+
+## Add a one-way event (main → renderer)
+
+When the main process needs to _push_ something (e.g. broadcast a state change), use an event channel instead of request/response.
+
+1. **Declare it in `IPCEventChannels`** in `electron/types/ipc.ts` (the interface opens at `electron/types/ipc.ts:781`). The value is the payload type directly (or `void` for no payload):
+
+   ```typescript
+   // electron/types/ipc.ts — inside interface IPCEventChannels
+   'braindump-category-changed': { categoryId: number }
+   ```
+
+2. **Emit it with `typedSend`** from `main.ts` or a manager. `typedSend` (`electron/ipc/typedSend.ts:33`) no-ops if `sender.isDestroyed()` (`electron/ipc/typedSend.ts:38`), so emitting to a window that just closed is a safe no-op, not a crash:
+
+   ```typescript
+   // electron/main.ts — e.g. inside the set-last-category handler
+   const brainDumpWin = windowManager?.getBrainDumpWindow()
+   if (brainDumpWin && !brainDumpWin.isDestroyed()) {
+     typedSend(brainDumpWin.webContents, 'braindump-category-changed', {
+       categoryId,
+     })
+   }
+   ```
+
+3. **Whitelist it on the inbound side of the preload.** Each preload gates its generic `on()` subscription behind a hard-coded allow-list of event-channel names and runs every payload through `sanitizeData` (strips `__proto__`/`constructor`/`prototype` keys — prototype-pollution defense — and trims strings). In `electron/preload-braindump.ts`, `braindump-category-changed` is the **only** inbound channel accepted (`ALLOWED_CHANNELS` at `electron/preload-braindump.ts:56`, gated by `validateChannel` at `:70`). The main preload uses the equivalent `validateChannel` + `sanitizeData` (`electron/preload.ts:162` / `:172`). Add your channel to the relevant allow-list or `on()` silently refuses it.
+
+   > Do **not** reach for `createTypedListener` (`electron/ipc/typedListener.ts`) — it is vestigial with zero call sites. The live inbound pattern is the guarded raw `ipcRenderer.on` shown above.
+
+### Worked example: `braindump-config-set-last-category`
+
+The BrainDump "remember my last category" feature exercises _both_ halves at once and is the cleanest end-to-end reference in the tree:
+
+- **Channel** declared in `IPCChannels` and validated by `z.tuple([z.number().int().positive()])` (`electron/ipc/ipc-schemas.ts:378`).
+- **Handler** at `electron/main.ts:1487` persists `braindump.lastCategoryId` via `configManager.set(...)`, then — in the same handler — broadcasts the change with `typedSend(..., 'braindump-category-changed', { categoryId })` (`electron/main.ts:1495`).
+- **Renderer side** is exposed as `brainDumpAPI.category.setLast` / `.getLast` (`electron/preload-braindump.ts:239`), and the BrainDump window subscribes to the event via the whitelisted `on('braindump-category-changed', …)`.
+
+Read those three spans together for the canonical shape.
+
+---
+
+## Add a new window type
+
+Rarer, and a bigger ritual — a window type touches the factory, two `'main'|'floating'|'braindump'` unions, config defaults, and the persistence layer. CoreLive currently ships five window kinds (main, floating navigator, BrainDump, settings popover, cold-boot startup pill); see [reference-electron.md](./reference-electron.md) for the factory line anchors and [explanation-electron-architecture.md](./explanation-electron-architecture.md) for the visibility-ownership model. The persisted-window types specifically are the `'main' | 'floating' | 'braindump'` set; the settings popover and startup pill are transient and not persisted.
+
+To add a new **persisted** window type:
+
+1. **Add a factory method** to `WindowManager` alongside the existing ones — `createMainWindow` (`electron/WindowManager.ts:343`), `createFloatingNavigator` (`:457`), `createBrainDumpWindow` (`:591`), `createSettingsWindow` (`:1249`). It returns a `BrowserWindow` and loads `'${serverUrl}/<your-route>'`. Note the visibility split: **`WindowManager` owns show/hide/toggle**, not `WindowStateManager`.
+
+2. **Extend the window-kind union — there are two, and one is the source of truth.** Add your kind to `WindowType` in `electron/WindowStateManager.ts:64` (`'main' | 'floating' | 'braindump'`). `WindowManager` derives `StartupPanelKind = Exclude<WindowType, 'main'>` from it (`electron/WindowManager.ts:62`), so a new panel type flows through automatically. Separately, the **IPC** window-state channels use `ManagedWindowKind` (`electron/types/ipc.ts:210`, also `'main' | 'floating' | 'braindump'`) — extend it too if your window participates in `window-state-*` IPC, and update the matching `z.enum([...])` schemas in `ipc-schemas.ts` (e.g. `electron/ipc/ipc-schemas.ts:293`).
+
+3. **Add `ConfigManager` defaults** so the window has persisted config and (if it should open at launch) a startup flag. Startup flags live under `behavior.startup` as `StartupWindowConfig` (`electron/types/ipc.ts:80`).
+
+4. **Respect the ≥1-startup-window invariant.** `ConfigManager.ensureAtLeastOneStartupWindow()` (`electron/ConfigManager.ts:597`) runs on every `set`/`update`/`import` and force-sets `showMain = true` if every startup flag is false (`electron/ConfigManager.ts:632-633`), so a persisted config can never launch zero windows and soft-brick the app. If you add a new startup flag, make sure the invariant still considers a valid "main shows" fallback — do not write a code path that could persist an all-false startup config. The invariant is pinned by `electron/__tests__/ConfigManager.startup.test.ts`.
+
+5. **Add `WindowStateManager` defaults** for the new kind (bounds, snap, the `isVisible` default derived from its startup flag). Remember the deliberate boundary: `applyWindowState` restores **bounds only, not visibility** (`electron/WindowStateManager.ts:735`), and `floating.isVisible` is re-pinned to the configured startup default on load (`electron/WindowStateManager.ts:305`) so stale persisted state can't override the user's startup choice. Mirror that pattern for your window.
+
+---
+
+## Verify and test
+
+```bash
+pnpm typecheck      # catches a missing schema (step 2) or a request/response mismatch (step 1)
+pnpm test:electron  # runs ipc-contract.test.ts + the manager specs
+pnpm validate       # the full gate (test + lint + build + typecheck) — run before commit
+```
+
+(Canonical command list: `package.json` "scripts"; see also [howto-local-dev-and-tests.md](./howto-local-dev-and-tests.md) and [reference-ci-and-commands.md](./reference-ci-and-commands.md).)
+
+### Native surfaces have NO automated coverage
+
+Menu bar, system tray, dock / activation policy, `open-url` deep links, traffic-light controls, vibrancy, and the multi-window flows are **invisible** to Playwright and the `mcp__electron__*` suite — those drive the renderer (web content) only, and the Linux + `xvfb` CI is renderer coverage. A new window type, a tray-affecting channel, or anything touching Cocoa chrome has **zero automated tests**. Smoke-test it manually on macOS with the `mcp__computer-use__*` MCP before any tag push:
+
+```bash
+pnpm electron:build:dir && open dist/mac/CoreLive.app
+```
+
+See the project's local `CLAUDE.md` "Electron Native QA (macOS, computer-use)" section for the full checklist, and verify any window/menu motion via **video frames, not screenshots**.
+
+## See also
+
+- [reference-electron.md](./reference-electron.md) — windows, IPC, preload, managers (file:line index).
+- [explanation-electron-architecture.md](./explanation-electron-architecture.md) — why three preloads, why version-skew-safe, why the remote-URL WebView.
+- [howto-add-sync-channel.md](./howto-add-sync-channel.md) — the higher-level cross-window sync layer that rides on top of these IPC events.
+- [docs/ELECTRON_ARCHITECTURE.md](../ELECTRON_ARCHITECTURE.md) — the deep architecture reference.
+- Hub index: [README.md](./README.md).

--- a/docs/dev/howto-add-orpc-procedure.md
+++ b/docs/dev/howto-add-orpc-procedure.md
@@ -1,0 +1,305 @@
+# How to add a new oRPC procedure
+
+oRPC is CoreLive's single type-safe HTTP API surface — the web app and the Electron renderer hit the exact same procedures over `POST/GET /api/orpc/*`. This guide walks you end-to-end: Zod schema → procedure → router registration → client hook → optimistic updates → a real-DB test.
+
+This is a recipe, not a tour. For the _why_ behind this layer (the Bearer-token auth model, the one-data-path architecture, query-vs-mutation), see [explanation-architecture.md](./explanation-architecture.md). For a point-to-source index of every existing procedure, see [reference-orpc-api.md](./reference-orpc-api.md).
+
+> **Prerequisites:** You've done [tutorial-getting-started.md](./tutorial-getting-started.md) and can run the local dev + test loop ([howto-local-dev-and-tests.md](./howto-local-dev-and-tests.md)). A local Postgres is running (`docker compose up -d`).
+
+## The shape of every procedure
+
+A procedure is always built from `authMiddleware` (`src/server/middleware/auth.ts:10`):
+
+```typescript
+authMiddleware
+  .input(InputSchema) // optional — read-only procedures omit it
+  .output(OutputSchema) // re-validates the DB result on the way out
+  .handler(async ({ input, context }) => {
+    /* ... */
+  })
+```
+
+Two facts that change how you write handlers:
+
+- **Auth is universal — there are no unauthenticated procedures.** Every procedure extends `authMiddleware`, which resolves the caller and injects `context.user` (a full Prisma `User`) into the handler (`src/server/middleware/auth.ts:6-8`, `41-50`). You never receive a `userId` as input — read it from `context.user.id`. Scope every query by it.
+- **`query` vs `mutation` is a _client_ convention, not a server tag.** `.handler()` does not mark a procedure as read or write. The distinction lives on the client (`orpc.<ns>.<proc>.queryOptions()` vs `.mutationOptions()`); you choose read=query, write=mutation when you consume it. See [explanation-architecture.md](./explanation-architecture.md).
+
+## Steps
+
+### 1. Define the Zod input/output schemas
+
+Schemas live in `src/server/schemas/<ns>.ts`, one file per namespace. Define an input schema (omit it for read-only procedures) and an output schema. The output schema **re-validates the database result** at the boundary, so it must match what Prisma returns.
+
+From `src/server/schemas/category.ts:50-53`:
+
+```typescript
+export const CreateCategorySchema = z.object({
+  name: z.string().min(1, 'Category name is required').max(30),
+  color: CategoryColorSchema.default('blue'),
+})
+```
+
+> **Gotcha — `Date` fields need the union+transform, never bare `z.date()`.** After the JSON round-trip the oRPC client hands back ISO **strings**, so a plain `z.date()` output schema fails validation on the wire. Copy the existing pattern for every `Date` field (`src/server/schemas/category.ts:35-40`, mirrored in `src/server/schemas/todo.ts:16-21`):
+>
+> ```typescript
+> createdAt: z
+>   .union([z.date(), z.string()])
+>   .transform((val) => (typeof val === 'string' ? new Date(val) : val)),
+> ```
+>
+> This is paired with a custom RPC Date serializer (`src/lib/orpc/serializer.ts`) so renderer code always gets real `Date` objects — but you only need the schema transform above.
+
+### 2. Build the procedure
+
+Procedures live in `src/server/procedures/<ns>.ts`. Build from `authMiddleware`, wire up the schemas, and read the user from `context`. Translate Prisma error codes (`P2002` unique, `P2003` FK, `P2025` not-found) into the matching `ORPCError` so the client gets a typed error instead of a 500.
+
+The `category.create` procedure (`src/server/procedures/category.ts:79-114`, comments abridged):
+
+```typescript
+export const createCategory = authMiddleware
+  .input(CreateCategorySchema)
+  .output(CategorySchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const { user } = context
+
+      const category = await prisma.category.create({
+        data: {
+          name: input.name,
+          color: input.color,
+          userId: user.id, // scope to the authed user — never an input
+        },
+      })
+
+      return category as Category
+    } catch (error) {
+      // Prisma P2002 = unique constraint violation (@@unique([name, userId]))
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as { code: string }).code === 'P2002'
+      ) {
+        throw new ORPCError('CONFLICT', {
+          message: `Category "${input.name}" already exists`,
+        })
+      }
+      if (error instanceof ORPCError) throw error
+      log.error({ error }, 'Error in createCategory')
+      throw new ORPCError('INTERNAL_SERVER_ERROR', {
+        message: 'Failed to create category',
+        cause: error,
+      })
+    }
+  })
+```
+
+Notes:
+
+- **No-input form:** procedures that take no input drop `.input()` entirely and start at `.output(...)` — whether a read like `listCategories` (`src/server/procedures/category.ts:43-45`) or a destructive write like `clearCompleted` (`src/server/procedures/todo.ts:262-264`), which archives-and-removes all completed todos. "No input" is independent of read-vs-write.
+- **Ownership checks:** for update/delete, `findFirst({ where: { id, userId: user.id } })` first and throw `ORPCError('NOT_FOUND')` if absent — that's how the codebase enforces per-user access (`src/server/procedures/category.ts:138-146`).
+- **Use the module logger**, not `console` — `const log = createModuleLogger('<ns>')` (`src/server/procedures/category.ts:32`).
+
+### 3. Register it in the router
+
+The router (`src/server/router.ts:37-73`) is a plain nested object literal grouping procedures into namespaces (`category`, `todo`, `completed`, `electronSettings`, `skillTree`). Import your procedure and add it to its namespace:
+
+```typescript
+export const router = {
+  category: {
+    list: listCategories,
+    create: createCategory, // ← your procedure
+    update: updateCategory,
+    delete: deleteCategory,
+  },
+  // ...
+}
+
+export type AppRouter = typeof router // the type the client is generated from
+```
+
+> **This is the only wiring step.** The catch-all route handler `src/app/api/orpc/[...path]/route.ts:7` mounts `new RPCHandler(router)` and re-exports it as `GET/POST/PUT/PATCH/DELETE` (route.ts:39-43), so adding the procedure to the router exposes it over HTTP automatically. There is no per-procedure route to write. The handler passes `{ headers: request.headers }` as context (route.ts:15-20), which is exactly what `authMiddleware` reads.
+
+### 4. Consume it on the client
+
+`src/lib/orpc/client-query.ts:21` wraps the typed client with `@orpc/tanstack-query` into a single `orpc` object. Every component reaches the API through it. The call shapes are exact:
+
+```typescript
+import { orpc } from '@/lib/orpc/client-query'
+import { useQuery, useMutation } from '@tanstack/react-query'
+
+// READ → queryOptions. Input NESTS under an `input` key:
+const { data } = useQuery(orpc.category.list.queryOptions())
+const todos = useQuery(
+  orpc.todo.list.queryOptions({ input: { completed: false } }),
+)
+
+// WRITE → mutationOptions (pass {} when you add no extra options):
+const create = useMutation(orpc.category.create.mutationOptions({}))
+create.mutate({ name: 'Work', color: 'blue' })
+
+// INVALIDATION key → .key() (partial) or .queryKey (exact, from queryOptions):
+queryClient.invalidateQueries({ queryKey: orpc.category.list.key() })
+```
+
+> **Gate protected queries on Clerk readiness.** A query that fires before Clerk hydrates sends no Bearer token and 401s. Use `useClerkQueryReady()` (`src/hooks/useClerkQueryReady.ts`) to set `enabled`. See [explanation-architecture.md](./explanation-architecture.md) for the auth handshake.
+
+### 5. Wire optimistic updates + invalidation (mutations)
+
+The canonical consumer is `useTodoMutations.ts`. Mutations follow the TanStack Query optimistic pattern: **`onMutate`** (cancel in-flight queries → snapshot → apply optimistic change), **`onError`** (roll back from the snapshot), **`onSettled`** (always invalidate to reconcile with the server).
+
+The `createMutation` (`src/hooks/useTodoMutations.ts:86-133`, comments abridged):
+
+```typescript
+const createMutation = useMutation({
+  ...orpc.todo.create.mutationOptions({}),
+  onMutate: async (newTodo) => {
+    // 1. Cancel outgoing refetches so they don't clobber the optimistic write
+    await queryClient.cancelQueries({ queryKey: pendingKey })
+
+    // 2. Snapshot previous value for rollback
+    const previousPending = queryClient.getQueryData<TodoResponse>(pendingKey)
+
+    // 3. Optimistically add a temp row
+    const optimisticTodo: Todo = {
+      id: -Date.now(), // Negative temp ID to avoid collision with real IDs
+      text: newTodo.text,
+      notes: newTodo.notes ?? null,
+      categoryId: newTodo.categoryId,
+      completed: false,
+      userId: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+    queryClient.setQueryData<TodoResponse>(pendingKey, (old) => {
+      if (!old) return old
+      return {
+        ...old,
+        todos: [optimisticTodo, ...old.todos],
+        total: old.total + 1,
+      }
+    })
+
+    // 4. Return context for rollback
+    return { previousPending }
+  },
+  onError: (_err, _newTodo, context) => {
+    if (context?.previousPending) {
+      queryClient.setQueryData(pendingKey, context.previousPending)
+    }
+  },
+  onSettled: () => {
+    // Always refetch to reconcile the temp row with the real server row
+    queryClient.invalidateQueries({ queryKey: pendingKey })
+    queryClient.invalidateQueries({ queryKey: orpc.category.list.key() })
+    broadcastTodoSync() // cross-window sync — see explanation-state-and-sync.md
+    broadcastCategorySync()
+  },
+})
+```
+
+> **The negative temp-id convention (`id: -Date.now()`)** is load-bearing and matches the server. `todo.update`, `todo.delete`, and `todo.toggle` accept `z.number().int()` (not `.positive()`) and **silently no-op for `id < 0`** (`src/server/procedures/todo.ts:130-132`, `164-166`, `217-219`), because a mutation can fire against an optimistic row before its real row exists. The `onSettled` invalidation then reconciles to real server state.
+
+**Invalidate every query the write touches.** A mutation often ripples across namespaces. `toggleMutation` is the richest example — its `onSettled` fans invalidations across `category.list`, `skillTree.getMyTree`, `skillTree.getUnassignedPool`, `completed.heatmap`, and `completed.dayDetail` because toggling a todo changes category counts, the skill-tree pool, and the heatmap (`src/hooks/useTodoMutations.ts:291-316`). When you add a mutation, ask which read models its write affects and invalidate each. Why completions ripple into the heatmap is covered in [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md).
+
+### 6. Write a real-DB integration test
+
+**Mocking auth or the DB is forbidden** (project rule — it hides exactly the TOCTOU / idempotency / archive bugs these tests catch). Instead, invoke the procedure with `@orpc/server`'s `call()` and a real `Headers`-bearing context so the **real `authMiddleware` runs** against live Postgres. Tests live next to the procedure as `src/server/procedures/<ns>.<topic>.test.ts` and are gated by `RUN_DB_INTEGRATION_TESTS=1`.
+
+The harness (from `src/server/procedures/completed.createMany.test.ts:14-55`):
+
+```typescript
+// @vitest-environment node
+
+// Runs only when RUN_DB_INTEGRATION_TESTS=1 (CI sets it once Postgres is up;
+// locally: `docker compose up`). Skips cleanly in DB-less contexts.
+const describeIfDb =
+  process.env.RUN_DB_INTEGRATION_TESTS === '1' ? describe : describe.skip
+
+// call() passes a Bearer token; the REAL authMiddleware upserts the user by it.
+function authContext(clerkId: string) {
+  return {
+    context: { headers: new Headers({ Authorization: `Bearer ${clerkId}` }) },
+  }
+}
+
+// A unique clerkId per test → a fresh user, so rows never collide across runs.
+const createdClerkIds = new Set<string>()
+function freshClerkId(): string {
+  const clerkId = `test_import_${randomUUID()}`
+  createdClerkIds.add(clerkId)
+  return clerkId
+}
+
+// FK-safe teardown: child rows before the user (User has NO onDelete cascade
+// from Completed/Todo/Category; only ImportBatch/SkillTree cascade).
+afterEach(async () => {
+  for (const clerkId of createdClerkIds) {
+    const user = await prisma.user.findUnique({ where: { clerkId } })
+    if (!user) continue
+    await prisma.completed.deleteMany({ where: { userId: user.id } })
+    await prisma.todo.deleteMany({ where: { userId: user.id } })
+    await prisma.importBatch.deleteMany({ where: { userId: user.id } })
+    await prisma.category.deleteMany({ where: { userId: user.id } })
+    await prisma.user.delete({ where: { id: user.id } })
+  }
+  createdClerkIds.clear()
+})
+```
+
+A test body then `call(procedure, input, authContext(clerkId))` and asserts against `prisma` directly. Note the **three identical titles** — they prove the no-dedup invariant: each item inserts its own row (`completed.createMany.test.ts:58-85`).
+
+```typescript
+const clerkId = freshClerkId()
+const importBatchId = randomUUID()
+
+const result = await call(
+  createManyCompleted,
+  {
+    items: [
+      { title: 'English study' },
+      { title: 'English study' },
+      { title: 'English study' },
+    ],
+    importBatchId,
+  },
+  authContext(clerkId),
+)
+
+expect(result).toEqual({ count: 3, idempotent: false })
+const user = await prisma.user.findUniqueOrThrow({ where: { clerkId } })
+const rows = await prisma.completed.findMany({
+  where: { userId: user.id, importBatchId },
+})
+expect(rows).toHaveLength(3)
+```
+
+Run it with the gate on:
+
+```bash
+RUN_DB_INTEGRATION_TESTS=1 pnpm test
+```
+
+Notes:
+
+- The teardown order is **not optional** — deleting the `User` first throws on the restricted FKs. If your namespace touches the skill tree, delete `skillTree` first (it cascades nodes + assignments), as `src/server/procedures/todo.archive.test.ts:64-78` does.
+- These suites make several sequential round-trips per case; bump the timeout (`vi.setConfig({ testTimeout: 30_000 })`, `todo.archive.test.ts:16`) so they don't flake on DB latency.
+
+## Bulk procedures: importBatchId idempotency
+
+If your procedure does a **bulk insert** (paste-import style), make it idempotent on a client-supplied `importBatchId`. The pattern (`src/server/procedures/todo.ts:351-432`, mirrored in `src/server/procedures/completed.ts:399-478`):
+
+1. Insert an `ImportBatch` guard row **in the same `$transaction`** as the `createMany`, keyed on `importBatchId`.
+2. A duplicate batch id throws Prisma `P2002` — **caught _outside_ the `$transaction`** (a failed statement aborts the entire PG transaction, so you cannot catch-and-continue on the `tx` client). On `P2002`, re-query the prior count and return `{ count, idempotent: true }`.
+
+The matching bulk-undo (`*.deleteMany`) deletes by `importBatchId`, guarded by a 60s window on `createdAt` (`COMPLETED_UNDO_WINDOW_MS`, `src/lib/constants/import.ts:21`). And there is **no dedup** — repeated titles are an intentional habit/XP signal, so uniqueness is on the batch id only, never on task text.
+
+## Pre-launch reminder
+
+This repo is pre-launch and volatile — schemas, fields, and APIs are reshaped freely with no migrations kept (`README.md` line 13; reset with `pnpm db:reset`). When this guide and the source disagree, **the source wins**. The _steps_ above are stable; for exact field shapes always read the Zod schema in `src/server/schemas/<ns>.ts` rather than trusting a transcription.
+
+## See also
+
+- [reference-orpc-api.md](./reference-orpc-api.md) — point-to-source index of all procedures by namespace + `file:line`.
+- [explanation-architecture.md](./explanation-architecture.md) — one codebase, two runtimes, one data path; the auth + query-vs-mutation model.
+- [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md) — why completions are archived (not deleted) and how the Todo ∪ Completed union feeds the heatmap.
+- [howto-local-dev-and-tests.md](./howto-local-dev-and-tests.md) — the dev + test loop, including the Postgres-up step the integration gate needs.

--- a/docs/dev/howto-add-route-or-setting.md
+++ b/docs/dev/howto-add-route-or-setting.md
@@ -1,0 +1,331 @@
+# How to add a route or a persisted client setting
+
+Two recipes that share a chapter of CoreLive's frontend. **Part A** adds a new
+page to the App Router (and decides whether it gets the sidebar or renders
+chromeless for its own Electron window). **Part B** adds a persisted Redux
+setting (a slice) and wires its cross-window sync. Both assume you have done the
+[Getting Started tutorial](./tutorial-getting-started.md) and can run the
+[local dev + test loop](./howto-local-dev-and-tests.md).
+
+For the durable "why" behind these mechanics, see
+[Architecture: one codebase, two runtimes](./explanation-architecture.md) and
+[Client state ownership & cross-window sync](./explanation-state-and-sync.md).
+The flat surface map lives in
+[the frontend reference](./reference-frontend.md).
+
+---
+
+## Part A — Add a route
+
+### Step 0 — Decide: `(main)` sidebar group, or standalone chromeless route?
+
+Every Electron window loads a **real `corelive.app` route** in a `BrowserWindow`
+— there is no embedded UI. So the first decision is which kind of page you are
+adding:
+
+| Kind                          | Lives under               | Gets the sidebar/app chrome?                                                     | Use it for                                                                                                |
+| ----------------------------- | ------------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **`(main)` route-group page** | `src/app/(main)/<route>/` | **Yes** — `(main)/layout.tsx` wraps children in `SidebarProvider` + `AppSidebar` | A normal in-app screen (like `/home`, `/skill-tree`)                                                      |
+| **Standalone route**          | `src/app/<route>/`        | **No** — renders bare                                                            | A chromeless body for a dedicated Electron window (like `/braindump`, `/floating-navigator`, `/settings`) |
+
+The parentheses in `(main)` are a Next.js **Route Group**: they add **no URL
+segment**, they only attach a shared layout. `(main)/layout.tsx:12-23` is that
+layout — it renders `<SidebarProvider><AppSidebar /><SidebarInset>{children}` so
+`/home` and `/skill-tree` get the sidebar without `(main)` appearing in their
+URL. The standalone routes live **outside** `(main)` for exactly the opposite
+reason: they must render sidebar-free inside their own native window. Which
+window loads which route is wired in `electron/WindowManager.ts` — see
+[the Electron reference](./reference-electron.md).
+
+### Step 1 — Create the page file
+
+For an in-app screen with the sidebar:
+
+```
+src/app/(main)/<route>/page.tsx
+```
+
+For a standalone window body:
+
+```
+src/app/<route>/page.tsx
+```
+
+A standalone page is typically a `'use client'` component that owns its own
+viewport (`h-screen w-full`) and may import its own CSS — see
+`src/app/floating-navigator/page.tsx:1-16`, which imports
+`floating-navigator.css` and renders a single full-height container.
+
+### Step 2 — Gate any protected client query with `useClerkQueryReady`
+
+If your page fires an oRPC query that needs the signed-in user, you **must not**
+let it fire before Clerk hydrates the session — otherwise you get a flaky
+`UNAUTHORIZED` request in the gap between mount and Clerk being ready (common
+right after an OAuth redirect). The gate is `useClerkQueryReady()`, which returns
+`isLoaded && Boolean(user)` (`src/hooks/useClerkQueryReady.ts:18-21`). Feed it
+into the query's `enabled` and render a loading state until it is `true`.
+
+This is the pattern `src/app/braindump/page.tsx:19-33` uses:
+
+```tsx
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
+import { orpc } from '@/lib/orpc/client-query'
+
+const isClerkReady = useClerkQueryReady()
+const { data, isLoading, error } = useQuery({
+  ...orpc.category.list.queryOptions({}),
+  enabled: isClerkReady, // do not fire until Clerk has a signed-in user
+})
+
+if (isLoading || !isClerkReady) {
+  return <div className="…">Loading…</div>
+}
+```
+
+> **Why the gate, not just `isLoading`?** React Query's `isLoading` is only
+> meaningful once the query is _enabled_. Gating on `enabled: isClerkReady`
+> keeps the request from being constructed (with an empty `Authorization`
+> header) during hydration. See
+> [the authentication explanation](./explanation-authentication.md) for how the
+> `Authorization: Bearer <clerk user id>` header is assembled and why it can be
+> empty before Clerk loads.
+
+A standalone page can also be **browser-tolerant** for dev: `/braindump` renders
+a placeholder when opened in a plain tab without the Electron `brainDumpAPI`, so
+you can iterate from a regular `pnpm dev` server without launching Electron
+(`src/app/braindump/page.tsx:11-18`).
+
+### Step 3 — Add the route prefix to `isProtectedRoute`
+
+Route protection is **centralized** in `src/proxy.ts` (Next.js 16 renamed
+`middleware.ts` → `proxy.ts`). It runs `clerkMiddleware` and redirects
+unauthenticated requests for protected prefixes to `/login?redirect_url=…`. Add
+your new route's path prefix to the `isProtectedRoute` matcher at
+`src/proxy.ts:4-15`:
+
+```ts
+const isProtectedRoute = createRouteMatcher([
+  '/home(.*)',
+  '/skill-tree(.*)',
+  '/braindump(.*)',
+  '/settings(.*)',
+  '/floating-navigator(.*)',
+  // '/<your-route>(.*)',  ← add here if the page requires a signed-in user
+])
+```
+
+The `(.*)` suffix protects the prefix and everything beneath it. If your page is
+genuinely public (like the marketing landing at `src/app/page.tsx`), do **not**
+add it — the default is public.
+
+> **Gotcha — a redirect can be load-bearing.** `/floating-navigator` is
+> protected on purpose so an unauthenticated Electron **cold boot** redirects to
+> `/login`; the main-process nav-watch detects that redirect and surfaces the
+> main window instead of leaving an empty floating panel
+> (`src/proxy.ts:11-14`). If you add a standalone Electron-window route, decide
+> deliberately whether an unauthenticated load should redirect (usually yes) so
+> the native side can react.
+
+You do **not** normally touch the `config.matcher` at `src/proxy.ts:33-40` — it
+already covers every non-static path and all `/api` routes.
+
+---
+
+## Part B — Add a persisted client setting (a Redux slice)
+
+Client/device state lives in **Redux** (two small persisted slices); all server
+data lives in **React Query**. Keep that split — do not put server data in Redux.
+The full rationale (and why each sync path is the way it is) is in
+[Client state ownership & cross-window sync](./explanation-state-and-sync.md).
+
+Before adding a _new_ slice, ask whether your setting belongs in an existing one:
+
+- `preferencesSlice` — core todo-experience prefs (`completionSound`,
+  `retainCompletedInList`), synced **between renderer windows** via
+  BroadcastChannel.
+- `electronSettingsSlice` — window-chrome settings (`hideAppIcon`,
+  `showInMenuBar`, `startAtLogin`), synced **to the Electron main process** via
+  IPC.
+
+If it fits one of those, just add a field + action + selector to that slice and
+follow Steps 3–5 below. The steps that follow assume a brand-new slice.
+
+### Step 1 — Write the slice with a defaults constant
+
+Put the slice at `src/lib/redux/slices/<name>Slice.ts`. Model it on
+`src/lib/redux/slices/preferencesSlice.ts`. Two non-negotiable conventions:
+
+1. **Defaults live in a shared constant**, not inline. `preferencesSlice.ts:44-46`
+   spreads `DEFAULT_PREFERENCES` from `src/lib/constants/preferences.ts` for its
+   `initialState`. This keeps the initial state and the selector fallbacks
+   (Step 2) reading from one source of truth.
+2. **Provide a `hydrate*` action** that replaces the whole slice from a payload
+   _without_ re-broadcasting — only if you intend cross-window sync (Step 4).
+   `preferencesSlice.ts:79-81` is the template; it is deliberately a separate
+   action from the user-facing `set*` ones.
+
+### Step 2 — Write selectors with `?? DEFAULT` fallbacks
+
+This is the single most important and least obvious rule. The persistence
+middleware's default `shallowMerge` **drops any field you ADD to a slice later**
+for a user who already persisted an older blob to `localStorage` — pre-launch,
+slices gain fields often. If a selector returned `state.x.newField` directly,
+that user would see `undefined` leak into the UI.
+
+So every selector coalesces through the default. `preferencesSlice.ts:109-119`:
+
+```ts
+export const selectCompletionSound = (state: RootState): boolean =>
+  state.preferences.completionSound ?? DEFAULT_PREFERENCES.completionSound
+```
+
+The rationale is documented at `src/lib/constants/preferences.ts:5-11`. Write
+yours the same way.
+
+> **Note the asymmetry.** `electronSettingsSlice.ts:115-144` selectors read the
+> field **directly** (no `?? DEFAULT`). That is fine _there_ because those values
+> are re-pushed to the main process on every launch (Step 4) and the slice has
+> been stable — but for any **new** slice, default-coalescing selectors are the
+> safe choice. When in doubt, coalesce.
+
+### Step 3 — Register the slice in the store (TWO places)
+
+Both registrations live in `src/lib/redux/store.ts` and **both are required** —
+miss the second and your slice will work in-memory but silently fail to persist:
+
+1. Add the reducer to `combineReducers` (`store.ts:28-31`):
+
+   ```ts
+   const rootReducer = combineReducers({
+     electronSettings: electronSettingsReducer,
+     preferences: preferencesReducer,
+     // <name>: <name>Reducer,   ← add the reducer
+   })
+   ```
+
+2. Add the slice **name** to the persisted-`slices` list passed to
+   `createStorageMiddleware` (`store.ts:48-53`):
+
+   ```ts
+   createStorageMiddleware({
+     rootReducer,
+     key: STORAGE_KEY, // 'corelive-redux-state'
+     slices: ['electronSettings', 'preferences'], // ← add '<name>' here to persist it
+   })
+   ```
+
+Components read/write the slice through the **pre-typed hooks** (`useAppSelector`
+/ `useAppDispatch`), re-exported from the barrel `src/lib/redux/index.ts:19-20`.
+Never import bare `useSelector` / `useDispatch`.
+
+### Step 4 — Choose the sync mechanism
+
+Each window has its **own** Redux store and its **own** `localStorage`, so a
+toggle in one window will not reach another (or the OS) without an explicit sync
+path. Pick based on _who needs to hear about the change_:
+
+| Destination                                             | Mechanism                                                                   | Reference implementation                          |
+| ------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------- |
+| **Other renderer windows** (web tab ↔ Electron windows) | `BroadcastChannel` Redux middleware                                         | `src/lib/preferences-sync-channel.ts`             |
+| **The Electron main process** (OS-facing chrome)        | renderer→main **IPC** in a `useCycleEffect`, mounted inside `ReduxProvider` | `src/components/electron/ElectronStartupSync.tsx` |
+
+**For BroadcastChannel sync**, model it on
+`createPreferencesSyncMiddleware` and concat it into the store's middleware chain
+(`store.ts:67-78`). Two correctness rules it encodes:
+
+- **Echo-loop guard** — only the user-initiated `set*` action types are in
+  `BROADCASTABLE_ACTION_TYPES` (`preferences-sync-channel.ts:19-22`); an inbound
+  snapshot is applied via `hydratePreferences`, which is _excluded_ from that
+  set, so an applied broadcast never re-broadcasts.
+- **Validate inbound payloads field-by-field** before dispatching
+  (`preferences-sync-channel.ts:38-55`): the selectors only coalesce
+  `null`/`undefined`, so non-boolean channel junk would otherwise be hydrated and
+  persisted. The middleware also no-ops on SSR / where `BroadcastChannel` is
+  unavailable (`preferences-sync-channel.ts:76-80`).
+
+If you only need cross-window sync (no new sync rules), the cheapest path is to
+add a channel that follows the same shape — see
+[How to add a cross-window sync channel](./howto-add-sync-channel.md).
+
+**For IPC-to-main sync**, model it on `ElectronStartupSync.tsx:91-123`. The
+load-bearing rules there:
+
+- Mount the syncing component **inside `<ReduxProvider>`** so it can read the
+  hydrated slice — it sits at `src/app/layout.tsx:65-66`, right after
+  `ReduxProvider` opens.
+- **Guard on the METHOD existing**, not just the namespace —
+  `typeof settings?.setHideAppIcon === 'function'`
+  (`ElectronStartupSync.tsx:106`). An installed desktop app loads the live remote
+  web bundle against its own **frozen preload**; calling `undefined()` would
+  throw a synchronous `TypeError` out of the effect (past `.catch`) and, from the
+  root layout, escape `error.tsx` entirely. (See
+  [the Electron architecture explanation](./explanation-electron-architecture.md)
+  and [How to add an Electron IPC channel](./howto-add-ipc-channel.md).)
+- **One effect per setting**, each with its own guard
+  (`ElectronStartupSync.tsx:103-120`), so a preload missing one method never
+  suppresses the others.
+
+### Step 5 — Surface the toggle in the UI
+
+The single settings home is `src/app/settings/page.tsx:32-43` (web + Electron,
+"D15"). It renders `PreferencesSettings` for everyone and `ElectronSettingsPage`
+(which self-returns `null` on web) for desktop-only chrome. Add your control to
+the matching component — preferences-style toggles go in `PreferencesSettings`,
+window-chrome ones in `ElectronSettingsPage`.
+
+---
+
+## Worked example — the `居残りモード` preference (end to end)
+
+`retainCompletedInList` ("keep completed todos in the active list") is a complete
+real example of a BroadcastChannel-synced preference. Trace it across the files:
+
+| Step                | File:line                                        | What it does                                              |
+| ------------------- | ------------------------------------------------ | --------------------------------------------------------- |
+| Default constant    | `src/lib/constants/preferences.ts:12-20`         | `retainCompletedInList: false` (default OFF)              |
+| State field         | `src/lib/redux/slices/preferencesSlice.ts:35-38` | typed `boolean` on `PreferencesState`                     |
+| `set*` action       | `preferencesSlice.ts:69-71`                      | `setRetainCompletedInList` mutates the field              |
+| Defensive selector  | `preferencesSlice.ts:117-119`                    | reads `?? DEFAULT_PREFERENCES.retainCompletedInList`      |
+| Persisted           | `src/lib/redux/store.ts:48-53`                   | `'preferences'` in the `slices` list                      |
+| Broadcast on change | `src/lib/preferences-sync-channel.ts:19-22`      | `'preferences/setRetainCompletedInList'` is broadcastable |
+| Applied inbound     | `preferences-sync-channel.ts:85-91`              | dispatched via `hydratePreferences` (no echo)             |
+
+A component toggles it through the typed hooks:
+
+```tsx
+import { useAppDispatch, useAppSelector } from '@/lib/redux/hooks'
+import {
+  selectRetainCompletedInList,
+  setRetainCompletedInList,
+} from '@/lib/redux/slices/preferencesSlice'
+
+const retain = useAppSelector(selectRetainCompletedInList)
+const dispatch = useAppDispatch()
+dispatch(setRetainCompletedInList(!retain)) // persists + broadcasts to other windows
+```
+
+---
+
+## Pitfalls checklist
+
+- **Put a standalone Electron-window page OUTSIDE `(main)`** — placing it inside
+  the group silently gives it a sidebar in its dedicated window.
+- **Gate protected client queries on `useClerkQueryReady`**, not on `isLoading`
+  alone — otherwise an `UNAUTHORIZED` request fires during Clerk hydration.
+- **Add the route to `isProtectedRoute`** (`src/proxy.ts:4-15`) — forgetting it
+  leaves a "logged-in" page reachable while signed out.
+- **Register a new slice in BOTH places** (`combineReducers` _and_ the persisted
+  `slices` list, `store.ts:28-53`) — miss the second and it won't survive a
+  reload.
+- **Write `?? DEFAULT` selectors** — `shallowMerge` drops newly-added fields for
+  users with an older persisted blob (`preferences.ts:5-11`).
+- **Guard IPC calls on the method, not the namespace**
+  (`ElectronStartupSync.tsx:106`) — a frozen preload makes a missing method
+  throw past `error.tsx`.
+- **Validate inbound BroadcastChannel payloads** field-by-field
+  (`preferences-sync-channel.ts:38-55`) — the selectors don't reject non-boolean
+  junk.

--- a/docs/dev/howto-add-sync-channel.md
+++ b/docs/dev/howto-add-sync-channel.md
@@ -1,0 +1,355 @@
+# How to add a cross-window sync channel
+
+CoreLive runs the same web app in several windows at once — the browser tab, the
+Electron main window, the Floating Navigator, and the BrainDump — and **each is a
+separate context with its own React Query cache, Redux store, and `localStorage`**.
+A mutation in one window is invisible to the others until you explicitly tell them.
+This guide shows how to add a channel that bridges that gap, using
+[`BroadcastChannel`](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel),
+which crosses Electron `BrowserWindow`s in this app with no custom IPC.
+
+For _why_ the system is shaped this way (separate stores per window, ping vs.
+snapshot, the intent-channel exception), read
+[explanation-state-and-sync.md](./explanation-state-and-sync.md). This is the
+recipe; that is the rationale.
+
+There are two variants. Pick by what the receiver needs to do:
+
+| Variant                     | Use when                                                              | Template                                                 |
+| --------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------- |
+| **Stateless ping** (common) | Receiver just needs "something changed → invalidate / open something" | `src/lib/todo-sync-channel.ts`                           |
+| **Stateful snapshot**       | Receiver must apply an _exact copy_ of some client state              | `src/lib/preferences-sync-channel.ts` (Redux middleware) |
+
+---
+
+## Variant A — a stateless "ping" channel (the common case)
+
+The three existing ping channels — `src/lib/todo-sync-channel.ts`,
+`src/lib/category-sync-channel.ts`, and `src/lib/paste-import-channel.ts` — are
+near-identical copies of one shape. Adding a fourth is a copy-and-rename job plus
+two wiring points. Do not hand-roll a new shape; copy the canonical one so the SSR
+guard and `close()` come along for free.
+
+### 1. Copy the canonical channel and rename three things
+
+Copy `src/lib/todo-sync-channel.ts` to a new file (e.g.
+`src/lib/<thing>-sync-channel.ts`) and rename:
+
+- the **channel name** constant — a globally-unique string, prefixed `corelive-`
+  (`TODO_SYNC_CHANNEL_NAME = 'corelive-todo-sync'`, `src/lib/todo-sync-channel.ts:1`).
+  Every window that opens a channel with the same name joins the same bus, so the
+  name _is_ the namespace — a collision silently cross-wires two features.
+- the **event type** constant + its message type
+  (`TODO_SYNC_EVENT_TYPE = 'todo-sync'` and `type TodoSyncMessage`,
+  `src/lib/todo-sync-channel.ts:2-4`). The message is a single `{ type }` object —
+  a ping carries no payload.
+- the **exported function names** — keep the `broadcastX` / `subscribeToX` verb
+  pair so call sites read clearly.
+
+Leave the three private helpers structurally intact:
+`isXSupported()` (the SSR guard), `createXChannel()` (returns the channel or
+`null`), and `isXMessage()` (the `event.data` type narrow).
+
+### 2. Keep the SSR guard
+
+`isTodoSyncSupported()` gates **every** entry point
+(`src/lib/todo-sync-channel.ts:14-18`):
+
+```typescript
+const isTodoSyncSupported = (): boolean => {
+  return (
+    typeof window !== 'undefined' && typeof BroadcastChannel !== 'undefined'
+  )
+}
+```
+
+The load-bearing clause for SSR safety is `typeof window !== 'undefined'`: there
+is no DOM `window` while Node renders these pages, so this short-circuits before a
+channel is ever opened server-side. (`BroadcastChannel` itself _is_ a Node global
+since v18, so it would construct fine on the server — the `typeof window` check is
+what keeps SSR from opening a stray channel; the `typeof BroadcastChannel` check
+covers any runtime that genuinely lacks the API.) Because of the guard,
+`broadcastX()` returns `false` and `subscribeToX()` returns a no-op cleanup on the
+server — both are safe to call unconditionally from client components that also
+render on the server.
+
+### 3. Broadcast at the mutation site (post, then `close()`)
+
+The broadcaster is fire-and-forget: open a fresh channel, post one message, **close
+it immediately** (`src/lib/todo-sync-channel.ts:62-71`):
+
+```typescript
+export const broadcastTodoSync = (): boolean => {
+  const channel = createTodoSyncChannel()
+  if (!channel) {
+    return false
+  }
+
+  channel.postMessage({ type: TODO_SYNC_EVENT_TYPE } satisfies TodoSyncMessage)
+  channel.close()
+  return true
+}
+```
+
+> **Why `close()` matters.** A `BroadcastChannel` you open but never close stays
+> bound to the window and keeps it pinned in memory; open one per broadcast without
+> closing and you leak a channel on every mutation. The broadcaster has no listener,
+> so there is nothing to lose by closing right after `postMessage` — the message is
+> already on the bus.
+
+Call `broadcastX()` from wherever the underlying data actually changes. The
+existing producers fire right after a mutation settles — for example
+`useTodoMutations` calls `broadcastTodoSync()` (and `broadcastCategorySync()`) in
+its `onSettled` paths (`src/hooks/useTodoMutations.ts:130-131`). That is
+deliberately `onSettled`, not `onSuccess`: `onSettled` runs after the mutation
+settles on _either_ success or error, so the other windows re-sync even when a
+mutation settles after a failure. The BrainDump editor broadcasts after it
+persists completions (`src/components/braindump/BrainDumpEditor.tsx:408`). A
+broadcaster does **not**
+need to also act locally — the window that mutated already updated its own cache;
+the broadcast is purely for the _other_ windows.
+
+### 4. Subscribe and return the cleanup from a `useCycleEffect`
+
+The receiver subscribes once and must tear the subscription down on unmount.
+`subscribeToTodoSync()` already returns a cleanup that removes the listener **and**
+closes the channel (`src/lib/todo-sync-channel.ts:82-100`):
+
+```typescript
+export const subscribeToTodoSync = (onSync: () => void): (() => void) => {
+  const channel = createTodoSyncChannel()
+  if (!channel) {
+    return () => {}
+  }
+
+  const handleMessage = (event: MessageEvent) => {
+    if (isTodoSyncMessage(event.data)) {
+      onSync()
+    }
+  }
+
+  channel.addEventListener('message', handleMessage)
+
+  return () => {
+    channel.removeEventListener('message', handleMessage)
+    channel.close()
+  }
+}
+```
+
+Your only job at the call site is to **return that cleanup** so the effect runs it.
+Use [`useCycleEffect`](../../src/hooks/use-cycle-effect.ts) — the 1:1 named alias of
+`useEffect`, and the only lifecycle wrapper in
+[`src/hooks`](./reference-frontend.md) that accepts an empty `[]` deps array
+(`src/hooks/use-cycle-effect.ts:30-33`). The receiving component must be a client
+component (`'use client'`), since `useEffect` only runs in a browser DOM context,
+never during SSR.
+
+> **Why return the cleanup.** If you call `subscribeToX()` and drop its return
+> value, the channel and its `message` listener live forever — every remount stacks
+> another listener and `onSync` fires N times. Returning the cleanup from the effect
+> is what closes the channel and removes the listener when the component unmounts.
+
+### Worked example (real code)
+
+`TodoList` invalidates the relevant React Query caches whenever any other window
+broadcasts a todo change (`src/app/(main)/home/_components/TodoList.tsx:358-371`):
+
+```typescript
+useCycleEffect(() => {
+  // Cross-window sync: BrainDump / Floating Navigator completions broadcast
+  // via the BroadcastChannel and also write to the Completed table, so the
+  // Home heatmap + day-detail caches need invalidation alongside the todo
+  // list. Without these two extra keys, completing a task in BrainDump
+  // leaves the main heatmap stale until reload (Codex review HIGH).
+  return subscribeToTodoSync(() => {
+    queryClient.invalidateQueries({ queryKey: orpc.todo.key() })
+    queryClient.invalidateQueries({ queryKey: orpc.completed.heatmap.key() })
+    queryClient.invalidateQueries({
+      queryKey: orpc.completed.dayDetail.key(),
+    })
+  })
+}, [queryClient])
+```
+
+Note the shape every ping receiver follows: `useCycleEffect(() =>
+subscribeToX(handler), [deps])`. The `subscribeToX(...)` call's return value is
+returned straight out of the effect callback — that is the cleanup. The Floating
+Navigator subscribes the same way in
+`src/components/floating-navigator/FloatingNavigatorContainer.tsx:311`.
+
+> **Receivers respond, they don't replay.** The ping carries no data, so the
+> handler re-derives state from a fresh source — almost always
+> `queryClient.invalidateQueries(...)` (which refetches from the server), as above
+> and in `src/app/(main)/home/_components/Category.tsx:91`. Don't try to mutate
+> local state from the ping; invalidate and let the query refetch.
+
+---
+
+## Variant B — a stateful channel that carries a snapshot
+
+Sometimes a ping is not enough: the receiver must apply an _exact copy_ of some
+state (not just refetch from the server). That is what `preferences-sync-channel.ts`
+does — it is **Redux middleware**, not a free function pair, and it carries a full
+`PreferencesState` snapshot. Use this variant only when the data lives client-side
+in Redux + `localStorage` (so there is no server to refetch from), as user
+preferences do.
+
+Two things make the stateful variant tricky that the ping variant never has to
+worry about: **echo loops** and **untrusted payloads**. Both are handled in
+`src/lib/preferences-sync-channel.ts`.
+
+### 1. Add a loop guard — exclude the apply action from the broadcastable set
+
+The middleware broadcasts only on the user-initiated `set*` actions, and applies an
+inbound snapshot through a **different** action (`hydratePreferences`) that is
+deliberately _not_ in the broadcastable set
+(`src/lib/preferences-sync-channel.ts:19-22`):
+
+```typescript
+// The local, user-initiated toggles that should propagate to other windows.
+// hydratePreferences is deliberately excluded so an applied broadcast never
+// re-broadcasts (the loop guard).
+const BROADCASTABLE_ACTION_TYPES = new Set<string>([
+  'preferences/setCompletionSound',
+  'preferences/setRetainCompletedInList',
+])
+```
+
+Inbound snapshots are applied with `dispatch(hydratePreferences(...))`
+(`src/lib/preferences-sync-channel.ts:87-91`), and the outgoing broadcast only fires
+when `action.type` is in `BROADCASTABLE_ACTION_TYPES`
+(`src/lib/preferences-sync-channel.ts:97-111`).
+
+> **Why the loop guard matters.** Window A toggles a preference → broadcasts →
+> window B receives and dispatches `hydratePreferences`. If `hydratePreferences`
+> were _also_ broadcastable, B's apply would broadcast back to A, A would re-apply
+> and re-broadcast, and the two windows would ping-pong forever. Splitting "user
+> changed it" (broadcastable `set*`) from "a peer pushed it" (non-broadcastable
+> `hydratePreferences`) breaks the cycle by construction.
+
+### 2. Validate the inner fields on receive
+
+A ping payload is trusted because it carries nothing. A snapshot payload gets
+**hydrated into Redux and persisted**, so it must be validated field-by-field —
+not merely "is `state` an object" (`src/lib/preferences-sync-channel.ts:38-55`):
+
+```typescript
+const isPreferencesSyncMessage = (
+  data: unknown,
+): data is PreferencesSyncMessage => {
+  if (typeof data !== 'object' || data === null) return false
+  const message = data as Partial<PreferencesSyncMessage>
+  if (message.type !== PREFERENCES_SYNC_EVENT_TYPE) return false
+  // Validate the inner preference fields, not just that `state` is an object: a
+  // malformed channel payload (e.g. `completionSound: 'yes'`) would otherwise be
+  // hydrated into Redux and persisted, since the selectors only coalesce
+  // null/undefined and would let non-boolean junk through unchanged.
+  const state = message.state as Partial<PreferencesState> | undefined
+  return (
+    typeof state === 'object' &&
+    state !== null &&
+    typeof state.completionSound === 'boolean' &&
+    typeof state.retainCompletedInList === 'boolean'
+  )
+}
+```
+
+> **Why deep validation matters.** The preference selectors only coalesce
+> `null`/`undefined`, so a junk value like `completionSound: 'yes'` would survive
+> into the store and `localStorage` and corrupt every future read. Validate each
+> field's type before hydrating.
+
+### 3. Keep the SSR pass-through, and wire it into the store
+
+Like the ping channels, the middleware no-ops when `BroadcastChannel` is
+unavailable — it returns a transparent pass-through
+(`src/lib/preferences-sync-channel.ts:78-80`):
+
+```typescript
+if (!isBrowserWithChannel()) {
+  return () => (next) => (action) => next(action)
+}
+```
+
+Unlike a ping channel, the stateful middleware opens **one long-lived channel** for
+the store's lifetime (`src/lib/preferences-sync-channel.ts:82`) rather than
+post-then-close per message, because it must keep listening. Wire it into the
+middleware chain in `src/lib/redux/store.ts:76`:
+
+```typescript
+.concat(createPreferencesSyncMiddleware()),
+```
+
+---
+
+## A note on intent channels (paste-import)
+
+`src/lib/paste-import-channel.ts` is a ping channel by shape, but its _meaning_ is
+different: it carries an **intent to open a dialog**, not a "data changed" signal —
+so its verbs are `requestOpenCompletedImport` / `subscribeToOpenCompletedImport`.
+It exists because the Floating Navigator lives in its own narrow `BrowserWindow` and
+cannot toggle the main window's dialog state directly
+(`src/lib/paste-import-channel.ts:1-11`).
+
+The catch: a `BroadcastChannel` ping alone won't _show_ the main window. So the
+producer pairs the broadcast with a `focusMainWindow()` preload IPC call
+(`src/components/floating-navigator/FloatingNavigator.tsx:535-543`):
+
+```typescript
+const handleOpenImport = useCallback(async () => {
+  requestOpenCompletedImport()
+  if (isFloatingNavigatorEnvironment()) {
+    try {
+      await window.floatingNavigatorAPI!.window.focusMainWindow()
+    } catch (error) {
+      log.error('Failed to focus main window for import:', error)
+    }
+  }
+```
+
+The main window's `CompletedImportEntry` subscribes and opens the dialog
+(`src/app/(main)/home/_components/CompletedImportEntry.tsx:60-62`):
+
+```typescript
+useCycleEffect(() => {
+  return subscribeToOpenCompletedImport(() => setOpen(true))
+}, [])
+```
+
+> **Takeaway.** Use a `BroadcastChannel` intent only to flip in-app state across
+> windows. If the action must also surface, focus, or otherwise touch the **native
+> window** itself, you need an Electron IPC call too — see
+> [howto-add-ipc-channel.md](./howto-add-ipc-channel.md) for adding one.
+
+---
+
+## Checklist
+
+Stateless ping (Variant A):
+
+- [ ] Copied `src/lib/todo-sync-channel.ts`; renamed channel name (unique,
+      `corelive-`-prefixed), event type, and exported `broadcastX` / `subscribeToX`.
+- [ ] Kept the SSR guard (`typeof window` + `typeof BroadcastChannel`).
+- [ ] `broadcastX()` posts then **`close()`s**; called at the mutation site.
+- [ ] Subscribed in a `useCycleEffect` in a `'use client'` component and
+      **returned the cleanup**.
+- [ ] Receiver invalidates queries (re-derives) — it does not replay payload data.
+
+Stateful snapshot (Variant B), additionally:
+
+- [ ] Apply action (`hydratePreferences`) is **excluded** from the broadcastable
+      action set (loop guard).
+- [ ] Inbound payload is **deep-validated** field-by-field before dispatching.
+- [ ] Middleware `.concat`-ed into `src/lib/redux/store.ts`.
+
+## See also
+
+- [explanation-state-and-sync.md](./explanation-state-and-sync.md) — why each
+  window owns its own cache/store, and why ping vs. snapshot vs. intent.
+- [howto-add-ipc-channel.md](./howto-add-ipc-channel.md) — when the cross-window
+  action must touch the native Electron window.
+- [reference-frontend.md](./reference-frontend.md) — the `src/hooks` lifecycle-effect
+  family (`useCycleEffect` and friends) and the Redux store.
+- [reference-electron.md](./reference-electron.md) — the Floating Navigator window
+  and preload API.

--- a/docs/dev/howto-add-theme-family.md
+++ b/docs/dev/howto-add-theme-family.md
@@ -1,0 +1,149 @@
+# How to add a new colored theme family
+
+This recipe walks you through adding one colored theme family (a light/dark pair) to CoreLive. The whole change lives in **one registry edit**, a regenerate, and a few test-lock bumps — the picker, the `dark:` variant, and the preview swatches all derive from the registry automatically.
+
+For _why_ the pipeline is shaped this way (build-time derivation, why `culori` never ships to the client, the `0,2,0` specificity choice), read [explanation-theme-system.md](./explanation-theme-system.md). For the surface map (every helper, anchored to `file:line`), read [reference-theme-system.md](./reference-theme-system.md). For the governing product rules and the heatmap invariant, read the **Theme System** (`DESIGN.md:119`) and **Heatmap Invariance Rule** (`DESIGN.md:147`) sections of [DESIGN.md](../../DESIGN.md). Do not deviate from those rules without explicit approval.
+
+## Before you start
+
+A family is **a light and a dark seed** — always add both. Cathedral (`Warm Cathedral`) is the only hand-authored family; it is `preserve: true` and lives in `src/globals.css`. Every colored family is a `DerivedTheme`: you supply ~7 OKLCH numbers and the build-time generator derives all 36 color tokens at the fixed cathedral lightness ladder. You never write CSS, and you never touch `src/lib/themes/generated.css` (it is machine-written).
+
+The two gates that will actually reject a bad seed:
+
+- **WCAG AA on the accent.** `--primary-foreground` is _contrast-computed_ (not hardcoded white) against your `--primary`, and must clear 4.5. Mid-lightness accents (`accentL` ≈ 0.5–0.6) are the danger zone where neither near-white nor near-ink text clears AA — see `registry.ts:121-122` (Harbor `0.56 → 0.555`) and `registry.ts:154-159` (Grove `0.55 → 0.54`).
+- **Heatmap "temperature = pride".** The two hottest stops must bloom warm on every theme, forever — never GitHub-green. That means `heatmapHues` **indices 3 and 4** (the last two) must each have hue ∈ **[20, 70]**. Indices 0–2 are the cool rest stops and stay family-hued by design (unconstrained).
+
+## Steps
+
+### 1. Add the family id to the `ThemeFamilyId` union
+
+`src/lib/themes/registry.ts:23`. Append your id to the union:
+
+```ts
+export type ThemeFamilyId =
+  | 'cathedral'
+  | 'harbor'
+  | 'grove'
+  | 'rose-tea'
+  | 'iris'
+  | 'graphite'
+  | 'sunset' // ← your new family
+```
+
+This one edit makes the type system point you at the two maps that must be filled: the moment you add the id, `pnpm typecheck` errors at `THEME_REGISTRY` (`satisfies Record<ThemeId, ThemeSeed>`, `registry.ts:290`) **and** at `THEME_FAMILY_LABEL` (`Record<ThemeFamilyId, string>`, `registry.ts:362`). The `ThemeId` template (`registry.ts:37-40`) auto-expands to include `'sunset-light' | 'sunset-dark'`, so you do not edit `ThemeId`.
+
+### 2. Add the light + dark `DerivedTheme` seeds to `THEME_REGISTRY`
+
+`src/lib/themes/registry.ts:94`. Add **two** entries, keyed by their stored id (`${family}-${mode}`). Use the existing **Harbor** pair (`registry.ts:123-152`) as your annotated template — it is real, shipped, and passes both gates:
+
+```ts
+'sunset-light': {
+  family: 'sunset',
+  mode: 'light',
+  id: 'sunset-light',
+  name: 'Sunset Light',
+  preview: '#c2603a',        // coarse brand/meta hex (picker uses a token composite, not this)
+  colorScheme: 'light',
+  preserve: false,           // union discriminant: derived, not hand-authored
+  accentL: 0.55,             // mid-L → AA danger zone; nudge if --primary-foreground fails (step 5)
+  accentChroma: 0.13,
+  accentHue: 40,             // the family signature color
+  neutralChroma: 0.012,      // low tint on neutral surfaces (~0.012 light / ~0.014 dark)
+  neutralHue: 40,            // convention: neutralHue = accentHue (surfaces lean toward the accent)
+  heatmapHues: [40, 45, 50, 55, 42], // indices 3 & 4 (here 55, 42) MUST be ∈ [20, 70]
+},
+'sunset-dark': {
+  family: 'sunset',
+  mode: 'dark',
+  id: 'sunset-dark',
+  name: 'Sunset Dark',
+  preview: '#e89368',
+  colorScheme: 'dark',
+  preserve: false,
+  accentL: 0.72,             // dark-mode accents sit higher (≈0.7–0.72) for contrast on dark surfaces
+  accentChroma: 0.13,
+  accentHue: 40,
+  neutralChroma: 0.014,
+  neutralHue: 40,
+  heatmapHues: [40, 45, 50, 55, 42],
+},
+```
+
+Field semantics are documented on the `DerivedTheme` interface (`registry.ts:69-85`). Do not invent values and assume they are good — `pnpm validate` (step 5) is the source of truth for any new numbers.
+
+> **Gotcha — heatmap rest stops vs. apex.** The L/C ramp is reused verbatim from cathedral; your `heatmapHues` only swaps the _hue_ at each stop. Let indices 0–2 rest on your family hue (Iris rests violet `300`, Grove rests green `140` — see `registry.ts:173,239`), but bend indices 3 and 4 into `[20, 70]`. A degenerate all-cool body like `[145, 145, 145, 145, 42]` keeps the ramp but renders a green grid with one warm cell — exactly the failure the build forbids.
+
+> **Note — fixed-identity tokens.** `--destructive` and `--chart-1..5` always emit the cathedral value for every theme (design decision #15, `generate-theme-css.ts:147,151-155`). If your accent hue lands near one of those (Grove's `145` sits by `--chart-2`'s `145`; Rose Tea's `18` sits near `--destructive`'s `25`), that collision is acceptable as long as it stays separable by chroma/lightness and AA passes — flag it in a code comment, as those families do (`registry.ts:154-159,191-192`).
+
+### 3. Add the family label to `THEME_FAMILY_LABEL`
+
+`src/lib/themes/registry.ts:362`. This is the human name shown in the picker; it is **not** derivable from a theme name (cathedral's label `'Warm Cathedral'` proves why the map is explicit):
+
+```ts
+export const THEME_FAMILY_LABEL: Record<ThemeFamilyId, string> = {
+  cathedral: 'Warm Cathedral',
+  harbor: 'Harbor',
+  grove: 'Grove',
+  'rose-tea': 'Rose Tea',
+  iris: 'Iris',
+  graphite: 'Graphite',
+  sunset: 'Sunset', // ← your new family
+}
+```
+
+That is the **only** other map you touch. `THEME_IDS`, `THEME_FAMILY_IDS`, the `useThemeAxis` picker, `getThemePreview`, and the `ThemeSelectorMenuItem` family handlers all derive from the registry — no edits needed there.
+
+### 4. Regenerate the static CSS
+
+```bash
+pnpm theme:generate
+```
+
+This runs `tsx scripts/generate-theme-css.ts` (`package.json:36`), which reads the registry, **skips** the preserved cathedral pair, derives your two new blocks, and rewrites `src/lib/themes/generated.css`. Each block is a `:root[data-theme='sunset-light'] { … }` selector (specificity `0,2,0`, so it outranks cathedral's `:root`). Commit the regenerated `generated.css` — it is committed and drift-checked.
+
+### 5. Let `pnpm validate` gate it
+
+```bash
+pnpm validate
+```
+
+`validate` (`package.json:40`) runs four relevant checks in parallel:
+
+| Check                                      | What it enforces                                                        | Where                                                                         |
+| ------------------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `pnpm typecheck`                           | `THEME_REGISTRY` and `THEME_FAMILY_LABEL` have your new entries         | `registry.ts:290,362`                                                         |
+| `pnpm theme:check`                         | `generated.css` is not stale (regenerate + `git diff --exit-code`)      | `package.json:37`                                                             |
+| `pnpm test` → per-family **WCAG AA** gate  | `--primary-foreground` on `--primary` ≥ 4.5 for **every** derived theme | `generate-theme-css.test.ts:262-294` (`$id clears AA …`)                      |
+| `pnpm test` → **temperature = pride** gate | `--hm-3` **and** `--hm-4` hue ∈ [20, 70] for **every** derived theme    | `generate-theme-css.test.ts:296-348` (`$id … blooms its two hottest stops …`) |
+
+The AA and temperature gates iterate `DERIVED_THEMES` (`generate-theme-css.test.ts:249-252`), so a bad seed fails CI **by name** (e.g. `sunset-light clears AA …`).
+
+- **AA failure** (`--primary-foreground` ratio < 4.5): nudge `accentL` toward the lighter or darker extreme to give one text candidate headroom, re-run `pnpm theme:generate`, re-validate. This is exactly what the Harbor/Grove nudges did.
+- **Temperature failure** (`--hm-3`/`--hm-4` hue outside `[20, 70]`): bend those two `heatmapHues` entries warmer (toward the cathedral apex of `40`/`65`); leave indices 0–2 alone.
+
+### 6. Update the test-count locks
+
+Adding a family is **+2 themes**, so four hard-coded counts must move. Each guards against an accidental add/drop; bump each:
+
+| Lock                    | Change                                                    | Where (`file:line` + test)                                                           |
+| ----------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| The explicit id array   | gains `'sunset-light'`, `'sunset-dark'` (12 → 14 entries) | `registry.test.ts:24-37` (`registers exactly the twelve shipped themes …`)           |
+| `modesByFamily.size`    | `6 → 7`                                                   | `registry.test.ts:51` (`pairs a light and a dark theme for every family`)            |
+| `colored` length        | `10 → 12`                                                 | `registry.test.ts:71` (`marks cathedral preserved and every colored family derived`) |
+| `DERIVED_THEMES` length | `10 → 12`                                                 | `generate-theme-css.test.ts:259` (`ships exactly 10 colored families …`)             |
+
+> **Why the `DERIVED_THEMES` lock matters.** The per-family AA and temperature gates use `it.each(DERIVED_THEMES)`, which passes _vacuously_ on an empty array. If the registry ever emptied or the `preserve` filter regressed, those gates would silently test nothing — the explicit count is the trip-wire (`generate-theme-css.test.ts:254-260`).
+
+Also update the `it(...)` description strings if you want them to stay literally accurate (e.g. "twelve shipped themes" → "fourteen"); the assertions are what fail, but stale prose misleads the next reader. Run `pnpm validate` once more — green means done.
+
+## Troubleshooting: my colored theme renders as Warm Cathedral in `pnpm dev`
+
+**Symptom.** You added the family, `pnpm validate` is green, but in `pnpm dev` (Turbopack) every colored family falls back to Warm Cathedral — with **no build error**. Production (`pnpm build`, webpack) is unaffected, which makes this easy to miss.
+
+**Cause — the `@import` contiguity trap.** Turbopack's `next dev` stops inlining `@import` statements once it hits a comment or blank line, so any non-`@import` line wedged _before_ the `generated.css` import makes Turbopack silently drop the whole colored-family stylesheet. This is trivially reintroduced by "tidying" a comment back up between the imports.
+
+**Fix.** Keep the leading `@import` block in `src/globals.css:1-4` **contiguous** — every line from the first `@import` through `@import './lib/themes/generated.css';` must itself be an `@import`. Comments are fine **after** the `generated.css` import (the contiguity-explaining comment lives at `globals.css:5-10`). Do not insert anything between lines 1 and 4.
+
+**Guard.** `src/lib/themes/globals-import-contiguity.test.ts` (the `keeps generated.css contiguous …` test, `:54-61`) is the only automated catch for this — it scans `globals.css` and fails if any comment/blank break appears before the `generated.css` import. It runs in `pnpm validate`.
+
+> Related contract: Tailwind's `dark:` variant is bound to `data-theme` via `@custom-variant dark (&:where([data-theme$=dark], …))` at `globals.css:20`. The `$=dark` suffix matches the flat `dark` id **and** every `*-dark` family id (e.g. `sunset-dark`), mirroring `getThemeMode()` — so your dark seed gets the dark variant automatically with no extra wiring.

--- a/docs/dev/howto-cut-a-release.md
+++ b/docs/dev/howto-cut-a-release.md
@@ -1,0 +1,140 @@
+# How to cut a macOS release
+
+Ship a new signed + notarized CoreLive desktop build to a GitHub Release. The entire pipeline is driven by **pushing a lightweight `v*` git tag** — you bump the version, validate, smoke-test, tag, and then **verify the published assets**. CI does the signing, notarizing, and publishing; you never run a publish command locally.
+
+This recipe assumes you have done the [Getting Started tutorial](./tutorial-getting-started.md) and can run the [local dev + test loop](./howto-local-dev-and-tests.md). For the _why_ behind the two-phase notarization and the CI topology, see [Why the build & CI topology looks the way it does](./explanation-build-and-ci.md).
+
+## Hard rules (read these first)
+
+These four mistakes are the easy ways to ship a broken release. None of the steps below violate them — but if you improvise, don't:
+
+| Rule                                                             | Why                                                                                                                                                                                                                         |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Never run `pnpm electron:publish`**                            | It is `electron-builder --publish=always` (`package.json:61`) — it would double-publish _and_ skip the `finalize-mac-release-artifacts.js` step that the release depends on. Releases go through the tag → CI path, period. |
+| **The generic `/electron-release` skill does NOT fit this repo** | This flow is a manual tag push that fires GitHub Actions. Cut releases by hand using the steps below.                                                                                                                       |
+| **Tag must be LIGHTWEIGHT** (`git tag vX.Y.Z`, no `-a`/`-m`)     | The workflow triggers on `refs/tags/v*` (`.github/workflows/build-and-release.yml:4-6`); all prior tags are lightweight.                                                                                                    |
+| **Stage with `git add package.json`, NEVER `git add -A`**        | The working tree carries tracked build/icon files that get regenerated; `git add -A` would sweep tracked deletions into your release commit.                                                                                |
+
+## Prerequisites (one-time, mostly already done)
+
+The standard flow needs **zero Apple credentials on your machine** — signing and notarization happen in the `build` job on a `macos-latest` runner, consuming **GitHub Secrets**.
+
+These Secrets must exist on the repo (set once; see [`docs/BUILD_AND_DEPLOYMENT.md`](../BUILD_AND_DEPLOYMENT.md) for the cert → `.p12` → base64 export procedure):
+
+- `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` — notarization (used by `scripts/notarize.js` and `scripts/finalize-mac-release-artifacts.js`)
+- `APPLE_CERTIFICATES_P12`, `APPLE_CERTIFICATES_PASSWORD` — the "Developer ID Application" signing cert, imported at `.github/workflows/build-and-release.yml:75-80`
+- The Clerk + Postgres Secrets the `next build` step needs (`.github/workflows/build-and-release.yml:51-70`)
+
+> Local Apple creds in `.env` only matter if you hand-run `pnpm electron:build:mac` for a local dry run — which this flow does **not** do.
+
+---
+
+## Step 1 — Bump the version
+
+`package.json` `version` is the **single source of truth**. `electron-builder.json` inherits it (no `build` key, no separate changelog to touch).
+
+Edit `package.json:3` to the new version, e.g. `0.9.0` → `0.9.1`. Nothing else.
+
+## Step 2 — Validate under the CI Node version
+
+Run the full gate, pinned to the CI Node so you reproduce CI exactly. Local Node (26) differs from CI (24.13.0) in ways that break tests — see [the local dev loop doc](./howto-local-dev-and-tests.md) for the `localStorage` gotcha.
+
+```bash
+mise exec node@24.13.0 -- pnpm validate
+```
+
+`pnpm validate` (`package.json:40`) runs six gates in parallel and aborts on the first failure: test + the in-repo `eslint-plugin-dslint` package tests (`test:packages`) + lint + `next build` + typecheck + theme-drift check. All six must be green before you tag.
+
+> The `next build` inside `validate` needs the Clerk env vars in your `.env`; see the env tables in [`README.md`](../../README.md).
+
+## Step 3 — Manual macOS smoke (mandatory before tagging)
+
+The Linux + xvfb E2E suite drives the **renderer only**. The native Cocoa chrome — menu bar, system tray, dock / activation policy, traffic-light window controls, `open-url` deep links, vibrancy, the floating / braindump / startup-pill windows — has **no automated coverage**. A packaged build also exposes packaged-only bugs (e.g. `NODE_ENV` is unset in a packaged app, and electron-builder + pnpm can drop leaf asar deps) that never reproduce in `electron:dev`.
+
+So build the real packaged app and exercise the native surfaces by hand:
+
+```bash
+pnpm electron:build:dir
+open dist/mac*/CoreLive.app   # mac* glob: --dir builds your host arch (mac-arm64 on Apple Silicon, mac on Intel)
+```
+
+Click through: menu bar items (and the menu-bar toggle), the tray menu, dock show/hide, the traffic-light buttons, and a `corelive://` deep link. Verify window/menu motion by recording video frames, not stills.
+
+## Step 4 — Commit the bump to `main`
+
+```bash
+git add package.json
+git commit -m "chore(release): bump version to X.Y.Z"
+git push origin main
+```
+
+> Pushing the bump commit to `main` does **not** trigger a release — a non-tag push to `main` does nothing here. Only the tag in the next step fires the pipeline. `main` is unprotected, so committing directly is expected.
+
+## Step 5 — Tag and push (this ships to real users)
+
+The tag push is the point of no return: it builds, signs, notarizes, and **publishes a release users auto-update from**. Push it only after Steps 2–3 are green and you (or Raphtalia) have confirmed.
+
+```bash
+git tag vX.Y.Z            # LIGHTWEIGHT — no -a, no -m
+git push origin vX.Y.Z
+```
+
+This fires `build-and-release.yml`. On a tag push the release dependency chain (`test` → `build` → `release`) runs (`.github/workflows/build-and-release.yml`):
+
+1. **`test`** (ubuntu): typecheck → unit tests → icon gen → electron tests.
+2. **`build`** (macos): `next build` → import signing cert → `pnpm electron:build:mac`. That script (`package.json:59`) does `electron-vite build` → `electron-builder --mac --publish never` → `node scripts/finalize-mac-release-artifacts.js`. **`--publish never` means electron-builder does not upload** — uploading is a separate job. The `.app` is notarized inside electron-builder via the `afterSign` hook (`electron-builder.json:106` → `scripts/notarize.js`); the **DMG wrapper** is notarized + stapled _separately_ by the finalize script, which then rewrites `latest-mac.yml` + `checksums.json` from the post-staple bytes.
+3. **`release`** (ubuntu, tag-only): downloads the artifacts and runs `gh release create`/`upload` (`.github/workflows/build-and-release.yml:142-146`).
+
+A parallel **`security-scan`** job (Trivy filesystem scan → SARIF upload, `.github/workflows/build-and-release.yml:148-172`) runs on every event — including this tag push — but it is release-irrelevant and has no `needs:` link to the chain above.
+
+> Two notarization passes and the manifest rewrite are explained in [Why the build & CI topology looks the way it does](./explanation-build-and-ci.md) — don't worry about the mechanics here.
+
+## Step 6 — VERIFY the release (workflow-green is not enough)
+
+A green workflow does not prove the release is shippable. Check **both** the asset set and the auto-update manifest version.
+
+### 6a. Exactly 8 assets
+
+```bash
+gh release view vX.Y.Z --json isDraft,assets \
+  --jq '{draft: .isDraft, count: (.assets | length), names: [.assets[].name]}'
+```
+
+`draft` must be `false` and `count` must be **8**:
+
+| Asset                                                                                | Count | Note                                                   |
+| ------------------------------------------------------------------------------------ | ----- | ------------------------------------------------------ |
+| `CoreLive-X.Y.Z.dmg`, `CoreLive-X.Y.Z-arm64.dmg`                                     | 2     | DMGs — **no `.dmg.blockmap`** (intentional, see below) |
+| `CoreLive-X.Y.Z-mac.zip` + `.blockmap`, `CoreLive-X.Y.Z-arm64-mac.zip` + `.blockmap` | 4     | ZIPs **with** their blockmaps                          |
+| `latest-mac.yml`                                                                     | 1     | auto-update manifest                                   |
+| `checksums.json`                                                                     | 1     | manual-download hashes                                 |
+
+**The DMG blockmaps are absent on purpose — this is not a failed upload.** Stapling the notarization ticket mutates the DMG bytes _after_ electron-builder generated the blockmap, so `finalize-mac-release-artifacts.js` deletes the stale `.dmg.blockmap` files (`removeDmgBlockmaps`, `scripts/finalize-mac-release-artifacts.js:172-179`). The asset count is therefore **8, not 10**.
+
+### 6b. `latest-mac.yml` version matches the tag
+
+If `latest-mac.yml`'s `version:` field is stale or missing, **auto-update silently breaks** for existing users.
+
+```bash
+gh release download vX.Y.Z --pattern latest-mac.yml --dir /tmp/rel --clobber
+grep '^version:' /tmp/rel/latest-mac.yml   # must print: version: X.Y.Z
+```
+
+The finalize script writes this field from `package.json`'s version (`scripts/finalize-mac-release-artifacts.js:199-211`), so a mismatch means the wrong build was published.
+
+## Rollback
+
+If verification fails (wrong assets, version mismatch, or a bad build slipped through), delete the release and its tag, fix, and re-cut:
+
+```bash
+gh release delete vX.Y.Z --cleanup-tag --yes
+```
+
+---
+
+## See also
+
+- [Why the build & CI topology looks the way it does](./explanation-build-and-ci.md) — the _why_ of two notarizations, the per-spec web matrix, and `workers: 1`.
+- [`docs/BUILD_AND_DEPLOYMENT.md`](../BUILD_AND_DEPLOYMENT.md) — signing-cert setup, GitHub Secrets, the auto-updater, and signing troubleshooting. **Stale in two ways**, flagged here so you don't trip on it: its prerequisites say Node 22.21.1 / pnpm 10.27.0 — the actual toolchain is **Node 24.13.0** (`package.json` `volta`) / **pnpm from `package.json` `packageManager`** (currently 10.33.4); and it predates `finalize-mac-release-artifacts.js`, so it omits the **DMG-notarize + manifest-rewrite** phase described above (which is why DMG blockmaps are dropped and the asset count is 8).
+- [How to run the local dev + test loop](./howto-local-dev-and-tests.md) — `pnpm validate` details and the CI-Node parity gotcha.
+- The full command surface lives in `package.json` `scripts` — that is the canonical command list.

--- a/docs/dev/howto-local-dev-and-tests.md
+++ b/docs/dev/howto-local-dev-and-tests.md
@@ -1,0 +1,194 @@
+# How to run the local dev + test loop
+
+A task-oriented recipe for the day-to-day inner loop: bring up the database, run the dev server (web or Electron), and drive the four test tiers plus the `pnpm validate` gate. Assumes you've already done [the getting-started tutorial](./tutorial-getting-started.md) (cloned the repo, copied `.env.example` to `.env`, filled in Clerk + DB values). The canonical, always-current command list lives in `package.json` `"scripts"` — this doc shows you _which_ command does _what_ and the gotchas around each.
+
+## Cold start (the worked example)
+
+From a clean checkout with `.env` in place, this is the whole loop:
+
+```bash
+# 1. Start the local Postgres container (background)
+docker compose up -d postgres
+
+# 2. Apply migrations + generate the Prisma client
+pnpm prisma:migrate
+#    …or, to wipe + re-migrate + reseed in one shot (the pre-launch habit):
+pnpm db:reset
+
+# 3. Run the web dev server on http://localhost:3011
+pnpm dev
+
+# 4. In another terminal, run the unit tests
+pnpm test
+```
+
+Everything below expands each step.
+
+## 1. Start the database
+
+The local Postgres 17 instance is defined in `compose.yml` (note: `compose.yml`, **not** `docker-compose.yml` — Compose resolves it by default).
+
+```bash
+docker compose up -d postgres
+```
+
+> **Pitfall — name the service.** Run `docker compose up -d postgres`, not a bare `docker compose up -d`. The compose file also defines a `network-delay` sidecar (`compose.yml:31-47`) that injects 100 ms of `netem` latency to simulate production — you do **not** want that locally. Naming the `postgres` service starts only the database.
+
+The working local connection string is (note: `.env.example:3` ships placeholders — `postgresql://username:password@localhost:5432/database_name?schema=public` — so after copying it to `.env` you must replace `username`/`database_name` with `postgres`/`corelive` to match the container below):
+
+```
+POSTGRES_PRISMA_URL="postgresql://postgres:password@localhost:5432/corelive?schema=public"
+```
+
+Container name `corelive-postgres`, db `corelive`, port `5432` (`compose.yml:2-12`). Common controls:
+
+| Command                                                     | Purpose                       |
+| ----------------------------------------------------------- | ----------------------------- |
+| `docker compose up -d postgres`                             | Start the DB (background)     |
+| `docker compose down`                                       | Stop and remove the container |
+| `docker compose logs postgres`                              | View DB logs                  |
+| `docker compose exec postgres psql -U postgres -d corelive` | Open a `psql` shell           |
+
+### Reset / migrate / reseed
+
+This repo is **pre-launch**: per `README.md:13`, there are no users and no need to preserve migrations or data — when the schema changes, just reset. The destructive commands:
+
+```bash
+pnpm prisma:migrate   # apply pending migrations (prisma migrate dev) + generate client
+pnpm db:reset         # migrate reset --force, then reseed (prisma/seed.ts)
+pnpm db:truncate      # migrate reset --force, NO reseed
+```
+
+The seed is idempotent (`prisma/seed.ts` wraps delete+insert in a transaction), so re-running `pnpm prisma:seed` standalone won't duplicate fixtures.
+
+> **Safety gate.** `prisma:migrate`, `db:reset`, and `db:truncate` are each prefixed with `node scripts/assert-local-db.cjs` (`package.json:43,50,51`). That gate is **fail-closed**: it only lets the destructive command proceed if it can _prove_ the target host is local (allowlist in `scripts/assert-local-db.cjs:24-31`), and it also inspects libpq `?host=`/`?hostname=` query params — so a URL like `postgresql://localhost/db?host=prod.neon.tech` is correctly **blocked**, not waved through. If your `POSTGRES_PRISMA_URL` points at a remote DB, these commands abort with `🛑 [assert-local-db]`. That's the gate working. See [the data-model reset how-to](./reference-data-model.md) for the schema side.
+
+## 2. Run the dev server
+
+### Web
+
+```bash
+pnpm dev
+```
+
+`next dev -p 3011` (`package.json:22`) — the web app on `http://localhost:3011`. Hot-reloads `src/**`. This is what you want most of the time; both the web app and the Electron renderer load the same Next.js app.
+
+### Electron (desktop wrapper)
+
+```bash
+pnpm electron:dev
+```
+
+This runs `node scripts/dev.js`, an orchestrator that (1) compiles the Electron main + preload via `electron-vite build`, (2) starts `pnpm dev` on `:3011`, (3) polls until the server answers `200`, then (4) launches `electron/dev-runner.ts` with `NODE_ENV=development` and `PLAYWRIGHT_REMOTE_DEBUGGING_PORT=9222` so MCP / Playwright tooling can attach (`scripts/dev.js:93-180`). It loads the **local** dev server in a `BrowserWindow`, not the production site. For the architecture of the desktop wrapper, see [the Electron reference](./reference-electron.md).
+
+> **Clerk webhook in local dev.** New Postgres `User` rows are provisioned by a Clerk `user.created` webhook (`src/app/api/webhooks/route.ts`), which Clerk delivers over HTTP — so Clerk needs a public URL to reach your machine. Tunnel `:3011` with ngrok and point the Clerk Dashboard webhook at it (`README.md:130-133`):
+>
+> ```bash
+> ngrok http --domain=foo.bar-ngrok.app 3011
+> ```
+>
+> The webhook is Svix-HMAC-verified against `WEBHOOK_SECRET`. You don't strictly need this for the dev backdoor login (below), but you do need it to test the real "sign up → row appears in Postgres" path.
+
+## 3. Authenticate locally
+
+There are two distinct auth paths; don't conflate them. Full detail in [the authentication reference](./reference-auth.md) and [explanation](./explanation-authentication.md).
+
+| Context                         | How you authenticate                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------- |
+| **Local dev** (manual clicking) | Real Clerk Dev session via the UI, **or** the oRPC dev backdoor (below)         |
+| **E2E tests**                   | Real Clerk Dev instance — **never mocked** — using the `E2E_CLERK_*` test creds |
+
+**The dev backdoor.** When `NODE_ENV === 'development'`, the oRPC auth middleware treats the literal Bearer token `user_mock_user_id` as a fixed test user and upserts `test@example.com` (`src/server/middleware/auth.ts:18-32`). So a request carrying `Authorization: Bearer user_mock_user_id` resolves to that user with no real Clerk session. This is how non-Clerk tooling and some local flows hit authed oRPC procedures. It is gated on `NODE_ENV === 'development'` and is unreachable in production builds.
+
+**E2E auth is real.** The Playwright web suite logs into the actual Clerk **Dev** instance using `E2E_CLERK_USER_USERNAME` / `_PASSWORD` / `_EMAIL`. Those credentials must be registered in the Clerk Dashboard (`README.md:67-75`); there is no mocking. Env-var details live in `README.md` — don't duplicate them here.
+
+## 4. The four test tiers
+
+Each tier has its own config so environments don't collide. **Four tiers, five commands** — three Vitest configs plus one E2E tier that has two Playwright projects (web and Electron):
+
+| Tier           | Command               | Runner / env                                                    | What it covers                                   |
+| -------------- | --------------------- | --------------------------------------------------------------- | ------------------------------------------------ |
+| Unit           | `pnpm test`           | Vitest, `happy-dom` (`vitest.config.ts`)                        | `src/**` units (components, hooks, server utils) |
+| Electron unit  | `pnpm test:electron`  | Vitest, `node` env (`vitest.config.electron.ts`)                | `electron/**` main + preload logic               |
+| Storybook      | `pnpm test:storybook` | Vitest in real headless Chromium (`vitest.config.storybook.ts`) | Story render/interaction tests                   |
+| E2E (web)      | `pnpm e2e:web`        | Playwright `web` project (`playwright.config.ts`)               | Full browser flows against a served build        |
+| E2E (Electron) | `pnpm e2e:electron`   | Playwright `electron` project (`playwright.electron.config.ts`) | Renderer paths via `_electron.launch`            |
+
+> **Run tests under Node 24.13.0 to match CI.** CI pins Node `24.13.0` (`package.json:11-12`, and the shared `.github/actions/prepare` action). A newer local Node can break the unit suite. If `pnpm test` fails locally but passes in CI, check your Node version first (e.g. via `volta`/`mise`) before chasing a phantom regression.
+
+### `pnpm e2e:web` — two preconditions
+
+```bash
+pnpm e2e:web
+```
+
+This runs `playwright test --project=web` (`package.json:54`). Two things must hold:
+
+1. **It needs a production build.** The Playwright `webServer` block runs `pnpm start` = `next start -p 3011` (`playwright.config.ts:103`, `package.json:26`), which serves the **built** app — so run `pnpm build` first (or have a build present). `next start` will not serve un-built sources.
+2. **The webServer may not boot locally on macOS.** On the maintainer's Mac the Playwright `webServer` fails to come up due to an IPv6/loopback mismatch (the server itself is healthy; Playwright's health-poll can't reach it). If `pnpm e2e:web` hangs at "waiting for server" locally, that's the known issue — **verify web E2E on CI** (the `E2E Tests (Web)` workflow) rather than fighting it locally.
+
+The web suite forces `workers: 1` (`playwright.config.ts:36`) because every spec shares one seeded Clerk user and one Postgres DB; parallel workers cause cross-file data races. True parallelism comes from the CI per-spec matrix, not Playwright workers — the _why_ is in [the build & CI explanation](./explanation-build-and-ci.md).
+
+### `pnpm e2e:electron` — native on macOS, xvfb on Linux
+
+```bash
+pnpm e2e:electron
+```
+
+This compiles the Electron main/preload (`pnpm electron:build:ts`) then runs the `electron` Playwright config (`package.json:55`). On **macOS, run it directly** — Electron uses the native display. On **Linux/CI it needs a virtual display**:
+
+```bash
+xvfb-run -a pnpm e2e:electron   # Linux / CI only
+```
+
+> **Coverage limit.** The Electron E2E suite drives the **renderer only** — the same web content the browser tests see. Native Cocoa chrome (menu bar, tray, dock, traffic-light controls, `open-url` deep links, vibrancy) has **no** automated coverage and requires a manual macOS smoke before releases (see [the Electron reference](./reference-electron.md)).
+
+## 5. `pnpm validate` — the pre-commit gate
+
+```bash
+pnpm validate
+```
+
+Run this before committing. It executes **six** tasks in parallel via `concurrently --kill-others-on-fail` (`package.json:40`) — the first failure aborts the rest:
+
+| Slot    | Command              | Checks                                             |
+| ------- | -------------------- | -------------------------------------------------- |
+| `test`  | `pnpm test`          | Unit suite                                         |
+| `pkg`   | `pnpm test:packages` | The in-repo `eslint-plugin-dslint` workspace tests |
+| `lint`  | `pnpm lint:fix`      | ESLint, zero-warnings, auto-fix                    |
+| `build` | `pnpm build`         | `next build --webpack` (production build)          |
+| `type`  | `pnpm typecheck`     | `tsc --noEmit`                                     |
+| `theme` | `pnpm theme:check`   | Fails if `src/lib/themes/generated.css` is stale   |
+
+> The E2E tiers (`e2e:web` / `e2e:electron`) and Storybook are **not** part of `validate` — they run as separate CI workflows. `validate` is the fast local gate; CI splits these out. For the full workflow/command map, see [the CI & commands reference](./reference-ci-and-commands.md).
+
+> **`build` uses `--webpack`, not Turbopack** (`package.json:23`) — this is deliberate. If you swap it for Turbopack you risk dropped CSS `@import`s; keep it as-is.
+
+## Debugging a packaged Electron build
+
+`pnpm electron:dev` runs the unbundled dev app — but some bugs only reproduce in a **packaged** build (e.g. `NODE_ENV` is unset in packaged apps, and electron-builder can drop transitive deps). To reproduce those, build and open the real `.app`:
+
+```bash
+pnpm electron:build:dir          # unpacked .app, no DMG, no signing
+open dist/mac*/CoreLive.app      # mac* glob: --dir builds your host arch
+```
+
+DevTools and the Chrome DevTools Protocol (CDP) port are **off by default** in packaged builds. Two opt-ins (`electron/utils/debugMode.ts:83-87` for the DevTools gate, `:133-158` for the CDP-port resolver):
+
+- `CORELIVE_DEBUG=1` — turns DevTools on for all windows and opens the default CDP port `9222` (override with `CORELIVE_REMOTE_DEBUGGING_PORT`).
+- `PLAYWRIGHT_REMOTE_DEBUGGING_PORT=<port>` — the E2E lever (highest precedence); the dev-runner sets it to `9222` automatically.
+
+```bash
+CORELIVE_DEBUG=1 open dist/mac*/CoreLive.app
+```
+
+For native-chrome QA (menu bar, tray, dock, deep links) you must drive the real desktop — the DOM/Playwright tools can't reach Cocoa surfaces. See [the Electron reference](./reference-electron.md) and the project's local `CLAUDE.md` Electron Native QA section.
+
+## See also
+
+- [Tutorial: Getting started](./tutorial-getting-started.md) — first-time `.env` + Clerk setup
+- [Reference: CI workflows & command index](./reference-ci-and-commands.md) — every workflow + the authoritative `package.json` script map
+- [Explanation: build & CI topology](./explanation-build-and-ci.md) — _why_ `workers: 1`, the per-spec web matrix, the single xvfb Electron job
+- [How to cut a macOS release](./howto-cut-a-release.md)
+- [Reference: Authentication surface](./reference-auth.md) · [Explanation: how auth works](./explanation-authentication.md)
+- The hub index: [docs/dev](./README.md)

--- a/docs/dev/howto-local-dev-and-tests.md
+++ b/docs/dev/howto-local-dev-and-tests.md
@@ -79,7 +79,7 @@ pnpm dev
 pnpm electron:dev
 ```
 
-This runs `node scripts/dev.js`, an orchestrator that (1) compiles the Electron main + preload via `electron-vite build`, (2) starts `pnpm dev` on `:3011`, (3) polls until the server answers `200`, then (4) launches `electron/dev-runner.ts` with `NODE_ENV=development` and `PLAYWRIGHT_REMOTE_DEBUGGING_PORT=9222` so MCP / Playwright tooling can attach (`scripts/dev.js:93-180`). It loads the **local** dev server in a `BrowserWindow`, not the production site. For the architecture of the desktop wrapper, see [the Electron reference](./reference-electron.md).
+This runs `node scripts/dev.js`, an orchestrator that (1) compiles the Electron main + preload via `electron-vite build`, (2) starts `pnpm dev` on `:3011`, (3) polls until the server answers `200`, then (4) launches `electron/dev-runner.ts` with `NODE_ENV=development` and `PLAYWRIGHT_REMOTE_DEBUGGING_PORT=9222` so MCP / Playwright tooling can attach (`scripts/dev.js:93-180`; step 3's poll-until-`200` loop is `checkServer`, `scripts/dev.js:55-91`). It loads the **local** dev server in a `BrowserWindow`, not the production site. For the architecture of the desktop wrapper, see [the Electron reference](./reference-electron.md).
 
 > **Clerk webhook in local dev.** New Postgres `User` rows are provisioned by a Clerk `user.created` webhook (`src/app/api/webhooks/route.ts`), which Clerk delivers over HTTP — so Clerk needs a public URL to reach your machine. Tunnel `:3011` with ngrok and point the Clerk Dashboard webhook at it (`README.md:130-133`):
 >

--- a/docs/dev/reference-auth.md
+++ b/docs/dev/reference-auth.md
@@ -1,0 +1,110 @@
+# Authentication surface reference
+
+A point-to-source index of every authentication surface in CoreLive: route protection, the Clerk webhook, the oRPC auth middleware and client header, the Electron system-browser OAuth bridge, and the Electron auth IPC. This is a map to the code, not a transcription of it — payload shapes are reshaped freely pre-launch ([README.md](../../README.md)), so field-level detail lives in the source.
+
+For the mental model (why the Bearer token is the raw Clerk user id, why there is no server-side token verification, why Electron needs a browser OAuth detour), see [./explanation-authentication.md](./explanation-authentication.md). For the user row this all resolves to, see [./reference-data-model.md](./reference-data-model.md) and `prisma/schema.prisma:57-71`.
+
+## Cross-cutting invariants
+
+These hold across the whole surface; the per-surface tables below assume them.
+
+- **One Clerk identity → one Postgres `User` row, joined on `clerkId`.** Clerk's user id (`user_…`) is the single join key, stored as `User.clerkId` (`@unique`, `prisma/schema.prisma:59`). Web and the Electron renderer authenticate against the same Clerk app and send the same user id, so both resolve to the same row.
+- **The `Authorization` Bearer value is the raw Clerk _user id_, not a JWT.** The client sends `Bearer <clerkUserId>` (`src/lib/orpc/create-client.ts:54-60`) and `authMiddleware` strips `Bearer ` and uses the remainder directly as `clerkId` (`src/server/middleware/auth.ts:14-15`). The middleware does **not** verify the value — it upserts on it (`src/server/middleware/auth.ts:41-48`). The doc comment at `src/lib/orpc/create-client.ts:11` says "session ID" but the code sends the user id.
+- **Web and Electron share one identical data path.** Both go through `/api/orpc` over HTTP with the same Bearer header (`src/app/api/orpc/[...path]/route.ts`). There is no separate Electron data channel — Electron IPC carries no oRPC data.
+- **`proxy.ts` gates pages, not the API.** `isProtectedRoute` (`src/proxy.ts:4-15`) lists only page prefixes; it does **not** include `/api/orpc`. API authentication is enforced _solely_ by `authMiddleware` (missing Bearer → `UNAUTHORIZED`), not by a proxy redirect.
+- **Two provisioning paths create the `User` row.** The Clerk `user.created` webhook (`src/app/api/webhooks/route.ts`) and the lazy upsert in `authMiddleware` (`src/server/middleware/auth.ts:41-48`) both create rows for the same `clerkId`. They diverge — see [Provisioning paths](#provisioning-paths-two-ways-to-create-a-user-row).
+
+## Surface map
+
+The authoritative artifact. Each surface, where it lives, what it does, and whether it enforces auth.
+
+| Surface                                            | `file:line`                                            | Role                                                                                                                                                                                                                  | Auth                                                       |
+| -------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `proxy` default export + `isProtectedRoute`        | `src/proxy.ts:4-31`                                    | Next.js v16 route gate (`clerkMiddleware`). Unauthenticated requests to protected page prefixes redirect to `/login?redirect_url=…`.                                                                                  | **This is the page auth gate.**                            |
+| `proxy` `config.matcher`                           | `src/proxy.ts:33-40`                                   | Request matcher: skips `_next` + static assets, always runs for `/api` and `/trpc`. (Matching `/api` ≠ protecting it — see invariants.)                                                                               | n/a                                                        |
+| `POST /api/webhooks`                               | `src/app/api/webhooks/route.ts:21-93`                  | Svix-verified Clerk webhook. On `user.created`, creates a `User` + default `General` `Category` in one `$transaction`. `runtime = 'nodejs'`.                                                                          | Svix HMAC signature (`WEBHOOK_SECRET`), not Clerk session. |
+| `authMiddleware`                                   | `src/server/middleware/auth.ts:10-51`                  | oRPC middleware that resolves the calling `User` from the Bearer header and exposes `AuthContext = { user }` to downstream procedures.                                                                                | **Produces the authed user context.**                      |
+| `createLink` / `createClient`                      | `src/lib/orpc/create-client.ts:16-77`                  | Browser oRPC link to `${origin}/api/orpc`; attaches `Authorization: Bearer <clerk user id>`, or `{}` when Clerk/user absent. Used identically by web and the Electron renderer.                                       | Supplies the credential.                                   |
+| `POST /api/oauth/create-signin-token`              | `src/app/api/oauth/create-signin-token/route.ts:22-54` | Mints a one-time, 60s-TTL Clerk sign-in token scoped to the browser-authed `userId` (`signInTokens.createSignInToken`). 401 if not authed.                                                                            | Requires an authenticated browser Clerk session.           |
+| `GET/POST/PUT/PATCH/DELETE /api/orpc/[...path]`    | `src/app/api/orpc/[...path]/route.ts:7-43`             | Single HTTP entry for all oRPC procedures. Forwards `request.headers` into context for `authMiddleware`. Same endpoint for web and Electron.                                                                          | Per-procedure, via `authMiddleware`.                       |
+| `/oauth/start` page                                | `src/app/oauth/start/page.tsx:39-114`                  | System-browser entry for Electron OAuth. Runs Clerk `authenticateWithRedirect`; shortcuts straight to the bridge if already signed in.                                                                                | Establishes the browser Clerk session.                     |
+| `/oauth/callback` page                             | `src/app/oauth/callback/page.tsx:34-124`               | Browser→Electron bridge. POSTs `create-signin-token`, then redirects to `corelive://oauth/callback?state=…&token=…`.                                                                                                  | Consumes the browser session.                              |
+| `ElectronAuthProvider` / `useElectronAuth`         | `src/lib/orpc/electron-auth-provider.tsx:23-351`       | Renderer provider (mounted in layout). Exchanges the OAuth ticket for a session and syncs the Clerk user to the Electron main process. No-ops outside Electron.                                                       | Client-side; only active inside Electron.                  |
+| `useClerkQueryReady`                               | `src/hooks/useClerkQueryReady.ts:18-21`                | Returns `isLoaded && Boolean(user)`. Gate so protected oRPC queries wait for Clerk hydration (web + Electron).                                                                                                        | n/a (read-only client hook).                               |
+| `OAuthManager` (main process)                      | `electron/OAuthManager.ts:80-521`                      | Main-process OAuth coordinator: generates CSRF `state`, opens the system browser, validates the deep-link callback, ferries the ticket to the renderer.                                                               | Reached only via OAuth IPC.                                |
+| Auth IPC handlers                                  | `electron/main.ts:1697-1728`                           | The **live** auth IPC: `auth-get-user`, `auth-set-user`, `auth-logout`, `auth-is-authenticated`, `auth-sync-from-web`. Hold lightweight `activeUser` state for native chrome only — they do **not** gate data access. | Renderer→main IPC; renderer is already Clerk-authed.       |
+| OAuth IPC handlers                                 | `electron/main.ts:1884-1931`                           | The **live** OAuth IPC: `oauth-start`, `oauth-get-supported-providers`, `oauth-cancel`, `oauth-get-pending-token`, `oauth-clear-pending-token`.                                                                       | Renderer→main IPC.                                         |
+| `open-url` deep-link handler                       | `electron/main.ts:312`                                 | Early macOS `open-url` handler (registered before `app.whenReady()`) that routes `corelive://` links into `DeepLinkManager` (loader at `electron/main.ts:854-877`).                                                   | n/a (transport).                                           |
+| `<ClerkProvider>` / `<ElectronAuthProvider>` mount | `src/app/layout.tsx:49,67`                             | `<ClerkProvider>` (no explicit props — keys from env) wraps `<ElectronAuthProvider>`, which wraps the app.                                                                                                            | n/a (provider wiring).                                     |
+
+> **Not a live surface:** `electron/auth-manager.ts:1-18` is **dead code** — its `AuthManager` class is never instantiated and describes an old IPC-data architecture (`ApiBridge.setUserId`). The live handlers are inlined in `main.ts` (rows above). It is kept only as reference for a future manager-class refactor and is exempt from the `no-raw-ipc` ESLint rule. Do not wire against it.
+
+## Provisioning paths (two ways to create a `User` row)
+
+Both create a row for the same `clerkId`; they are not equivalent. Defer field shapes to `src/app/api/webhooks/route.ts:58-89` and `prisma/schema.prisma:57-71`.
+
+| Path        | `file:line`                           | Trigger                    | Creates                                        | Seeds default `General` category?                 |
+| ----------- | ------------------------------------- | -------------------------- | ---------------------------------------------- | ------------------------------------------------- |
+| Webhook     | `src/app/api/webhooks/route.ts:58-89` | Clerk `user.created` event | `User` with `clerkId` + email + name           | **Yes** — same `$transaction` (`route.ts:81-88`). |
+| Lazy upsert | `src/server/middleware/auth.ts:41-48` | First authed oRPC request  | `User` with **only** `clerkId` (no email/name) | **No.**                                           |
+
+Consequences: if an authed request lands before the webhook fires, the row exists with an empty profile. The webhook handler branches **only** on `user.created` (`route.ts:58`) — there is **no** `user.updated` / `user.deleted` handler, so Clerk profile edits and deletions are not propagated to Postgres.
+
+## Electron OAuth bridge
+
+Exists because Google OAuth returns `403 disallowed_useragent` inside WebViews and the browser's Clerk cookie is not shared with the WebView's separate cookie store (`src/app/oauth/callback/page.tsx:21-24`, `src/app/oauth/start/page.tsx:26-29`). OAuth runs in the **system browser**; a one-time Clerk sign-in token is bridged back over a `corelive://` deep link, and the WebView mints its own session. The _why_ lives in [./explanation-authentication.md](./explanation-authentication.md); the deep-link transport detail in [docs/DEEP_LINKING_IMPLEMENTATION_SUMMARY.md](../DEEP_LINKING_IMPLEMENTATION_SUMMARY.md) and [./reference-electron.md](./reference-electron.md).
+
+Hop-by-hop, with the owner of each step:
+
+| Hop                                                                                                                                  | Owner (`file:line`)                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| Renderer requests OAuth → `oauth-start` IPC                                                                                          | `electron/main.ts:1887-1905`                                   |
+| Generate CSRF `state`, store it, open system browser at `/oauth/start`                                                               | `electron/OAuthManager.ts:200-228`                             |
+| Build the start URL from the **live BrowserWindow origin** (dev `localhost:3011` / prod `corelive.app`)                              | `electron/OAuthManager.ts:156-163` (origin resolver `178-192`) |
+| Browser runs Clerk `authenticateWithRedirect` (or shortcuts if already signed in)                                                    | `src/app/oauth/start/page.tsx:50-114`                          |
+| Browser POSTs `create-signin-token`, then redirects to `corelive://oauth/callback?state&token`                                       | `src/app/oauth/callback/page.tsx:62-103`                       |
+| macOS `open-url` routes the deep link into `DeepLinkManager`                                                                         | `electron/main.ts:312`                                         |
+| Main process validates `state` + TTL, shows/focuses the window, sends the ticket to the renderer (IPC channel `clerk-sign-in-token`) | `electron/OAuthManager.ts:252-381`                             |
+| Renderer exchanges the ticket: `client.signIn.create({ strategy: 'ticket', ticket })` → `setActive` → navigate `/home`               | `src/lib/orpc/electron-auth-provider.tsx:163-251`              |
+| Renderer syncs the resolved Clerk user to the main process (`auth.setUser`) or logs out                                              | `src/lib/orpc/electron-auth-provider.tsx:280-313`              |
+
+### Token & state lifetimes
+
+| Item                                        | TTL / lifecycle                                         | `file:line`                                                   |
+| ------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------- |
+| OAuth `state` (CSRF)                        | 10 min, single pending Map entry                        | `electron/OAuthManager.ts:113` (TTL), `292-299` (enforcement) |
+| Sign-in token (server-minted)               | 60 s, single-use                                        | `src/app/api/oauth/create-signin-token/route.ts:36-46`        |
+| Pending sign-in token (main-process buffer) | 60 s                                                    | `electron/OAuthManager.ts:360-381`                            |
+| Token cleared **before** consume            | A failed exchange cannot retry the same one-time ticket | `src/lib/orpc/electron-auth-provider.tsx:186-188`             |
+
+### Race recovery & failure handling
+
+- **Ticket-before-`signIn`-ready race.** The ticket may arrive over IPC before Clerk's `signIn` is ready, so a temporary buffering listener stores it (`pendingToken` ref, `src/lib/orpc/electron-auth-provider.tsx:254-277`), and the main process is polled as a fallback (`oauth.getPendingToken`, `src/lib/orpc/electron-auth-provider.tsx:126-145`).
+- **MFA / device-trust statuses.** If the ticket exchange returns `needs_second_factor` / `needs_client_trust`, Electron cannot complete in-WebView and tells the user to finish in the browser. Mapping at `src/lib/orpc/electron-auth-provider.tsx:365-376`; spec at `src/lib/orpc/electron-auth-provider.test.tsx:144-171`. Happy path (`ticket` → `sess_123` → `setActive`) at `electron-auth-provider.test.tsx:112-142`.
+- **Extra sign-in steps.** `setActive`'s `navigate` aborts to an error instead of redirecting to `/home` when `session.currentTask` is present (`src/lib/orpc/electron-auth-provider.tsx:84-94`).
+- **`/floating-navigator` is protected on purpose** (`src/proxy.ts:11-14`) so an unauthenticated Electron cold boot redirects to `/login`, letting the main-process nav-watch surface the main window instead of an empty panel.
+
+### Provider asymmetry
+
+`OAuthManager.getSupportedProviders()` returns `['google', 'github', 'apple']` (`electron/OAuthManager.ts:484-486`), but the browser `/oauth/start` page only accepts and validates `google` / `github` (`src/app/oauth/start/page.tsx:47,57`). Treat `apple` as not wired end-to-end.
+
+### PKCE is not part of this flow
+
+`OAuthManager` defines `generatePKCE` (`electron/OAuthManager.ts:124-133`) and `exchangeCodeForSession` (`electron/OAuthManager.ts:401-422`), but the **live** `startOAuthFlow` stores only `{ provider, createdAt }` with no verifier (`electron/OAuthManager.ts:206-209`). The sign-in-token bridge does **not** use PKCE or an authorization-code exchange — those methods are unused by the current path.
+
+## Development backdoor
+
+In `NODE_ENV === 'development'`, a Bearer value of `user_mock_user_id` upserts a fixed test user (`test@example.com`, name `Test User`) and bypasses the unauthorized check (`src/server/middleware/auth.ts:18-32`). This branch is gated on `NODE_ENV` and is never reachable in production builds. E2E tests instead talk to the real Clerk Dev instance — see the E2E credentials note and command list in [README.md](../../README.md) and the project's local `CLAUDE.md`.
+
+## Environment variables
+
+Auth depends on `WEBHOOK_SECRET`, `CLERK_SECRET_KEY`, and the `NEXT_PUBLIC_CLERK_*` keys, validated at startup via `src/env.mjs`. Do not transcribe them here — the canonical table (variable, side, description) is in [README.md](../../README.md).
+
+## Related
+
+- [./explanation-authentication.md](./explanation-authentication.md) — the mental model and trust boundary.
+- [./reference-orpc-api.md](./reference-orpc-api.md) — how `authMiddleware` composes into procedures.
+- [./reference-data-model.md](./reference-data-model.md) — the `User` / `Category` rows this resolves to.
+- [./reference-electron.md](./reference-electron.md) — Electron windows, IPC, preload `window.electronAPI`.
+- [docs/DEEP_LINKING_IMPLEMENTATION_SUMMARY.md](../DEEP_LINKING_IMPLEMENTATION_SUMMARY.md) — `corelive://` deep-link mechanics.
+- [./README.md](./README.md) — developer docs hub.

--- a/docs/dev/reference-ci-and-commands.md
+++ b/docs/dev/reference-ci-and-commands.md
@@ -1,0 +1,132 @@
+# CI workflows & command index
+
+A point-to-source map of CoreLive's command surface (`package.json` scripts), GitHub Actions workflows, the shared CI setup action, the `validate` parallel gate, and the four test tiers with their four configs. This is an index — the authoritative command strings live in `package.json` "scripts" and the env tables in [`README.md`](../../README.md); follow the `file:line` anchors rather than trusting any value transcribed here (this repo is pre-launch and reshaped freely — see [`README.md`](../../README.md)).
+
+For the _why_ behind the CI topology, see [explanation: Why the build & CI topology looks the way it does](./explanation-build-and-ci.md). For the release procedure, see [how-to: How to cut a macOS release](./howto-cut-a-release.md). For the local loop, see [how-to: How to run the local dev + test loop](./howto-local-dev-and-tests.md). Signing/notarization setup and troubleshooting live in [`docs/BUILD_AND_DEPLOYMENT.md`](../BUILD_AND_DEPLOYMENT.md) (note: that doc's pinned Node/pnpm versions have drifted — trust `package.json:10-12` and `.github/actions/prepare/action.yml:13`).
+
+## Cross-cutting invariants
+
+These rules hold across the whole command/CI surface:
+
+- **`package.json` "scripts" is the single source of truth for every command.** Do not re-document command strings elsewhere; cite `package.json:<line>`. The env-var tables are owned by [`README.md`](../../README.md).
+- **One shared setup action.** Every workflow installs Node + pnpm via `./.github/actions/prepare` (`.github/actions/prepare/action.yml`) — Node `24.13.0`, pnpm via `pnpm/action-setup`, `pnpm install --frozen-lockfile`. Bump the toolchain in one place there.
+- **The Compose file is `compose.yml`, NOT `docker-compose.yml`.** `docker compose up -d` finds it by Compose's default filename resolution; CI passes `-f compose.yml -p corelive` explicitly (e.g. `.github/workflows/test.yml:47`). A doc or command saying `docker-compose.yml` is wrong.
+- **`validate` is the _local_ pre-commit gate; CI splits the same checks into separate workflows.** `pnpm validate` (`package.json:40`) runs six checks in parallel locally; CI fans them out (`build.yml`, `lint.yml`, `typecheck.yml`, `test.yml`, …) so a single check's failure is isolated per workflow.
+- **Destructive Prisma commands route through a fail-closed safety gate.** `db:reset`, `db:truncate`, `prisma:migrate` (`package.json:50,51,43`) are each prefixed with `node scripts/assert-local-db.cjs && …`. See [Safety & guard scripts](#safety--guard-scripts).
+- **macOS releases are tag-driven; never `pnpm electron:publish`.** Pushing a lightweight `v*` tag fires `build-and-release.yml`. The `electron:publish` script exists but is intentionally never invoked (it would double-publish and bypass the DMG finalize step). See [how-to: How to cut a macOS release](./howto-cut-a-release.md).
+- **The packaged Electron app bundles no Next.js output.** `electron-builder.json:22` excludes `src/**`; the renderer is omitted from the electron-vite build (`electron.vite.config.ts:85-86`). The `.app` loads `https://corelive.app/` remotely. So `electron:build:mac`/`:dir` do **not** run `pnpm build`; `next build` matters for the web deploy, for E2E (which serve the app locally), and as a build-check step in the release workflow's macOS `build` job (`build-and-release.yml:73`), whose output the package does not consume. See [explanation: Electron architecture decisions](./explanation-electron-architecture.md).
+
+## Command index (point to `package.json`)
+
+The canonical list is `package.json:20-63` ("scripts"). The most load-bearing entries and their anchors:
+
+| Command                                       | `package.json`        | What it is                                                                                                                         |
+| --------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm validate`                               | `:40`                 | Local pre-commit gate — six checks in parallel via `concurrently --kill-others-on-fail`. See [below](#the-validate-parallel-gate). |
+| `pnpm dev`                                    | `:22`                 | Next.js dev server on port 3011 (web only).                                                                                        |
+| `pnpm build`                                  | `:23`                 | Production Next.js build, `--webpack` (not Turbopack); `prebuild` (`:25`) regenerates icons first.                                 |
+| `pnpm typecheck`                              | `:39`                 | `tsc --noEmit`.                                                                                                                    |
+| `pnpm lint` / `lint:fix`                      | `:27` / `:28`         | ESLint, zero-warning policy, 8 GB heap; `validate` uses `lint:fix`.                                                                |
+| `pnpm test`                                   | `:29`                 | Unit tier (vitest). See [test tiers](#four-test-tiers-four-configs).                                                               |
+| `pnpm test:electron`                          | `:30`                 | Electron main/preload unit tier.                                                                                                   |
+| `pnpm test:storybook`                         | `:32`                 | Storybook story tier (real Chromium).                                                                                              |
+| `pnpm test:packages`                          | `:35`                 | In-repo `eslint-plugin-dslint` workspace package's own tests (part of `validate`).                                                 |
+| `pnpm theme:generate` / `theme:check`         | `:36` / `:37`         | Regenerate / drift-check `src/lib/themes/generated.css`. See [reference: Theme system](./reference-theme-system.md).               |
+| `pnpm build:icons`                            | `:24`                 | Regenerate app/tray/favicon assets via `sharp`; wired as `prebuild` (`:25`).                                                       |
+| `pnpm e2e:web`                                | `:54`                 | Web E2E (`--project=web`). Boots the app via the Playwright `webServer` block (`pnpm start`).                                      |
+| `pnpm e2e:electron`                           | `:55`                 | Electron E2E — compiles main/preload then launches via `_electron.launch`; prefix with `xvfb-run -a` on Linux.                     |
+| `pnpm electron:dev`                           | `:57`                 | Dev orchestrator (`scripts/dev.js`): build electron → start Next → poll `:3011` → launch.                                          |
+| `pnpm electron:build:ts`                      | `:58`                 | `electron-vite build` — compiles `electron/` main + preload to CJS into `dist-electron/`.                                          |
+| `pnpm electron:build:dir`                     | `:60`                 | Unpacked `.app` for local prod testing (no DMG, no signing).                                                                       |
+| `pnpm electron:build:mac`                     | `:59`                 | Full signed+notarized release build, then DMG finalize. See [release builds](#release-build-pipeline).                             |
+| `pnpm electron:publish`                       | `:61`                 | **DO NOT USE** — auto-publishing path; releases go via tag instead.                                                                |
+| `pnpm prisma:migrate` / `:deploy` / `:status` | `:43` / `:45` / `:44` | Local migrate (gated) / prod deploy / status.                                                                                      |
+| `pnpm db:reset` / `db:truncate`               | `:50` / `:51`         | Destructive local reset (+seed) / reset (no seed); both gated.                                                                     |
+| `pnpm storybook` / `build-storybook`          | `:52` / `:53`         | Storybook dev server (port 6006) / static build.                                                                                   |
+
+Ports and the env-var tables are documented in [`README.md`](../../README.md), not here.
+
+## The `validate` parallel gate
+
+`pnpm validate` (`package.json:40`) runs **six** checks concurrently via `concurrently … --kill-others-on-fail` — the first failure aborts the rest:
+
+| Label   | Underlying script                                       | `package.json` |
+| ------- | ------------------------------------------------------- | -------------- |
+| `test`  | `pnpm test` (unit vitest)                               | `:29`          |
+| `pkg`   | `pnpm test:packages` (`eslint-plugin-dslint` workspace) | `:35`          |
+| `lint`  | `pnpm lint:fix`                                         | `:28`          |
+| `build` | `pnpm build` (`next build --webpack`)                   | `:23`          |
+| `type`  | `pnpm typecheck` (`tsc --noEmit`)                       | `:39`          |
+| `theme` | `pnpm theme:check` (generated-CSS drift)                | `:37`          |
+
+CI does **not** run `validate`; it runs the equivalent checks as separate workflows (see the table below) so each surfaces independently.
+
+## GitHub Actions workflows
+
+All workflow files live in `.github/workflows/`. Most jobs begin with `uses: ./.github/actions/prepare`; the lean jobs that need no Node skip it — they only checkout, then enumerate specs (`detect-specs` in `e2e.web.yml`) / run `gh release` (`release` in `build-and-release.yml`) / run Trivy (`security-scan` in `build-and-release.yml`).
+
+| File                    | Trigger                                                                                                    | Job(s) → purpose                                                                                                                                                                                                                                           |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `build.yml`             | PR + push `main`                                                                                           | `build` (ubuntu) → `pnpm build` (Next.js webpack build check).                                                                                                                                                                                             |
+| `lint.yml`              | PR + push `main`                                                                                           | `lint` (ubuntu) → build the `eslint-plugin-dslint` workspace (`:22`), run `pnpm lint` (`:24`), then lint the workspace package (`:26`).                                                                                                                    |
+| `typecheck.yml`         | PR + push `main`                                                                                           | `typecheck` (ubuntu) → `pnpm typecheck`.                                                                                                                                                                                                                   |
+| `test.yml`              | PR + push `main`                                                                                           | `test` (ubuntu, `TZ=Asia/Tokyo` at `:19`) → provision Postgres via Compose, migrate, run unit tests with `RUN_DB_INTEGRATION_TESTS=1` (`:66`), `theme:check` (`:71`), electron unit tests (`:73`), upload coverage to Codecov.                             |
+| `storybook-test.yml`    | PR + push `main`/`develop`, manual                                                                         | `storybook-test` (ubuntu) → install Chromium, build Storybook, `pnpm test:storybook` in headless Chromium.                                                                                                                                                 |
+| `e2e.web.yml`           | PR (skips `**/*.md`, `docs/**`) + push `main`                                                              | `detect-specs` (enumerate `e2e/web/*.spec.ts` → JSON array) → `e2e-web` **per-spec matrix** (own Postgres + Next.js each, blob report each) → `merge-reports` (combine blobs into one HTML report).                                                        |
+| `e2e.electron.yml`      | PR (skips docs) + push `main`                                                                              | `e2e-electron-linux` — **single** ubuntu job under `xvfb-run`; renderer paths only, no Cocoa chrome (`:1-34` rationale, `:146` the xvfb run).                                                                                                              |
+| `build-and-release.yml` | push tag `v*` (`:4-6`), PR `main`, manual                                                                  | `test` (ubuntu) → `build` (macOS: `pnpm build` + signed `electron:build:mac` on tag / unsigned `electron:build:dir` on PR, `:82-95`) → `release` (ubuntu, tag-only: `gh release` upload/create, `:109-146`) + `security-scan` (Trivy → SARIF, `:148-171`). |
+| `db-migrate.yml`        | manual (type `DEPLOY`, `:24`) + push `main` on `prisma/migrations/**` or `prisma/schema.prisma` (`:37-39`) | `migrate` (ubuntu, GitHub `production` environment for an approval gate, `:55`) → `pnpm prisma:deploy`; supports `dry_run` (`:80,89`).                                                                                                                     |
+
+### Shared composite action
+
+`.github/actions/prepare/action.yml` is the single setup step reused by every workflow: `pnpm/action-setup` (`:8`) + `actions/setup-node` pinned to `24.13.0` with pnpm cache (`:10-17`) + `pnpm install --frozen-lockfile` (`:19-21`). Bump the Node/pnpm toolchain here, not per-workflow.
+
+### CI Postgres
+
+`test.yml`, `e2e.web.yml`, and `e2e.electron.yml` start the database with `docker compose -f compose.yml -p corelive up -d postgres --wait` — note this starts **only** the `postgres` service. The `network-delay` sidecar in `compose.yml:31-47` (a `netem` latency simulator) is opt-in locally and is **not** started in CI. The healthcheck and a follow-up `psql` poll both wait until the `corelive` database exists before migrations run.
+
+## Four test tiers, four configs
+
+Each tier has its own config so environments don't collide. Tier names below are the vitest `test.name` values.
+
+| Tier                       | Config file                                              | Environment         | Scope                                                                               | Notable                                                                                                                    |
+| -------------------------- | -------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Unit (`unit`)              | `vitest.config.ts`                                       | `happy-dom`         | `src/**/*.{spec,test}` + `src/**/__tests__`                                         | `setupTests.ts`; `@/electron` alias listed **before** `@` so prefix-matching resolves it first (`vitest.config.ts:25-28`). |
+| Electron unit (`electron`) | `vitest.config.electron.ts`                              | `node`              | `electron/**`                                                                       | `testTimeout: 10000`; `esbuild.target: 'node18'`.                                                                          |
+| Storybook (`storybook`)    | `vitest.config.storybook.ts`                             | real Chromium       | Stories via `@storybook/addon-vitest`                                               | Browser mode through `@vitest/browser-playwright`, `headless: true`.                                                       |
+| E2E (web + electron)       | `playwright.config.ts` + `playwright.electron.config.ts` | Chromium / Electron | `e2e/web/*.spec.ts` (`web` project) / `e2e/electron/*.spec.ts` (`electron` project) | See below.                                                                                                                 |
+
+The Playwright base config (`playwright.config.ts`) defines three projects — `setup`, `web`, `electron` — forces `workers: 1` (`:36`, shared Clerk user + single DB), uses the `blob` reporter on CI / `list` locally (`:38-46`), and boots Next.js via the `webServer` block running `pnpm start` (`:102-107`). `playwright.electron.config.ts` reuses that base but narrows `projects` to the `electron` project and swaps to an HTML reporter (`:25-33`) — a separate file is required because Playwright evaluates `reporter` at config-load time, before `--project` is parsed (`playwright.electron.config.ts:5-24`). The rationale for `workers: 1`, the per-spec web matrix, and the single xvfb electron job is in [explanation: Why the build & CI topology looks the way it does](./explanation-build-and-ci.md).
+
+`setupTests.ts` (unit tier setup) installs `@testing-library/jest-dom` matchers and force-installs happy-dom `Storage` onto `window`/`globalThis` to defeat Node 24+'s experimental `localStorage` global that would otherwise shadow the browser-like one — run unit tests under Node `24.13.0` to match CI.
+
+## Release build pipeline
+
+`pnpm electron:build:mac` (`package.json:59`) chains three steps:
+
+1. `pnpm electron:build:ts` — `electron-vite build` compiles `electron/` main (index + 8 lazily-loaded managers) and 3 preloads to CJS into `dist-electron/` (`electron.vite.config.ts:17-84`). The renderer is omitted (`:85-86`).
+2. `electron-builder --mac --publish never` — packages DMG + ZIP for x64 and arm64, hardened runtime, `notarize: true` (`electron-builder.json:64-84`). `--publish never` means it does **not** upload. During packaging the `afterSign` hook (`electron-builder.json:106` → `scripts/notarize.js`) notarizes the `.app` via `@electron/notarize` (no-op when Apple creds are missing or off-darwin, `scripts/notarize.js:7,18`).
+3. `node scripts/finalize-mac-release-artifacts.js` — separately notarizes + staples each **DMG** via `xcrun notarytool`/`stapler` (the DMG wrapper isn't covered by `afterSign`), deletes now-stale `.dmg.blockmap`s, and rewrites `latest-mac.yml` + `checksums.json` from the post-staple bytes (functions `finalizeDmg:138`, `removeDmgBlockmaps:172`, `rewriteLatestMacYaml:187`, `rewriteChecksumsJson:221`; darwin-only guard at `:252`). Stapling mutates DMG bytes, so the manifests must be regenerated afterward or auto-update hash checks fail.
+
+Artifact upload to a GitHub Release is a **separate** CI job (`build-and-release.yml:109-146`, `gh release`), not part of the build script. The `electron:publish` script (`package.json:61`) uses `electron-builder --publish=always` and is intentionally never used. Output naming, signing-cert setup, and the auto-updater are documented in [`docs/BUILD_AND_DEPLOYMENT.md`](../BUILD_AND_DEPLOYMENT.md); the full release procedure is [how-to: How to cut a macOS release](./howto-cut-a-release.md).
+
+## Build-time generators
+
+| Generator | Script                          | Wiring                                                                                                                                                              | Output                                                                                                                                                                                                                   |
+| --------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Theme CSS | `scripts/generate-theme-css.ts` | `pnpm theme:generate` (`package.json:36`); pinned by `theme:check` (`:37`) in `validate` and `test.yml:71`                                                          | `src/lib/themes/generated.css` (derived/colored themes only; Warm Cathedral is hand-authored in `globals.css` and skipped). Build-time only — `culori` never ships to the client (`scripts/generate-theme-css.ts:1-18`). |
+| Icons     | `scripts/generate-icons.js`     | `pnpm build:icons` (`package.json:24`), wired as `prebuild` (`:25`); CI runs it explicitly before electron tests/builds (`test.yml:63`, `build-and-release.yml:35`) | `build/icons/` — app icon (`sharp`), tray-icon states, favicons. See [`docs/ICON_SYSTEM_IMPLEMENTATION_SUMMARY.md`](../ICON_SYSTEM_IMPLEMENTATION_SUMMARY.md).                                                           |
+
+## Safety & guard scripts
+
+`scripts/assert-local-db.cjs` is a fail-**closed** gate that runs before every destructive Prisma command (`db:reset`/`db:truncate`/`prisma:migrate`, `package.json:50,51,43`). It proceeds only when the connection target is _provably_ local: it checks an allowlist of local hosts (`localhost`, `127.0.0.1`, `::1`, `postgres`, `corelive-postgres`, …; `:24-31`), validates both the WHATWG `.hostname` **and** the libpq `?host=`/`?hostname=` query params (which override the URL authority — a naive hostname check is fail-open; `:80-95`), and aborts on backslash URLs or an empty host (`:64-68`, `:101-103`). This is what prevents `pnpm db:reset` from wiping production Neon. The reasoning is captured in [explanation: Why the build & CI topology looks the way it does](./explanation-build-and-ci.md) (which covers the DB-gate rationale) and the script's own header comment (`scripts/assert-local-db.cjs:1-17`).
+
+## See also
+
+- [explanation: Why the build & CI topology looks the way it does](./explanation-build-and-ci.md)
+- [how-to: How to cut a macOS release](./howto-cut-a-release.md)
+- [how-to: How to run the local dev + test loop](./howto-local-dev-and-tests.md)
+- [reference: Theme system reference](./reference-theme-system.md)
+- [reference: Data model reference](./reference-data-model.md)
+- [`docs/BUILD_AND_DEPLOYMENT.md`](../BUILD_AND_DEPLOYMENT.md) — signing, auto-updater, troubleshooting (version pins drifted)
+- [`README.md`](../../README.md) — env-var tables, ports, getting started

--- a/docs/dev/reference-data-model.md
+++ b/docs/dev/reference-data-model.md
@@ -1,0 +1,120 @@
+# Data model reference
+
+Point-to-source reference for CoreLive's persistence layer: the 10 Prisma models, their relations, the load-bearing data-integrity rules, and the Prisma client. `prisma/schema.prisma` is the single source of truth and is heavily commented with WHY-design-notes; this doc anchors each surface to a line range and defers exact field shapes to the schema.
+
+> **Volatility warning (pre-launch).** Per [`README.md`](../../README.md) (the "Pre-launch" banner): the schema, APIs, and data may be reshaped freely and abruptly — **no migrations are preserved, no backward compatibility is maintained**. When the schema changes you just run `pnpm db:reset`. Do not treat field-by-field details copied out of this doc as durable. Always re-read `prisma/schema.prisma` for the current shape.
+
+## Cross-cutting invariants
+
+These rules apply across the whole schema and are the highest-value thing to know before touching any model. Each is enforced in column nullability, defaults, unique constraints, or `onDelete` — not in application code.
+
+| Invariant                                                                                                                                                                         | Where enforced                                                                                                     | Why it matters                                                                                                                                                                                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Two completion surfaces feed one heatmap.** `Todo` (live list) and `Completed` (archive/import/BrainDump stream) are disjoint tables that the heatmap UNIONs.                   | Consumed in `src/server/utils/completedAggregation.ts:61-153`                                                      | Disjoint by construction, so **no row-level dedup** is performed — repetition is an intended habit/XP signal, never collapsed.                                                                                      |
+| **Heatmap day = a stable semantic timestamp.** `Completed.completedAt` (`schema.prisma:30`) and `Todo.completedAt` (`schema.prisma:101`) are `DateTime?` with **no `@default`**.  | `completedAggregation.ts:130` (Todo → `completedAt ?? updatedAt`), `:141` (Completed → `completedAt ?? createdAt`) | Decouples the heatmap day from `updatedAt`, which drifts on every text/notes edit. See [why](#design-notes-load-bearing) below.                                                                                     |
+| **`Completed.archived: false` is load-bearing.** The archive flow must always write `archived:false`.                                                                             | `schema.prisma:18`; `src/server/utils/archiveCompletedTodos.ts:13-21`; filtered at `completedAggregation.ts:99`    | An `archived:true` row silently drops from the heatmap and reintroduces the erasure bug the archive helper exists to fix.                                                                                           |
+| **Paste-import is undoable by batch id, never by content.** `ImportBatch.id` is a client-supplied unique key; `Completed.importBatchId` / `Todo.importBatchId` tag inserted rows. | `schema.prisma:73-87`, `:34`, `:110` (both indexed: `:39`, `:116`)                                                 | A bulk undo `deleteMany`s by batch id (`createMany` returns only `{count}`). Uniqueness is on the **batch id only**, never task title.                                                                              |
+| **The Prisma client is unscoped.** No per-user filtering happens at the client level.                                                                                             | `src/lib/prisma.ts:10` (no auth, no middleware)                                                                    | Per-user scoping is the **caller's** responsibility — every query passes `userId` in its where-clause.                                                                                                              |
+| **No `userId` index on `Completed` / `Todo` is deliberate.**                                                                                                                      | `completedAggregation.ts:66-68`                                                                                    | Each heatmap query is bounded by `userId`, so the planner uses the primary `userId` access path; an extra index was judged unnecessary. (Contrast: `ImportBatch` **does** `@@index([userId])`, `schema.prisma:86`.) |
+
+### onDelete / referential-action matrix
+
+Deletion behavior is asymmetric and is the easiest thing to break in a refactor. Anchored to the relation lines in `schema.prisma` (where no `onDelete` is written, Prisma's default for a **required** relation is `Restrict` on PostgreSQL — confirmed in the DDL, e.g. `Completed_userId_fkey ... ON DELETE RESTRICT`).
+
+| Relation                                    | `onDelete`           | `schema.prisma` | Effect                                                                                                                                                                                        |
+| ------------------------------------------- | -------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ImportBatch.user` → User                   | `Cascade`            | `:82`           | Deleting a user wipes their import batches.                                                                                                                                                   |
+| `SkillTree.user` → User                     | `Cascade`            | `:136`          | Deleting a user wipes their tree (and transitively nodes/edges/assignments).                                                                                                                  |
+| `Completed.user` → User                     | _default_ `Restrict` | `:20`           | **Blocks** user deletion if any Completed row exists.                                                                                                                                         |
+| `Category.user` → User                      | _default_ `Restrict` | `:47`           | **Blocks** user deletion if any Category exists.                                                                                                                                              |
+| `Todo.user` → User                          | _default_ `Restrict` | `:104`          | **Blocks** user deletion if any Todo exists.                                                                                                                                                  |
+| `ElectronSettings.user` → User              | _default_ `Restrict` | `:122`          | **Blocks** user deletion while settings exist.                                                                                                                                                |
+| `Completed.category` → Category             | `Restrict`           | `:22`           | A category in use by a Completed row cannot be deleted.                                                                                                                                       |
+| `Todo.category` → Category                  | `Restrict`           | `:106`          | A category in use by a Todo cannot be deleted.                                                                                                                                                |
+| `SkillNode.skillTree` → SkillTree           | `Cascade`            | `:155`          | Deleting a tree removes its nodes.                                                                                                                                                            |
+| `NodeEdge.skillTree` → SkillTree            | `Cascade`            | `:189`          | Deleting a tree removes its edges (the end-to-end cascade path).                                                                                                                              |
+| `NodeEdge.fromNode` / `.toNode` → SkillNode | `NoAction`           | `:190-191`      | Composite FK on `(skillTreeId, id)` — forces both endpoints into the edge's own tree. `NoAction` (not Cascade) because Prisma forbids overlapping Cascade on the shared `skillTreeId` scalar. |
+| `NodeAssignment.node` → SkillNode           | `Cascade`            | `:212`          | Deleting a node removes its XP assignments.                                                                                                                                                   |
+| `NodeAssignment.todo` → Todo                | `SetNull`            | `:213`          | **XP survives task deletion** — the row orphans with `todoId=null` and reads the `todoText` snapshot.                                                                                         |
+
+> **Net effect:** deleting a `User` is asymmetric — `ImportBatch` + `SkillTree` (and the skill-tree subgraph) cascade away, but a user holding any `Todo`, `Completed`, `Category`, or `ElectronSettings` row **cannot be deleted at all** without first clearing those rows.
+
+## Models
+
+One-line purpose + line anchor per model. Open `prisma/schema.prisma` at the cited range for the authoritative field list, types, and inline design comments.
+
+| Model              | `schema.prisma` | Purpose                                                                                                                                                                                                          |
+| ------------------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Completed`        | `16-40`         | Separate completion-event stream: BrainDump checkbox-ticks, paste-import, and archived Todos. `archived` gates heatmap visibility; `completedAt` nullable-no-default; indexed on `categoryId` + `importBatchId`. |
+| `Category`         | `42-55`         | User-scoped task category. Name unique per user (`@@unique([name, userId])`). Referenced by both `Completed` and `Todo` with `onDelete: Restrict`.                                                               |
+| `User`             | `57-71`         | Account record. `clerkId` (`@unique`) bridges to Clerk auth (synced by the Clerk webhook); internal `id` (Int) is the FK target for every other model.                                                           |
+| `ImportBatch`      | `80-87`         | Paste-import idempotency guard + bulk-undo anchor. `id` is client-supplied and globally unique; a duplicate insert throws Prisma `P2002`, caught as an idempotent no-op. Doc-comment at `:73-79`.                |
+| `Todo`             | `89-117`        | Live to-do item (the TodoList `complete()` flow). `completedAt` nullable-no-default (heatmap day); `order` nullable for drag-reorder back-compat; indexed on `categoryId` + `importBatchId`.                     |
+| `ElectronSettings` | `119-128`       | 1:1 per-user desktop preferences (`userId @unique` ⇒ `User.electronSettings` is an optional 1:1). Booleans: `hideAppIcon`, `showInMenuBar`, `startAtLogin`.                                                      |
+| `SkillTree`        | `130-144`       | One skill tree per user (`@@unique([userId])` prevents a duplicate-tree race on concurrent first-load).                                                                                                          |
+| `SkillNode`        | `146-174`       | Tree node with normalized `x`/`y` coords (0.0–1.0). `@@unique([skillTreeId, id])` is the composite-FK target that lets `NodeEdge` enforce same-tree endpoints.                                                   |
+| `NodeEdge`         | `176-196`       | Directed edge between two nodes via a composite FK on `(skillTreeId, fromNodeId/toNodeId)` → `SkillNode(skillTreeId, id)`, so both endpoints must share the edge's tree.                                         |
+| `NodeAssignment`   | `198-219`       | XP record linking a `Todo` to a node. `todoId` nullable + `SetNull` + a `todoText` snapshot so XP survives Todo deletion; `@@unique([todoId])` blocks a multi-node XP-inflation exploit.                         |
+
+## Design notes (load-bearing)
+
+The schema comments are the richest documentation; these are summarized here, not transcribed. For the full narrative, see [`./explanation-completion-and-heatmap.md`](./explanation-completion-and-heatmap.md) and [`./explanation-skill-tree.md`](./explanation-skill-tree.md).
+
+- **`completedAt` nullable with no `@default`** (`schema.prisma:24-30` Completed, `93-101` Todo). A non-null default would stamp every historical row with the migration timestamp, jumping all old rows to migration-day on the heatmap. Keeping it nullable + backfilling each row to its real day, then coalescing `completedAt ?? createdAt` / `?? updatedAt` in JS, keeps each completion on its true day and decouples it from `updatedAt` (which drifts on edits).
+- **`Completed.archived` defaults false; the archive helper must never write `true`** (`schema.prisma:18`; `archiveCompletedTodos.ts:13-21`). `archiveCompletedTodos` copies a cleared/deleted Todo's completion **into** `Completed` so its heatmap day survives the Todo's deletion; an `archived:true` row would silently drop from the heatmap (`completedAggregation.ts:99` filters `archived: false`).
+- **`ImportBatch.id` client-supplied + unique; uniqueness on batch id only** (`schema.prisma:73-87`). `createMany` returns only `{count}`, never inserted ids, so an undo needs the batch tag. Title is intentionally **not** unique so intentional repetition is never collapsed.
+- **`NodeAssignment.todoId` nullable + `SetNull`, with a `todoText` VARCHAR snapshot** (`schema.prisma:200-213`). Earned XP must persist after the source Todo is deleted; the row survives with `todoId=null` and the read path prefers the `todoText` snapshot.
+- **`NodeAssignment @@unique([todoId])`** (`schema.prisma:215-217`). One assignment per todo, ever — blocks a multi-node XP-inflation exploit. PostgreSQL treats NULLs as distinct, so many orphaned (`todoId=null`) rows coexist while still blocking two assignments for one real `todoId`.
+- **`NodeEdge` composite FK + `SkillNode @@unique([skillTreeId, id])`** (`schema.prisma:167-172`, `184-191`). Single-column FKs would let an edge reference endpoints in different trees — a corruption path app code can't catch. The composite FK makes Postgres enforce same-tree endpoints. `NoAction` is required because Prisma forbids overlapping Cascade on the shared `skillTreeId` scalar; the cascade still works end-to-end via `NodeEdge.skillTree`.
+- **`SkillNode.updatedAt @default(now())`** (`schema.prisma:161-165`). Matches the DB-level `DEFAULT CURRENT_TIMESTAMP` added by the hardening migration, so the next `prisma migrate dev` does not detect drift and drop it.
+
+### Accepted limitations
+
+- **Concurrent clears are not idempotent** (`archiveCompletedTodos.ts:23-32`). Two parallel `clearCompleted` calls can each read the same completed Todo before either deletes it, inserting two `Completed` rows and inflating that day's heatmap **count**. Display-only; no data or XP loss. Accepted to avoid touching the load-bearing archive invariants for a count-only edge case.
+- **Individual `SkillNode` deletion is blocked** by `NodeEdge`'s composite `NoAction` FKs unless the node's edges are removed first. Accepted because normal operation only deletes whole trees (Cascade via the `skillTree` relation).
+- **Heatmap buckets by UTC date string** (`completedAt.toISOString()` first 10 chars); bounds are UTC-anchored to avoid mis-bucketing on non-UTC hosts (masked on Vercel, which runs UTC, but explicit in the day-detail/heatmap procedures).
+
+## Prisma client
+
+- **Singleton:** `export const prisma` in `src/lib/prisma.ts:10` — the shared client used by all server code.
+- **Driver adapter:** constructed with `@prisma/adapter-pg` (`PrismaPg`) reading `POSTGRES_PRISMA_URL` (`src/lib/prisma.ts:6-10`), **not** the default query engine. The `datasource db` block in `schema.prisma:12-14` declares `provider` only and **no `url`** — the adapter supplies the connection.
+- **Minimal instance:** a plain module-level `new PrismaClient({ adapter })` with **no `globalThis` HMR guard**. `import 'dotenv/config'` at the top (`:1`) loads env for non-Next.js entrypoints (scripts, tests).
+- **Generated client location:** `node_modules/.prisma/client` (`generator client.output`, `schema.prisma:9`).
+- **Env var:** `POSTGRES_PRISMA_URL` is validated by `src/env.mjs`; the app fails to start if it is missing. See the environment-variable table in [`README.md`](../../README.md).
+
+## Migrations & reset policy
+
+**Policy first:** this is a pre-launch repo. The canonical way to apply a schema change locally is to **reset**, not to evolve a preserved migration chain — see [`README.md`](../../README.md) ("no need to write or preserve migrations… just reset the database with `pnpm db:reset`").
+
+| Command (see `package.json` `scripts`) | Effect                                                           |
+| -------------------------------------- | ---------------------------------------------------------------- |
+| `pnpm prisma:migrate`                  | `prisma migrate dev` (guarded by `scripts/assert-local-db.cjs`). |
+| `pnpm db:reset`                        | `prisma migrate reset --force` **then** `pnpm prisma:seed`.      |
+| `pnpm db:truncate`                     | `prisma migrate reset --force` with **no** seed.                 |
+| `pnpm prisma:seed`                     | Runs `prisma/seed.ts`.                                           |
+| `pnpm prisma:studio`                   | Opens Prisma Studio.                                             |
+
+For the local DB bring-up sequence (`docker compose up -d` → migrate → seed), see [`./howto-local-dev-and-tests.md`](./howto-local-dev-and-tests.md) and [`./tutorial-getting-started.md`](./tutorial-getting-started.md).
+
+**The migration files still exist** under `prisma/migrations/` and several encode design rationale verbatim in their SQL comments — treat them as **historical/illustrative artifacts**, not a maintained chain. The highest-value ones to read:
+
+| Migration directory                                   | What it documents                                                                                                                              |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `20260529164052_paste_import_completedat_importbatch` | Adds `Completed.completedAt` + `ImportBatch`; backfills `completedAt = createdAt`.                                                             |
+| `20260603235155_add_todo_completedat`                 | Adds `Todo.completedAt`; backfills from `updatedAt`.                                                                                           |
+| `20260409000000_skill_tree_v1_hardening`              | One-tree-per-user, `NodeAssignment.todoId` SetNull, `todoText` snapshot, `@@unique([todoId])` XP-exploit guard, `SkillNode.updatedAt` default. |
+| `20260409080000_skill_tree_v1_edge_composite_fk`      | `NodeEdge` composite FK enforcing same-tree endpoints.                                                                                         |
+
+For the Prisma v7 / driver-adapter migration background, see [`../PRISMA_V7_MIGRATION.md`](../PRISMA_V7_MIGRATION.md).
+
+### Seed
+
+`prisma/seed.ts` is **idempotent**. It upserts the Clerk-dev test `User` and a default `"General"` `Category`, then inserts 10 deterministic fixture Todos. The delete-then-insert is wrapped in a single `$transaction` (`seed.ts:67-83`) so a standalone re-run does not duplicate fixtures. Autoincrement IDs are `1..N` only right after `migrate reset --force` (`seed.ts:45-46`), which is what `pnpm db:reset` chains.
+
+## Consumers (separate subsystems)
+
+This schema is read/written by code outside this reference. See:
+
+- oRPC procedures in `src/server/procedures/*` (heatmap, day-detail, todo, skill-tree) — [`./reference-orpc-api.md`](./reference-orpc-api.md).
+- `src/server/utils/completedAggregation.ts` (the heatmap UNION reader) and `src/server/utils/archiveCompletedTodos.ts` (the archive helper).
+- The Clerk webhook, which writes `User` rows — [`./reference-auth.md`](./reference-auth.md).

--- a/docs/dev/reference-electron.md
+++ b/docs/dev/reference-electron.md
@@ -1,0 +1,162 @@
+# Electron reference: windows, IPC, preload, managers
+
+Information-oriented map of CoreLive's Electron main process: the five window types, the typed-IPC contract, the three preload bridges, and the native-macOS managers. This is **point-to-source** — it names each surface and anchors it to `file:line`, then defers exact channel/field/option shapes to the source, because this subsystem is pre-launch and reshapes its API freely (`README.md:13`). For the _why_ behind these choices read [Electron architecture decisions](./explanation-electron-architecture.md); for the runtime/data-path picture read [Architecture](./explanation-architecture.md) and `docs/ELECTRON_ARCHITECTURE.md`.
+
+All paths are relative to the repo root. `electron/` holds the main-process TypeScript; it is compiled by electron-vite and is **not** part of the renderer bundle.
+
+---
+
+## Cross-cutting invariants (read first)
+
+These rules apply to the whole surface. Violating one is almost always the bug.
+
+| Invariant                                                              | Where enforced                                                                                      | Note                                                                                                                                                                                                                                                                  |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Electron loads the **remote** web app, not a bundled server            | `serverUrl` resolution `electron/main.ts:915`                                                       | dev → `http://localhost:3011`; packaged → `https://corelive.app`; E2E override via `ELECTRON_RENDERER_URL`. Data flows over oRPC HTTP exactly like web — the main process carries **no data IPC**.                                                                    |
+| Dev detected by `NODE_ENV === 'development'`, never `!== 'production'` | `electron/main.ts:173`, `electron/WindowManager.ts:148`, `electron/AutoUpdater.ts:163`              | Packaged builds run with `NODE_ENV` **unset**; the positive equality reads unset as not-dev (correct). There is **no `app.isPackaged` check** in the window/IPC subsystem. See `MEMORY.md` `packaged-electron-node-env-unset`.                                        |
+| Runtime IPC validation happens in exactly one place                    | `typedHandle` parse+throw `electron/ipc/typedHandle.ts:60`                                          | Every inbound invoke payload is `IPC_ARG_SCHEMAS[channel].parse`d before the handler runs; a bad payload throws `IPC validation failed on '<channel>': <detail>`.                                                                                                     |
+| The IPC contract is total by construction                              | `electron/ipc/ipc-schemas.ts` (`Record<IPCChannel, z.ZodTypeAny>`)                                  | Omitting a channel's Zod schema is a **compile** error. `electron/__tests__/ipc-contract.test.ts` guards alignment of the three surfaces.                                                                                                                             |
+| Visibility is owned by `WindowManager`, never `WindowStateManager`     | `applyWindowState` bounds-only `electron/WindowStateManager.ts:735`                                 | The state layer persists bounds/snap; it deliberately does **not** restore visibility.                                                                                                                                                                                |
+| At least one startup window always opens                               | `ensureAtLeastOneStartupWindow` `electron/ConfigManager.ts:597`, forces `showMain = true` at `:633` | Runs on every `set`/`update`/`import`; an all-false startup config is impossible.                                                                                                                                                                                     |
+| Renderer must feature-detect preload methods at **method** granularity | consumer `src/components/electron/ElectronStartupSync.tsx`                                          | An installed app ships a frozen preload while the renderer loads the always-current web bundle. Guard `typeof api?.ns?.method === 'function'`, never just the namespace. See `MEMORY.md` `electron-preload-version-skew`; `src/app/error.tsx` is the route-level net. |
+
+> **Native surfaces have no automated coverage.** Menu bar, tray, dock / `setActivationPolicy`, `open-url` deep links, traffic-light controls, and vibrancy are invisible to Playwright and `mcp__electron__*` (those drive the renderer only). Linux + xvfb CI is renderer-only. These must be smoke-tested manually on macOS with `mcp__computer-use__*` — see the project's local `CLAUDE.md` "Electron Native QA" section.
+
+---
+
+## Window types
+
+Five `BrowserWindow` kinds. Each is created by a `WindowManager` factory and manages its own show/hide/toggle. Constructor options (titleBarStyle, vibrancy, transparency, frame) live in the factory bodies — read them at the anchors rather than trusting a transcription.
+
+| Window                 | URL loaded            | Factory (`electron/WindowManager.ts`)         | Notable traits                                                                                                                                                                                                                  |
+| ---------------------- | --------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Main**               | `${serverUrl}/home`   | `createMainWindow(showOnReady = true)` `:343` | `titleBarStyle: 'hiddenInset'`, preload `preload.cjs`; panel-only boots pass `false` to create it hidden.                                                                                                                       |
+| **Floating navigator** | `/floating-navigator` | `createFloatingNavigator()` `:457`            | Always-on-top, `skipTaskbar`, traffic lights moved off-screen; frame/resizable from config.                                                                                                                                     |
+| **Brain Dump**         | `/braindump`          | `createBrainDumpWindow()` `:591`              | Frameless + transparent, vibrancy `under-window`, opacity clamped `[0.30, 1.00]`.                                                                                                                                               |
+| **Settings popover**   | `/settings`           | `createSettingsWindow()` `:1249`              | Frameless, vibrancy `popover`, tray-anchored, auto-hides on blur.                                                                                                                                                               |
+| **Startup pill**       | inline `data:` URL    | rendered by `armStartupPill()` `:1125`        | Transparent click-through cold-boot indicator; HTML from `buildStartupPillHtml()` (`electron/startup-pill-html.ts`), loaded inline because electron-builder excludes `electron/` sources and there is no renderer build for it. |
+
+### Window lifecycle helpers (`electron/WindowManager.ts`)
+
+| Concern                         | Symbol(s)                                                                         | Anchor            |
+| ------------------------------- | --------------------------------------------------------------------------------- | ----------------- |
+| Panel-only launch entry         | `openStartupPanel(kind)`                                                          | `:970`            |
+| Auth-aware nav-watch            | `watchStartupPanelLoad(panel, kind)` (private)                                    | `:1005`           |
+| Post-login re-show              | `armPostLoginReshow(panel, kind)` (private)                                       | `:1092`           |
+| Cold-boot pill arm / identity   | `armStartupPill()` / `isStartupPill(window)`                                      | `:1125` / `:1236` |
+| Tray restore / minimize         | `restoreFromTray()` / `minimizeToTray()`                                          | `:847`            |
+| Brain Dump visibility / opacity | `toggleBrainDump()` / `setBrainDumpOpacity(value)` (clamps `[0.30,1.00]`, `:761`) | `:760`            |
+| Floating visibility             | `toggleFloatingNavigator()` (create-on-demand)                                    | `:801`            |
+
+**Startup nav-watch behavior** (so you never see an empty panel): a startup panel is created hidden; if its final navigated URL is an auth page (`AUTH_PATHNAMES = ['/login','/sign-up']`, `electron/constants.ts:28`) the panel is suppressed and the main window surfaces instead, then `armPostLoginReshow` re-shows the panel after sign-in. `net::ERR_ABORTED` (`-3`, `electron/constants.ts:40`) fires during the redirect chain and is **not** treated as a load failure. Pill timing constants: `STARTUP_PILL_GAP_MS = 400`, `STARTUP_PILL_TIMEOUT_MS = 8000` (`electron/constants.ts:52,59`). The narrative is in [Electron architecture decisions](./explanation-electron-architecture.md).
+
+---
+
+## IPC contract (three synced surfaces)
+
+Channel safety is enforced by three co-located surfaces plus thin wrappers. **`electron/types/ipc.ts` is the single source of truth** — enumerate channels there, do not transcribe.
+
+| Surface                    | File                          | What it declares                                                                                                                                                                                                      |
+| -------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Compile-time channel types | `electron/types/ipc.ts`       | `IPCChannels` (request/response per invoke channel, interface at `:248`) and `IPCEventChannels` (one-way main→renderer, interface at `:781`). `IPCChannel`/`IPCEventChannel` are the `keyof` aliases (`:874`/`:877`). |
+| Runtime Zod validation     | `electron/ipc/ipc-schemas.ts` | `IPC_ARG_SCHEMAS: Record<IPCChannel, z.ZodTypeAny>` — exhaustive by construction; the **only** runtime check of inbound IPC. Carries the Electron security-checklist #17 comment.                                     |
+| Typed wrappers             | `electron/ipc/*`              | bridge the two type sources at call sites (table below).                                                                                                                                                              |
+
+### Channel families (registered, not transcribed)
+
+All ~100 invoke handlers are registered centrally in **`setupIPCHandlers()` (`electron/main.ts:1099`)**, guarded against double-run by `ipcHandlersInitialized` (`electron/main.ts:1106`). Despite manager docstrings implying per-manager `registerIpcHandlers()`, **managers do not register their own IPC** — they are logic classes called by these handlers. The channel-name prefixes you will find there:
+
+`window-*`, `floating-window-*`, `braindump-window-*`, `braindump-note-*`, `braindump-config-*`, `tray-*`, `notification-*`, `config-*`, `window-state-*`, `auth-*`, `oauth-*`, `settings:*`, `performance-*`, `shortcuts-*`, `deep-link-*`, `updater-*`, `display-*`, `app-*`, `menu-*`, `test-*`.
+
+Two `settings:*` handlers worth naming directly:
+
+| Handler                     | Anchor                  | Effect                                                                                                         |
+| --------------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `settings:setHideAppIcon`   | `electron/main.ts:1760` | macOS dock toggle via `app.setActivationPolicy('accessory'\|'regular')` (`:1770`), darwin-guarded.             |
+| `settings:setStartupConfig` | `electron/main.ts:1847` | Persists which windows open at launch through `configManager.update`, so the ≥1-startup-window invariant runs. |
+
+### Typed wrappers
+
+| Wrapper                                  | File:line                                         | Role                                                                                                                                                           |
+| ---------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `typedHandle(channel, handler)`          | `electron/ipc/typedHandle.ts:40` (throw at `:60`) | Main-side `ipcMain.handle`; runs the channel's Zod schema, throws on `ZodError`.                                                                               |
+| `typedInvoke(channel, ...args)`          | `electron/ipc/typedInvoke.ts`                     | Renderer-side `ipcRenderer.invoke`; used inside preload methods.                                                                                               |
+| `typedSend(sender, channel, ...payload)` | `electron/ipc/typedSend.ts:33`                    | Main→renderer event emit; **no-ops if `sender.isDestroyed()`** (`:38`).                                                                                        |
+| `ArgsOf<C>`                              | `electron/ipc/types.ts`                           | Conditional type mapping a request type to its arg tuple (`void`→`[]`, `T[]`→`T[]`, else `[T]`).                                                               |
+| `createTypedListener(channel)`           | `electron/ipc/typedListener.ts:36`                | **Vestigial** — zero call sites. The live inbound pattern is raw `ipcRenderer.on` + a channel whitelist (see preloads). Do not document this as "the pattern". |
+
+Notable shared payload types in `electron/types/ipc.ts` (defer field shapes to source): `ElectronUser` (`:25`), `AuthUserPayload` (`:46`), `WindowState` (`:62`), `StartupWindowConfig` + `DEFAULT_STARTUP_WINDOW_CONFIG` (`:80`/`:99`, default `{ showMain: true, showBraindump: false, showFloating: false }`), `AuxWindowVisibility` (`:113`), `ManagedWindowKind = 'main' | 'floating' | 'braindump'` (`:210`).
+
+To add a channel safely, follow [How to add an Electron IPC channel](./howto-add-ipc-channel.md).
+
+---
+
+## Preload bridges
+
+Three preload scripts, each exposing one isolated API object via `contextBridge` (the renderer never sees `ipcRenderer` or Node). Each window kind gets only the channels it needs — least privilege. Inbound events are gated by a hard-coded channel allow-list and payloads pass through `sanitizeData` (strips `__proto__`/`constructor`/`prototype`, trims strings).
+
+| Window namespace                            | Preload file                        | `exposeInMainWorld` anchors | Surface                                                                                                                                                      |
+| ------------------------------------------- | ----------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `window.electronAPI` + `window.electronEnv` | `electron/preload.ts` (~1968 lines) | `:232` / `:1960`            | The full app bridge — **18 namespaces** (see below) plus top-level `on`/`removeListener`/`removeAllListeners`.                                               |
+| `window.floatingNavigatorAPI` + `…Env`      | `electron/preload-floating.ts`      | `:126` / `:297`             | Narrow: window controls + `brainDump.toggle` + menu-action events.                                                                                           |
+| `window.brainDumpAPI` + `…Env`              | `electron/preload-braindump.ts`     | `:121` / `:319`             | Window controls + `note.get/set`, `sync.getEnabled/setEnabled`, `category.getLast/setLast`; **only inbound channel** `'braindump-category-changed'` (`:57`). |
+
+The 18 `electronAPI` namespaces (each a `key: { ... }` block in `electron/preload.ts`): `window` `:240`, `floatingPanels` `:389`, `system` `:419`, `notifications` `:519`, `shortcuts` `:641`, `auth` `:806`, `oauth` `:909`, `menu` `:1088`, `config` `:1109`, `windowState` `:1337`, `app` `:1458`, `deepLink` `:1484`, `settings` `:1543`, `brainDump` `:1673`, `updater` `:1847`, `tray` `:1886`, `display` `:1900`, `test` `:1915`. Each method is `try/catch`-wrapped to return a safe default or re-throw. `removeListener` is a deprecated no-op.
+
+> **No runtime `performance` namespace.** `window.electronAPI` exposes no `performance` object, even though `electron/types/electron-api.d.ts:355` declares one. **`electron/preload.ts` is the only source of truth for what is actually exposed.**
+
+---
+
+## Native managers
+
+Each is a logic/side-effect class constructed in the main process (most lazily, via `LazyLoadManager`) and _called by_ the central IPC handlers; they emit events back via `typedSend`. One file each:
+
+| Manager               | File                              | Responsibility (one line)                                                                                                                                                                                            |
+| --------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MenuManager`         | `electron/MenuManager.ts`         | macOS application menu bar; emits `menu-action` events.                                                                                                                                                              |
+| `SystemTrayManager`   | `electron/SystemTrayManager.ts`   | macOS menu-bar (tray) icon; `setMenuBarVisible` toggles tray vs window-minimize fallback with idempotency + an in-flight-promise guard (`createTray` `:85`) so two interleaved creates build only one native `Tray`. |
+| `DeepLinkManager`     | `electron/DeepLinkManager.ts`     | Parses `corelive://` URLs (`this.protocol = 'corelive'` `:104`) into focus-task / create-task / navigate / search events; returns `null` for any other scheme.                                                       |
+| `AutoUpdater`         | `electron/AutoUpdater.ts`         | `electron-updater` wrapper (`checkForUpdatesAndNotify`); skips in dev via `NODE_ENV === 'development'` (`:163`).                                                                                                     |
+| `NotificationManager` | `electron/NotificationManager.ts` | Native OS notifications + preferences.                                                                                                                                                                               |
+| `ShortcutManager`     | `electron/ShortcutManager.ts`     | Global shortcut registration; exposes `getStats`.                                                                                                                                                                    |
+| `ConfigManager`       | `electron/ConfigManager.ts`       | Persists `config.json` (userData); dot-notation `get`/`set`/`update`/`import`/`export`; owns the ≥1-startup-window invariant (`:597`).                                                                               |
+
+Supporting infrastructure (not per-window managers): `WindowStateManager` (`electron/WindowStateManager.ts`, bounds/snap persistence + multi-monitor re-home), `LazyLoadManager` (`electron/LazyLoadManager.ts`, deferred manager construction), `PerformanceOptimizer` (`electron/performance-config.ts`). The authoritative behavioral spec for the tray is `electron/__tests__/SystemTrayManager.menu-bar.test.ts`. Deep-link details are in `docs/DEEP_LINKING_IMPLEMENTATION_SUMMARY.md`.
+
+---
+
+## Standing caveats (dead / dormant / drifted code)
+
+Record these so you don't document non-functional code as live, or trust a stale `.d.ts`:
+
+| Item                               | File:line                          | Status                                                                                                                                                                                                                            |
+| ---------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IPCErrorHandler` retry/wrap/stats | `electron/IPCErrorHandler.ts`      | **Dormant.** Constructed (`electron/main.ts:898`) and `.cleanup()`'d (`:2327`), but `executeWithRetry`/`wrapHandler`/`getStats` are never called — no handler is actually wrapped. Do not document "automatic IPC retry" as live. |
+| `createTypedListener`              | `electron/ipc/typedListener.ts:36` | **Vestigial.** Zero call sites; the only other mention is a comment (`electron/preload.ts:113`). Inbound events use raw `ipcRenderer.on` + channel whitelist.                                                                     |
+| `auth-manager.ts`                  | `electron/auth-manager.ts:150`     | **Dead code.** Raw `ipcMain.handle('auth-*')`, never imported; superseded by the `auth-*` `typedHandle` blocks in `main.ts`. If it ever loaded it would double-register and throw — proof it doesn't.                             |
+| `electron/types/electron-api.d.ts` | `:355`                             | **Drifted.** Declares a `performance` namespace `preload.ts` does not expose; namespaces marked optional to encode the version-skew guard.                                                                                        |
+| `src/types/electron.d.ts`          | renderer-side augmentation         | **Drifted.** Omits `performance` but adds `settings`/`brainDump`; disagrees with the other `.d.ts`.                                                                                                                               |
+
+For both `.d.ts` files: **`electron/preload.ts` is the source of truth** for what is actually exposed at runtime.
+
+---
+
+## Build & packaging gotchas (cited, not re-derived)
+
+These bite only in a packaged build (`pnpm electron:build:dir` → `open dist/mac/CoreLive.app`), never `electron:dev`. Full write-ups live in `MEMORY.md`:
+
+- **`NODE_ENV` unset in packaged builds** → gate on `=== 'development'` (or `!app.isPackaged`), never `!== 'production'`. (`packaged-electron-node-env-unset`)
+- **electron-builder + pnpm drops leaf transitive deps from `app.asar`** → a missing `ms` once silently broke `electron-updater`. `ms` and `wrappy` are kept as **direct** deps (`package.json:120`, `:140`); `electron/__tests__/packaged-runtime-deps.test.ts` is the regression guard. (`electron-builder-pnpm-drops-asar-leaf-deps`)
+- **Frozen preload vs live web bundle** → method-granular feature detection in the renderer. (`electron-preload-version-skew`)
+
+Build/release flow: `docs/BUILD_AND_DEPLOYMENT.md` and [How to cut a macOS release](./howto-cut-a-release.md). Command list: `package.json` `scripts`.
+
+---
+
+## Related docs
+
+- [Electron architecture decisions](./explanation-electron-architecture.md) — _why_ the windows / startup / ownership split look this way.
+- [Architecture: one codebase, two runtimes, one data path](./explanation-architecture.md)
+- [How to add an Electron IPC channel](./howto-add-ipc-channel.md) · [How to add a cross-window sync channel](./howto-add-sync-channel.md)
+- `docs/ELECTRON_ARCHITECTURE.md` · `docs/DEEP_LINKING_IMPLEMENTATION_SUMMARY.md` · `docs/BUILD_AND_DEPLOYMENT.md`
+- Hub index: [docs/dev](./README.md)

--- a/docs/dev/reference-frontend.md
+++ b/docs/dev/reference-frontend.md
@@ -1,0 +1,171 @@
+# Frontend reference: routes, providers, store, components, hooks
+
+A point-to-source index of the Next.js App Router shell: every route and which Electron window loads it, the root-layout provider tree, the Redux store's public exports, the feature-component / data-hook map, and the lifecycle-effect hook family. This repo is pre-launch and reshapes schemas/types freely (see `README.md`), so this reference names each surface and anchors it to `file:line` rather than transcribing field/prop shapes — defer those to the source.
+
+## Cross-cutting rules
+
+These hold across the whole frontend surface; internalize them before reading the tables.
+
+- **One shell, two runtimes.** There is no separate Electron UI. Each Electron `BrowserWindow` loads a real `corelive.app` route, so the same `src/app/layout.tsx` provider tree and the same page components render on web and desktop. "Web vs Electron" is a runtime branch (`isElectronEnvironment()` in `electron/utils/electron-client.ts`), not a separate codebase. See [explanation-architecture.md](./explanation-architecture.md).
+- **Provider nesting order is load-bearing.** Do not reorder the providers in `src/app/layout.tsx:49-74` without understanding why each layer sits where it is (see the table below).
+- **Redux owns client/device state; React Query owns server state.** Redux holds two small persisted slices (`src/lib/redux/store.ts:28-31`); all server data lives in React Query via oRPC. Never duplicate server data into Redux, and never call `revalidatePath`/`revalidateTag` for Redux/Prisma writes (they do not use the Next.js cache). See [explanation-state-and-sync.md](./explanation-state-and-sync.md).
+- **Two sync paths.** Cross-window state moves two different ways: `preferences` syncs to other renderer windows over `BroadcastChannel`; `electronSettings` syncs to the Electron main process over IPC. They are not interchangeable — see [explanation-state-and-sync.md](./explanation-state-and-sync.md) and `src/lib/preferences-sync-channel.ts`.
+- **Two-tier error boundaries.** `src/app/error.tsx` catches throws inside a page subtree; `src/app/global-error.tsx` catches throws from the root layout / its providers and is deliberately dependency-free. See [Error boundaries](#error-boundaries).
+- **Prefer the named lifecycle-effect hooks over raw `useEffect`.** `src/hooks/use-*-effect.ts` — see [Lifecycle-effect hooks](#lifecycle-effect-hooks-cheatsheet). Subscriptions read _into render_ use `useSyncExternalStore` instead (e.g. `src/hooks/use-mounted.ts`, `src/hooks/useSelectedCategory.ts`).
+- **Use the pre-typed Redux hooks.** Import `useAppSelector` / `useAppDispatch` from `@/lib/redux`, never bare `react-redux` hooks (`src/lib/redux/hooks.ts:39,52`).
+- **Design invariants live in `DESIGN.md`.** Heatmap warmth (temperature = pride, never GitHub-green), quiet-pride microcopy, no streak-shame, opt-in sound — read `DESIGN.md` before any UI change.
+
+## Routes
+
+App Router routes under `src/app/`. The "Electron window" column names the native window that loads the route (`electron/WindowManager.ts`); routes with no window are web-only screens. Auth is enforced in `src/proxy.ts` (Next.js v16 middleware, renamed from `middleware.ts`) for the protected matcher; `/skill-tree` additionally re-checks `auth()` in its server component.
+
+| Route                                                    | File                                      | Electron window                                     | Auth                                                                     |
+| -------------------------------------------------------- | ----------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------ |
+| `/`                                                      | `src/app/page.tsx:15`                     | —                                                   | Public landing (Login / Sign Up)                                         |
+| `/home`                                                  | `src/app/(main)/home/page.tsx:14`         | **Main** (`WindowManager.ts:391-396`)               | Protected (`proxy.ts:5`)                                                 |
+| `/skill-tree`                                            | `src/app/(main)/skill-tree/page.tsx:13`   | —                                                   | Protected (`proxy.ts:6`); server-component `auth()` redirect to `/login` |
+| `/braindump`                                             | `src/app/braindump/page.tsx:19`           | **BrainDump** (`WindowManager.ts:931-935`)          | Protected (`proxy.ts:7`)                                                 |
+| `/floating-navigator`                                    | `src/app/floating-navigator/page.tsx:8`   | **Floating Navigator** (`WindowManager.ts:931-934`) | Protected (`proxy.ts:11-14`)                                             |
+| `/settings`                                              | `src/app/settings/page.tsx:32`            | **Settings** (`WindowManager.ts:1303-1307`)         | Protected (`proxy.ts:8-10`)                                              |
+| `/login/[[...login]]`                                    | `src/app/login/[[...login]]/page.tsx`     | — (auth target)                                     | Public (Clerk)                                                           |
+| `/sign-up/[[...sign-up]]`                                | `src/app/sign-up/[[...sign-up]]/page.tsx` | —                                                   | Public (Clerk)                                                           |
+| `/oauth/start`, `/oauth/callback`, `/oauth/sso-callback` | `src/app/oauth/**/page.tsx`               | —                                                   | Public (OAuth handoff)                                                   |
+
+For the auth flow itself (Clerk, the protected matcher, the Electron OAuth ticket exchange) see [reference-auth.md](./reference-auth.md).
+
+### Route groups vs standalone routes
+
+- **`(main)` Route Group** (`src/app/(main)/layout.tsx:12-23`) — parentheses add **no** URL segment; the layout wraps `/home` and `/skill-tree` in `SidebarProvider` + `AppSidebar`. This is why those two screens have the sidebar.
+- **Standalone routes** (`/braindump`, `/floating-navigator`, `/settings`) live **outside** `(main)` on purpose, so they render chromeless (no sidebar) as the dedicated bodies of their Electron windows.
+- `/settings` is the single settings home for web **and** Electron (D15): it renders the shared Preferences + Theme sections for everyone, then `ElectronSettingsPage`, which returns `null` on web (`src/app/settings/page.tsx:32-42`).
+- `/floating-navigator` intentionally redirects to `/login` when unauthenticated (rather than rendering empty) so the Electron main-process nav-watch can detect an unauthenticated cold boot — the rationale is in the `proxy.ts:11-14` comment.
+
+To add a route (and choose `(main)` vs standalone), see [howto-add-route-or-setting.md](./howto-add-route-or-setting.md).
+
+## Provider tree
+
+The root layout assembles the entire provider stack for every route, web and Electron. Order matters — read the rationale inline at `src/app/layout.tsx:49-74`. Nesting, outermost to innermost:
+
+| Order | Provider               | Source                                               | Why here                                                                                                                                                |
+| ----- | ---------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | `ClerkProvider`        | `@clerk/nextjs`                                      | Auth context everyone needs, incl. the persist sign-out guard — must be outermost                                                                       |
+| 2     | `<html>` / `<body>`    | `layout.tsx:50-59`                                   | Loads 3 Google fonts as CSS vars (Newsreader, Inter Tight, Geist Mono); `suppressHydrationWarning` because next-themes mutates `data-theme` client-side |
+| 3     | `ThemeProvider`        | `src/providers/ThemeProvider.tsx:50`                 | Sets `data-theme` before paint; owns `attribute` + `disableTransitionOnChange` (layout deliberately does **not** re-pass them — `layout.tsx:60-62`)     |
+| 4     | `QueryClientProvider`  | `src/providers/QueryClientProvider.tsx:119`          | TanStack Query + persistence; above Redux because the Electron auth provider (inside Redux) drives the Clerk session/cache                              |
+| 5     | `ReduxProvider`        | `src/lib/redux/providers.tsx:62`                     | Supplies the singleton store; persistence/hydration handled by the storage middleware                                                                   |
+| 6     | `ElectronStartupSync`  | `src/components/electron/ElectronStartupSync.tsx:91` | Renders `null`; must sit **inside** Redux because it reads persisted Redux settings                                                                     |
+| 7     | `ElectronAuthProvider` | `src/lib/orpc/electron-auth-provider.tsx:23`         | Wraps `children`; Electron-only Clerk↔main-process sync + OAuth ticket exchange (pass-through on web)                                                   |
+| 8     | `Toaster`              | `src/components/ui/sonner`                           | Sonner toasts (sibling of children, inside Redux)                                                                                                       |
+
+`RootLayout` (default export) is at `src/app/layout.tsx:47`.
+
+### Provider notes (defer details to source)
+
+- **`ThemeProvider`** wraps `next-themes`, sourcing theme ids from the registry SSoT (`src/lib/themes/registry`), and mounts `ThemeAllowlistGuard` (self-heals a stale/tampered persisted theme) + `ThemeTransition` (crossfade on switch). Exports `THEMES`, `THEME_META`, `ThemeId`. `storageKey='corelive-theme'`. Full theme pipeline: [reference-theme-system.md](./reference-theme-system.md).
+- **`QueryClientProvider`** configures the oRPC serializer for query-key hashing + dehydrate/hydrate, `staleTime` 60s, `gcTime` 1 week, localStorage persistence. On Clerk sign-out it **rebuilds** the `QueryClient` + persister and remounts via `key={resetKey}` to prevent cross-user cache leaks — the `clear()`-is-not-enough rationale (in-flight mutations) is documented at `QueryClientProvider.tsx:98-143`. Re-exports `orpc` for convenience (`QueryClientProvider.tsx:66`).
+- **`ElectronStartupSync`** pushes persisted `hideAppIcon` + `showInMenuBar` to the main process over IPC after Redux hydrates, each in its **own** method-guarded `useCycleEffect` (`ElectronStartupSync.tsx:103-120`); no-op on web. The method-existence guard (`typeof settings?.setHideAppIcon === 'function'`) defends against a frozen Electron preload — see [reference-electron.md](./reference-electron.md).
+
+## Redux store
+
+The singleton store combines two small slices, persists both to `localStorage` key `corelive-redux-state`, and runs the storage + preferences-sync middlewares. Public import surface is the barrel `src/lib/redux/index.ts`.
+
+| Export           | Source                           | Notes                                                                                                                                                                                     |
+| ---------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `store`          | `src/lib/redux/store.ts:67`      | `configureStore`; reducers `electronSettings` + `preferences`; persisted slices listed at `store.ts:52`; middleware chain `store.ts:69-76`; `serializableCheck` off; devTools off in prod |
+| `RootState`      | `src/lib/redux/store.ts:85`      | `ReturnType<typeof store.getState>`                                                                                                                                                       |
+| `AppDispatch`    | `src/lib/redux/store.ts:91`      | `typeof store.dispatch`                                                                                                                                                                   |
+| `useAppSelector` | `src/lib/redux/hooks.ts:52`      | `useSelector.withTypes<RootState>()` — use instead of bare `useSelector`                                                                                                                  |
+| `useAppDispatch` | `src/lib/redux/hooks.ts:39`      | `useDispatch.withTypes<AppDispatch>()` — use instead of bare `useDispatch`                                                                                                                |
+| `ReduxProvider`  | `src/lib/redux/providers.tsx:62` | Client wrapper supplying the store                                                                                                                                                        |
+
+### Slices (defer field/action shapes to source)
+
+Both slices default OFF and are persisted; their actions/selectors are the stable surface. Read the source for exact field names and payload types (volatile).
+
+| Slice                              | Source                                                  | Actions                                                                                    | Selectors                                                                                               | Sync mechanism                                           |
+| ---------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `electronSettings` (window chrome) | `src/lib/redux/slices/electronSettingsSlice.ts:101-106` | `setHideAppIcon`, `setShowInMenuBar`, `setStartAtLogin`, `resetSettings`                   | `selectHideAppIcon`, `selectShowInMenuBar`, `selectStartAtLogin`, `selectElectronSettings` (`:115-144`) | IPC → main process (via `ElectronStartupSync`)           |
+| `preferences` (todo experience)    | `src/lib/redux/slices/preferencesSlice.ts:94-99`        | `setCompletionSound`, `setRetainCompletedInList`, `hydratePreferences`, `resetPreferences` | `selectCompletionSound`, `selectRetainCompletedInList`, `selectPreferences` (`:109-129`)                | `BroadcastChannel` → other windows (via sync middleware) |
+
+Implementation gotchas worth knowing before editing a slice:
+
+- **Selectors read through `?? DEFAULT`** (`preferencesSlice.ts:101-129`) because the storage middleware's shallow-merge drops any field added to a slice _after_ a user persisted an older blob; coalescing avoids surfacing `undefined`.
+- **`hydratePreferences`** applies an inbound cross-window snapshot **without** re-broadcasting (it is excluded from the broadcastable action set), which breaks the echo loop. The sync middleware is `createPreferencesSyncMiddleware()` at `src/lib/preferences-sync-channel.ts:76`, wired in at `store.ts:76`. Field-level validation lives at `preferences-sync-channel.ts:38-55`.
+
+To add a persisted setting (and choose broadcast vs IPC), see [howto-add-route-or-setting.md](./howto-add-route-or-setting.md). For the full state-ownership and cross-window-sync rationale, see [explanation-state-and-sync.md](./explanation-state-and-sync.md).
+
+## Feature components
+
+The user-facing UI layer. Home-screen components live under `src/app/(main)/home/_components/`; desktop/dialog/settings surfaces live under `src/components/`. Each is a `memo`/`React.memo` component; defer props/types to the source (the brief seed lists them but they rot pre-launch).
+
+| Component                       | Source                                                                | One line                                                                                                                                                                                                                   |
+| ------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `ContributionGraph`             | `src/app/(main)/home/_components/ContributionGraph.tsx:184`           | The Activity Heatmap hero (`@uiw/react-heat-map`): warm intensity tokens, monthly-peak overlay, category tooltip, cell-click → `DayDetailDialog`, `?date=` deep-link                                                       |
+| `TodoList`                      | `src/app/(main)/home/_components/TodoList.tsx:63`                     | Home orchestrator: pending column (add form + import + drag-sortable rows) and completed column (heatmap, summaries, completed list); wires the todo/heatmap/category hooks                                                |
+| `TodoItem` (+ `Todo` interface) | `src/app/(main)/home/_components/TodoItem.tsx:50` (interface `:23`)   | Single row: checkbox (fires completion feedback on false→true), notes collapsible, drag handle, delete; hides trash when completed + 居残りモード (D14). `Todo` is the canonical todo shape across surfaces                |
+| `DayDetailDialog`               | `src/app/(main)/home/_components/DayDetailDialog.tsx:201`             | Per-day modal reading `orpc.completed.dayDetail`; `getDayState` (`:61`) is a `ts-pattern` mapping count → affirming copy + band token; `j`/`k` navigation; share-as-image                                                  |
+| `CompletedTodos`                | `src/app/(main)/home/_components/CompletedTodos.tsx:44`               | Infinite-scroll completed list (`useInfiniteQuery`, `IntersectionObserver`), grouped by date, Clear-all dialog, empty state surfacing import                                                                               |
+| `PasteImport`                   | `src/components/import/PasteImport.tsx:86`                            | oRPC **container** for bulk paste-import; idempotent `importBatchId` (reused on retry → P2002 no-op), 10s Sonner Undo; zones `'completed'                                                                                  | 'todo'` |
+| `PasteImportDialog`             | `src/components/import/PasteImportDialog.tsx:115`                     | Presentational, **oRPC-free** dialog shell (Storybook-renderable): zone copy, live `computePasteImportPreview` parsing, per-row category override                                                                          |
+| `ImportUndoBanner`              | `src/components/import/ImportUndoBanner.tsx:42`                       | 60s inline undo banner for the most recent import (D5); Todo zone also offers Move-to-Completed (create-before-delete)                                                                                                     |
+| `BrainDumpEditor`               | `src/components/braindump/BrainDumpEditor.tsx:128`                    | Electron-only frameless markdown panel; `Cmd/Ctrl+Enter` toggles a `[ ]`↔`[x]` checkbox → creates/deletes a Completed row (title-based line lookup); per-category note persistence via `brainDumpAPI.note.set` (debounced) |
+| `FloatingNavigator`             | `src/components/floating-navigator/FloatingNavigator.tsx:343`         | Presentational, **props-only** always-on-top desktop window shell (todo rows, category pills, dnd reorder, Electron window controls). Barrel: `src/components/floating-navigator/index.ts`                                 |
+| `FloatingNavigatorContainer`    | `src/components/floating-navigator/FloatingNavigatorContainer.tsx:48` | Data-wiring layer for the floating window (hooks + oRPC queries → props down to `FloatingNavigator`)                                                                                                                       |
+| `SkillTreeView`                 | `src/app/(main)/skill-tree/SkillTreeView.tsx:57`                      | Skill-tree page: `useOptimistic` + `startTransition` + dnd-kit to drag completed-todo cards onto skill nodes; wires `orpc.skillTree.*`; `todoText` snapshot survives source-todo deletion                                  |
+| `PreferencesSettings`           | `src/components/settings/PreferencesSettings.tsx:28`                  | Web-common settings card: the 居残りモード and completion-sound switches; writes `preferencesSlice`                                                                                                                        |
+| `CategoryFilterChips`           | `src/app/(main)/home/_components/CategoryFilterChips.tsx:198`         | Per-category 7-day trend chips; collapses to a `Select` on mobile at ≥5 categories; toggles `useSelectedCategory`                                                                                                          |
+
+> The **presentational/container split** (`FloatingNavigator` vs `FloatingNavigatorContainer`; `PasteImportDialog` vs `PasteImport`) deliberately keeps the visual shell renderable/testable without a server. The desktop-only surfaces (`BrainDumpEditor`, `FloatingNavigator`) are inert on the web — they render only when their Electron preload bridge (`brainDumpAPI` / `floatingNavigatorAPI`) is present; see [reference-electron.md](./reference-electron.md).
+
+For the heatmap-as-hero, no-dedup, and archive-before-delete invariants these components encode, see [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md) and `DESIGN.md`.
+
+## Data hooks
+
+The React-Query / state hooks that wire feature components to oRPC and to client state. Defer return-shape details to the source.
+
+| Hook                    | Source                                  | One line                                                                                                                                                                                                                                                                               |
+| ----------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useTodoMutations`      | `src/hooks/useTodoMutations.ts:60`      | Central optimistic todo CRUD/reorder (`onMutate`→`onError`→`onSettled`); `isRetaining` drives 居残りモード; `deleteCompletedWithUndo` (`:612`) archives-then-deletes so the heatmap day survives; invalidates pending/completed/category/skillTree/heatmap/dayDetail keys + broadcasts |
+| `useHeatmapData`        | `src/hooks/useHeatmapData.ts:46`        | Fetches `orpc.completed.heatmap` and memoizes the derived per-date `Map` + array; exports `HeatmapCategory` (`:14`) and `HeatmapDay` (`:26`) — the universal input to every `src/lib` aggregator                                                                                       |
+| `useCategoryMutations`  | `src/hooks/useCategoryMutations.ts:36`  | Optimistic category CRUD via `orpc.category.*`; delete also invalidates the todo base key (orphaned todos reassign to the default category server-side)                                                                                                                                |
+| `useCompletionFeedback` | `src/hooks/useCompletionFeedback.ts:63` | Returns the checkbox amber-fill motion class + `fire()` that plays the opt-in synthesized completion tone (default OFF); module-level singleton `AudioContext`/oscillator enforce one sound app-wide; `resetCompletionFeedbackAudioForTest` at `:139`                                  |
+| `useSelectedCategory`   | `src/hooks/useSelectedCategory.ts:82`   | Persists the active category filter under `localStorage` key `corelive-selected-category` via `useSyncExternalStore` + cross-tab `StorageEvent`; `useAutoSelectDefaultCategory` (`:121`) auto-picks the default category                                                               |
+| `useKeyboardNav`        | `src/hooks/useKeyboardNav.ts:36`        | Global key handler for `DayDetailDialog` (`j` = next day, `k` = prev); guards IME composition and skips input/textarea/contentEditable targets; `Esc` delegated to the Radix Dialog                                                                                                    |
+
+Pure domain helpers consumed by these hooks/components (streaks, weekly/yearly rollups, category trends, heatmap intensity, paste parsing, share-image) live under `src/lib/` and are documented in [explanation-state-and-sync.md](./explanation-state-and-sync.md) and [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md).
+
+## Lifecycle-effect hooks (cheatsheet)
+
+Named wrappers around `useEffect` that make the lifecycle intent obvious at the call site (`src/hooks/use-*-effect.ts`). Prefer these over a raw `useEffect`; reach for raw `useEffect` only when none fits. **`useCycleEffect` is the 1:1 alias of `useEffect` and the de-facto default** (the most-used wrapper in the codebase). The JSDoc in each file carries `@example`s.
+
+| Hook               | Fires                                                                                                     | Allows `[]`?                                                                                                                       | Source                                 |
+| ------------------ | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `useInitialEffect` | Once, after mount (cleanup supported)                                                                     | n/a — always mount-only                                                                                                            | `src/hooks/use-initial-effect.ts:18`   |
+| `useUpdateEffect`  | On post-mount re-renders only (skips the mount run)                                                       | No — `[]` is a **compile-time** error (use `useInitialEffect`); wraps effect in `useEffectEvent` to always call the latest closure | `src/hooks/use-update-effect.ts:32-54` |
+| `useRenderEffect`  | Every render, or mount + whenever a non-empty dep changes                                                 | No — `[]` rejected at compile time                                                                                                 | `src/hooks/use-render-effect.ts:54-65` |
+| `useUnmountEffect` | Only on unmount (latest callback via `useEffectEvent`)                                                    | n/a                                                                                                                                | `src/hooks/use-unmount-effect.ts:17`   |
+| `useCycleEffect`   | Mount + dep changes — **1:1 alias of `useEffect`** (the default)                                          | **Yes** — the only wrapper that accepts `[]`                                                                                       | `src/hooks/use-cycle-effect.ts:30`     |
+| `useMounted`       | Returns SSR-safe boolean (`false` on server, `true` on client) via `useSyncExternalStore` — not an effect | n/a                                                                                                                                | `src/hooks/use-mounted.ts:39`          |
+
+> `useMounted` uses an empty `subscribe` deliberately: the mounted value never changes after the first client render, so there is no re-render cascade (unlike a `useState` + `useEffect` approach). It exists to avoid hydration-mismatch warnings for client-only UI.
+
+## Error boundaries
+
+| Boundary                             | Source                         | Catches                                                     | Notes                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------ | ------------------------------ | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RouteError` (route boundary)        | `src/app/error.tsx:47`         | Throws inside a page subtree                                | On-brand recovery card with a `reset()` "Try again" button; logs the real error via `log.error` on mount                                                                                                                                                                                                                   |
+| `GlobalError` (root-layout boundary) | `src/app/global-error.tsx:115` | Throws from the root layout / its providers / `globals.css` | The **last** line of defense: renders its own `<html>`/`<body>` with inline (token-free) styles and a `console.error`-only logger. **Intentionally dependency-free** — importing shadcn UI / design tokens / the app logger would re-enter the exact import graph that may have failed. Rationale: `global-error.tsx:3-21` |
+
+A primary motivation for the two-tier strategy is **Electron version-skew**: an installed app's frozen preload missing a method can throw out of a layout effect, escaping `error.tsx` from the root layout. See [explanation-state-and-sync.md](./explanation-state-and-sync.md) and the in-file docstring at `global-error.tsx:3-21`.
+
+## See also
+
+- [reference-orpc-api.md](./reference-orpc-api.md) — the server procedures these hooks call
+- [reference-data-model.md](./reference-data-model.md) — Prisma models behind the queries
+- [reference-electron.md](./reference-electron.md) — windows, IPC, preload bridges, native managers
+- [reference-theme-system.md](./reference-theme-system.md) — the theme registry → build-time CSS pipeline
+- [reference-auth.md](./reference-auth.md) — Clerk auth, the protected matcher, the Electron OAuth exchange
+- [explanation-state-and-sync.md](./explanation-state-and-sync.md) — client-state ownership & cross-window sync (the "why" for this reference)
+- [explanation-architecture.md](./explanation-architecture.md) — one codebase, two runtimes, one data path
+- [howto-add-route-or-setting.md](./howto-add-route-or-setting.md) — add a route or a persisted client setting
+- The hub index: [README.md](./README.md)

--- a/docs/dev/reference-orpc-api.md
+++ b/docs/dev/reference-orpc-api.md
@@ -1,0 +1,119 @@
+# oRPC API reference
+
+The complete oRPC procedure surface — the single type-safe HTTP API shared identically by the web app and the Electron renderer. This is a point-to-source index: it names every procedure, its router path, and its source `file:line`, then defers exact input/output shapes to the Zod schemas, because this repo is pre-launch and reshapes schemas/APIs freely (see `README.md:13`).
+
+For the _why_ behind this layer, read [explanation-architecture.md](./explanation-architecture.md) (one codebase, two runtimes, one data path) and [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md) (the archive-on-delete invariant). To add a procedure, see [howto-add-orpc-procedure.md](./howto-add-orpc-procedure.md).
+
+---
+
+## Cross-cutting invariants
+
+These hold for the **entire** surface. Read them once; they are not repeated per procedure.
+
+| #   | Invariant                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Source                                                                |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 1   | **Every procedure requires authentication.** All procedures are built from `authMiddleware` — there are **no** unauthenticated procedures. It reads the `authorization` header, strips `Bearer `, treats the remainder as the Clerk user id, and `prisma.user.upsert`s the `User` row (so the first API call auto-provisions a user the Clerk webhook hasn't synced yet). A missing/empty token throws `ORPCError('UNAUTHORIZED')`.                                                                                                                   | `src/server/middleware/auth.ts:10` (upsert `41`, `UNAUTHORIZED` `34`) |
+| 2   | **`context.user` is the Prisma `User`.** Handlers receive `context.user` (a full Prisma `User`) and scope every query by `user.id` (internal int PK). The Clerk id string is never used past the middleware.                                                                                                                                                                                                                                                                                                                                          | `src/server/middleware/auth.ts:6` (`AuthContext`), `50` (inject)      |
+| 3   | **Query vs. mutation is a client convention, not a server tag.** oRPC `.handler()` does not mark a procedure read-or-write. The R/W column below is the _semantic intent_; the client (`@orpc/tanstack-query`) exposes `.queryOptions()` / `.mutationOptions()` / `.key()` on every procedure and the consumer picks.                                                                                                                                                                                                                                 | `src/lib/orpc/client-query.ts:21`                                     |
+| 4   | **`importBatchId` idempotency on bulk creates.** `todo.createMany` / `completed.createMany` insert an `ImportBatch` guard row in the **same** transaction as the `createMany`, keyed on a client-generated `importBatchId`. A duplicate id throws Prisma `P2002` — caught **outside** the transaction (a failed statement aborts the PG tx) — and the handler re-queries the prior count and returns `{ count, idempotent: true }`. No dedup of titles (repetition is an intentional habit/XP signal).                                                | `src/server/procedures/todo.ts:398` (guard + tx), `409` (P2002 catch) |
+| 5   | **60s undo window on destructive deletes.** Single `completed.delete` and the bulk `*.deleteMany` endpoints only remove rows whose `createdAt` is within `COMPLETED_UNDO_WINDOW_MS` (60s) — older rows are out of reach, so a leaked token can't weaponize them against historical data. The window keys off `createdAt` (the real insert time), never the semantic `completedAt`.                                                                                                                                                                    | `src/lib/constants/import.ts:21`; `src/server/procedures/todo.ts:456` |
+| 6   | **Archive-on-clear / archive-on-delete (heatmap safety).** The heatmap reads completed `Todo` rows directly, so hard-deleting a completed todo erases its heatmap day. Instead, completed todos are **copied into the `Completed` table (always `archived:false`) before the `Todo` row is removed**, inside one transaction, by the shared `archiveCompletedTodos` util. `todo.clearCompleted` archives all completed; `todo.delete` archives a single one _only if it is completed_. Pending todos are still hard-deleted (no heatmap day to lose). | `src/server/utils/archiveCompletedTodos.ts:13` (load-bearing doc)     |
+| 7   | **Negative-id optimistic no-op.** `todo.update`, `todo.delete`, `todo.toggle` accept `z.number().int()` (**not** positive) and silently no-op for `id < 0` (return `null` / `{ success: true }`), because the client creates optimistic rows with temp id `-Date.now()`. The client's `onSettled` invalidation reconciles with real server state.                                                                                                                                                                                                     | `src/server/procedures/todo.ts:130`, `164`, `217`                     |
+| 8   | **Output is re-validated; Dates round-trip via a custom serializer.** Every procedure declares an output Zod schema (not just input), so DB results are re-validated at the boundary. A custom RPC serializer (type `21`) serializes `Date` to ISO strings and deserializes back to `Date`, so renderer code receives real `Date` objects deterministically.                                                                                                                                                                                          | `src/lib/orpc/serializer.ts:3`                                        |
+
+> **Dev-only auth fixture:** `authMiddleware` has a development-only branch that accepts the literal token `user_mock_user_id` and upserts a fixed test user (`src/server/middleware/auth.ts:17`). It still runs through the same middleware, so invariant #1 holds — this is a test fixture, not an auth bypass.
+
+---
+
+## Transport & wiring
+
+| Concern                | What                                                                                                                                                                                                                                                                                                                                                                    | Source                                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **Mount point**        | A single catch-all route hosts `new RPCHandler(router)` with `prefix: '/api/orpc'` and `context: { headers: request.headers }`, exported as `GET`/`POST`/`PUT`/`PATCH`/`DELETE`. A thrown `ORPCError` is serialized by oRPC; any other throw becomes a `500` JSON with `message` + `stack`.                                                                             | `src/app/api/orpc/[...path]/route.ts:7` (handler), `15` (context), `39`–`43` (verb exports) |
+| **Router**             | Plain nested object literal grouping procedures into 5 namespaces (`category` / `todo` / `completed` / `electronSettings` / `skillTree`). `export type AppRouter = typeof router` is the type the client is generated from.                                                                                                                                             | `src/server/router.ts:37` (tree), `75` (`AppRouter`)                                        |
+| **Client builder**     | `createLink()` builds an `RPCLink` whose `url()` is `` `${window.location.origin}/api/orpc` `` (throws on the server — client-only) and whose async `headers()` reads `window.Clerk.session?.user?.id ?? window.Clerk.user?.id` and returns `Authorization: Bearer <id>` (or `{}` → `UNAUTHORIZED` if Clerk isn't loaded). Web and Electron use the **identical** path. | `src/lib/orpc/create-client.ts:16` (`url` `18`, `headers` `24`)                             |
+| **React Query bridge** | `createTanstackQueryUtils(client)` exports `orpc` — the object every component uses as `orpc.<ns>.<proc>.queryOptions()` / `.mutationOptions()` / `.key()`.                                                                                                                                                                                                             | `src/lib/orpc/client-query.ts:21`                                                           |
+| **Consumer pattern**   | `useTodoMutations.ts` is the canonical consumer: optimistic `onMutate` snapshot → `onError` rollback → `onSettled` cross-query invalidation fan-out (category / skillTree / heatmap / dayDetail).                                                                                                                                                                       | `src/hooks/useTodoMutations.ts`                                                             |
+
+> **Schemas.** Input/output Zod schemas live in `src/server/schemas/<namespace>.ts` — one file per namespace: `category.ts`, `todo.ts`, `completed.ts`, `electronSettings.ts`, `skillTree.ts`. Each procedure imports its schemas from there. **This doc does not transcribe field shapes or constraints** (they churn on `db:reset`); open the namespace schema file for the exact `z.object` shape.
+
+---
+
+## Procedures
+
+Each table: router path → source `file:line` → **R/W** (semantic read/write intent per invariant #3) → one-line purpose. Exact input/output shapes live in `src/server/schemas/<namespace>.ts`.
+
+### `category` — `src/server/procedures/category.ts`
+
+Schemas: `src/server/schemas/category.ts`
+
+| Router path       | Source            | R/W | Purpose                                                                                                                                                                        |
+| ----------------- | ----------------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `category.list`   | `category.ts:43`  | R   | Lists the user's categories with `_count.todos` (counts only `completed:false` todos, for sidebar badges), ordered `createdAt` asc.                                            |
+| `category.create` | `category.ts:79`  | W   | Creates a category. Duplicate name (`@@unique([name, userId])`) → `ORPCError('CONFLICT')`.                                                                                     |
+| `category.update` | `category.ts:124` | W   | Partial update; ownership-checked (`findFirst` by id + userId, else `NOT_FOUND`). Rename collision → `CONFLICT`.                                                               |
+| `category.delete` | `category.ts:182` | W   | Reassigns the category's `Todo` **and** `Completed` rows to the user's default category, then deletes — one transaction. `FORBIDDEN` if `isDefault`; `NOT_FOUND` if not owned. |
+
+### `todo` — `src/server/procedures/todo.ts`
+
+Schemas: `src/server/schemas/todo.ts`
+
+| Router path           | Source        | R/W | Purpose                                                                                                                                                                                                                                       |
+| --------------------- | ------------- | --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `todo.list`           | `todo.ts:27`  | R   | Paginated todos for the user, ordered `order asc, createdAt desc`. Optional `completed` / `categoryId` filters.                                                                                                                               |
+| `todo.create`         | `todo.ts:76`  | W   | Creates a todo; verifies category ownership first (`NOT_FOUND` otherwise).                                                                                                                                                                    |
+| `todo.createMany`     | `todo.ts:351` | W   | Bulk paste-import into the active (incomplete) zone. Idempotent on `importBatchId` (invariant #4). Normalizes + drops empty titles (`BAD_REQUEST` if all empty); foreign `categoryId` → `NOT_FOUND`. No dedup.                                |
+| `todo.update`         | `todo.ts:116` | W   | Partial update; **cannot** change `completed` (by design — completion flows only through `toggle`). `id < 0` → `null` (optimistic temp). Ownership-checked else `NOT_FOUND`.                                                                  |
+| `todo.delete`         | `todo.ts:155` | W   | `id < 0` → `{ success: true }` no-op. In **one tx**: archive-if-completed via `archiveCompletedTodos` (heatmap-safe), else hard-delete pending. TOCTOU-safe — the archive-vs-delete decision is made inside the tx. `NOT_FOUND` if not owned. |
+| `todo.deleteMany`     | `todo.ts:449` | W   | Bulk-undo a paste batch: atomic `deleteMany` by `importBatchId`, guarded by the 60s `createdAt` window (invariant #5). Returns `0` once expired.                                                                                              |
+| `todo.toggle`         | `todo.ts:208` | W   | Flips `completed`. `id < 0` → `null`. On false→true stamps `completedAt = now()`; on true→false `deleteMany`s `NodeAssignment` rows (double-XP guard) — both in one tx. `NOT_FOUND` if not owned.                                             |
+| `todo.clearCompleted` | `todo.ts:262` | W   | (No input.) Archive-and-remove **all** completed todos via `archiveCompletedTodos` in one tx (heatmap day survives as `archived:false` `Completed` rows).                                                                                     |
+| `todo.reorder`        | `todo.ts:283` | W   | Batch-updates `order` in one tx (drag-drop). Verifies ownership of every id (`NOT_FOUND` lists offenders). Empty list → success.                                                                                                              |
+
+### `completed` — `src/server/procedures/completed.ts`
+
+Schemas: `src/server/schemas/completed.ts`. The heatmap/day-detail readers UNION `Todo` + `Completed` via `fetchCompletedEntries` (`src/server/utils/completedAggregation.ts:61`) — see [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md).
+
+| Router path            | Source             | R/W | Purpose                                                                                                                                                                                                                                                                   |
+| ---------------------- | ------------------ | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `completed.heatmap`    | `completed.ts:43`  | R   | UTC-bucketed daily activity from the `Todo`+`Completed` UNION, with per-day category rollup and consecutive-day streaks. Window = exactly N UTC dates ending today.                                                                                                       |
+| `completed.dayDetail`  | `completed.ts:208` | R   | One UTC day's completions (UNION) for the day-detail dialog. `(source, id)` is the React key — `Todo.id` and `Completed.id` are independent sequences and can collide.                                                                                                    |
+| `completed.create`     | `completed.ts:278` | W   | Inserts directly into `Completed` (BrainDump checkbox-tick path, bypasses the `Todo` lifecycle). Verifies category ownership (`NOT_FOUND`).                                                                                                                               |
+| `completed.createMany` | `completed.ts:399` | W   | Bulk paste-import into `Completed` (lights the heatmap). Idempotent on `importBatchId` (invariant #4). `completedAt` defaults to `now()`; `createdAt` stays separate (undo window). Normalize + drop empty (`BAD_REQUEST`); foreign `categoryId` → `NOT_FOUND`. No dedup. |
+| `completed.delete`     | `completed.ts:329` | W   | Hard-deletes a `Completed` row **only** within the 60s `createdAt` window (atomic conditional `deleteMany`). `FORBIDDEN` if expired, `NOT_FOUND` if missing. Used by the BrainDump toast-undo.                                                                            |
+| `completed.deleteMany` | `completed.ts:497` | W   | Bulk-undo a paste batch: atomic `deleteMany` by `importBatchId`, guarded by the 60s `createdAt` window. Returns `0` once expired.                                                                                                                                         |
+
+### `electronSettings` — `src/server/procedures/electronSettings.ts`
+
+Schemas: `src/server/schemas/electronSettings.ts`
+
+| Router path               | Source                    | R/W | Purpose                                                                                                                            |
+| ------------------------- | ------------------------- | --- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `electronSettings.get`    | `electronSettings.ts:48`  | R   | (No input.) Returns the user's `ElectronSettings`, creating a defaults row on first access (concurrent-create `P2002` → re-fetch). |
+| `electronSettings.upsert` | `electronSettings.ts:124` | W   | Prisma upsert (create with defaults + input, or update with input). Partial — only provided fields change.                         |
+
+### `skillTree` — `src/server/procedures/skillTree.ts`
+
+Schemas: `src/server/schemas/skillTree.ts`. See [explanation-completion-and-heatmap.md](./explanation-completion-and-heatmap.md) for how completed-todo XP feeds this.
+
+| Router path                   | Source             | R/W | Purpose                                                                                                                                                                                                                                                                 |
+| ----------------------------- | ------------------ | --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `skillTree.getMyTree`         | `skillTree.ts:177` | R   | (No input.) Returns the user's skill tree; on first visit seeds the default template (batched `createMany`, one tx). Concurrent first-visit `P2002` on `@@unique([userId])` → re-query winner. Assignments filtered to orphaned (`todoId` null) **or** still-completed. |
+| `skillTree.getUnassignedPool` | `skillTree.ts:227` | R   | (No input.) Completed todos not yet assigned to any node, newest first. Narrow `{ id, text }` shape on purpose (avoids leaking PII into the localStorage persister).                                                                                                    |
+| `skillTree.assignTask`        | `skillTree.ts:262` | W   | Assigns a **completed** todo to a node (ownership + `requireCompleted`). Move-supported: `deleteMany` existing assignment then create, in one tx. Snapshots `todoText`. Concurrent `P2002`/`P2003`/`P2025` → `NOT_FOUND` (converge).                                    |
+| `skillTree.unassignTask`      | `skillTree.ts:335` | W   | Removes a todo's assignment. Returns `null` on node mismatch / already-gone (`P2025`) so the client reconciles. `todoId` is globally `@@unique` → single row.                                                                                                           |
+
+---
+
+## Error model
+
+| Condition                          | Result                                                                                                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Missing / empty Bearer token       | `ORPCError('UNAUTHORIZED')` — `src/server/middleware/auth.ts:34`                                                                                       |
+| Row not owned by `context.user`    | `ORPCError('NOT_FOUND')` (per-procedure ownership `findFirst`)                                                                                         |
+| Unique-constraint clash (`P2002`)  | Translated per procedure — `CONFLICT` (category), idempotent re-query (bulk creates), `NOT_FOUND` (`assignTask` race)                                  |
+| Delete outside the 60s window      | `completed.delete` → `FORBIDDEN`; bulk `*.deleteMany` → `{ count: 0 }`                                                                                 |
+| All paste lines normalize to empty | `ORPCError('BAD_REQUEST')` (bulk creates)                                                                                                              |
+| Any other uncaught throw           | oRPC serializes `ORPCError`s; the route handler turns anything else into a `500` JSON (`message` + `stack`) — `src/app/api/orpc/[...path]/route.ts:23` |
+
+Prisma error codes referenced above: `P2002` (unique violation), `P2003` (FK violation), `P2025` (record not found). These are caught in handlers and translated to `ORPCError`s; they never reach the client raw.

--- a/docs/dev/reference-theme-system.md
+++ b/docs/dev/reference-theme-system.md
@@ -1,0 +1,135 @@
+# Theme system reference
+
+A point-to-source surface map for CoreLive's theme system: 12 themes (Warm Cathedral light/dark default + 5 colored families × light/dark) derived from a single TypeScript registry into static CSS at build time, plus the heatmap intensity SSoT. The authoritative _why_ lives in [`DESIGN.md`](../../DESIGN.md) ("Theme System" and "Heatmap Invariance Rule"). This file is the _what / where_.
+
+> **Volatility note.** This repo reshapes schemas and seed values freely (no migrations kept). Per-theme OKLCH seeds, the ~36 token names, and exact contrast ratios are deliberately **not** transcribed here — they rot on the next theme tweak. Each surface is named and anchored to `file:line`; open the source for current shapes.
+
+## Cross-cutting invariants
+
+These rules govern the whole surface. Most are CI-enforced.
+
+| Invariant                                                                                                                                                                                                                                                                           | Where it lives / is enforced                                                                                               |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Registry is the single source of truth.** Add a theme by appending a `ThemeFamilyId` + a light/dark seed to `THEME_REGISTRY` — never in `globals.css`, the provider, or the picker. `THEME_IDS`, `THEME_META`, `THEME_FAMILY_IDS`, and `useThemeAxis` all derive from it.         | `src/lib/themes/registry.ts:94` (`satisfies Record<ThemeId, ThemeSeed>` at `:290`)                                         |
+| **Cathedral is never machine-generated.** The generator skips every `preserve: true` theme; the brand stays hand-authored in `globals.css` and is pinned byte-for-byte by a snapshot test (so the `CATHEDRAL` mirror in the generator cannot drift).                                | generator filter `!theme.preserve` at `scripts/generate-theme-css.ts:329`; `src/lib/themes/cathedral-css-snapshot.test.ts` |
+| **Derived blocks use `:root[data-theme='id']` (specificity `0,2,0`).** This outranks cathedral's `:root` (`0,1,0`) regardless of `@import` order. A bare `[data-theme]` (`0,1,0`) would tie and lose.                                                                               | emitted at `scripts/generate-theme-css.ts:303`; asserted `generate-theme-css.test.ts:196`                                  |
+| **Tailwind `dark:` is bound to `data-theme`, not the OS.** `@custom-variant dark` keys off `[data-theme$=dark]`, matching the flat `dark` id **and** every `*-dark` id, mirroring `getThemeMode()`. `:where()` keeps specificity at 0.                                              | `src/globals.css:20`; mirrored in charts at `src/components/ui/chart.tsx:33`                                               |
+| **`culori` (OKLCH/WCAG math) is build/test-only.** It is a `devDependency`; importing it at runtime would pull color math back into the client bundle, which the static-CSS architecture exists to prevent. The runtime picker preview re-derives swatches without it.              | `src/lib/themes/contrast.ts:10` and `scripts/generate-theme-css.ts:22` import it; `src/lib/themes/preview.ts` does **not** |
+| **Heatmap temperature = pride.** The two hottest stops (`--hm-3`, `--hm-4`) must have hue ∈ `[20, 70]` on **every** derived theme — never GitHub-green. This is the only seed-controlled heatmap axis (L/C are reused from cathedral).                                              | `src/lib/themes/generate-theme-css.test.ts:296` (`WARM_BAND_MIN_HUE`/`WARM_BAND_MAX_HUE` 20–70, `WARMEST_STOPS`)           |
+| **The `@import` block in `globals.css` must stay contiguous.** Turbopack `next dev` stops inlining `@import` after a comment/blank break and silently drops `generated.css` → every colored family falls back to cathedral in dev with no error (production webpack is unaffected). | `src/globals.css:1`–`4`; guarded by `src/lib/themes/globals-import-contiguity.test.ts`                                     |
+
+## Theme model
+
+- **6 families, 12 themes.** Warm Cathedral (default) + Harbor, Grove, Rose Tea, Iris, Graphite — each in `{light, dark}`. Family list and seeds: `src/lib/themes/registry.ts:23` (`ThemeFamilyId`), `:94` (`THEME_REGISTRY`).
+- **Stored id shape.** Cathedral keeps the **flat** ids `light` / `dark` (zero migration). Colored families use `` `${family}-${mode}` `` (e.g. `harbor-dark`). Type at `registry.ts:37` (`ThemeId`).
+- **Two independent axes.** The picker treats _family_ and _mode_ as separate axes even though only one id is stored. `useThemeAxis` (`src/hooks/useThemeAxis.ts:66`) maps the stored id ↔ `(family, mode)`.
+- **`System` belongs to cathedral only** (Fork-A rule). System is OS-managed (a light↔dark axis, not a palette). Colored families expose Light/Dark only; picking a colored family while on System collapses to an explicit id. Encoded in `availableModes` and `setFamily`/`setMode` at `useThemeAxis.ts:82`–`118`.
+- **Persistence is 100% web.** `next-themes` writes `localStorage` under `storageKey="corelive-theme"` and sets `data-theme` on `<html>`. The Electron shell reads nothing native. Provider config: `src/providers/ThemeProvider.tsx:56`–`65`.
+
+The family-signature **hue table** and the heatmap **OKLCH palette table** are owned by [`DESIGN.md`](../../DESIGN.md) ("Theme System", "Heatmap palette") — consult it rather than this file for those values.
+
+## Public surface
+
+### Registry helpers — `src/lib/themes/registry.ts`
+
+Framework-agnostic (no `'use client'`); imported by the generator, tests, Electron, and React alike.
+
+| Symbol                                    | Signature                                                                              | Anchor                                              | Purpose                                                                                                                                                                                                            |
+| ----------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `THEME_REGISTRY`                          | `Record<ThemeId, ThemeSeed>`                                                           | `registry.ts:94`                                    | SSoT — all 12 themes keyed by stored id. Cathedral pair is `PreservedTheme` (metadata only); 10 colored entries are `DerivedTheme` with OKLCH seeds.                                                               |
+| `isThemeId`                               | `(value: unknown) => value is ThemeId`                                                 | `registry.ts:306`                                   | Type guard via `Object.hasOwn`; rejects bare family names (`'harbor'`), unknown ids, non-strings, inherited keys. Backs the allowlist guard and the `useThemeAxis` stale-value fallback.                           |
+| `getThemeMode`                            | `(id: string \| undefined) => ThemeMode`                                               | `registry.ts:328`                                   | Resolves any id to its light/dark axis: `'dark'` for `dark` or any `*-dark` suffix, else `'light'` (incl. `undefined`). The `*-dark` suffix rule is load-bearing; mirrored by the `@custom-variant dark` selector. |
+| `getThemeId`                              | `(family: ThemeFamilyId, mode: ThemeMode) => ThemeId`                                  | `registry.ts:347`                                   | Builds the stored id for a `(family, mode)` pair: cathedral → flat `light`/`dark`, every other family → `` `${family}-${mode}` ``.                                                                                 |
+| `DEFAULT_THEME_ID`                        | `ThemeId` (`'light'`)                                                                  | `registry.ts:293`                                   | Fallback when nothing is stored or the id is unknown.                                                                                                                                                              |
+| `THEME_IDS`                               | `ThemeId[]`                                                                            | `registry.ts:311`                                   | Every registered id, derived from the registry.                                                                                                                                                                    |
+| `THEME_FAMILY_LABEL` / `THEME_FAMILY_IDS` | `Record<ThemeFamilyId, string>` / `ThemeFamilyId[]`                                    | `registry.ts:362` / `:377`                          | Human family names (cathedral → `'Warm Cathedral'`) and the default-first family-axis order for the picker.                                                                                                        |
+| Types                                     | `ThemeMode`, `ThemeFamilyId`, `ThemeId`, `ThemeSeed`, `PreservedTheme`, `DerivedTheme` | `registry.ts:14`, `:23`, `:37`, `:88`, `:65`, `:77` | `ThemeId` is a template literal that auto-expands when a family is added to `ThemeFamilyId`.                                                                                                                       |
+
+### Two-axis picker hook — `src/hooks/useThemeAxis.ts`
+
+| Symbol         | Signature         | Anchor               | Notes                                                                                                                                                                                                                                                                    |
+| -------------- | ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `useThemeAxis` | `() => ThemeAxis` | `useThemeAxis.ts:66` | Drives the Settings `ThemeSelector` + sidebar quick-switch. Returns `{ family, mode, isSystem, resolvedMode, activeId, availableModes, families, setFamily, setMode, mounted }` (interface at `:31`). Client component (`'use client'`). Encodes the Fork-A System rule. |
+
+### Build-time generator — `scripts/generate-theme-css.ts`
+
+**Build/test only** (imports `culori` via `contrast.ts`); never import in runtime app code. Run directly, it writes `src/lib/themes/generated.css`.
+
+| Symbol              | Signature                                          | Anchor                      | Notes                                                                                                                                                                                                                   |
+| ------------------- | -------------------------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `deriveThemeTokens` | `(seed: DerivationSeed) => Record<string, string>` | `generate-theme-css.ts:241` | Two-pass derivation of all 36 tokens for one theme: pass 1 neutral/accent/fixed/heatmap, pass 2 computed foregrounds reading their now-derived accent. Throws if a token lacks a `TOKEN_CATEGORY` classification.       |
+| `deriveThemeCss`    | `(theme: DerivedTheme) => string`                  | `generate-theme-css.ts:303` | Wraps one theme's tokens in a `:root[data-theme='id'] { … }` block — `color-scheme` first, then the token lines.                                                                                                        |
+| `generateThemesCss` | `(themes: readonly ThemeSeed[]) => string`         | `generate-theme-css.ts:327` | Emits the AUTO-GENERATED header + one block per **non-preserved** theme; header-only when all are preserved.                                                                                                            |
+| `CATHEDRAL`         | `Record<ThemeMode, Record<string, string>>`        | `generate-theme-css.ts:41`  | The cathedral token values copied verbatim from `globals.css` — the fixed lightness ladder + fixed-identity palette reused by every theme. Pinned to `globals.css` by the snapshot test.                                |
+| `TOKEN_CATEGORY`    | `Record<string, TokenCategory>`                    | `generate-theme-css.ts:132` | Classifies each token as `neutral` \| `accent` \| `computedFg` \| `fixed` \| `heatmap`. Fixed-identity tokens (`--destructive`, `--chart-1…5`) emit the cathedral value unchanged for all themes (design decision #15). |
+
+### Contrast utilities — `src/lib/themes/contrast.ts`
+
+**Build/test only** (`culori` is a `devDependency`).
+
+| Symbol               | Signature                     | Anchor           | Notes                                                                                                                                                                                                       |
+| -------------------- | ----------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contrastRatio`      | `(fg, bg) => number`          | `contrast.ts:38` | WCAG 2.x ratio (1–21), order-independent.                                                                                                                                                                   |
+| `meetsAA`            | `(fg, bg, large?) => boolean` | `contrast.ts:53` | AA gate. Thresholds `AA_TEXT_CONTRAST` / `AA_LARGE_CONTRAST` are the named constants at `contrast.ts:13`–`15` — read them there rather than inlining the numbers.                                           |
+| `readableForeground` | `(bg, candidates?) => string` | `contrast.ts:76` | Picks the highest-contrast foreground, so `--primary-foreground` is contrast-computed per theme, never hardcoded white. The generator passes its own `FOREGROUND_CANDIDATES` (`generate-theme-css.ts:190`). |
+
+> AA thresholds in `contrast.ts` (4.5 text / 3 large) and the per-surface gates DESIGN.md cites (e.g. `fg/bg ≥ 7`) are different checks for different pairs — consult each source directly; they are not reconciled here.
+
+### Runtime-safe preview — `src/lib/themes/preview.ts`
+
+Ships in the client bundle (no `culori`).
+
+| Symbol            | Signature                       | Anchor           | Notes                                                                                                                                                                                                                                                                                                                          |
+| ----------------- | ------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `getThemePreview` | `(id: ThemeId) => ThemePreview` | `preview.ts:101` | Composite swatch `{ surface, card, accent, text, heatmap[5] }` reconstructed from the registry seed at the cathedral ladder — identical to the generated CSS, cross-checked by `preview.test.ts`. Cathedral returns hand-copied `globals.css` values. Powers the picker family cards (`src/components/ThemeSelector.tsx:145`). |
+
+### Heatmap intensity SSoT — `src/lib/heatmap-intensity.ts`
+
+Runtime-safe. Maps a day's raw completion **count** to one of 5 levels; shared by the heatmap cells and the day-detail band so they can never drift.
+
+| Symbol                         | Signature                                                                       | Anchor                         | Notes                                                                                                                                                                 |
+| ------------------------------ | ------------------------------------------------------------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getHeatmapIntensityFromCount` | `(dayCount: number) => Intensity`                                               | `heatmap-intensity.ts:56`      | 5 bands: `0` rest, `1` = 1–3, `2` = 4–9, `3` = 10–19, `4` = 20+. Buckets the **raw** count including repeats; never dedups, never weights by recency/streak/category. |
+| `HEATMAP_LEVEL_TOKENS`         | `readonly ['var(--hm-0)' … 'var(--hm-4)']`                                      | `heatmap-intensity.ts:32`      | The 5 CSS `var(--hm-N)` tokens, indexed by `Intensity`.                                                                                                               |
+| Thresholds                     | `HEATMAP_GOOD_DAY_MIN=4`, `HEATMAP_FULL_DAY_MIN=10`, `HEATMAP_CATHEDRAL_MIN=20` | `heatmap-intensity.ts:19`–`25` | Named constants shared with the graph's `PANEL_COLORS` map.                                                                                                           |
+
+**Consumers:** `ContributionGraph.tsx` builds `PANEL_COLORS` (a `@uiw/react-heat-map` `panelColors` map) from these tokens at `src/app/(main)/home/_components/ContributionGraph.tsx:74` (passed as `panelColors={PANEL_COLORS}` at `:348`); `DayDetailDialog.tsx` resolves its band token at `src/app/(main)/home/_components/DayDetailDialog.tsx:64`.
+
+### Providers — `src/providers/`
+
+| Component             | Anchor                       | Role                                                                                                                                                                                                                                           |
+| --------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ThemeProvider`       | `ThemeProvider.tsx:50`       | Wraps `next-themes` (`attribute="data-theme"`, `storageKey="corelive-theme"`, `themes` from `THEME_IDS`, `enableColorScheme={false}`). Exports `THEMES` + `THEME_META` derived from the registry (`:22`, `:33`). Mounts the two helpers below. |
+| `ThemeAllowlistGuard` | `ThemeAllowlistGuard.tsx:26` | Post-mount self-heal: a stored id that is neither `system` nor a registered id (stale after a downgrade that dropped a family, or tampered) is rewritten to `DEFAULT_THEME_ID`. `next-themes` does not validate its own `localStorage`.        |
+| `ThemeTransition`     | `ThemeTransition.tsx:19`     | A `MutationObserver` on `<html>` `data-theme` adds a transient `theme-transition` class for one crossfade window (`THEME_CROSSFADE_DURATION_MS`), so the switch crossfades but hover/focus stay instant.                                       |
+
+## Application contract
+
+- **Attribute:** `next-themes` sets `data-theme` on `<html>`. `ThemeProvider.tsx:58`.
+- **Derived block selector:** `:root[data-theme='id'] { color-scheme: …; <tokens> }`, specificity `0,2,0`. `generate-theme-css.ts:303`.
+- **Dark variant binding:** `@custom-variant dark (&:where([data-theme$=dark], [data-theme$=dark] *))`. `globals.css:20`.
+- **Crossfade CSS:** an **unlayered** rule (so it beats Tailwind's layered `transition-*` utilities) under `@media (prefers-reduced-motion: no-preference)`, `200ms ease-out`, scoped to `html.theme-transition`. `globals.css:173`. `THEME_CROSSFADE_DURATION_MS` (`src/lib/constants/theme.ts:9`) **must** equal the CSS `200ms` or the class clears mid-fade.
+- **Generated output:** `src/lib/themes/generated.css` — AUTO-GENERATED, **do not edit**; one `:root[data-theme='id']` block per colored family (10 blocks). Cathedral is **not** here (it lives in `globals.css`). Committed and drift-checked.
+
+## Operational commands
+
+Both are defined in `package.json` `"scripts"` and run inside `pnpm validate`.
+
+```bash
+# Regenerate src/lib/themes/generated.css from the registry
+pnpm theme:generate    # package.json:36 → tsx scripts/generate-theme-css.ts
+
+# Fail if the committed generated.css is stale (regenerate + git diff --exit-code)
+pnpm theme:check       # package.json:37
+```
+
+`pnpm validate` (`package.json:40`) runs `theme:check` alongside `test` / `lint` / `build` / `typecheck`. The per-family WCAG AA gate and the temperature=pride gate run as part of `pnpm test` (`src/lib/themes/generate-theme-css.test.ts`).
+
+## Related, but separate
+
+`getColorDotClass` / `COLOR_DOT_CLASSES` (`src/lib/category-colors.ts:12,29`) is the per-**category** dot palette (blue/green/amber/rose/violet/orange → Tailwind `bg-*-500`). It uses Tailwind palette classes, **not** the OKLCH `--hm`/theme tokens, and is not part of this theme system.
+
+## See also
+
+- [`DESIGN.md`](../../DESIGN.md) — "Theme System" (the 10 governing rules + family/hue table) and "Heatmap Invariance Rule" (the three-tier temperature=pride guarantee). The canonical _why_.
+- `src/lib/themes/generate-theme-css.test.ts`, `cathedral-css-snapshot.test.ts`, `globals-import-contiguity.test.ts`, `preview.test.ts`, `contrast.test.ts`, `registry.test.ts`, `src/hooks/useThemeAxis.test.tsx` — the CI guards behind every invariant above.

--- a/docs/dev/tutorial-getting-started.md
+++ b/docs/dev/tutorial-getting-started.md
@@ -1,0 +1,346 @@
+# Getting Started: from clone to your first lit heatmap cell
+
+A hand-held, linear walkthrough that takes a brand-new contributor from a fresh
+clone all the way to the product's north-star moment: completing a task and
+watching that day light up on the Activity Heatmap. Follow every step in order
+— this is one happy path designed to succeed on the first try.
+
+> **You will run the web app only.** The macOS Electron wrapper loads the same
+> web app remotely and is **not** needed to reach the heatmap. Skip it for now;
+> see [the Electron architecture doc](../ELECTRON_ARCHITECTURE.md) when you are
+> ready.
+
+---
+
+## Prerequisites
+
+Install these before you start. The pinned versions are what CI uses — match
+them to avoid surprises.
+
+| Tool                                                                                                       | Version / note                              | Why                                                                                                                                                   |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Docker](https://docs.docker.com/get-docker/) + [Docker Compose](https://docs.docker.com/compose/install/) | any recent                                  | Runs the local PostgreSQL 17 database                                                                                                                 |
+| [Node.js](https://nodejs.org/)                                                                             | **24.13.0** (pinned — `package.json:11-12`) | Toolchain. Node 26 makes the unit-test tier fail (a `happy-dom` / `localStorage` gotcha), so the final `pnpm validate` step needs 24.13.0 to go green |
+| [pnpm](https://pnpm.io/)                                                                                   | `10.33.4` (pinned — `package.json:10`)      | The only supported package manager here                                                                                                               |
+| [Clerk](https://clerk.com/) account                                                                        | a free **Development** instance             | Authentication — there is no mock-auth path; you sign in for real                                                                                     |
+| [ngrok](https://ngrok.com/)                                                                                | optional for this tutorial                  | Only needed to deliver Clerk webhooks locally; this tutorial sidesteps that, so you can skip ngrok                                                    |
+
+> **Node version managers:** the repo pins Node via Volta (`package.json:11-12`).
+> If you use [Volta](https://volta.sh/) it will auto-switch to `24.13.0` inside
+> the repo. Otherwise install `24.13.0` yourself (e.g. `nvm install 24.13.0 &&
+nvm use 24.13.0`) and confirm with `node --version`.
+
+---
+
+## Step 1 — Clone the repository
+
+```bash
+git clone https://github.com/laststance/corelive.git
+cd corelive
+```
+
+**Expected:** a `corelive/` directory containing `package.json`, `compose.yml`,
+`prisma/`, and `src/`.
+
+---
+
+## Step 2 — Install dependencies
+
+```bash
+pnpm install
+```
+
+**Expected:** pnpm installs all packages, then a `postinstall` hook runs
+`pnpm prisma generate` (`package.json:21`) to generate the Prisma client. The
+run ends with no errors.
+
+---
+
+## Step 3 — Create your `.env` file
+
+Copy the example file:
+
+```bash
+cp .env.example .env
+```
+
+**Expected:** a new `.env` file in the repo root. Now open it and edit two
+groups of values (leave the rest as their placeholders for this tutorial).
+
+### 3a — Set the database URL
+
+`.env.example` ships a generic placeholder for `POSTGRES_PRISMA_URL`. Replace it
+with the exact connection string for the local database you will start in
+Step 4. The user, password, and database name come straight from
+`compose.yml:7-9`; the host and port (`localhost:5432`) come from the published
+port mapping (`compose.yml:11-12`):
+
+```dotenv
+POSTGRES_PRISMA_URL="postgresql://postgres:password@localhost:5432/corelive?schema=public"
+```
+
+The `localhost` host matters: every destructive Prisma command is guarded by
+`scripts/assert-local-db.cjs`, which only proceeds when the host is provably
+local. `localhost` passes the gate, so migrations will run.
+
+### 3b — Fill in your Clerk keys
+
+From your Clerk **Development** instance dashboard
+(<https://dashboard.clerk.com/>), copy your two API keys into `.env`:
+
+```dotenv
+CLERK_SECRET_KEY=sk_test_...your key...
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...your key...
+```
+
+Leave the three `NEXT_PUBLIC_CLERK_*` URL values at their `.env.example`
+defaults (`/login`, `/sign-up`, `/home`) — they already match this app's routes.
+
+> **Where the variables are documented:** the full required-variable table
+> (names, which side they run on, descriptions) lives in
+> [`README.md`](../../README.md#environment-variables). All Next.js env vars are
+> validated at startup by `src/env.mjs`, so the app refuses to boot if a
+> required one is missing. Do **not** invent variable names — use exactly the
+> keys present in `.env.example`.
+
+---
+
+## Step 4 — Start the local database
+
+CoreLive uses PostgreSQL 17 in a Docker container. The Compose file is named
+`compose.yml` (not `docker-compose.yml`); `docker compose` finds it
+automatically. Start **only** the `postgres` service:
+
+```bash
+docker compose up -d postgres
+```
+
+**Expected:** Docker pulls `postgres:17` (first run only) and starts a
+background container named `corelive-postgres` on port `5432`.
+
+> **Why name the service explicitly?** `compose.yml` also defines a
+> `network-delay` sidecar that simulates production latency — it is Linux-only
+> (`compose.yml:31-47`) and should not start on a Mac. Naming `postgres` keeps
+> it out.
+
+Wait until the container reports healthy before migrating (the health check has
+a 30s start period — `compose.yml:25`):
+
+```bash
+docker compose ps
+```
+
+**Expected:** the `corelive-postgres` row shows status `Up ... (healthy)`.
+If it still says `health: starting`, wait a few seconds and run it again.
+
+---
+
+## Step 5 — Apply database migrations
+
+```bash
+pnpm prisma:migrate
+```
+
+**Expected:** `scripts/assert-local-db.cjs` confirms the target host is local,
+then Prisma applies every migration in `prisma/migrations/` and regenerates the
+client. You will see a list of applied migrations ending with something like
+`Your database is now in sync with your schema`.
+
+This creates all the tables behind the app — `User`, `Category`, `Todo`,
+`Completed`, and the rest. The full schema lives in `prisma/schema.prisma`.
+
+---
+
+## Step 6 — Seed initial data (optional)
+
+```bash
+pnpm prisma:seed
+```
+
+**Expected:** `prisma/seed.ts` upserts a test user, a default `General`
+category, and 10 sample to-dos. The seed is idempotent — running it twice does
+not duplicate rows (`prisma/seed.ts:60-83`).
+
+> **Note:** the seed user is tied to a specific Clerk test account
+> (`prisma/seed.ts:22-32`). Unless you sign in as that exact account, you
+> **won't** see the seeded to-dos under your own login — and that is fine. This
+> tutorial has you create your own category and task in Step 9, so seeding is
+> just a convenience here, not a requirement.
+
+---
+
+## Step 7 — Start the dev server
+
+```bash
+pnpm dev
+```
+
+**Expected:** Next.js starts on port **3011** (`package.json:22`) and prints a
+ready message. Leave this running.
+
+Open <http://localhost:3011> in your browser.
+
+**Expected:** the app loads. Because the home routes are protected by Clerk
+(`src/proxy.ts`), an unauthenticated visit redirects you to the `/login` page.
+
+---
+
+## Step 8 — Sign in with Clerk
+
+On the `/login` page, sign up or sign in using your Clerk Development instance
+(email/password or any social provider you enabled in Clerk).
+
+**Expected:** after authenticating, Clerk redirects you to `/home`
+(the `NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL` you left as `/home`). You
+land on the home page: a **pending** column on the left and a **completed**
+column (with the Activity Heatmap) on the right.
+
+> **First-login note:** the very first time _your_ Clerk identity hits an
+> authenticated API call, the server lazily creates your `User` row from your
+> Clerk id (`src/server/middleware/auth.ts`). A brand-new account starts with
+> **no categories**, which is exactly why the next step has you create one.
+
+---
+
+## Step 9 — Create your first category
+
+A task must belong to a category, so create one first. In the left sidebar, find
+the **Categories** section and click the **+** (Add) button to open the
+Add-category popover (`src/app/(main)/home/_components/Category.tsx`).
+
+1. Type a name in the **Category name** field, e.g. `Focus`.
+2. (Optional) pick a color dot.
+3. Click **Create** (or press **Enter**) to save it.
+
+**Expected:** the new category appears in the sidebar and becomes the selected
+category. (Creating it also finalizes your `User` row server-side.)
+
+---
+
+## Step 10 — Add a task
+
+With your new category selected, use the new-todo input (placeholder
+`Enter a new todo...`) at the top of the pending column. The form lives in
+`src/app/(main)/home/_components/AddTodoForm.tsx` (its placeholder is on line 68)
+and is rendered by `src/app/(main)/home/_components/TodoList.tsx`. Type a task,
+e.g. `Write the getting-started doc`, and submit.
+
+**Expected:** the task appears instantly at the top of the pending list (the UI
+updates optimistically, then reconciles with the server).
+
+---
+
+## Step 11 — Check it off and watch the motion
+
+Click the checkbox to the left of your task
+(`src/app/(main)/home/_components/TodoItem.tsx`).
+
+**Expected:**
+
+- The checkbox plays a brief **amber fill** completion motion
+  (`src/hooks/useCompletionFeedback.ts`) — this affirms "you did something."
+- By default the task moves into the **Completed** column.
+
+> **Sound is off by default.** A soft completion tone exists but is **opt-in**
+> (default OFF). Don't expect a sound unless you enable "Completion sound" in
+> Settings. To verify the _motion_ properly, record it — per the project's
+> motion-review rule, screenshots can't reveal how an animation actually feels.
+
+---
+
+## Step 12 — Open that day on the Activity Heatmap (the north-star moment)
+
+In the completed column, look at the **Activity Heatmap**
+(`src/app/(main)/home/_components/ContributionGraph.tsx:184`). Today's cell is
+now warm — a single completion lights the first ("started") intensity band
+(`src/lib/heatmap-intensity.ts:19` — a day needs 4 completions for "good day",
+so one task is band 1, not a full cell).
+
+Click today's cell.
+
+**Expected:** the **Day Detail** dialog opens
+(`src/app/(main)/home/_components/DayDetailDialog.tsx`), showing the task you
+just completed plus affirming, on-voice copy for the day. You did it — your
+first lit heatmap cell.
+
+> Want it warmer? Add and complete a few more tasks. At 4 completions the day
+> reaches the "good day" band; the warmth is **pride, not a KPI** — the palette
+> is intentionally warm amber, never GitHub-green. See
+> [`DESIGN.md`](../../DESIGN.md) for the why.
+
+---
+
+## Step 13 — Confirm the project is healthy
+
+Stop the dev server (`Ctrl-C` in its terminal), then run the full local gate:
+
+```bash
+pnpm validate
+```
+
+**Expected:** `concurrently` runs six checks in parallel — unit tests, the
+in-repo ESLint plugin's tests, lint (auto-fix), the Next.js build, `tsc`
+type-check, and the theme-CSS drift check (`package.json:40`). Any single
+failure aborts the rest. A green run means your environment is set up correctly
+and matches what CI expects.
+
+> **If a unit test fails about `localStorage`/`window`,** you are almost
+> certainly not on Node `24.13.0` — re-check the Prerequisites section (the Node
+> `24.13.0` row) and re-run.
+
+> **Pre-launch volatility:** this repo has no users yet, so the schema and APIs
+> are reshaped freely and old data is not preserved
+> ([`README.md`](../../README.md) line 13). Whenever the schema changes under
+> you, just reset your local database with `pnpm db:reset` (drops, re-migrates,
+> and re-seeds — guarded by the same local-DB safety check).
+
+---
+
+## What you just learned: the data path
+
+You drove one completion end to end. Here is the path that lit your heatmap
+cell:
+
+1. **Browser (web)** — you clicked the checkbox in `TodoItem`. The mutation hook
+   (`src/hooks/useTodoMutations.ts`) updated the UI optimistically and sent the
+   change.
+2. **oRPC over HTTP** — the client posts to `/api/orpc/*`
+   (`src/app/api/orpc/[...path]/route.ts`), carrying your Clerk identity so the
+   server knows it's you (`src/server/middleware/auth.ts`). The heatmap itself
+   reads the `completed.heatmap` procedure (`src/server/procedures/completed.ts`).
+3. **Prisma → PostgreSQL** — procedures talk to Postgres through the shared
+   Prisma client (`src/lib/prisma.ts`). Checking off a task stamps the to-do's
+   `completedAt`.
+4. **Heatmap aggregation** — `fetchCompletedEntries`
+   (`src/server/utils/completedAggregation.ts`) unions completed `Todo` rows
+   with the separate `Completed` stream and buckets them by day. With the
+   default settings, checking off a normal task lights the heatmap via its
+   **`Todo` row** (it does **not** write a `Completed`-table row — that table is
+   the archive / BrainDump / paste-import stream). `useHeatmapData`
+   (`src/hooks/useHeatmapData.ts`) feeds the result to `ContributionGraph`.
+
+The Electron desktop app uses this **exact same** web → oRPC → Prisma path; it
+just renders the web app inside a macOS window.
+
+---
+
+## Next steps
+
+You've seen the core loop. The rest of the developer docs are organized by the
+[Diátaxis](https://diataxis.fr/) framework — browse the
+**[documentation hub](./README.md)**, or jump straight to:
+
+- **Understand the design** — [Architecture: one codebase, two runtimes, one data
+  path](./explanation-architecture.md), then [why a finished day stays
+  lit](./explanation-completion-and-heatmap.md) (the heatmap invariant you just saw
+  in action).
+- **Do more** — [run the local dev + test loop](./howto-local-dev-and-tests.md),
+  [add a new oRPC procedure](./howto-add-orpc-procedure.md), or [add a colored theme
+  family](./howto-add-theme-family.md).
+- **Look things up** — the [oRPC API](./reference-orpc-api.md) and [data
+  model](./reference-data-model.md) references, or the deeper [Electron
+  internals](../ELECTRON_ARCHITECTURE.md).
+
+The authoritative command list is always the `scripts` block in
+[`package.json`](../../package.json); environment variables are in
+[`README.md`](../../README.md#environment-variables).

--- a/docs/dev/tutorial-getting-started.md
+++ b/docs/dev/tutorial-getting-started.md
@@ -7,7 +7,7 @@ watching that day light up on the Activity Heatmap. Follow every step in order
 
 > **You will run the web app only.** The macOS Electron wrapper loads the same
 > web app remotely and is **not** needed to reach the heatmap. Skip it for now;
-> see [the Electron architecture doc](../ELECTRON_ARCHITECTURE.md) when you are
+> see [the Electron architecture doc](./explanation-electron-architecture.md) when you are
 > ready.
 
 ---
@@ -339,7 +339,7 @@ You've seen the core loop. The rest of the developer docs are organized by the
   family](./howto-add-theme-family.md).
 - **Look things up** — the [oRPC API](./reference-orpc-api.md) and [data
   model](./reference-data-model.md) references, or the deeper [Electron
-  internals](../ELECTRON_ARCHITECTURE.md).
+  internals](./explanation-electron-architecture.md).
 
 The authoritative command list is always the `scripts` block in
 [`package.json`](../../package.json); environment variables are in


### PR DESCRIPTION
## What

A complete **developer documentation suite** under [`docs/dev/`](https://github.com/laststance/corelive/tree/docs/diataxis-dev-docs/docs/dev), organized by the [Diátaxis](https://diataxis.fr/) framework — **24 files**: 1 tutorial, 7 how-to, 7 reference, 8 explanation, plus a hub index. Generated via multi-agent research → write → adversarial source-verification, then consolidated.

## Structure

| Quadrant | Count | Examples |
| --- | --- | --- |
| **Tutorial** | 1 | `tutorial-getting-started.md` — clone → dev server → first heatmap cell |
| **How-to** | 7 | add an oRPC procedure / IPC channel / theme family / sync channel; cut a macOS release |
| **Reference** | 7 | oRPC API, data model, frontend, Electron, theme system, auth, CI & commands |
| **Explanation** | 8 | architecture, archive-not-delete heatmap invariant, state & sync, Electron decisions, auth, Skill Tree integrity, theme pipeline, build & CI |

Everything is reachable within two clicks of [`docs/dev/README.md`](https://github.com/laststance/corelive/blob/docs/diataxis-dev-docs/docs/dev/README.md).

## Design choices

- **Reference docs are point-to-source.** Because the app is pre-launch and intentionally volatile (schema reset, not migrated), reference docs name a surface and anchor it to `file:line`, deferring exact field/type shapes to the code — "when a reference and the code disagree, the code wins." This keeps them from going stale on the next reshape.
- **Cross-linked from the root [`README.md`](https://github.com/laststance/corelive/blob/docs/diataxis-dev-docs/README.md)** via a new Documentation section.
- **`CLAUDE.md` is now committed** (force-added past the global gitignore) so agent guidance travels with the repo. The E2E test password is redacted to an `.env` pointer; service IDs and the project log are kept deliberately. A follow-up commit clarifies that the `ryota-murakami` prohibition is **Vercel-scoped** (deploy/billing) — the `ryota-murakami` GitHub account is the repo admin/owner.
- **`AGENTS.md` (a symlink → `CLAUDE.md`) is intentionally not committed** — Prettier 3.x refuses explicitly-specified symlinks, which would block the `lint-staged` pre-commit hook. The local symlink is untouched; nothing in the docs depends on it.

## Verification

- ✅ **298** relative Markdown links resolve — **0 broken**.
- ✅ Every content doc is linked from the hub index (no orphans).
- ✅ No secrets (password redacted; no live keys).
- ✅ Prettier-clean; pre-commit hook (`lint-staged`) passed.
- ✅ Three highest-risk technical claims re-checked against source and corrected during verification (sync broadcast fires in `onSettled` not `onSuccess`; CI prepare-action coverage; `clearCompleted` archives-then-deletes with `NodeAssignment` `onDelete: SetNull`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added extensive developer docs: architecture, authentication, build/CI, data model, Electron/renderer details, theme system, and operational how‑tos.
  * Added practical guides: adding routes, IPC/sync channels, oRPC procedures, theme families, cutting releases, local dev & tests.
  * Added a contributor getting‑started tutorial.

*No end-user facing changes in this release.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->