### PR TITLE
feat(home): 居残りモード enter-fade (D8/T10) + track AGENTS.md symlink

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,9 @@ html
 # Generated (machine-written; formatting is owned by scripts/generate-theme-css.ts
 # so prettier must not reformat it and break the generated-not-stale CI check)
 src/lib/themes/generated.css
+
+# Agent tooling — AGENTS.md is a symlink → CLAUDE.md (single source for agents).
+# Prettier 3.x refuses to format a symlink ("is a symbolic link"), which would
+# hard-block the lint-staged pre-commit `*` glob; ignore it so the symlink can
+# be tracked without breaking commits.
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/TODOS.md
+++ b/TODOS.md
@@ -127,32 +127,37 @@ function that will pull it off the deferred list.
       Forcing function: post-ship polish pass on the completion-feedback feature.
       Effort: ~1-2h human / ~20 min CC.
 
-- [ ] **居残りモード切替時の fade トランジション (D8) — enter-half built, runtime-unverified.**
+- [ ] **居残りモード切替時の fade トランジション (D8) — enter-half SHIPPED + runtime-verified; only the fade-OUT remains.**
       Surfaced in `/plan-design-review` (2026-06-04, D8); built as plan task T10
       (P2). Toggling 居残りモード ON should make todos completed since the last
       clear RETROACTIVELY fade INTO the active list (DESIGN.md enter easing,
       `motion-safe:` gated); toggling OFF should fade them OUT symmetrically, so
       the "watch your day accumulate" reveal feels gentle, not a jarring pop.
-      STATUS (branch `feat/d8-fade-and-agents-md`): the ENTER half is IMPLEMENTED.
-      `retroactivePopulateFade.ts` tells a mode-toggle populate apart from an
-      in-place check by diffing the visible row-id set against the previous render
-      (armed on the OFF→ON transition via `useUpdateEffect`), so D7 stays quiet;
-      matching rows get a `motion-safe:` `tw-animate-css` fade-in. LOGIC-verified
-      (4 unit tests, `pnpm validate` green) but RUNTIME-UNVERIFIED: the fade class
-      lands one commit AFTER the rows mount (passive settle effect + the
-      `localPendingTodos` one-render lag), so there may be a leading ~1-frame
-      opacity-1 blink before the fade — needs the global video-frame check (record
-      the OFF→ON toggle, `ffmpeg` the frames); the existing Loading-flash on toggle
-      may mask it. IF frames show a blink, the fix is to apply the class before
-      paint (a layout-effect for the settle step) — verify first, don't pre-fix.
+      STATUS (branch `feat/d8-fade-and-agents-md`, PR #75): the ENTER half is
+      IMPLEMENTED + RUNTIME-VERIFIED. `retroactivePopulateFade.ts` tells a
+      mode-toggle populate apart from an in-place check by diffing the visible
+      row-id set against the previous render (armed on the OFF→ON transition via
+      `useUpdateEffect`), so D7 stays quiet; matching rows get a `motion-safe:`
+      `tw-animate-css` fade-in. Verified on a live `pnpm dev` via Playwright (rAF
+      opacity time-series + recorded video frames; OFF→ON toggle driven over the
+      preferences BroadcastChannel): the completed rows fade opacity 0→1 over
+      ~200ms (`animationName: enter`) with **NO leading blink** — they paint at
+      opacity 0 on the very first frame (the Loading-flash full-remount resolves
+      the fade-ids before paint, so rows never paint without the class). The
+      pending control row stays opacity 1 / `anim:none` (selectivity holds, D7).
+      Reduced-motion run: opacity flat at 1, `enter` never runs → instant (a11y
+      honored). The advisor-flagged "fade class lands one commit after mount"
+      blink does NOT materialize in practice — no layout-effect fix needed. Side
+      note (pre-existing, NOT this work): toggling retain briefly blanks the list
+      ~100ms (TanStack query-key change, no `keepPreviousData`); the fade plays
+      cleanly right after. A `placeholderData: keepPreviousData` pass could smooth
+      that flash — separate follow-up.
       STILL DEFERRED: the symmetric fade-OUT (ON→OFF) needs an unmount animation
       (framer-motion `AnimatePresence`, not yet wired for this list), so OFF is
       enter-only / instant for now (TODOS.md-sanctioned fallback). Feature works
-      without either: rows appear / disappear instantly on toggle.
-      Forcing function: the macOS native smoke that closes this surface, or
-      whenever `AnimatePresence` lands for any list.
-      Effort remaining: ~20 min CC (frame check + conditional layout-effect fix);
-      the fade-OUT waits on `AnimatePresence`.
+      without it: rows disappear instantly on toggle-OFF.
+      Forcing function: whenever `AnimatePresence` lands for any list.
+      Effort remaining: the fade-OUT waits on `AnimatePresence` (~30 min CC then).
 
 ## Electron resilience
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -127,24 +127,32 @@ function that will pull it off the deferred list.
       Forcing function: post-ship polish pass on the completion-feedback feature.
       Effort: ~1-2h human / ~20 min CC.
 
-- [ ] **居残りモード切替時の fade トランジション (D8) — deferred polish.**
+- [ ] **居残りモード切替時の fade トランジション (D8) — enter-half built, runtime-unverified.**
       Surfaced in `/plan-design-review` (2026-06-04, D8); built as plan task T10
       (P2). Toggling 居残りモード ON should make todos completed since the last
       clear RETROACTIVELY fade INTO the active list (DESIGN.md enter easing,
       `motion-safe:` gated); toggling OFF should fade them OUT symmetrically, so
       the "watch your day accumulate" reveal feels gentle, not a jarring pop.
-      DEFERRED from the completion-feedback / 居残りモード ship (PR #60) because a
-      naive `animate-in` on completed-retained rows MISFIRES — it also fires on
-      every in-place check, contradicting D7 ("the check feedback is the checkbox
-      motion, not a row fade"). A correct impl must DISTINGUISH
-      mode-toggle-retroactive-populate from in-place-check (track previous retain
-      state + diff the visible row set), and the fade-OUT needs an unmount
-      animation (framer-motion `AnimatePresence`, not yet wired for this list —
-      or limit to enter-only via the existing `tw-animate-css`). Feature works
-      without it: rows appear / disappear instantly on toggle.
-      Forcing function: a focused motion-polish pass on the completion feature,
-      or whenever `AnimatePresence` lands for any list.
-      Effort: ~1.5-2h human / ~30 min CC.
+      STATUS (branch `feat/d8-fade-and-agents-md`): the ENTER half is IMPLEMENTED.
+      `retroactivePopulateFade.ts` tells a mode-toggle populate apart from an
+      in-place check by diffing the visible row-id set against the previous render
+      (armed on the OFF→ON transition via `useUpdateEffect`), so D7 stays quiet;
+      matching rows get a `motion-safe:` `tw-animate-css` fade-in. LOGIC-verified
+      (4 unit tests, `pnpm validate` green) but RUNTIME-UNVERIFIED: the fade class
+      lands one commit AFTER the rows mount (passive settle effect + the
+      `localPendingTodos` one-render lag), so there may be a leading ~1-frame
+      opacity-1 blink before the fade — needs the global video-frame check (record
+      the OFF→ON toggle, `ffmpeg` the frames); the existing Loading-flash on toggle
+      may mask it. IF frames show a blink, the fix is to apply the class before
+      paint (a layout-effect for the settle step) — verify first, don't pre-fix.
+      STILL DEFERRED: the symmetric fade-OUT (ON→OFF) needs an unmount animation
+      (framer-motion `AnimatePresence`, not yet wired for this list), so OFF is
+      enter-only / instant for now (TODOS.md-sanctioned fallback). Feature works
+      without either: rows appear / disappear instantly on toggle.
+      Forcing function: the macOS native smoke that closes this surface, or
+      whenever `AnimatePresence` lands for any list.
+      Effort remaining: ~20 min CC (frame check + conditional layout-effect fix);
+      the fade-OUT waits on `AnimatePresence`.
 
 ## Electron resilience
 

--- a/src/app/(main)/home/_components/SortableTodoItem.tsx
+++ b/src/app/(main)/home/_components/SortableTodoItem.tsx
@@ -3,6 +3,7 @@
 import { useSortable } from '@dnd-kit/react/sortable'
 import React from 'react'
 
+import { RETROACTIVE_POPULATE_FADE_CLASS } from './retroactivePopulateFade'
 import type { Todo } from './TodoItem'
 import { TodoItem } from './TodoItem'
 
@@ -12,6 +13,8 @@ interface SortableTodoItemProps {
   onToggleComplete: (id: string) => void
   onDelete: (id: string) => void
   onUpdateNotes?: (id: string, notes: string) => void
+  /** D8: play the 居残りモード retroactive-populate fade-in on this row. */
+  isRetroactivelyPopulated?: boolean
 }
 
 /**
@@ -22,6 +25,9 @@ interface SortableTodoItemProps {
  * @param onToggleComplete - Callback fired when completion changes.
  * @param onDelete - Callback fired when the item is deleted.
  * @param onUpdateNotes - Optional callback fired when notes change.
+ * @param isRetroactivelyPopulated - D8: fade this row in (the 居残りモード toggle
+ *   just surfaced it). Omitted/false for rows already on screen, so an in-place
+ *   check stays quiet (D7).
  * @returns A sortable wrapper around the TodoItem row.
  * @example
  * <SortableTodoItem todo={todo} index={0} onToggleComplete={toggle} onDelete={remove} />
@@ -32,6 +38,7 @@ export const SortableTodoItem = React.memo(function SortableTodoItem({
   onToggleComplete,
   onDelete,
   onUpdateNotes,
+  isRetroactivelyPopulated,
 }: SortableTodoItemProps) {
   const { ref, handleRef, isDragging } = useSortable({ id: todo.id, index })
 
@@ -41,7 +48,13 @@ export const SortableTodoItem = React.memo(function SortableTodoItem({
   }
 
   return (
-    <div ref={ref} style={style}>
+    <div
+      ref={ref}
+      style={style}
+      className={
+        isRetroactivelyPopulated ? RETROACTIVE_POPULATE_FADE_CLASS : undefined
+      }
+    >
       <TodoItem
         todo={todo}
         onToggleComplete={onToggleComplete}

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -344,6 +344,12 @@ export const TodoList = memo(function TodoList() {
       if (newlyPresentCompletedIds.length > 0) {
         retroactivePopulateArmedRef.current = false
         setRetroactivePopulateFadeIds(new Set(newlyPresentCompletedIds))
+      } else if (pendingTodos.length > 0) {
+        // Refetch settled with rows but none surfaced — consume the arm so a later
+        // unrelated diff (an imported/synced completed row) can't replay the fade.
+        // The flash blanks the list, so the first non-empty render is the settled
+        // one; revisit if placeholderData/keepPreviousData is added (stale rows race).
+        retroactivePopulateArmedRef.current = false
       }
     }
     previousVisibleTodoIdsRef.current = new Set(

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -4,7 +4,7 @@ import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react'
 import { isSortable } from '@dnd-kit/react/sortable'
 import { useIsRestoring, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Circle } from 'lucide-react'
-import { memo, Suspense, useCallback, useMemo, useState } from 'react'
+import { memo, Suspense, useCallback, useMemo, useRef, useState } from 'react'
 
 import {
   AlertDialog,
@@ -26,6 +26,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { useCycleEffect } from '@/hooks/use-cycle-effect'
+import { useUpdateEffect } from '@/hooks/use-update-effect'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
 import { useHeatmapData } from '@/hooks/useHeatmapData'
 import { useSelectedCategory } from '@/hooks/useSelectedCategory'
@@ -42,6 +43,11 @@ import { AddTodoForm } from './AddTodoForm'
 import { CategoryFilterChips } from './CategoryFilterChips'
 import { CompletedTodos } from './CompletedTodos'
 import { ContributionGraph } from './ContributionGraph'
+import {
+  EMPTY_TODO_ID_SET,
+  RETROACTIVE_POPULATE_FADE_MS,
+  selectNewlyPresentCompletedTodoIds,
+} from './retroactivePopulateFade'
 import { SortableTodoItem } from './SortableTodoItem'
 import { SundayDigestCard } from './SundayDigestCard'
 import { TodoImportEntry } from './TodoImportEntry'
@@ -306,6 +312,56 @@ export const TodoList = memo(function TodoList() {
   ).length
   const pendingCount = pendingTodos.length - completedInListCount
 
+  // ── 居残りモード retroactive-populate fade (D8) ───────────────────────────
+  // Flipping 居残りモード ON refetches the active list WITH completed-since-clear
+  // rows; those should fade IN gently (DESIGN.md enter, motion-safe). An in-place
+  // check must stay quiet (D7), so we fade only rows that are NEWLY present vs the
+  // previous render — never a row that was already on screen and merely flipped to
+  // completed. The completed rows land a few renders after the toggle (the toggle
+  // changes the query input → refetch), so we ARM on the OFF→ON transition and
+  // play the fade when they actually arrive. Enter-only by design: ON→OFF removes
+  // the rows instantly — no framer-motion exit animation is wired here (TODOS.md T10).
+  const previousVisibleTodoIdsRef =
+    useRef<ReadonlySet<string>>(EMPTY_TODO_ID_SET)
+  const [retroactivePopulateFadeIds, setRetroactivePopulateFadeIds] =
+    useState<ReadonlySet<string>>(EMPTY_TODO_ID_SET)
+  // Armed ONLY by an OFF→ON toggle; ON→OFF clears it so a stale arm can't replay.
+  const retroactivePopulateArmedRef = useRef(false)
+
+  useUpdateEffect(() => {
+    retroactivePopulateArmedRef.current = isRetaining
+  }, [isRetaining])
+
+  // After the toggle's refetch settles, fade the rows it surfaced — once. The
+  // newly-present diff excludes in-place checks even within the armed window, so
+  // checking a task right after toggling ON (with nothing else done) stays quiet.
+  useCycleEffect(() => {
+    if (retroactivePopulateArmedRef.current) {
+      const newlyPresentCompletedIds = selectNewlyPresentCompletedTodoIds(
+        pendingTodos,
+        previousVisibleTodoIdsRef.current,
+      )
+      if (newlyPresentCompletedIds.length > 0) {
+        retroactivePopulateArmedRef.current = false
+        setRetroactivePopulateFadeIds(new Set(newlyPresentCompletedIds))
+      }
+    }
+    previousVisibleTodoIdsRef.current = new Set(
+      pendingTodos.map((todoRow) => todoRow.id),
+    )
+  }, [pendingTodos])
+
+  // Strip the fade class once the enter animation has played, so a later
+  // re-render/remount (reorder, cross-window sync) can't replay it.
+  useUpdateEffect(() => {
+    if (retroactivePopulateFadeIds.size === 0) return
+    const fadeCleanupTimer = setTimeout(
+      () => setRetroactivePopulateFadeIds(EMPTY_TODO_ID_SET),
+      RETROACTIVE_POPULATE_FADE_MS,
+    )
+    return () => clearTimeout(fadeCleanupTimer)
+  }, [retroactivePopulateFadeIds])
+
   /**
    * Handles drag end event to reorder todos.
    * Updates local state optimistically and syncs with server.
@@ -450,6 +506,9 @@ export const TodoList = memo(function TodoList() {
                   onToggleComplete={toggleComplete}
                   onDelete={deleteTodo}
                   onUpdateNotes={updateNotes}
+                  isRetroactivelyPopulated={retroactivePopulateFadeIds.has(
+                    todo.id,
+                  )}
                 />
               ))}
             </div>

--- a/src/app/(main)/home/_components/retroactivePopulateFade.test.ts
+++ b/src/app/(main)/home/_components/retroactivePopulateFade.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectNewlyPresentCompletedTodoIds } from './retroactivePopulateFade'
+
+// The D8/D7 boundary lives here: switching 居残りモード ON fades in the
+// completed-since-clear rows the refetch surfaces, while checking a task that is
+// already on screen must stay quiet. If this gate regresses, an in-place check
+// would wrongly flash a fade (breaks D7) or the retroactively-loaded rows would
+// pop in with no motion (breaks D8).
+describe('selectNewlyPresentCompletedTodoIds — 居残りモード retroactive-populate fade gate', () => {
+  it('fades the completed tasks that retroactively appear when 居残りモード is switched on', () => {
+    // Arrange: before the toggle only pending rows were visible; the refetch now
+    // surfaces two completed-since-clear rows alongside them.
+    const previousVisibleTodoIds = new Set(['1', '2'])
+    const currentTodos = [
+      { id: '1', completed: false },
+      { id: '2', completed: false },
+      { id: '3', completed: true },
+      { id: '4', completed: true },
+    ]
+
+    // Act
+    const fadeIds = selectNewlyPresentCompletedTodoIds(
+      currentTodos,
+      previousVisibleTodoIds,
+    )
+
+    // Assert: only the newly-surfaced completed rows fade in.
+    expect(fadeIds).toEqual(['3', '4'])
+  })
+
+  it('stays quiet when a task already on screen is checked off in place (no false D8 fade)', () => {
+    // Arrange: row 1 was already visible (pending) and the user just checked it —
+    // same id, now completed. That is an in-place check, not a populate.
+    const previousVisibleTodoIds = new Set(['1', '2'])
+    const currentTodos = [
+      { id: '1', completed: true },
+      { id: '2', completed: false },
+    ]
+
+    // Act
+    const fadeIds = selectNewlyPresentCompletedTodoIds(
+      currentTodos,
+      previousVisibleTodoIds,
+    )
+
+    // Assert: an already-present row never fades — the check stays quiet (D7).
+    expect(fadeIds).toEqual([])
+  })
+
+  it('fades nothing when the toggle surfaces no completed tasks', () => {
+    // Arrange: 居残りモード on, but nothing has been completed since the last clear.
+    const previousVisibleTodoIds = new Set(['1'])
+    const currentTodos = [{ id: '1', completed: false }]
+
+    // Act
+    const fadeIds = selectNewlyPresentCompletedTodoIds(
+      currentTodos,
+      previousVisibleTodoIds,
+    )
+
+    // Assert
+    expect(fadeIds).toEqual([])
+  })
+
+  it('does not re-fade a completed task that was already visible last render', () => {
+    // Arrange: a completed row that persisted across renders (it already faded
+    // once on the toggle that surfaced it).
+    const previousVisibleTodoIds = new Set(['3'])
+    const currentTodos = [{ id: '3', completed: true }]
+
+    // Act
+    const fadeIds = selectNewlyPresentCompletedTodoIds(
+      currentTodos,
+      previousVisibleTodoIds,
+    )
+
+    // Assert: present last render → not newly present → no replay.
+    expect(fadeIds).toEqual([])
+  })
+})

--- a/src/app/(main)/home/_components/retroactivePopulateFade.ts
+++ b/src/app/(main)/home/_components/retroactivePopulateFade.ts
@@ -1,0 +1,60 @@
+import type { Todo } from './TodoItem'
+
+/**
+ * D8 retroactive-populate fade — duration of the 居残りモード OFF→ON enter fade.
+ * Short tier per DESIGN.md Motion (150–250ms), matching the page-transition
+ * fade. MUST stay in sync with the `duration-200` baked into
+ * {@link RETROACTIVE_POPULATE_FADE_CLASS} (Tailwind needs a literal class, so the
+ * value is duplicated); the cleanup timeout that strips the class reuses this.
+ */
+export const RETROACTIVE_POPULATE_FADE_MS = 200
+
+/**
+ * tw-animate-css class that fades a row IN (opacity 0→1) over
+ * {@link RETROACTIVE_POPULATE_FADE_MS} with DESIGN.md enter easing (`ease-out`),
+ * gated behind `motion-safe:` so `prefers-reduced-motion` users get the rows
+ * instantly. Applied ONLY to rows that retroactively appear on a 居残りモード
+ * OFF→ON toggle (D8) — never on an in-place check (D7, which stays quiet).
+ */
+export const RETROACTIVE_POPULATE_FADE_CLASS =
+  'motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200 motion-safe:ease-out'
+
+/**
+ * Stable empty-set reference for the fade-id state + baseline ref, so an idle
+ * list never re-renders rows just because a fresh `new Set()` changed identity.
+ */
+export const EMPTY_TODO_ID_SET: ReadonlySet<string> = new Set<string>()
+
+/**
+ * Picks the rows that should play the D8 retroactive-populate fade: completed
+ * rows that are NEWLY present versus the previous render. Exists to tell a
+ * 居残りモード mode-toggle (rows the refetch surfaced → fade IN) apart from an
+ * in-place check (a row already on screen that flipped to completed → stays
+ * quiet, D7). Called by `TodoList` on every settled render while a toggle is armed.
+ *
+ * @param currentTodos - Rows about to render (only `id` + `completed` are read).
+ * @param previousVisibleTodoIds - Row ids from the previous committed render.
+ * @returns
+ * - The ids of completed rows absent last render (the retroactive-populate set)
+ * - An empty array when nothing newly-completed appeared (e.g. an in-place check)
+ * @example
+ * // 居残りモード switched ON: row 2 (completed) was not visible before → fades
+ * selectNewlyPresentCompletedTodoIds(
+ *   [{ id: '1', completed: false }, { id: '2', completed: true }],
+ *   new Set(['1']),
+ * ) // => ['2']
+ * @example
+ * // In-place check: row 1 was already visible → no fade (D7 quiet)
+ * selectNewlyPresentCompletedTodoIds(
+ *   [{ id: '1', completed: true }],
+ *   new Set(['1']),
+ * ) // => []
+ */
+export function selectNewlyPresentCompletedTodoIds(
+  currentTodos: ReadonlyArray<Pick<Todo, 'id' | 'completed'>>,
+  previousVisibleTodoIds: ReadonlySet<string>,
+): string[] {
+  return currentTodos
+    .filter((todo) => todo.completed && !previousVisibleTodoIds.has(todo.id))
+    .map((todo) => todo.id)
+}


### PR DESCRIPTION
## What

Two unrelated changes batched into one PR (two focused commits + a docs commit).

### 1. `chore`: track `AGENTS.md` symlink (`f0eb899`)

`AGENTS.md` is a symlink → `CLAUDE.md`, so agent tooling that looks for `AGENTS.md` reads the **single source of truth** (no copy to drift). It was globally gitignored + untracked, so it's force-added as a real symlink (git mode `120000`, not dereferenced).

**Blocker handled:** Prettier 3.x refuses to format a symlink (`is a symbolic link`), which would hard-block the lint-staged pre-commit `*` glob. Fix: add `AGENTS.md` to `.prettierignore` so the hook skips it and the symlink can be tracked without breaking commits.

### 2. `feat`: 居残りモード retroactive-populate fade-in (D8 / T10) (`f4984a9`)

When 居残りモード (retain-completed-in-list) is toggled **ON**, the todos completed since the last clear now **fade IN** to the active list (DESIGN.md enter easing, `motion-safe:` gated, 200 ms) instead of popping in — the "watch your day accumulate" reveal from `/plan-design-review` (D8).

The hard part is telling a **mode-toggle populate** apart from an **in-place check** (D7 — checking a task already on screen must stay quiet, no row fade):

- Pure, unit-tested discriminator `selectNewlyPresentCompletedTodoIds` — diffs the **visible row-id set** against the previous render. A completed row that is *newly present* fades; an already-present row that just flipped to completed does not.
- Armed only on the OFF→ON transition (`useUpdateEffect` on `isRetaining`), because flipping retain changes the query input, so the completed rows arrive renders later (refetch + `localPendingTodos` lag).
- 4 unit tests cover the D7/D8 boundary.

**Scope: enter-only.** The symmetric fade-OUT (ON→OFF) needs an unmount animation (framer-motion `AnimatePresence`, not wired for this list), so toggle-OFF is instant for now — a TODOS.md-sanctioned fallback.

### 3. `docs`: honest T10 backlog status (`0726224`)

Updates the TODOS.md T10 entry from "deferred polish" to "enter-half built, runtime-unverified."

## Verification

- ✅ `pnpm validate` green (test + lint + build + typecheck) at the feat commit.
- ✅ 4 new unit tests pass (`retroactivePopulateFade.test.ts`) — the D7/D8 discriminator.
- ✅ lint-staged (eslint `--max-warnings 0` + prettier) clean on every commit.
- ⚠️ **Motion is runtime-UNVERIFIED.** The fade is logic-verified but I have **not** watched it run. Two specific things a reviewer / macOS smoke should check with **video frames** (per the repo's motion rule — screenshots / `getComputedStyle` won't reveal it):
  1. **Leading-blink risk:** the fade class lands one commit *after* the rows mount (passive settle effect + the `localPendingTodos` one-render lag), so the completed rows may paint one frame at opacity 1 before the fade-in starts. The existing Loading-flash on toggle may mask it. **If** frames show a blink, the fix is to apply the class *before* paint (a layout-effect for the settle step) — verify first, don't pre-fix.
  2. **D7 quiet:** toggling ON with nothing done, then checking the first task in place, must NOT fade that row.

Local web E2E can't boot the Playwright webServer on this Mac (known loopback issue), so the frame check belongs in the macOS native smoke that closes this surface.

## Test plan

- [ ] macOS smoke: record OFF→ON toggle, `ffmpeg` the frames, confirm (a) completed rows fade (not pop), (b) no leading blink.
- [ ] Confirm an in-place check stays quiet (D7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an enter-only, motion-safe (~200ms) fade-in for completed to-dos that reappear when toggling the keep-completed mode; verified to show no leading blink.

* **Tests**
  * Added tests covering newly-surfaced vs in-place completed items and visibility logic.

* **Documentation**
  * Updated TODO notes to document the implemented enter-only behavior and remaining unmount/fade work.

* **Chores**
  * Ignored a linked docs file in formatting to prevent pre-commit formatting failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->