### PR TITLE
feat(electron): add BrainDump spaces toggle

### DIFF
--- a/electron/ConfigManager.ts
+++ b/electron/ConfigManager.ts
@@ -117,6 +117,8 @@ interface ShortcutsConfig {
   minimize: string
   toggleAlwaysOnTop: string
   focusFloatingNavigator: string
+  toggleFloatingNavigator: string
+  toggleBrainDump: string
 }
 
 /** Notifications configuration */
@@ -327,6 +329,8 @@ export class ConfigManager {
         minimize: `${modifier}+M`,
         toggleAlwaysOnTop: `${modifier}+Shift+A`,
         focusFloatingNavigator: `${modifier}+Shift+N`,
+        toggleFloatingNavigator: `${modifier}+3`,
+        toggleBrainDump: 'Alt+Space',
       },
 
       notifications: {
@@ -375,7 +379,7 @@ export class ConfigManager {
         visibleOnAllWorkspaces: false,
         opacity: 0.95,
         syncMode: true,
-        shortcut: '',
+        shortcut: 'Alt+Space',
         lastCategoryId: null,
         notes: {},
       },

--- a/electron/MenuManager.ts
+++ b/electron/MenuManager.ts
@@ -331,7 +331,7 @@ export class MenuManager {
    * Creates the Window menu for window management.
    *
    * Adds a "BrainDump Note" entry that toggles the frameless panel via
-   * WindowManager (no accelerator by default — users opt-in via Settings).
+   * WindowManager; the global accelerator is owned by ShortcutManager.
    */
   createWindowMenu(): MenuItemConstructorOptions {
     const submenu: MenuItemConstructorOptions[] = [
@@ -612,6 +612,8 @@ Copyright © 2025 CoreLive`,
       'Ctrl/Cmd + Shift + A: Toggle Always on Top',
       'Ctrl/Cmd + Shift + T: Show Main Window',
       'Ctrl/Cmd + Shift + N: Focus Floating Navigator',
+      'Ctrl/Cmd + 3: Toggle Floating Navigator',
+      'Alt/Option + Space: Toggle BrainDump',
       'Ctrl/Cmd + Q: Quit Application',
       'Ctrl/Cmd + ,: Preferences',
       'Ctrl/Cmd + R: Reload',
@@ -622,7 +624,7 @@ Copyright © 2025 CoreLive`,
       'Ctrl/Cmd + W: Close Window',
       'F11 (Ctrl+Cmd+F on Mac): Toggle Fullscreen',
       '',
-      '* Search Tasks and Toggle Floating Navigator are available in View > Floating Navigator menu',
+      '* Shortcut defaults can be changed from Preferences > Keyboard Shortcuts',
     ]
 
     dialog.showMessageBox(this.mainWindow, {

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -28,10 +28,7 @@ interface ShortcutConfig {
   toggleAlwaysOnTop?: string
   focusFloatingNavigator?: string
   toggleFloatingNavigator?: string
-  /**
-   * Empty string disables the shortcut — BrainDump ships with no default
-   * accelerator (per BrainDump plan D2 — opt-in to avoid global-key conflicts).
-   */
+  /** BrainDump's global quick-open accelerator; empty string disables it. */
   toggleBrainDump?: string
   [key: string]: string | boolean | undefined
 }
@@ -129,7 +126,10 @@ export class ShortcutManager {
       'toggleAlwaysOnTop',
       'focusFloatingNavigator',
     ])
-    this._globalShortcuts = new Set(['toggleFloatingNavigator'])
+    this._globalShortcuts = new Set([
+      'toggleFloatingNavigator',
+      'toggleBrainDump',
+    ])
     this.focusListenersSetup = false
     this.focusHandlers = new Map()
 
@@ -168,16 +168,13 @@ export class ShortcutManager {
     // Electron will translate this to Cmd on macOS and Ctrl on Windows/Linux
     // Note: 'quit' is not included as macOS already handles Cmd+Q natively
     // and we don't have a custom quit handler
-    //
-    // toggleBrainDump defaults to '' so the user opts in via Settings —
-    // BrainDump is meant to be a personal hotkey, not a global default.
     return {
       newTask: 'CommandOrControl+N',
       minimize: 'CommandOrControl+M',
       toggleAlwaysOnTop: 'CommandOrControl+Shift+A',
       focusFloatingNavigator: 'CommandOrControl+Shift+N',
-      toggleFloatingNavigator: 'Alt+Space',
-      toggleBrainDump: '',
+      toggleFloatingNavigator: 'CommandOrControl+3',
+      toggleBrainDump: 'Alt+Space',
     }
   }
 
@@ -633,6 +630,7 @@ export class ShortcutManager {
       toggleAlwaysOnTop: ['T', 'Up', 'P'],
       focusFloatingNavigator: ['W', 'Space', 'F'],
       toggleFloatingNavigator: ['F12', 'Backquote', 'F'],
+      toggleBrainDump: ['B', 'F13', 'Backquote'],
     }
 
     return alternatives[id] || []
@@ -687,6 +685,7 @@ export class ShortcutManager {
       toggleAlwaysOnTop: 'Toggle Always On Top',
       focusFloatingNavigator: 'Focus Floating Navigator',
       toggleFloatingNavigator: 'Toggle Floating Navigator',
+      toggleBrainDump: 'Toggle BrainDump',
     }
 
     return displayNames[id] || id

--- a/electron/SystemTrayManager.ts
+++ b/electron/SystemTrayManager.ts
@@ -486,7 +486,7 @@ export class SystemTrayManager {
         { type: 'separator' },
         {
           label: 'Toggle Floating Navigator',
-          accelerator: 'Alt+Space',
+          accelerator: 'CommandOrControl+3',
           click: () => {
             try {
               this.windowManager.toggleFloatingNavigator()

--- a/electron/__tests__/ShortcutManager.defaults.test.ts
+++ b/electron/__tests__/ShortcutManager.defaults.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  globalShortcut: {
+    isRegistered: vi.fn(() => false),
+    register: vi.fn(() => true),
+    unregister: vi.fn(),
+    unregisterAll: vi.fn(),
+  },
+}))
+
+import ShortcutManager from '../ShortcutManager'
+import type { WindowManager } from '../WindowManager'
+
+/**
+ * Creates a minimal WindowManager stand-in for default-shortcut tests.
+ * @returns WindowManager-compatible stub with no focused windows.
+ * @example
+ * const manager = new ShortcutManager(createWindowManagerStub(), null)
+ */
+function createWindowManagerStub(): WindowManager {
+  return {
+    getFloatingNavigator: vi.fn(() => null),
+    getMainWindow: vi.fn(() => null),
+    toggleBrainDump: vi.fn(() => true),
+    toggleFloatingNavigator: vi.fn(),
+  } as unknown as WindowManager
+}
+
+describe('ShortcutManager default shortcuts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses Option+Space for BrainDump and Command+3 for Floating Navigator defaults', () => {
+    // Arrange
+    const shortcutManager = new ShortcutManager(createWindowManagerStub(), null)
+
+    // Act
+    const defaults = shortcutManager.getDefaultShortcuts()
+
+    // Assert
+    expect(defaults.toggleBrainDump).toBe('Alt+Space')
+    expect(defaults.toggleFloatingNavigator).toBe('CommandOrControl+3')
+  })
+})

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1966,7 +1966,7 @@ function setupIPCHandlers(): void {
       accelerator,
       description: id,
       enabled: true,
-      isGlobal: id === 'toggleFloatingNavigator',
+      isGlobal: ['toggleFloatingNavigator', 'toggleBrainDump'].includes(id),
     }))
   })
 
@@ -1982,7 +1982,7 @@ function setupIPCHandlers(): void {
         accelerator: accelerator as string,
         description: id,
         enabled: true,
-        isGlobal: id === 'toggleFloatingNavigator',
+        isGlobal: ['toggleFloatingNavigator', 'toggleBrainDump'].includes(id),
       }))
   })
 

--- a/electron/preload-braindump.ts
+++ b/electron/preload-braindump.ts
@@ -7,6 +7,7 @@
  * - Window controls (close/minimize/opacity/bounds) for the frameless panel
  * - Per-category note text persistence (`braindump-note-*`)
  * - Local config (sync mode, shortcut, last-category) used by Settings UI
+ * - Shared Spaces tracking for BrainDump + Floating Navigator utility panels
  * - One inbound event (`braindump-category-changed`) to mirror FloatingNav
  *
  * Why a separate preload:
@@ -115,6 +116,7 @@ function sanitizeData<T>(data: T): T {
  * Renderer usage:
  * @example
  * await window.brainDumpAPI.window.setOpacity(0.85)
+ * const followsSpaces = await window.brainDumpAPI.spaces.getVisibleOnAllWorkspaces()
  * const text = await window.brainDumpAPI.note.get(42)
  * const cleanup = window.brainDumpAPI.on('braindump-category-changed', handler)
  */
@@ -260,6 +262,46 @@ contextBridge.exposeInMainWorld('brainDumpAPI', {
         await typedInvoke('braindump-config-set-last-category', categoryId)
       } catch (error) {
         log.error('BrainDump: Failed to set last category:', error)
+      }
+    },
+  },
+
+  spaces: {
+    /**
+     * Read whether utility panels stay visible while switching macOS Spaces.
+     *
+     * @returns True when BrainDump and Floating Navigator follow all Spaces.
+     * @example
+     * const enabled = await window.brainDumpAPI.spaces.getVisibleOnAllWorkspaces()
+     */
+    getVisibleOnAllWorkspaces: async (): Promise<boolean> => {
+      try {
+        return await typedInvoke(
+          'floating-window-get-visible-on-all-workspaces',
+        )
+      } catch (error) {
+        log.error('BrainDump: Failed to get Spaces tracking:', error)
+        return false
+      }
+    },
+
+    /**
+     * Persist and apply whether utility panels follow macOS Spaces.
+     *
+     * @param enabled - true keeps BrainDump and Floating Navigator visible across Spaces.
+     * @returns The value confirmed by the main process.
+     * @example
+     * await window.brainDumpAPI.spaces.setVisibleOnAllWorkspaces(true)
+     */
+    setVisibleOnAllWorkspaces: async (enabled: boolean): Promise<boolean> => {
+      try {
+        return await typedInvoke(
+          'floating-window-set-visible-on-all-workspaces',
+          enabled,
+        )
+      } catch (error) {
+        log.error('BrainDump: Failed to set Spaces tracking:', error)
+        throw error
       }
     },
   },

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -593,6 +593,7 @@ export interface FloatingNavigatorEnv {
  * - `note.*`   — per-category text persistence
  * - `sync.*`   — toggle for "follow FloatingNav category"
  * - `category.*` — last-active category id used to restore state
+ * - `spaces.*` — shared macOS Spaces tracking for utility panels
  * - `on(channel, cb)` — subscribe to whitelisted main-process events
  */
 export interface BrainDumpAPI {
@@ -639,6 +640,12 @@ export interface BrainDumpAPI {
     getLast: () => Promise<number | null>
     /** Persist the active category id. */
     setLast: (categoryId: number) => Promise<void>
+  }
+  spaces: {
+    /** Read whether BrainDump and Floating Navigator follow macOS Spaces. */
+    getVisibleOnAllWorkspaces: () => Promise<boolean>
+    /** Persist and apply whether both utility panels follow macOS Spaces. */
+    setVisibleOnAllWorkspaces: (enabled: boolean) => Promise<boolean>
   }
   /** Subscribe to a whitelisted event; returns a cleanup function. */
   on: (

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -1,0 +1,202 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CategoryWithCount } from '@/server/schemas/category'
+
+import { BrainDumpEditor } from './BrainDumpEditor'
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('@/hooks/use-mounted', () => ({
+  useMounted: () => true,
+}))
+
+vi.mock('@/hooks/useClerkQueryReady', () => ({
+  useClerkQueryReady: () => true,
+}))
+
+vi.mock('@/hooks/useSelectedCategory', () => ({
+  useSelectedCategory: () => [1],
+}))
+
+vi.mock('@/lib/orpc/client-query', () => ({
+  orpc: {
+    completed: {
+      create: {
+        mutationOptions: vi.fn(() => ({})),
+      },
+      delete: {
+        mutationOptions: vi.fn(() => ({})),
+      },
+      heatmap: {
+        key: vi.fn(() => ['completed', 'heatmap']),
+      },
+    },
+  },
+}))
+
+vi.mock('@/lib/todo-sync-channel', () => ({
+  broadcastTodoSync: vi.fn(),
+}))
+
+vi.mock('../../../electron/utils/electron-client', () => ({
+  isBrainDumpEnvironment: () => true,
+}))
+
+const categories: CategoryWithCount[] = [
+  {
+    id: 1,
+    name: 'Today',
+    color: 'amber',
+    isDefault: true,
+    userId: 1,
+    createdAt: new Date('2026-06-12T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-12T00:00:00.000Z'),
+    _count: { todos: 0 },
+  },
+]
+
+type BrainDumpSpacesBridge = {
+  getVisibleOnAllWorkspaces: ReturnType<typeof vi.fn>
+  setVisibleOnAllWorkspaces: ReturnType<typeof vi.fn>
+}
+
+/**
+ * Installs the BrainDump preload bridge used by the editor in renderer tests.
+ * @param spaces - Fake Spaces bridge methods for this scenario.
+ * @returns Nothing; mutates the happy-dom window object.
+ * @example
+ * installBrainDumpAPI({ getVisibleOnAllWorkspaces, setVisibleOnAllWorkspaces })
+ */
+function installBrainDumpAPI(spaces: BrainDumpSpacesBridge): void {
+  Object.defineProperty(window, 'brainDumpAPI', {
+    configurable: true,
+    writable: true,
+    value: {
+      window: {
+        close: vi.fn().mockResolvedValue(undefined),
+        getBounds: vi.fn().mockResolvedValue(null),
+        getOpacity: vi.fn().mockResolvedValue(1),
+        setBounds: vi.fn().mockResolvedValue(undefined),
+        setOpacity: vi.fn().mockResolvedValue(undefined),
+        toggle: vi.fn().mockResolvedValue(undefined),
+      },
+      note: {
+        get: vi.fn().mockResolvedValue(''),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      sync: {
+        getEnabled: vi.fn().mockResolvedValue(true),
+        setEnabled: vi.fn().mockResolvedValue(undefined),
+      },
+      category: {
+        getLast: vi.fn().mockResolvedValue(1),
+        setLast: vi.fn().mockResolvedValue(undefined),
+      },
+      spaces,
+      on: vi.fn(() => vi.fn()),
+    },
+  })
+}
+
+describe('BrainDumpEditor Spaces tracking switch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reflects the saved Mac desktop tracking preference in the header switch', async () => {
+    // Arrange
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+
+    // Act
+    render(<BrainDumpEditor categories={categories} />)
+    const spacesSwitch = screen.getByRole('switch', {
+      name: 'Show BrainDump on all Mac desktops',
+    })
+
+    // Assert
+    await waitFor(() => {
+      expect(spacesSwitch).toBeChecked()
+    })
+  })
+
+  it('persists the header switch change through the BrainDump preload bridge', async () => {
+    // Arrange
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    const user = userEvent.setup()
+    render(<BrainDumpEditor categories={categories} />)
+    const spacesSwitch = screen.getByRole('switch', {
+      name: 'Show BrainDump on all Mac desktops',
+    })
+    await waitFor(() => {
+      expect(spacesSwitch).toBeChecked()
+    })
+
+    // Act
+    await user.click(spacesSwitch)
+
+    // Assert
+    expect(setVisibleOnAllWorkspaces).toHaveBeenCalledWith(false)
+    await waitFor(() => {
+      expect(spacesSwitch).not.toBeChecked()
+    })
+  })
+
+  it('rolls the header switch back when the main process rejects the change', async () => {
+    // Arrange
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi
+      .fn()
+      .mockRejectedValue(new Error('main process unavailable'))
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    const user = userEvent.setup()
+    render(<BrainDumpEditor categories={categories} />)
+    const spacesSwitch = screen.getByRole('switch', {
+      name: 'Show BrainDump on all Mac desktops',
+    })
+    await waitFor(() => {
+      expect(spacesSwitch).not.toBeChecked()
+    })
+
+    // Act
+    await user.click(spacesSwitch)
+
+    // Assert
+    await waitFor(() => {
+      expect(spacesSwitch).not.toBeChecked()
+    })
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to update desktop tracking',
+    )
+  })
+})

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -137,6 +137,7 @@ describe('BrainDumpEditor Spaces tracking switch', () => {
     })
 
     // Assert
+    expect(screen.getByText('Follow Spaces')).toBeInTheDocument()
     await waitFor(() => {
       expect(spacesSwitch).toBeChecked()
     })
@@ -198,5 +199,40 @@ describe('BrainDumpEditor Spaces tracking switch', () => {
     expect(toast.error).toHaveBeenCalledWith(
       'Failed to update desktop tracking',
     )
+  })
+
+  it('blocks rapid repeats while the Mac desktop tracking save is pending', async () => {
+    // Arrange
+    let resolveSpacesUpdate: (value: boolean) => void = () => undefined
+    const pendingSpacesUpdate = new Promise<boolean>((resolve) => {
+      resolveSpacesUpdate = resolve
+    })
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn(async () => pendingSpacesUpdate)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    render(<BrainDumpEditor categories={categories} />)
+    const spacesSwitch = screen.getByRole('switch', {
+      name: 'Show BrainDump on all Mac desktops',
+    })
+    await waitFor(() => {
+      expect(spacesSwitch).not.toBeChecked()
+    })
+
+    // Act
+    fireEvent.click(spacesSwitch)
+    fireEvent.click(spacesSwitch)
+
+    // Assert
+    expect(setVisibleOnAllWorkspaces).toHaveBeenCalledTimes(1)
+    expect(spacesSwitch).toBeDisabled()
+
+    resolveSpacesUpdate(true)
+    await waitFor(() => {
+      expect(spacesSwitch).toBeChecked()
+    })
+    expect(spacesSwitch).not.toBeDisabled()
   })
 })

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -143,10 +143,13 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
   )
   const [noteText, setNoteText] = useState<string>('')
   const [isLoadingNote, setIsLoadingNote] = useState<boolean>(false)
+  const [spacesTrackingEnabled, setSpacesTrackingEnabled] =
+    useState<boolean>(false)
   const noteInputId = useId()
   const opacityInputId = useId()
   const syncInputId = useId()
   const categoryInputId = useId()
+  const spacesInputId = useId()
 
   const activeCategoryId = syncEnabled ? floatingCategoryId : localCategoryId
   const checkedRowsRef = useRef<Map<BrainDumpLineIndex, CheckedRowMemory>>(
@@ -177,7 +180,7 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
     orpc.completed.delete.mutationOptions({}),
   )
 
-  // Initial pull of opacity + sync mode + last category from the main process.
+  // Initial pull of opacity + sync mode + Spaces tracking from the main process.
   useCycleEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment()) return
     let cancelled = false
@@ -187,12 +190,14 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
       api.window.getOpacity(),
       api.sync.getEnabled(),
       api.category.getLast(),
+      api.spaces?.getVisibleOnAllWorkspaces?.() ?? Promise.resolve(false),
     ])
-      .then(([opacityValue, enabled, lastCategoryId]) => {
+      .then(([opacityValue, enabled, lastCategoryId, followsSpaces]) => {
         if (cancelled) return
         setOpacity(opacityValue)
         setSyncEnabled(enabled)
         setLocalCategoryId(lastCategoryId)
+        setSpacesTrackingEnabled(followsSpaces)
       })
       .catch((error) => {
         // Failures here keep the safe defaults seeded by useState; surface
@@ -345,6 +350,32 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
       if (next !== undefined) handleOpacityChange(next)
     },
     [handleOpacityChange],
+  )
+
+  /**
+   * Applies the Mac Spaces tracking switch from the BrainDump header.
+   *
+   * @param enabled - true keeps both utility panels visible across Spaces.
+   * @returns Promise that settles after the main process confirms or rolls back.
+   * @example
+   * await handleSpacesTrackingChange(true)
+   */
+  const handleSpacesTrackingChange = useCallback(
+    async (enabled: boolean): Promise<void> => {
+      const previous = spacesTrackingEnabled
+      setSpacesTrackingEnabled(enabled)
+
+      try {
+        const applied =
+          await window.brainDumpAPI?.spaces?.setVisibleOnAllWorkspaces(enabled)
+        setSpacesTrackingEnabled(applied ?? enabled)
+      } catch (error) {
+        setSpacesTrackingEnabled(previous)
+        toast.error('Failed to update desktop tracking')
+        log.error('BrainDump Spaces tracking update failed', error)
+      }
+    },
+    [spacesTrackingEnabled],
   )
 
   /**
@@ -605,15 +636,22 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
             BrainDump
           </span>
         </div>
-        <button
-          type="button"
-          onClick={closeWindow}
-          className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-          style={NO_DRAG_REGION_STYLE}
-          aria-label="Close BrainDump"
-        >
-          ✕
-        </button>
+        <div className="flex items-center gap-2" style={NO_DRAG_REGION_STYLE}>
+          <Switch
+            id={spacesInputId}
+            checked={spacesTrackingEnabled}
+            onCheckedChange={handleSpacesTrackingChange}
+            aria-label="Show BrainDump on all Mac desktops"
+          />
+          <button
+            type="button"
+            onClick={closeWindow}
+            className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Close BrainDump"
+          >
+            ✕
+          </button>
+        </div>
       </header>
 
       <div

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -145,6 +145,8 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
   const [isLoadingNote, setIsLoadingNote] = useState<boolean>(false)
   const [spacesTrackingEnabled, setSpacesTrackingEnabled] =
     useState<boolean>(false)
+  const [isUpdatingSpacesTracking, setIsUpdatingSpacesTracking] =
+    useState<boolean>(false)
   const noteInputId = useId()
   const opacityInputId = useId()
   const syncInputId = useId()
@@ -162,6 +164,8 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
   )
   // Latest noteText for callbacks (toast Undo) so they never see a stale snapshot.
   const noteTextRef = useRef<string>('')
+  // Synchronous guard because state-driven disabled UI applies after render.
+  const isUpdatingSpacesTrackingRef = useRef<boolean>(false)
   // Last value persisted via `note.set` — guards against the load effect
   // re-emitting a write for content the renderer just received from main.
   const lastPersistedRef = useRef<{
@@ -362,6 +366,10 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
    */
   const handleSpacesTrackingChange = useCallback(
     async (enabled: boolean): Promise<void> => {
+      if (isUpdatingSpacesTrackingRef.current) return
+      isUpdatingSpacesTrackingRef.current = true
+      setIsUpdatingSpacesTracking(true)
+
       const previous = spacesTrackingEnabled
       setSpacesTrackingEnabled(enabled)
 
@@ -373,6 +381,9 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
         setSpacesTrackingEnabled(previous)
         toast.error('Failed to update desktop tracking')
         log.error('BrainDump Spaces tracking update failed', error)
+      } finally {
+        isUpdatingSpacesTrackingRef.current = false
+        setIsUpdatingSpacesTracking(false)
       }
     },
     [spacesTrackingEnabled],
@@ -641,8 +652,15 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
             id={spacesInputId}
             checked={spacesTrackingEnabled}
             onCheckedChange={handleSpacesTrackingChange}
+            disabled={isUpdatingSpacesTracking}
             aria-label="Show BrainDump on all Mac desktops"
           />
+          <Label
+            htmlFor={spacesInputId}
+            className="cursor-pointer text-xs text-muted-foreground"
+          >
+            Follow Spaces
+          </Label>
           <button
             type="button"
             onClick={closeWindow}

--- a/src/components/electron/BrainDumpSettings.test.tsx
+++ b/src/components/electron/BrainDumpSettings.test.tsx
@@ -93,7 +93,7 @@ describe('BrainDumpSettings', () => {
     installBrainDumpBridge({
       syncMode: false,
       opacity: 0.7,
-      shortcut: 'CommandOrControl+Shift+B',
+      shortcut: 'Alt+Space',
     })
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
@@ -105,9 +105,7 @@ describe('BrainDumpSettings', () => {
     // Assert: the ready UI renders; the old conditional useMemo crash would abort here.
     expect(await screen.findByText('Window opacity')).toBeInTheDocument()
     expect(screen.getByText('70%')).toBeInTheDocument()
-    expect(
-      screen.getByDisplayValue('CommandOrControl+Shift+B'),
-    ).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Alt+Space')).toBeInTheDocument()
     expect(consoleErrorSpy).not.toHaveBeenCalledWith(
       expect.stringContaining(
         'React has detected a change in the order of Hooks',

--- a/src/components/electron/ShortcutSettings.test.tsx
+++ b/src/components/electron/ShortcutSettings.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ShortcutSettings } from './ShortcutSettings'
+
+const getRegisteredMock = vi.fn()
+const getDefaultsMock = vi.fn()
+const getStatsMock = vi.fn()
+const updateMock = vi.fn()
+
+/**
+ * Defines the Electron shortcuts bridge consumed by ShortcutSettings.
+ * @returns Nothing; mutates the happy-dom window object for this test.
+ * @example
+ * installShortcutsBridge()
+ */
+function installShortcutsBridge(): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: {
+      shortcuts: {
+        disable: vi.fn().mockResolvedValue(true),
+        enable: vi.fn().mockResolvedValue(true),
+        getDefaults: getDefaultsMock,
+        getRegistered: getRegisteredMock,
+        getStats: getStatsMock,
+        isRegistered: vi.fn().mockResolvedValue(true),
+        register: vi.fn().mockResolvedValue(true),
+        unregister: vi.fn().mockResolvedValue(true),
+        update: updateMock,
+      },
+    },
+  })
+}
+
+describe('ShortcutSettings defaults', () => {
+  beforeEach(() => {
+    getRegisteredMock.mockReset()
+    getDefaultsMock.mockReset()
+    getStatsMock.mockReset()
+    updateMock.mockReset()
+
+    getRegisteredMock.mockResolvedValue([])
+    getDefaultsMock.mockResolvedValue([
+      {
+        id: 'toggleFloatingNavigator',
+        accelerator: 'CommandOrControl+3',
+        description: 'toggleFloatingNavigator',
+        enabled: true,
+        isGlobal: true,
+      },
+      {
+        id: 'toggleBrainDump',
+        accelerator: 'Alt+Space',
+        description: 'toggleBrainDump',
+        enabled: true,
+        isGlobal: true,
+      },
+    ])
+    getStatsMock.mockResolvedValue({
+      totalRegistered: 0,
+      isEnabled: true,
+      platform: 'darwin',
+      shortcuts: {},
+    })
+    updateMock.mockResolvedValue(true)
+    installShortcutsBridge()
+  })
+
+  it('resets Floating Navigator and BrainDump inputs to the new default accelerators', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    render(<ShortcutSettings />)
+    const resetButton = await screen.findByRole('button', {
+      name: 'Reset to Defaults',
+    })
+
+    // Act
+    await user.click(resetButton)
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByLabelText('Toggle floating navigator')).toHaveValue(
+        'CommandOrControl+3',
+      )
+    })
+    expect(screen.getByLabelText('Toggle BrainDump')).toHaveValue('Alt+Space')
+  })
+})

--- a/src/components/electron/ShortcutSettings.tsx
+++ b/src/components/electron/ShortcutSettings.tsx
@@ -44,6 +44,7 @@ const SHORTCUT_DESCRIPTIONS: Record<string, string> = {
   newTask: 'Create new task',
   search: 'Focus search',
   toggleFloatingNavigator: 'Toggle floating navigator',
+  toggleBrainDump: 'Toggle BrainDump',
   minimize: 'Minimize window',
   toggleAlwaysOnTop: 'Toggle always on top',
   focusFloatingNavigator: 'Focus floating navigator',


### PR DESCRIPTION
## Summary
- add a compact BrainDump header switch for the shared macOS Spaces tracking setting
- expose `window.brainDumpAPI.spaces.*` through the BrainDump preload and reuse the existing floating-panel IPC channels
- update default shortcuts so BrainDump uses `Alt+Space` and Floating Navigator uses `CommandOrControl+3`

## Screenshot
Captured locally for review: `/tmp/corelive-braindump-spaces-toggle.png`

## Tests
- `pnpm test -- BrainDumpEditor ShortcutSettings BrainDumpSettings`
- `pnpm test:electron -- ShortcutManager ipc-contract`
- `pnpm typecheck`
- `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mac "Follow Spaces" toggle to show BrainDump across all desktops
* **Changes**
  * BrainDump keyboard shortcut enabled by default (Alt+Space)
  * Floating Navigator default shortcut changed to Ctrl/Cmd+3
  * Shortcut help now references Preferences > Keyboard Shortcuts
* **Tests**
  * Added tests covering default shortcuts and the new Spaces toggle behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->