### PR TITLE
feat(electron): show auto-update download progress

### DIFF
--- a/electron/AutoUpdater.ts
+++ b/electron/AutoUpdater.ts
@@ -357,7 +357,11 @@ export class AutoUpdater {
    */
   private showUpdateProgressWindow(progress: UpdaterDownloadProgress): void {
     if (!this.updateProgressWindow || this.updateProgressWindow.isDestroyed()) {
-      const { workArea } = screen.getPrimaryDisplay()
+      const display =
+        this.mainWindow && !this.mainWindow.isDestroyed()
+          ? screen.getDisplayMatching(this.mainWindow.getBounds())
+          : screen.getPrimaryDisplay()
+      const { workArea } = display
       const x = Math.round(
         workArea.x + (workArea.width - UPDATE_PROGRESS_WINDOW_WIDTH_PX) / 2,
       )

--- a/electron/AutoUpdater.ts
+++ b/electron/AutoUpdater.ts
@@ -6,13 +6,24 @@
  * @module electron/AutoUpdater
  */
 
-import type { BrowserWindow } from 'electron'
-import { dialog } from 'electron'
+import { BrowserWindow, dialog, screen } from 'electron'
 import { autoUpdater } from 'electron-updater'
-import type { UpdateInfo } from 'electron-updater'
+import type { ProgressInfo, UpdateInfo } from 'electron-updater'
 
+import {
+  UPDATE_PROGRESS_PERCENT_MAX,
+  UPDATE_PROGRESS_PERCENT_MIN,
+  UPDATE_PROGRESS_WINDOW_BOTTOM_OFFSET_PX,
+  UPDATE_PROGRESS_WINDOW_HEIGHT_PX,
+  UPDATE_PROGRESS_WINDOW_WIDTH_PX,
+} from './constants'
 import { typedSend } from './ipc/typedSend'
 import { log } from './logger'
+import type { UpdaterDownloadProgress } from './types/ipc'
+import {
+  buildUpdateProgressWindowHtml,
+  buildUpdateProgressWindowUpdateScript,
+} from './update-progress-window-html'
 
 // ============================================================================
 // Type Definitions
@@ -22,6 +33,7 @@ import { log } from './logger'
 interface UpdateStatus {
   updateAvailable: boolean
   updateDownloaded: boolean
+  downloadProgress: UpdaterDownloadProgress | null
 }
 
 /**
@@ -33,6 +45,58 @@ interface UpdaterLogger {
   warn: (...args: unknown[]) => void
   error: (...args: unknown[]) => void
   debug: (...args: unknown[]) => void
+}
+
+/**
+ * Keeps update progress values finite before they reach UI surfaces.
+ * @param value - Raw numeric value from electron-updater.
+ * @param min - Inclusive lower bound.
+ * @param max - Inclusive upper bound.
+ * @returns Finite number clamped between min and max.
+ * @example
+ * clampFiniteProgressValue(Number.NaN, 0, 100) // => 0
+ */
+function clampFiniteProgressValue(
+  value: number,
+  min: number,
+  max: number,
+): number {
+  if (!Number.isFinite(value)) return min
+  return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Keeps byte metrics non-negative before renderer IPC receives them.
+ * @param value - Raw byte or speed metric from electron-updater.
+ * @returns Finite non-negative metric, or 0 when the source is invalid.
+ * @example
+ * normalizeProgressMetric(-1) // => 0
+ */
+function normalizeProgressMetric(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, value)
+}
+
+/**
+ * Converts electron-updater progress into the stable renderer/native shape.
+ * @param progress - Raw electron-updater ProgressInfo payload.
+ * @returns Clamped progress where percent is always in the inclusive 0-100 range.
+ * @example
+ * normalizeDownloadProgress({ percent: 140, bytesPerSecond: 1, transferred: 2, total: 3, delta: 0 })
+ */
+export function normalizeDownloadProgress(
+  progress: ProgressInfo,
+): UpdaterDownloadProgress {
+  return {
+    percent: clampFiniteProgressValue(
+      progress.percent,
+      UPDATE_PROGRESS_PERCENT_MIN,
+      UPDATE_PROGRESS_PERCENT_MAX,
+    ),
+    bytesPerSecond: normalizeProgressMetric(progress.bytesPerSecond),
+    transferred: normalizeProgressMetric(progress.transferred),
+    total: normalizeProgressMetric(progress.total),
+  }
 }
 
 // ============================================================================
@@ -52,6 +116,12 @@ export class AutoUpdater {
   /** Track if update is ready */
   private updateDownloaded: boolean
 
+  /** Latest download progress, or null when no download is active */
+  private downloadProgress: UpdaterDownloadProgress | null
+
+  /** Native passive window that shows update download progress */
+  private updateProgressWindow: BrowserWindow | null
+
   /** Initial check timeout reference for cleanup */
   private initialCheckTimeout: ReturnType<typeof setTimeout> | null = null
 
@@ -62,6 +132,8 @@ export class AutoUpdater {
     this.mainWindow = null
     this.updateAvailable = false
     this.updateDownloaded = false
+    this.downloadProgress = null
+    this.updateProgressWindow = null
 
     // Type for pino logger methods that accept rest parameters
     type LogMethod = (...args: unknown[]) => void
@@ -95,6 +167,7 @@ export class AutoUpdater {
       // Reset state flags at the start of each check to ensure consistency
       this.updateAvailable = false
       this.updateDownloaded = false
+      this.clearDownloadProgress()
       this.sendStatusToWindow('Checking for update...')
     })
 
@@ -112,6 +185,7 @@ export class AutoUpdater {
       // Reset status flags when no update is available
       this.updateAvailable = false
       this.updateDownloaded = false
+      this.clearDownloadProgress()
       this.sendStatusToWindow('Update not available')
     })
 
@@ -120,22 +194,33 @@ export class AutoUpdater {
       // Reset status flags on error to allow retry
       this.updateAvailable = false
       this.updateDownloaded = false
+      this.clearDownloadProgress()
       this.sendStatusToWindow('Error in auto-updater')
     })
 
-    autoUpdater.on('download-progress', (progressObj) => {
+    autoUpdater.on('download-progress', (progressObj: ProgressInfo) => {
+      const progress = normalizeDownloadProgress(progressObj)
       let logMessage = `Download speed: ${progressObj.bytesPerSecond}`
       logMessage += ` - Downloaded ${progressObj.percent}%`
       logMessage += ` (${progressObj.transferred}/${progressObj.total})`
       log.info(logMessage)
+      this.sendDownloadProgress(progress)
       this.sendStatusToWindow(
-        `Downloading update: ${Math.round(progressObj.percent)}%`,
+        `Downloading update: ${Math.round(progress.percent)}%`,
       )
     })
 
     autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
       log.info('Update downloaded', info)
       this.updateDownloaded = true
+      this.sendDownloadProgress({
+        percent: UPDATE_PROGRESS_PERCENT_MAX,
+        bytesPerSecond: this.downloadProgress?.bytesPerSecond ?? 0,
+        transferred: this.downloadProgress?.total ?? 0,
+        total: this.downloadProgress?.total ?? 0,
+      })
+      this.closeUpdateProgressWindow()
+      this.downloadProgress = null
       this.sendStatusToWindow('Update downloaded')
       this.showUpdateDownloadedDialog().catch((err) => {
         log.error('Failed to show update downloaded dialog:', err)
@@ -171,6 +256,7 @@ export class AutoUpdater {
       // Reset state flags on error to allow retry
       this.updateAvailable = false
       this.updateDownloaded = false
+      this.clearDownloadProgress()
     })
   }
 
@@ -194,9 +280,16 @@ export class AutoUpdater {
     })
 
     if (result.response === 0) {
+      this.sendDownloadProgress({
+        percent: UPDATE_PROGRESS_PERCENT_MIN,
+        bytesPerSecond: 0,
+        transferred: 0,
+        total: 0,
+      })
       // Handle async rejection from downloadUpdate Promise
       void autoUpdater.downloadUpdate().catch((error) => {
         log.error('Failed to download update:', error)
+        this.clearDownloadProgress()
         this.sendStatusToWindow('Failed to download update')
       })
     }
@@ -236,6 +329,127 @@ export class AutoUpdater {
   }
 
   /**
+   * Broadcasts and displays update download progress while a package downloads.
+   * @param progress - Normalized progress payload to show in native + renderer UI.
+   * @returns Nothing; lost renderer/window updates are logged and ignored.
+   * @example
+   * updater.sendDownloadProgress({ percent: 42, bytesPerSecond: 1, transferred: 2, total: 4 })
+   */
+  private sendDownloadProgress(progress: UpdaterDownloadProgress): void {
+    this.downloadProgress = progress
+    this.showUpdateProgressWindow(progress)
+
+    if (this.mainWindow && this.mainWindow.webContents) {
+      typedSend(
+        this.mainWindow.webContents,
+        'updater-download-progress',
+        progress,
+      )
+    }
+  }
+
+  /**
+   * Opens or updates the passive native progress window.
+   * @param progress - Normalized progress payload to paint.
+   * @returns Nothing; window creation is skipped only when Electron cannot build it.
+   * @example
+   * updater.showUpdateProgressWindow({ percent: 10, bytesPerSecond: 1, transferred: 1, total: 10 })
+   */
+  private showUpdateProgressWindow(progress: UpdaterDownloadProgress): void {
+    if (!this.updateProgressWindow || this.updateProgressWindow.isDestroyed()) {
+      const { workArea } = screen.getPrimaryDisplay()
+      const x = Math.round(
+        workArea.x + (workArea.width - UPDATE_PROGRESS_WINDOW_WIDTH_PX) / 2,
+      )
+      const y = Math.round(
+        workArea.y +
+          workArea.height -
+          UPDATE_PROGRESS_WINDOW_HEIGHT_PX -
+          UPDATE_PROGRESS_WINDOW_BOTTOM_OFFSET_PX,
+      )
+
+      this.updateProgressWindow = new BrowserWindow({
+        width: UPDATE_PROGRESS_WINDOW_WIDTH_PX,
+        height: UPDATE_PROGRESS_WINDOW_HEIGHT_PX,
+        x,
+        y,
+        show: false,
+        frame: false,
+        transparent: true,
+        hasShadow: false,
+        resizable: false,
+        movable: false,
+        minimizable: false,
+        maximizable: false,
+        fullscreenable: false,
+        skipTaskbar: true,
+        focusable: false,
+        alwaysOnTop: true,
+        acceptFirstMouse: false,
+        backgroundColor: '#00000000',
+        webPreferences: {
+          nodeIntegration: false,
+          contextIsolation: true,
+          devTools: false,
+        },
+      })
+      this.updateProgressWindow.setIgnoreMouseEvents(true)
+      this.updateProgressWindow.on('closed', () => {
+        this.updateProgressWindow = null
+      })
+      this.updateProgressWindow.once('ready-to-show', () => {
+        if (
+          this.updateProgressWindow &&
+          !this.updateProgressWindow.isDestroyed()
+        ) {
+          this.updateProgressWindow.showInactive()
+        }
+      })
+      void this.updateProgressWindow
+        .loadURL(
+          `data:text/html;charset=utf-8,${encodeURIComponent(
+            buildUpdateProgressWindowHtml(progress),
+          )}`,
+        )
+        .catch((error: unknown) => {
+          log.debug('Failed to load native update progress window:', error)
+        })
+      return
+    }
+
+    void this.updateProgressWindow.webContents
+      .executeJavaScript(buildUpdateProgressWindowUpdateScript(progress))
+      .catch((error: unknown) => {
+        log.debug('Failed to update native update progress window:', error)
+      })
+  }
+
+  /**
+   * Destroys the passive native progress window if it exists.
+   * @returns Nothing; safe to call repeatedly.
+   * @example
+   * updater.closeUpdateProgressWindow()
+   */
+  private closeUpdateProgressWindow(): void {
+    if (!this.updateProgressWindow) return
+    if (!this.updateProgressWindow.isDestroyed()) {
+      this.updateProgressWindow.destroy()
+    }
+    this.updateProgressWindow = null
+  }
+
+  /**
+   * Clears active download state and removes the passive native progress UI.
+   * @returns Nothing; used by no-update, error, failed-download, and cleanup paths.
+   * @example
+   * updater.clearDownloadProgress()
+   */
+  private clearDownloadProgress(): void {
+    this.downloadProgress = null
+    this.closeUpdateProgressWindow()
+  }
+
+  /**
    * Manual update check (called from menu or UI).
    */
   manualCheckForUpdates(): void {
@@ -245,6 +459,7 @@ export class AutoUpdater {
       // Reset state flags on error to allow retry
       this.updateAvailable = false
       this.updateDownloaded = false
+      this.clearDownloadProgress()
     })
   }
 
@@ -266,6 +481,7 @@ export class AutoUpdater {
     return {
       updateAvailable: this.updateAvailable,
       updateDownloaded: this.updateDownloaded,
+      downloadProgress: this.downloadProgress,
     }
   }
 
@@ -295,10 +511,12 @@ export class AutoUpdater {
 
     // Clear window reference
     this.mainWindow = null
+    this.closeUpdateProgressWindow()
 
     // Reset status flags
     this.updateAvailable = false
     this.updateDownloaded = false
+    this.downloadProgress = null
   }
 }
 

--- a/electron/__tests__/AutoUpdater.test.ts
+++ b/electron/__tests__/AutoUpdater.test.ts
@@ -1,0 +1,270 @@
+import type { BrowserWindow } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AutoUpdater, normalizeDownloadProgress } from '../AutoUpdater'
+import {
+  UPDATE_PROGRESS_PERCENT_MAX,
+  UPDATE_PROGRESS_PERCENT_MIN,
+} from '../constants'
+
+type MockListener = (...args: unknown[]) => void
+
+interface MockWindow {
+  options: Record<string, unknown>
+  destroy: ReturnType<typeof vi.fn>
+  isDestroyed: ReturnType<typeof vi.fn>
+  loadURL: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
+  once: ReturnType<typeof vi.fn>
+  setIgnoreMouseEvents: ReturnType<typeof vi.fn>
+  showInactive: ReturnType<typeof vi.fn>
+  webContents: {
+    executeJavaScript: ReturnType<typeof vi.fn>
+    isDestroyed: ReturnType<typeof vi.fn>
+    send: ReturnType<typeof vi.fn>
+  }
+}
+
+const electronMocks = vi.hoisted(() => {
+  const listeners: Record<string, MockListener[]> = {}
+  const createdWindows: MockWindow[] = []
+
+  const mockAutoUpdater = {
+    logger: null as unknown,
+    on: vi.fn((eventName: string, listener: MockListener) => {
+      listeners[eventName] = [...(listeners[eventName] ?? []), listener]
+      return mockAutoUpdater
+    }),
+    emit: vi.fn((eventName: string, ...args: unknown[]) => {
+      for (const listener of listeners[eventName] ?? []) listener(...args)
+      return true
+    }),
+    removeAllListeners: vi.fn((eventName?: string) => {
+      if (eventName) {
+        delete listeners[eventName]
+      } else {
+        for (const key of Object.keys(listeners)) delete listeners[key]
+      }
+      return mockAutoUpdater
+    }),
+    checkForUpdatesAndNotify: vi.fn().mockResolvedValue(undefined),
+    downloadUpdate: vi.fn().mockResolvedValue(undefined),
+    quitAndInstall: vi.fn(),
+  }
+
+  return {
+    createdWindows,
+    listeners,
+    mockAutoUpdater,
+    mockShowMessageBox: vi.fn().mockResolvedValue({ response: 1 }),
+  }
+})
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(function (options: Record<string, unknown>) {
+    let destroyed = false
+    const instance: MockWindow = {
+      options,
+      destroy: vi.fn(() => {
+        destroyed = true
+      }),
+      isDestroyed: vi.fn(() => destroyed),
+      loadURL: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+      once: vi.fn(),
+      setIgnoreMouseEvents: vi.fn(),
+      showInactive: vi.fn(),
+      webContents: {
+        executeJavaScript: vi.fn().mockResolvedValue(undefined),
+        isDestroyed: vi.fn(() => false),
+        send: vi.fn(),
+      },
+    }
+    electronMocks.createdWindows.push(instance)
+    return instance
+  }),
+  dialog: {
+    showMessageBox: electronMocks.mockShowMessageBox,
+  },
+  screen: {
+    getPrimaryDisplay: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+  },
+}))
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: electronMocks.mockAutoUpdater,
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+/**
+ * Creates a main-window stub with the webContents surface `typedSend` needs.
+ * @returns BrowserWindow-compatible object for AutoUpdater tests.
+ * @example
+ * const mainWindow = createMainWindowStub()
+ */
+function createMainWindowStub(): BrowserWindow {
+  return {
+    webContents: {
+      isDestroyed: vi.fn(() => false),
+      send: vi.fn(),
+    },
+  } as unknown as BrowserWindow
+}
+
+/**
+ * Returns the native update-progress BrowserWindow created by AutoUpdater.
+ * @returns Captured progress window mock.
+ * @example
+ * const progressWindow = getProgressWindow()
+ */
+function getProgressWindow(): MockWindow {
+  const progressWindow = electronMocks.createdWindows[0]
+  if (!progressWindow) {
+    throw new Error('Expected native update progress window to be created')
+  }
+  return progressWindow
+}
+
+describe('AutoUpdater download progress', () => {
+  beforeEach(() => {
+    electronMocks.createdWindows.length = 0
+    electronMocks.mockShowMessageBox.mockClear()
+    electronMocks.mockShowMessageBox.mockResolvedValue({ response: 1 })
+    electronMocks.mockAutoUpdater.on.mockClear()
+    electronMocks.mockAutoUpdater.emit.mockClear()
+    electronMocks.mockAutoUpdater.removeAllListeners()
+    electronMocks.mockAutoUpdater.removeAllListeners.mockClear()
+    electronMocks.mockAutoUpdater.downloadUpdate.mockClear()
+    electronMocks.mockAutoUpdater.downloadUpdate.mockResolvedValue(undefined)
+    electronMocks.mockAutoUpdater.quitAndInstall.mockClear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('clamps raw electron-updater progress into the renderer payload range', () => {
+    // Arrange + Act
+    const overMax = normalizeDownloadProgress({
+      percent: 140,
+      bytesPerSecond: 10,
+      transferred: 20,
+      total: 30,
+      delta: 0,
+    })
+    const underMin = normalizeDownloadProgress({
+      percent: -12,
+      bytesPerSecond: -1,
+      transferred: -2,
+      total: -3,
+      delta: 0,
+    })
+    const invalidMetrics = normalizeDownloadProgress({
+      percent: Number.NaN,
+      bytesPerSecond: Number.NaN,
+      transferred: Number.NaN,
+      total: Number.NaN,
+      delta: 0,
+    })
+
+    // Assert
+    expect(overMax.percent).toBe(UPDATE_PROGRESS_PERCENT_MAX)
+    expect(underMin.percent).toBe(UPDATE_PROGRESS_PERCENT_MIN)
+    expect(underMin.bytesPerSecond).toBe(0)
+    expect(underMin.transferred).toBe(0)
+    expect(underMin.total).toBe(0)
+    expect(invalidMetrics.percent).toBe(UPDATE_PROGRESS_PERCENT_MIN)
+    expect(invalidMetrics.bytesPerSecond).toBe(0)
+    expect(invalidMetrics.transferred).toBe(0)
+    expect(invalidMetrics.total).toBe(0)
+  })
+
+  it('creates a passive native window and broadcasts progress on download-progress', () => {
+    // Arrange
+    const updater = new AutoUpdater()
+    const mainWindow = createMainWindowStub()
+    updater.setMainWindow(mainWindow)
+
+    // Act
+    electronMocks.mockAutoUpdater.emit('download-progress', {
+      percent: 42,
+      bytesPerSecond: 1024,
+      transferred: 42,
+      total: 100,
+      delta: 0,
+    })
+
+    // Assert
+    const progressWindow = getProgressWindow()
+    expect(progressWindow.options.frame).toBe(false)
+    expect(progressWindow.options.transparent).toBe(true)
+    expect(progressWindow.options.alwaysOnTop).toBe(true)
+    expect(progressWindow.options.skipTaskbar).toBe(true)
+    expect(progressWindow.options.focusable).toBe(false)
+    expect(progressWindow.setIgnoreMouseEvents).toHaveBeenCalledWith(true)
+    expect(progressWindow.loadURL).toHaveBeenCalledWith(
+      expect.stringMatching(/^data:text\/html;charset=utf-8,/),
+    )
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith(
+      'updater-download-progress',
+      {
+        percent: 42,
+        bytesPerSecond: 1024,
+        transferred: 42,
+        total: 100,
+      },
+    )
+  })
+
+  it('destroys the native progress window after update-downloaded', () => {
+    // Arrange
+    const updater = new AutoUpdater()
+    updater.setMainWindow(createMainWindowStub())
+    electronMocks.mockAutoUpdater.emit('download-progress', {
+      percent: 42,
+      bytesPerSecond: 1024,
+      transferred: 42,
+      total: 100,
+      delta: 0,
+    })
+    const progressWindow = getProgressWindow()
+
+    // Act
+    electronMocks.mockAutoUpdater.emit('update-downloaded', {
+      version: '1.2.4',
+    })
+
+    // Assert
+    expect(progressWindow.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys the native progress window during cleanup', () => {
+    // Arrange
+    const updater = new AutoUpdater()
+    updater.setMainWindow(createMainWindowStub())
+    electronMocks.mockAutoUpdater.emit('download-progress', {
+      percent: 42,
+      bytesPerSecond: 1024,
+      transferred: 42,
+      total: 100,
+      delta: 0,
+    })
+    const progressWindow = getProgressWindow()
+
+    // Act
+    updater.cleanup()
+
+    // Assert
+    expect(progressWindow.destroy).toHaveBeenCalledTimes(1)
+    expect(
+      electronMocks.mockAutoUpdater.removeAllListeners,
+    ).toHaveBeenCalledWith('download-progress')
+  })
+})

--- a/electron/__tests__/AutoUpdater.test.ts
+++ b/electron/__tests__/AutoUpdater.test.ts
@@ -87,6 +87,9 @@ vi.mock('electron', () => ({
     showMessageBox: electronMocks.mockShowMessageBox,
   },
   screen: {
+    getDisplayMatching: vi.fn(() => ({
+      workArea: { x: 1440, y: 0, width: 1440, height: 900 },
+    })),
     getPrimaryDisplay: vi.fn(() => ({
       workArea: { x: 0, y: 0, width: 1920, height: 1080 },
     })),
@@ -109,6 +112,8 @@ vi.mock('../logger', () => ({
  */
 function createMainWindowStub(): BrowserWindow {
   return {
+    getBounds: vi.fn(() => ({ x: 1500, y: 40, width: 900, height: 700 })),
+    isDestroyed: vi.fn(() => false),
     webContents: {
       isDestroyed: vi.fn(() => false),
       send: vi.fn(),
@@ -208,6 +213,8 @@ describe('AutoUpdater download progress', () => {
     expect(progressWindow.options.alwaysOnTop).toBe(true)
     expect(progressWindow.options.skipTaskbar).toBe(true)
     expect(progressWindow.options.focusable).toBe(false)
+    expect(progressWindow.options.x).toBe(1980)
+    expect(progressWindow.options.y).toBe(690)
     expect(progressWindow.setIgnoreMouseEvents).toHaveBeenCalledWith(true)
     expect(progressWindow.loadURL).toHaveBeenCalledWith(
       expect.stringMatching(/^data:text\/html;charset=utf-8,/),

--- a/electron/__tests__/update-progress-window-html.test.ts
+++ b/electron/__tests__/update-progress-window-html.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildUpdateProgressWindowHtml,
+  buildUpdateProgressWindowUpdateScript,
+} from '../update-progress-window-html'
+
+const halfwayProgress = {
+  percent: 42,
+  bytesPerSecond: 1024,
+  transferred: 42,
+  total: 100,
+}
+
+describe('update progress window markup', () => {
+  it('renders accessible progressbar markup with the initial percent', () => {
+    // Arrange + Act
+    const html = buildUpdateProgressWindowHtml(halfwayProgress)
+
+    // Assert
+    expect(html).toContain('role="progressbar"')
+    expect(html).toContain('aria-label="Update download progress"')
+    expect(html).toContain('aria-valuenow="42"')
+    expect(html).toContain('42%')
+  })
+
+  it('renders a complete standalone document without external assets', () => {
+    // Arrange + Act
+    const html = buildUpdateProgressWindowHtml(halfwayProgress)
+
+    // Assert
+    expect(html.startsWith('<!doctype html>')).toBe(true)
+    expect(html).toContain('</html>')
+    expect(html).not.toMatch(/rel=["']stylesheet/)
+    expect(html).not.toContain('fonts.googleapis.com')
+  })
+
+  it('stays click-through so the native progress window never blocks work', () => {
+    // Arrange + Act
+    const html = buildUpdateProgressWindowHtml(halfwayProgress)
+
+    // Assert
+    expect(html).toContain('pointer-events: none')
+    expect(html).toContain('user-select: none')
+  })
+
+  it('honors reduced motion for progress updates', () => {
+    // Arrange + Act
+    const html = buildUpdateProgressWindowHtml(halfwayProgress)
+
+    // Assert
+    expect(html).toContain('@media (prefers-reduced-motion: reduce)')
+    expect(html).toContain('transition: none')
+  })
+
+  it('builds a tiny update script for an already-loaded window', () => {
+    // Arrange + Act
+    const script = buildUpdateProgressWindowUpdateScript(halfwayProgress)
+
+    // Assert
+    expect(script).toBe('window.__coreliveSetUpdateProgress?.(42)')
+  })
+})

--- a/electron/__tests__/update-progress-window-html.test.ts
+++ b/electron/__tests__/update-progress-window-html.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import type { UpdaterDownloadProgress } from '../types/ipc'
 import {
   buildUpdateProgressWindowHtml,
   buildUpdateProgressWindowUpdateScript,
 } from '../update-progress-window-html'
 
-const halfwayProgress = {
+const halfwayProgress: UpdaterDownloadProgress = {
   percent: 42,
   bytesPerSecond: 1024,
   transferred: 42,

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -65,6 +65,25 @@ export const STARTUP_PILL_WIDTH_PX = 260
 export const STARTUP_PILL_HEIGHT_PX = 76
 
 // ============================================================================
+// Auto-update download progress window
+// ============================================================================
+
+/** Update-progress window width (transparent; the visible panel is centered). */
+export const UPDATE_PROGRESS_WINDOW_WIDTH_PX = 360
+
+/** Update-progress window height (transparent; the visible panel is centered). */
+export const UPDATE_PROGRESS_WINDOW_HEIGHT_PX = 118
+
+/** Distance from the bottom of the active work area for the progress window. */
+export const UPDATE_PROGRESS_WINDOW_BOTTOM_OFFSET_PX = 92
+
+/** Minimum percent emitted for update download progress. */
+export const UPDATE_PROGRESS_PERCENT_MIN = 0
+
+/** Maximum percent emitted for update download progress. */
+export const UPDATE_PROGRESS_PERCENT_MAX = 100
+
+// ============================================================================
 // Opt-in debug mode (Issue #61 — DevTools / CDP in packaged builds)
 // ============================================================================
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2121,7 +2121,11 @@ function setupIPCHandlers(): void {
     if (autoUpdater) {
       return autoUpdater.getUpdateStatus()
     }
-    return { updateAvailable: false, updateDownloaded: false }
+    return {
+      updateAvailable: false,
+      updateDownloaded: false,
+      downloadProgress: null,
+    }
   })
 
   // Note: Quick todo operations removed - Floating Navigator uses oRPC via web app

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -132,6 +132,7 @@ const ALLOWED_CHANNELS = {
   'app-update-available': true,
   'app-update-downloaded': true,
   'updater-message': true,
+  'updater-download-progress': true,
   'focus-task': true,
   'mark-task-complete': true,
   'shortcut-new-task': true,
@@ -1877,7 +1878,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         return await typedInvoke('updater-get-status')
       } catch (error) {
         log.error('Failed to get update status:', error)
-        return { updateAvailable: false, updateDownloaded: false }
+        return {
+          updateAvailable: false,
+          updateDownloaded: false,
+          downloadProgress: null,
+        }
       }
     },
   },

--- a/electron/types/ipc.ts
+++ b/electron/types/ipc.ts
@@ -221,6 +221,15 @@ export interface DeepLinkExamples {
 export interface UpdaterStatus {
   updateAvailable: boolean
   updateDownloaded: boolean
+  downloadProgress: UpdaterDownloadProgress | null
+}
+
+/** Normalized auto-update download progress sent from main to renderer. */
+export interface UpdaterDownloadProgress {
+  percent: number
+  bytesPerSecond: number
+  transferred: number
+  total: number
 }
 
 // ============================================================================
@@ -800,6 +809,7 @@ export interface IPCEventChannels {
   'app-update-available': { version: string; releaseNotes?: string }
   'app-update-downloaded': { version: string }
   'updater-message': string
+  'updater-download-progress': UpdaterDownloadProgress
 
   // Task events (from shortcuts/deep links)
   'focus-task': { taskId: string }

--- a/electron/update-progress-window-html.ts
+++ b/electron/update-progress-window-html.ts
@@ -1,0 +1,188 @@
+/**
+ * @fileoverview Self-contained auto-update download progress markup.
+ *
+ * Why this module exists: the update download runs in Electron main process
+ * while the app may be minimized, offline-ish, or away from authenticated web
+ * routes. A native `data:` window paints immediately and keeps the user aware
+ * of progress without depending on Next.js, Clerk, or the network.
+ *
+ * @module electron/update-progress-window-html
+ */
+
+import type { UpdaterDownloadProgress } from './types/ipc'
+
+/**
+ * Build the native update-progress window HTML shown while an app update downloads.
+ * @param progress - Normalized 0-100 download progress payload.
+ * @returns Complete offline-safe HTML for a transparent data-url BrowserWindow.
+ * @example
+ * buildUpdateProgressWindowHtml({ percent: 42, bytesPerSecond: 1, transferred: 2, total: 4 })
+ */
+export function buildUpdateProgressWindowHtml(
+  progress: UpdaterDownloadProgress,
+): string {
+  const percent = Math.round(progress.percent)
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        --surface: oklch(0.98 0.008 70 / 96%);
+        --foreground: oklch(0.18 0.015 30);
+        --muted: oklch(0.5 0.026 56);
+        --border: oklch(0.92 0.01 70);
+        --track: oklch(0.88 0.018 74);
+        --fill: oklch(0.56 0.16 50);
+        --shadow: oklch(0.18 0.015 30 / 20%);
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: oklch(0.22 0.015 40 / 96%);
+          --foreground: oklch(0.96 0.005 75);
+          --muted: oklch(0.74 0.026 66);
+          --border: oklch(1 0 0 / 8%);
+          --track: oklch(1 0 0 / 12%);
+          --fill: oklch(0.7 0.16 55);
+          --shadow: oklch(0 0 0 / 45%);
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: transparent;
+        user-select: none;
+        -webkit-user-select: none;
+        pointer-events: none;
+        -webkit-app-region: no-drag;
+        cursor: default;
+      }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family:
+          'Inter Tight',
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+      }
+      .panel {
+        width: 320px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 16px 18px;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        background: var(--surface);
+        box-shadow: 0 10px 28px var(--shadow);
+        backdrop-filter: blur(18px);
+      }
+      .row {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .label {
+        color: var(--foreground);
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 1.2;
+      }
+      .percent {
+        color: var(--muted);
+        font-family:
+          'Geist Mono',
+          ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace;
+        font-size: 13px;
+        font-variant-numeric: tabular-nums;
+        line-height: 1.2;
+      }
+      .track {
+        height: 8px;
+        width: 100%;
+        overflow: hidden;
+        border-radius: 9999px;
+        background: var(--track);
+      }
+      .fill {
+        height: 100%;
+        width: var(--progress-percent);
+        border-radius: inherit;
+        background: var(--fill);
+        transition: width 160ms ease-out;
+      }
+      .hint {
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.2;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .fill {
+          transition: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <section class="panel" aria-live="polite">
+      <div class="row">
+        <div class="label">Downloading CoreLive update...</div>
+        <div class="percent" id="percent">${percent}%</div>
+      </div>
+      <div
+        class="track"
+        role="progressbar"
+        aria-label="Update download progress"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="${percent}"
+      >
+        <div class="fill" id="fill" style="--progress-percent: ${percent}%"></div>
+      </div>
+      <div class="hint">You can keep working while this finishes.</div>
+    </section>
+    <script>
+      window.__coreliveSetUpdateProgress = function setUpdateProgress(nextPercent) {
+        var safePercent = Math.max(0, Math.min(100, Math.round(Number(nextPercent) || 0)));
+        var percent = document.getElementById('percent');
+        var fill = document.getElementById('fill');
+        var progressbar = document.querySelector('[role="progressbar"]');
+        if (percent) percent.textContent = safePercent + '%';
+        if (fill) fill.style.setProperty('--progress-percent', safePercent + '%');
+        if (progressbar) progressbar.setAttribute('aria-valuenow', String(safePercent));
+      };
+    </script>
+  </body>
+</html>
+`
+}
+
+/**
+ * Build the script that updates an already-loaded native progress window.
+ * @param progress - Normalized 0-100 download progress payload.
+ * @returns JavaScript string safe to pass to `webContents.executeJavaScript`.
+ * @example
+ * buildUpdateProgressWindowUpdateScript({ percent: 75, bytesPerSecond: 1, transferred: 3, total: 4 })
+ */
+export function buildUpdateProgressWindowUpdateScript(
+  progress: UpdaterDownloadProgress,
+): string {
+  return `window.__coreliveSetUpdateProgress?.(${JSON.stringify(
+    Math.round(progress.percent),
+  )})`
+}

--- a/src/components/electron/AppUpdateSettings.test.tsx
+++ b/src/components/electron/AppUpdateSettings.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { UpdaterDownloadProgress } from '@/electron/types/ipc'
 
 import { AppUpdateSettings } from './AppUpdateSettings'
 
@@ -9,6 +11,14 @@ const checkForUpdatesMock = vi.fn()
 const quitAndInstallMock = vi.fn()
 const getStatusMock = vi.fn()
 const onMock = vi.fn()
+const eventListeners: Partial<Record<string, (payload: unknown) => void>> = {}
+
+const downloadingHalfway: UpdaterDownloadProgress = {
+  percent: 42,
+  bytesPerSecond: 1024,
+  transferred: 42,
+  total: 100,
+}
 
 /**
  * Install a fake electronAPI on window for Electron renderer tests.
@@ -25,6 +35,9 @@ function installElectronAPI(api: unknown): void {
 
 describe('AppUpdateSettings', () => {
   beforeEach(() => {
+    for (const key of Object.keys(eventListeners)) {
+      delete eventListeners[key]
+    }
     getVersionMock.mockReset()
     checkForUpdatesMock.mockReset()
     quitAndInstallMock.mockReset()
@@ -37,8 +50,177 @@ describe('AppUpdateSettings', () => {
     getStatusMock.mockResolvedValue({
       updateAvailable: false,
       updateDownloaded: false,
+      downloadProgress: null,
     })
-    onMock.mockReturnValue(() => {})
+    onMock.mockImplementation(
+      (channel: string, callback: (payload: unknown) => void) => {
+        eventListeners[channel] = callback
+        return () => {
+          delete eventListeners[channel]
+        }
+      },
+    )
+  })
+
+  it('restores in-progress update download progress from updater status', async () => {
+    // Arrange
+    getStatusMock.mockResolvedValue({
+      updateAvailable: true,
+      updateDownloaded: false,
+      downloadProgress: downloadingHalfway,
+    })
+    installElectronAPI({
+      app: { getVersion: getVersionMock },
+      updater: {
+        checkForUpdates: checkForUpdatesMock,
+        quitAndInstall: quitAndInstallMock,
+        getStatus: getStatusMock,
+      },
+      on: onMock,
+    })
+
+    // Act
+    render(<AppUpdateSettings />)
+
+    // Assert
+    expect(
+      await screen.findByText('Downloading update — 42%'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Download progress')).toBeInTheDocument()
+    expect(
+      screen.getByRole('progressbar', { name: 'Update download progress' }),
+    ).toHaveAttribute('aria-valuenow', '42')
+  })
+
+  it('shows update download progress when the main process emits progress', async () => {
+    // Arrange
+    installElectronAPI({
+      app: { getVersion: getVersionMock },
+      updater: {
+        checkForUpdates: checkForUpdatesMock,
+        quitAndInstall: quitAndInstallMock,
+        getStatus: getStatusMock,
+      },
+      on: onMock,
+    })
+    render(<AppUpdateSettings />)
+    await screen.findByText("You're running CoreLive 1.2.3.")
+
+    // Act
+    act(() => {
+      eventListeners['updater-download-progress']?.(downloadingHalfway)
+    })
+
+    // Assert
+    expect(screen.getByText('Downloading update — 42%')).toBeInTheDocument()
+    expect(
+      screen.getByRole('progressbar', { name: 'Update download progress' }),
+    ).toHaveAttribute('aria-valuenow', '42')
+  })
+
+  it('hides update download progress once the update is downloaded', async () => {
+    // Arrange
+    getStatusMock.mockResolvedValue({
+      updateAvailable: true,
+      updateDownloaded: false,
+      downloadProgress: downloadingHalfway,
+    })
+    installElectronAPI({
+      app: { getVersion: getVersionMock },
+      updater: {
+        checkForUpdates: checkForUpdatesMock,
+        quitAndInstall: quitAndInstallMock,
+        getStatus: getStatusMock,
+      },
+      on: onMock,
+    })
+    render(<AppUpdateSettings />)
+    await screen.findByRole('progressbar', {
+      name: 'Update download progress',
+    })
+
+    // Act
+    act(() => {
+      eventListeners['updater-message']?.('Update downloaded')
+    })
+
+    // Assert
+    expect(
+      screen.queryByRole('progressbar', { name: 'Update download progress' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Update ready. Restart CoreLive to finish installing.'),
+    ).toBeInTheDocument()
+  })
+
+  it('hides update download progress when the updater reports an error', async () => {
+    // Arrange
+    getStatusMock.mockResolvedValue({
+      updateAvailable: true,
+      updateDownloaded: false,
+      downloadProgress: downloadingHalfway,
+    })
+    installElectronAPI({
+      app: { getVersion: getVersionMock },
+      updater: {
+        checkForUpdates: checkForUpdatesMock,
+        quitAndInstall: quitAndInstallMock,
+        getStatus: getStatusMock,
+      },
+      on: onMock,
+    })
+    render(<AppUpdateSettings />)
+    await screen.findByRole('progressbar', {
+      name: 'Update download progress',
+    })
+
+    // Act
+    act(() => {
+      eventListeners['updater-message']?.('Error in auto-updater')
+    })
+
+    // Assert
+    expect(
+      screen.queryByRole('progressbar', { name: 'Update download progress' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText("Couldn't check for updates. Try again in a moment."),
+    ).toBeInTheDocument()
+  })
+
+  it('hides update download progress when no update is available', async () => {
+    // Arrange
+    getStatusMock.mockResolvedValue({
+      updateAvailable: true,
+      updateDownloaded: false,
+      downloadProgress: downloadingHalfway,
+    })
+    installElectronAPI({
+      app: { getVersion: getVersionMock },
+      updater: {
+        checkForUpdates: checkForUpdatesMock,
+        quitAndInstall: quitAndInstallMock,
+        getStatus: getStatusMock,
+      },
+      on: onMock,
+    })
+    render(<AppUpdateSettings />)
+    await screen.findByRole('progressbar', {
+      name: 'Update download progress',
+    })
+
+    // Act
+    act(() => {
+      eventListeners['updater-message']?.('Update not available')
+    })
+
+    // Assert
+    expect(
+      screen.queryByRole('progressbar', { name: 'Update download progress' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText("You're on the latest version."),
+    ).toBeInTheDocument()
   })
 
   it('shows the installed version once the main process responds', async () => {
@@ -92,6 +274,7 @@ describe('AppUpdateSettings', () => {
     getStatusMock.mockResolvedValue({
       updateAvailable: true,
       updateDownloaded: true,
+      downloadProgress: null,
     })
     installElectronAPI({
       app: { getVersion: getVersionMock },
@@ -120,6 +303,7 @@ describe('AppUpdateSettings', () => {
     getStatusMock.mockResolvedValue({
       updateAvailable: true,
       updateDownloaded: true,
+      downloadProgress: null,
     })
     installElectronAPI({
       app: { getVersion: getVersionMock },

--- a/src/components/electron/AppUpdateSettings.test.tsx
+++ b/src/components/electron/AppUpdateSettings.test.tsx
@@ -151,6 +151,9 @@ describe('AppUpdateSettings', () => {
     expect(
       screen.getByText('Update ready. Restart CoreLive to finish installing.'),
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Check for Updates' }),
+    ).toBeEnabled()
   })
 
   it('hides update download progress when the updater reports an error', async () => {

--- a/src/components/electron/AppUpdateSettings.tsx
+++ b/src/components/electron/AppUpdateSettings.tsx
@@ -173,6 +173,7 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
 
         if (message === 'Update downloaded') {
           setUpdateDownloaded(true)
+          setIsChecking(false)
           setDownloadProgress(null)
         }
 

--- a/src/components/electron/AppUpdateSettings.tsx
+++ b/src/components/electron/AppUpdateSettings.tsx
@@ -21,12 +21,35 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import type { UpdaterDownloadProgress } from '@/electron/types/ipc'
 import { useCycleEffect } from '@/hooks/use-cycle-effect'
 import { useMounted } from '@/hooks/use-mounted'
+import { UPDATE_DOWNLOAD_PROGRESS_MAX_PERCENT } from '@/lib/constants/appUpdate'
 import { log } from '@/lib/logger'
 
 interface AppUpdateSettingsProps {
   className?: string
+}
+
+/**
+ * Verifies the updater progress event payload before rendering the fallback bar.
+ * @param value - Unknown IPC payload from the generic Electron event bridge.
+ * @returns True when value has the numeric progress fields AppUpdateSettings needs.
+ * @example
+ * isUpdaterDownloadProgress({ percent: 42, bytesPerSecond: 1, transferred: 2, total: 4 }) // => true
+ */
+function isUpdaterDownloadProgress(
+  value: unknown,
+): value is UpdaterDownloadProgress {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Partial<UpdaterDownloadProgress>
+  return (
+    typeof candidate.percent === 'number' &&
+    typeof candidate.bytesPerSecond === 'number' &&
+    typeof candidate.transferred === 'number' &&
+    typeof candidate.total === 'number'
+  )
 }
 
 /** User-facing copy derived from main-process updater status strings. */
@@ -63,6 +86,21 @@ function formatUpdaterStatus(rawMessage: string): string {
 }
 
 /**
+ * Converts a normalized progress payload into the existing updater status copy.
+ * @param progress - Download progress emitted by the Electron main process.
+ * @returns Human-readable status text with rounded percent.
+ * @example
+ * formatUpdaterDownloadProgress({ percent: 41.6, bytesPerSecond: 1, transferred: 2, total: 4 }) // => "Downloading update — 42%"
+ */
+function formatUpdaterDownloadProgress(
+  progress: UpdaterDownloadProgress,
+): string {
+  return formatUpdaterStatus(
+    `Downloading update: ${Math.round(progress.percent)}%`,
+  )
+}
+
+/**
  * Settings card for manually checking and installing desktop app updates.
  *
  * @param props - Component props
@@ -79,6 +117,8 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [isChecking, setIsChecking] = useState(false)
   const [updateDownloaded, setUpdateDownloaded] = useState(false)
+  const [downloadProgress, setDownloadProgress] =
+    useState<UpdaterDownloadProgress | null>(null)
 
   useCycleEffect(() => {
     const updaterApi = window.electronAPI?.updater
@@ -104,13 +144,22 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
         setUpdateDownloaded(status.updateDownloaded)
         if (status.updateDownloaded) {
           setStatusMessage(formatUpdaterStatus('Update downloaded'))
+          setDownloadProgress(null)
+          return
+        }
+        if (status.downloadProgress) {
+          setDownloadProgress(status.downloadProgress)
+          setStatusMessage(
+            formatUpdaterDownloadProgress(status.downloadProgress),
+          )
+          setIsChecking(true)
         }
       })
       .catch((statusError: unknown) => {
         log.error('Failed to load updater status:', statusError)
       })
 
-    const cleanup = window.electronAPI?.on(
+    const cleanupMessage = window.electronAPI?.on(
       'updater-message',
       (message: unknown) => {
         if (typeof message !== 'string') return
@@ -118,8 +167,13 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
         setStatusMessage(formatUpdaterStatus(message))
         setIsChecking(message.startsWith('Checking for update'))
 
+        if (message.startsWith('Checking for update')) {
+          setDownloadProgress(null)
+        }
+
         if (message === 'Update downloaded') {
           setUpdateDownloaded(true)
+          setDownloadProgress(null)
         }
 
         if (
@@ -128,6 +182,7 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
           message === 'Failed to download update'
         ) {
           setIsChecking(false)
+          setDownloadProgress(null)
         }
 
         if (message.startsWith('Downloading update:')) {
@@ -136,13 +191,25 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
 
         if (message === 'Update available') {
           setIsChecking(false)
+          setDownloadProgress(null)
         }
+      },
+    )
+
+    const cleanupProgress = window.electronAPI?.on(
+      'updater-download-progress',
+      (progress: unknown) => {
+        if (!isUpdaterDownloadProgress(progress)) return
+        setDownloadProgress(progress)
+        setStatusMessage(formatUpdaterDownloadProgress(progress))
+        setIsChecking(true)
       },
     )
 
     return () => {
       cancelled = true
-      cleanup?.()
+      cleanupMessage?.()
+      cleanupProgress?.()
     }
   }, [])
 
@@ -155,6 +222,7 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
 
     setIsChecking(true)
     setStatusMessage(formatUpdaterStatus('Checking for update...'))
+    setDownloadProgress(null)
 
     try {
       await updaterApi.checkForUpdates()
@@ -162,6 +230,7 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
       log.error('Failed to check for updates:', checkError)
       setStatusMessage(formatUpdaterStatus('Error in auto-updater'))
       setIsChecking(false)
+      setDownloadProgress(null)
     }
   }, [])
 
@@ -177,6 +246,7 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
     } catch (installError: unknown) {
       log.error('Failed to restart for update:', installError)
       setStatusMessage(formatUpdaterStatus('Failed to download update'))
+      setDownloadProgress(null)
     }
   }, [])
 
@@ -209,7 +279,7 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
             : 'Check for the latest CoreLive release.'}
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-3">
+      <CardContent className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-2">
           <Button
             type="button"
@@ -241,6 +311,23 @@ export const AppUpdateSettings = memo(function AppUpdateSettings({
           >
             {statusMessage}
           </p>
+        ) : null}
+
+        {downloadProgress ? (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+              <span>Download progress</span>
+              <span className="font-mono tabular-nums">
+                {Math.round(downloadProgress.percent)}%
+              </span>
+            </div>
+            <Progress
+              value={downloadProgress.percent}
+              max={UPDATE_DOWNLOAD_PROGRESS_MAX_PERCENT}
+              aria-label="Update download progress"
+              aria-valuenow={Math.round(downloadProgress.percent)}
+            />
+          </div>
         ) : null}
       </CardContent>
     </Card>

--- a/src/lib/constants/appUpdate.ts
+++ b/src/lib/constants/appUpdate.ts
@@ -1,2 +1,1 @@
-/** Maximum percent shown by auto-update download progress UI. */
-export const UPDATE_DOWNLOAD_PROGRESS_MAX_PERCENT = 100
+export { UPDATE_PROGRESS_PERCENT_MAX as UPDATE_DOWNLOAD_PROGRESS_MAX_PERCENT } from '@/electron/constants'

--- a/src/lib/constants/appUpdate.ts
+++ b/src/lib/constants/appUpdate.ts
@@ -1,0 +1,2 @@
+/** Maximum percent shown by auto-update download progress UI. */
+export const UPDATE_DOWNLOAD_PROGRESS_MAX_PERCENT = 100


### PR DESCRIPTION
## Summary
- Add a passive native auto-update download progress window that appears only during downloads.
- Broadcast typed updater progress over IPC and expose it in updater status.
- Show a Settings fallback progress bar using the existing shadcn/Radix Progress component.
- Cover progress normalization, native window lifecycle, HTML markup, IPC contract, and Settings fallback behavior.

## Tests
- pnpm test -- AppUpdateSettings
- pnpm test:electron -- AutoUpdater update-progress-window-html ipc-contract
- pnpm typecheck
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time download progress during app updates (percent, transferred, speed) surfaced to the app UI.
  * Native transparent progress indicator window shown during downloads.

* **Bug Fixes**
  * Progress state now reliably initializes and is cleared on checks, errors, cancellations, and after download completion.

* **Tests**
  * Added tests for download-progress normalization, native progress window output, and renderer UI/update-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->