### PR TITLE
feat(electron): VSCode-style keybind capture, live tray hotkeys, BrainDump toggle

### DIFF
--- a/electron/SystemTrayManager.ts
+++ b/electron/SystemTrayManager.ts
@@ -61,6 +61,22 @@ export class SystemTrayManager {
   /** Whether tray notification has been shown */
   private hasShownTrayNotification: boolean
 
+  /**
+   * Live accelerator provider, injected after ShortcutManager loads (it is
+   * constructed AFTER this manager, so it cannot arrive via the constructor).
+   * Returns the current `{ shortcutId: accelerator }` map so the tray menu can
+   * DISPLAY each hotkey live — tray accelerators are display-only, they register
+   * no key binding.
+   */
+  private getShortcutAccelerators?: () => Record<string, string>
+
+  /**
+   * Last task list passed to updateTrayMenu, cached so a shortcut-triggered
+   * refreshTrayMenu() re-renders with current accelerators without wiping the
+   * recent-tasks section.
+   */
+  private lastTasks: TaskItem[]
+
   constructor(windowManager: WindowManager) {
     this.windowManager = windowManager
     this.tray = null
@@ -68,6 +84,7 @@ export class SystemTrayManager {
     this.isQuitting = false
     this.fallbackMode = false
     this.hasShownTrayNotification = false
+    this.lastTasks = []
   }
 
   /**
@@ -463,6 +480,28 @@ export class SystemTrayManager {
   }
 
   /**
+   * Inject the live accelerator provider. Called from main.ts after
+   * ShortcutManager loads (it is constructed after this manager), so the tray
+   * menu can display each shortcut's current hotkey. Display-only — registers
+   * no key binding.
+   *
+   * @param provider - Returns the current `{ shortcutId: accelerator }` map.
+   */
+  setShortcutAcceleratorProvider(provider: () => Record<string, string>): void {
+    this.getShortcutAccelerators = provider
+  }
+
+  /**
+   * Re-render the tray menu with the last tasks + current accelerators.
+   * Triggered after a shortcut rebind so a displayed hotkey never goes stale.
+   *
+   * @returns True when the menu was rebuilt, false when no tray is available.
+   */
+  refreshTrayMenu(): boolean {
+    return this.updateTrayMenu(this.lastTasks)
+  }
+
+  /**
    * Update tray context menu.
    */
   updateTrayMenu(tasks: TaskItem[] = []): boolean {
@@ -471,7 +510,17 @@ export class SystemTrayManager {
       return false
     }
 
+    // Cache so refreshTrayMenu() can re-render with live accelerators without
+    // losing the recent-tasks section.
+    this.lastTasks = tasks
+
     try {
+      // Live, display-only hotkeys; an empty/absent value omits the accelerator
+      // so a rebound or unset shortcut never shows a stale or orphan glyph.
+      const accelerators = this.getShortcutAccelerators?.() ?? {}
+      const floatingNavigatorAccelerator = accelerators.toggleFloatingNavigator
+      const brainDumpAccelerator = accelerators.toggleBrainDump
+
       const template: MenuItemConstructorOptions[] = [
         {
           label: 'Show TODO App',
@@ -486,7 +535,9 @@ export class SystemTrayManager {
         { type: 'separator' },
         {
           label: 'Toggle Floating Navigator',
-          accelerator: 'CommandOrControl+3',
+          ...(floatingNavigatorAccelerator
+            ? { accelerator: floatingNavigatorAccelerator }
+            : {}),
           click: () => {
             try {
               this.windowManager.toggleFloatingNavigator()
@@ -496,12 +547,15 @@ export class SystemTrayManager {
           },
         },
         {
-          label: 'Open BrainDump',
+          label: 'Toggle BrainDump',
+          ...(brainDumpAccelerator
+            ? { accelerator: brainDumpAccelerator }
+            : {}),
           click: () => {
             try {
-              this.windowManager.showBrainDump()
+              this.windowManager.toggleBrainDump()
             } catch (error) {
-              log.error('Failed to open BrainDump:', error)
+              log.error('Failed to toggle BrainDump:', error)
             }
           },
         },

--- a/electron/__tests__/SystemTrayManager.tray-menu.test.ts
+++ b/electron/__tests__/SystemTrayManager.tray-menu.test.ts
@@ -1,0 +1,181 @@
+import { Menu } from 'electron'
+import type { MenuItemConstructorOptions, Tray } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SystemTrayManager } from '../SystemTrayManager'
+import type { TaskItem } from '../SystemTrayManager'
+import type { WindowManager } from '../WindowManager'
+
+// vitest hoists BOTH vi.mock calls above every import in this file, so the
+// electron + logger stubs are installed before SystemTrayManager (and the `Menu`
+// import above) resolve at module load — the import position is irrelevant.
+// Menu.buildFromTemplate is stubbed to capture the template array each
+// updateTrayMenu() builds, so tests can assert on the rendered items.
+vi.mock('electron', () => ({
+  app: { on: vi.fn(), quit: vi.fn() },
+  Menu: { buildFromTemplate: vi.fn((template) => ({ template })) },
+  nativeImage: {
+    createFromPath: vi.fn(),
+    createEmpty: vi.fn(),
+    createFromBuffer: vi.fn(),
+  },
+  Notification: vi.fn(),
+  Tray: vi.fn(),
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+// A never-destroyed tray with a spyable setContextMenu — updateTrayMenu reads
+// isDestroyed() then calls setContextMenu(builtMenu).
+const fakeTray = {
+  isDestroyed: () => false,
+  setContextMenu: vi.fn(),
+} as unknown as Tray
+
+/**
+ * Build a SystemTrayManager over a stub WindowManager exposing spies for the
+ * window actions the tray menu items invoke, with a live tray already primed.
+ * @returns The manager plus the WindowManager action spies.
+ * @example const { manager, toggleBrainDump } = createManager()
+ */
+function createManager(): {
+  manager: SystemTrayManager
+  toggleBrainDump: ReturnType<typeof vi.fn>
+  toggleFloatingNavigator: ReturnType<typeof vi.fn>
+} {
+  const toggleBrainDump = vi.fn()
+  const toggleFloatingNavigator = vi.fn()
+  const stubWindowManager = {
+    restoreFromTray: vi.fn(),
+    openSettings: vi.fn(),
+    toggleBrainDump,
+    toggleFloatingNavigator,
+  } as unknown as WindowManager
+  const manager = new SystemTrayManager(stubWindowManager)
+  // Mirror createTray's side effect so updateTrayMenu's `if (this.tray)` guard
+  // passes without standing up the native Tray stack.
+  ;(manager as unknown as { tray: Tray | null }).tray = fakeTray
+  return { manager, toggleBrainDump, toggleFloatingNavigator }
+}
+
+/** Read the template array from the most recent Menu.buildFromTemplate call. */
+function lastBuiltTemplate(): MenuItemConstructorOptions[] {
+  const calls = vi.mocked(Menu.buildFromTemplate).mock.calls
+  return calls[calls.length - 1]![0] as MenuItemConstructorOptions[]
+}
+
+/** Find a tray menu item by its visible label. */
+function findItem(
+  template: MenuItemConstructorOptions[],
+  label: string,
+): MenuItemConstructorOptions | undefined {
+  return template.find((item) => item.label === label)
+}
+
+describe('SystemTrayManager tray menu — BrainDump toggle + live hotkeys', () => {
+  beforeEach(() => {
+    vi.mocked(Menu.buildFromTemplate).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    fakeTray.setContextMenu = vi.fn()
+  })
+
+  it('toggles the BrainDump window when its tray item is clicked', () => {
+    // Arrange
+    const { manager, toggleBrainDump } = createManager()
+
+    // Act
+    manager.updateTrayMenu([])
+    const brainDumpItem = findItem(lastBuiltTemplate(), 'Toggle BrainDump')
+    ;(brainDumpItem?.click as () => void)?.()
+
+    // Assert: the item is the toggle (not the old one-way "Open BrainDump")
+    // and it routes to the window toggle, matching Floating Navigator.
+    expect(brainDumpItem).toBeDefined()
+    expect(findItem(lastBuiltTemplate(), 'Open BrainDump')).toBeUndefined()
+    expect(toggleBrainDump).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows each toggle item’s live hotkey supplied by the accelerator provider', () => {
+    // Arrange
+    const { manager } = createManager()
+    manager.setShortcutAcceleratorProvider(() => ({
+      toggleFloatingNavigator: 'CommandOrControl+3',
+      toggleBrainDump: 'Alt+Space',
+    }))
+
+    // Act
+    manager.updateTrayMenu([])
+    const template = lastBuiltTemplate()
+
+    // Assert
+    expect(findItem(template, 'Toggle Floating Navigator')?.accelerator).toBe(
+      'CommandOrControl+3',
+    )
+    expect(findItem(template, 'Toggle BrainDump')?.accelerator).toBe(
+      'Alt+Space',
+    )
+  })
+
+  it('omits the accelerator entirely when a shortcut is unbound', () => {
+    // Arrange: provider reports no BrainDump binding (empty string disables it).
+    const { manager } = createManager()
+    manager.setShortcutAcceleratorProvider(() => ({
+      toggleFloatingNavigator: 'CommandOrControl+3',
+      toggleBrainDump: '',
+    }))
+
+    // Act
+    manager.updateTrayMenu([])
+    const brainDumpItem = findItem(lastBuiltTemplate(), 'Toggle BrainDump')
+
+    // Assert: no orphan accelerator glyph for an unbound shortcut.
+    expect(brainDumpItem).toBeDefined()
+    expect('accelerator' in brainDumpItem!).toBe(false)
+  })
+
+  it('falls back to no hotkey when no accelerator provider is injected', () => {
+    // Arrange: provider never set (e.g. boot before ShortcutManager wiring).
+    const { manager } = createManager()
+
+    // Act
+    manager.updateTrayMenu([])
+    const template = lastBuiltTemplate()
+
+    // Assert: items render, just without accelerators — never a hardcoded ⌘3.
+    expect(
+      'accelerator' in findItem(template, 'Toggle Floating Navigator')!,
+    ).toBe(false)
+    expect('accelerator' in findItem(template, 'Toggle BrainDump')!).toBe(false)
+  })
+
+  it('refreshes the displayed hotkey after a rebind without losing recent tasks', () => {
+    // Arrange: first render shows the default BrainDump hotkey with one task.
+    const { manager } = createManager()
+    let brainDumpAccelerator = 'Alt+Space'
+    manager.setShortcutAcceleratorProvider(() => ({
+      toggleBrainDump: brainDumpAccelerator,
+    }))
+    const tasks: TaskItem[] = [
+      { title: 'Write the release notes', completed: false },
+    ]
+    manager.updateTrayMenu(tasks)
+
+    // Act: the user rebinds BrainDump, then a refresh re-renders the tray.
+    brainDumpAccelerator = 'CommandOrControl+Shift+B'
+    manager.refreshTrayMenu()
+    const template = lastBuiltTemplate()
+
+    // Assert: the new hotkey shows AND the cached task survived the refresh.
+    expect(findItem(template, 'Toggle BrainDump')?.accelerator).toBe(
+      'CommandOrControl+Shift+B',
+    )
+    expect(
+      template.some((item) => item.label?.includes('Write the release notes')),
+    ).toBe(true)
+  })
+})

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -841,6 +841,22 @@ async function loadSystemIntegrationStack(): Promise<void> {
   )
   log.info('✅ [DEFERRED] ShortcutManager loaded')
 
+  // Feed the tray live, display-only hotkeys for the two toggle items it shows.
+  // ShortcutManager is constructed AFTER SystemTrayManager, so this is a setter
+  // injection rather than a constructor argument. Only the two displayed keys
+  // are exposed, and only when they hold a real accelerator string.
+  systemTrayManager?.setShortcutAcceleratorProvider(() => {
+    const current = shortcutManager?.getCurrentShortcuts() ?? {}
+    const accelerators: Record<string, string> = {}
+    if (typeof current.toggleFloatingNavigator === 'string') {
+      accelerators.toggleFloatingNavigator = current.toggleFloatingNavigator
+    }
+    if (typeof current.toggleBrainDump === 'string') {
+      accelerators.toggleBrainDump = current.toggleBrainDump
+    }
+    return accelerators
+  })
+
   log.info('🔧 [DEFERRED] Wiring managers + initializing system integration...')
   systemIntegrationErrorHandler.setManagers(
     systemTrayManager,
@@ -1474,6 +1490,8 @@ function setupIPCHandlers(): void {
       }
     }
     configManager.set('braindump.shortcut', accelerator)
+    // Keep the tray's displayed BrainDump hotkey in sync with the rebind.
+    systemTrayManager?.refreshTrayMenu()
     return true
   })
 
@@ -1990,7 +2008,12 @@ function setupIPCHandlers(): void {
     if (!shortcutManager) {
       return false
     }
-    return shortcutManager.updateShortcuts(shortcuts)
+    const didUpdate = shortcutManager.updateShortcuts(shortcuts)
+    // Keep the tray's displayed hotkeys in sync with the rebind.
+    if (didUpdate) {
+      systemTrayManager?.refreshTrayMenu()
+    }
+    return didUpdate
   })
 
   typedHandle('shortcuts-register', (_event, definition) => {

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -120,8 +120,8 @@ export interface ElectronAPI {
     getRegistered: () => Promise<ShortcutDefinition[]>
     /** Get default shortcuts */
     getDefaults: () => Promise<ShortcutDefinition[]>
-    /** Update shortcut accelerator */
-    update: (id: string, accelerator: string) => Promise<boolean>
+    /** Update shortcut accelerators in one batch (id → accelerator; `''` unbinds). */
+    update: (shortcuts: Record<string, string>) => Promise<boolean>
     /** Register new shortcut */
     register: (shortcut: ShortcutDefinition) => Promise<boolean>
     /** Unregister shortcut */

--- a/plans/2026-06-14-hotkey-ux.md
+++ b/plans/2026-06-14-hotkey-ux.md
@@ -1,0 +1,260 @@
+# Hotkey UX — Design Doc
+
+> **Date:** 2026-06-14 · **Branch:** `feat/hotkey-menu-keybind-capture` · **Base:** `origin/main` @ v0.10.0
+> **Mode:** autonomous (user asleep — no questions; decisions auto-made + logged here)
+
+## Goal (verbatim, 3 parts)
+
+1. **braindump を toggle に変更** — the BrainDump tray item is one-way "Open"; make it a
+   toggle (open ↔ close), matching "Toggle Floating Navigator".
+2. **メニューにホットキーを表示する** — the tray menu shows `⌘3` on "Toggle Floating
+   Navigator" but nothing on the BrainDump item; display the live hotkey on it.
+3. **キーバインド設定を VSCode の設定のようにプレスする方式に変更** — keybinding settings
+   currently make you **type** an accelerator string (`e.g. Ctrl+N`); change to VSCode-style
+   "click, then press the key combination to capture it".
+
+Pipeline: design doc → implement → `pnpm validate` → `/ship` → `/coderabbit-resolver` →
+macOS tray smoke (computer-use) → `/electron-release patch bump` (manual sequence).
+
+---
+
+## Architecture recap (verified this session)
+
+- **Tray** = `electron/SystemTrayManager.ts` `updateTrayMenu()` — the surface in the user's
+  screenshot. Tray context-menu accelerators are **display-only** (proven: the hardcoded
+  `CommandOrControl+3` coexists with the global registration in production — no double-bind).
+- **`toggleBrainDump()` already exists** — `electron/WindowManager.ts:718` (create→show / visible→hide
+  / hidden→show) and `ShortcutManager.handleToggleBrainDump()` already calls it. So Part 1 is a
+  2-line tray change.
+- **`getCurrentShortcuts()`** — `electron/ShortcutManager.ts:982` returns `{ ...this.shortcuts }`,
+  the **live merged defaults+overrides map**. Ideal source for the tray's live hotkey display.
+- **Construction order** — `main.ts` builds `SystemTrayManager` (line ~816) **before**
+  `ShortcutManager` (line ~837). So the tray can't get the shortcut map via constructor →
+  **setter injection** after `shortcutManager` loads.
+- **Two braindump-shortcut config paths (pre-existing):**
+  - (a) `shortcuts.toggleBrainDump` — `ShortcutManager`, default `Alt+Space`, edited via
+    `ShortcutSettings.tsx` → IPC `shortcuts.update`.
+  - (b) `braindump.shortcut` — separate config key, edited via `BrainDumpSettings.tsx` →
+    IPC `braindump-config-set-shortcut`, which ALSO calls `shortcutManager.updateShortcuts({toggleBrainDump})`.
+    Both mutate the live `toggleBrainDump` binding → **the tray refresh must hook both paths.**
+- **App menu (`MenuManager.ts`)** — left untouched. App-menu accelerators are **live bindings**
+  (via `Menu.setApplicationMenu`); adding the global shortcuts there would **double-register** and
+  conflict with `ShortcutManager`. The tray is the requested surface anyway.
+
+---
+
+## Part 1 — BrainDump tray item → Toggle
+
+`SystemTrayManager.updateTrayMenu()`, the BrainDump item:
+
+- `label: 'Open BrainDump'` → `'Toggle BrainDump'`
+- `click: () => this.windowManager.showBrainDump()` → `() => this.windowManager.toggleBrainDump()`
+
+No new behavior code (toggle already exists). Matches the existing "Toggle Floating Navigator" item.
+
+## Part 2 — Live hotkey display in tray
+
+**Provider injection (no construction-order break):**
+
+- Add `private getShortcutAccelerators?: () => Record<string, string>` to `SystemTrayManager`.
+- Add `setShortcutAcceleratorProvider(fn)` setter.
+- In `main.ts`, after `shortcutManager` is constructed (~842):
+  `systemTrayManager.setShortcutAcceleratorProvider(() => shortcutManager.getCurrentShortcuts())`.
+
+**In `updateTrayMenu()`:**
+
+- Resolve `const accel = this.getShortcutAccelerators?.() ?? {}`.
+- "Toggle Floating Navigator": `accelerator: accel.toggleFloatingNavigator` — replaces the
+  hardcoded `'CommandOrControl+3'` so it tracks rebinds.
+- "Toggle BrainDump": add `accelerator: accel.toggleBrainDump`.
+- **Empty/undefined → omit the `accelerator` property** (no orphan glyph). Build the menu-item
+  objects so the key is absent when the value is falsy (spread a conditional fragment).
+
+**Stay fresh after rebinds (cache + refresh):**
+
+- Cache the last tasks: `private lastTasks: TaskItem[] = []`; `updateTrayMenu` stores its arg.
+- Add `refreshTrayMenu()` → `this.updateTrayMenu(this.lastTasks)` (re-renders with current accelerators
+  without losing the recent task list).
+- In `main.ts`, after a shortcut mutation, call `systemTrayManager.refreshTrayMenu()`:
+  - the `shortcuts.update` / `update-shortcuts` IPC handler path, AND
+  - the `braindump-config-set-shortcut` handler (line ~1463).
+- Tray accelerators are display-only, so this never registers a key — purely visual.
+
+## Part 3 — VSCode-style key capture
+
+**New util — `src/components/electron/utils/keyboardEventToAccelerator.ts`** (one util/file):
+
+- `keyboardEventToAccelerator(event: KeyboardEvent): string | null`
+- Uses **`event.code`** (physical key, layout/shift-independent) for the main key, not `event.key`
+  (which mutates: Shift+3→`#`, Option+e→`´` on macOS).
+- Modifiers (in canonical Electron order): `event.metaKey`→`CommandOrControl` (matches existing
+  defaults + the recommended cross-platform modifier; renders ⌘ on mac), `event.ctrlKey`→`Control`,
+  `event.altKey`→`Alt`, `event.shiftKey`→`Shift`.
+- Main key via a `CODE_TO_ACCELERATOR_KEY` map: `KeyA…KeyZ`→`A…Z`, `Digit0…9`→`0…9`, `F1…F24` (same),
+  `Space`→`Space`, `Enter`→`Return`, `Tab`→`Tab`, `ArrowUp/Down/Left/Right`→`Up/Down/Left/Right`,
+  `Home/End/PageUp/PageDown` (same), `Minus`→`-`, `Equal`→`=`, `BracketLeft/Right`→`[`/`]`,
+  `Backslash`→`\`, `Semicolon`→`;`, `Quote`→`'`, `Comma`→`,`, `Period`→`.`, `Slash`→`/`,
+  `Backquote`→`` ` ``, `Numpad0…9`→`num0…num9`, `NumpadDecimal/Add/Subtract/Multiply/Divide`→
+  `numdec/numadd/numsub/nummult/numdiv`.
+- **Validity:** returns `null` (keep recording) when (a) only modifiers are pressed, or (b) a
+  non-F-key main key has **zero modifiers** (guards against binding a bare letter as a global
+  shortcut). F1–F24 may bind with no modifier.
+- Modifier keys themselves (`MetaLeft`, `ShiftLeft`, `ControlLeft`, `AltLeft`, right variants) are
+  treated as "still pressing" → `null`.
+
+**New util — `src/components/electron/utils/formatAcceleratorForDisplay.ts`** (one util/file):
+
+- `formatAcceleratorForDisplay(accelerator: string, platform: 'darwin' | 'other'): string`
+- macOS glyphs: `CommandOrControl|CmdOrCtrl|Command|Cmd|Meta|Super`→`⌘`, `Control|Ctrl`→`⌃`,
+  `Alt|Option`→`⌥`, `Shift`→`⇧`; special keys → mac glyphs (`Return`→`⏎`, `Up/Down/Left/Right`→
+  `↑↓←→`, `Escape`→`⎋`, `Tab`→`⇥`, others kept literal); join with no separator (mac convention).
+- non-darwin: `CommandOrControl`→`Ctrl`, join with `+`. (App is macOS-only, but the util stays
+  pure + platform-param'd so it's testable and correct.)
+
+**New component — `src/components/electron/KeybindingCaptureInput.tsx`:**
+
+- Props: `{ value: string; onChange: (accelerator: string) => void; disabled?: boolean; id?: string; ariaLabel?: string }`.
+- Idle: a button-like box showing `formatAcceleratorForDisplay(value)` in **Geist Mono** (DESIGN.md:
+  keys = Data/mono tier), or quiet-companion empty text when unset (not "DISABLED").
+- Click / focus + Enter/Space → **recording**: box shows "Press keys…" (quiet-companion microcopy),
+  `--ring` amber focus ring, subtle (micro-tier ≤100ms) state change — no bounce/flash.
+- `keydown` while recording → `preventDefault` + `keyboardEventToAccelerator`; non-null →
+  `onChange(accel)` + stop recording. `Escape` → cancel (revert, no change). `Backspace`/`Delete`
+  (no modifiers) → clear to `''` (unbound) + stop.
+- Listener lifecycle: attach the keydown handler only while recording. Stop recording on blur.
+- a11y: `role="button"`, `aria-label`, focusable, screen-reader text announces current binding +
+  "press to change".
+
+**Wire into both shortcut UIs (shared component, consistency):**
+
+- `ShortcutSettings.tsx` — replace `<Input>` (341–349) with `<KeybindingCaptureInput value={shortcuts[id] || ''}
+onChange={(a) => updateShortcut(id, a)} disabled={isSaving} id={`shortcut-${id}`} ariaLabel={description} />`.
+  Remove now-dead `handleShortcutChange` + `ChangeEvent` import. Update the "Tip" copy (372–378)
+  from "type Cmd+N" to "Click a binding, then press the keys you want. Esc cancels, Delete clears."
+- `BrainDumpSettings.tsx` — replace its plain shortcut `<Input>` (~348) with the same component
+  bound to `braindump.shortcut`. (Drops the type-then-onBlur flow; capture is immediate.)
+
+**Constants — `src/lib/constants/keybinding.ts`:** modifier-glyph maps, the `CODE_TO_ACCELERATOR_KEY`
+map, recording placeholder/empty microcopy, any `_MS` timings. (No magic literals in components.)
+
+---
+
+## New / modified files
+
+**New:** `src/components/electron/KeybindingCaptureInput.tsx`,
+`src/components/electron/utils/keyboardEventToAccelerator.ts`,
+`src/components/electron/utils/formatAcceleratorForDisplay.ts`,
+`src/lib/constants/keybinding.ts`, + 3 test files.
+
+**Modified:** `electron/SystemTrayManager.ts` (Parts 1+2), `electron/main.ts` (provider wiring +
+refresh on both paths), `src/components/electron/ShortcutSettings.tsx` (Part 3),
+`src/components/electron/BrainDumpSettings.tsx` (Part 3), `ShortcutSettings.test.tsx` (rewrite the
+`.toHaveValue()` assertions — the input is now a capture box, not a text field).
+
+**Unchanged (asserted):** `ShortcutManager.defaults.test.ts` (defaults untouched:
+`toggleBrainDump='Alt+Space'`, `toggleFloatingNavigator='CommandOrControl+3'`).
+
+## Test plan (DAMP, AAA, hard-coded expecteds, named by behavior)
+
+- **`keyboardEventToAccelerator.test.ts`** — ⌘+3→`CommandOrControl+3`; ⌥+Space→`Alt+Space`;
+  ⌘⇧+N→`CommandOrControl+Shift+N`; F5 alone→`F5`; bare `A`→`null`; modifier-only→`null`;
+  Shift+Equal physical key→`Shift+=` (code-based, not `+`).
+- **`formatAcceleratorForDisplay.test.ts`** — `CommandOrControl+3`→`⌘3` (darwin); `Alt+Space`→`⌥Space`;
+  `CommandOrControl+Shift+N`→`⌘⇧N`; non-darwin `CommandOrControl+3`→`Ctrl+3`.
+- **`KeybindingCaptureInput.test.tsx`** — "captures a pressed combination and emits the accelerator";
+  "Escape cancels without changing the binding"; "Delete clears the binding to empty"; "shows the
+  current binding as glyphs when idle".
+- **`ShortcutSettings.test.tsx`** — rewrite: reset shows the default binding rendered as glyphs
+  (assert on displayed `⌘3` / `⌥Space` text, not `.toHaveValue()`).
+
+## Verification plan — two halves, do NOT conflate
+
+- **Parts 1+2 (tray, main process):** the packaged build's **main process IS this branch's code**,
+  so the tray changes show in the packaged app. Verify via the **macOS computer-use tray smoke**
+  (CLAUDE.md mandate before any tag push after tray/menu code): `pnpm electron:build:dir && open
+dist/mac/CoreLive.app` → drive the tray → confirm "Toggle BrainDump" + its live hotkey glyph +
+  toggle behavior + Floating-Navigator hotkey tracks a rebind. Tray has **zero automated coverage**;
+  green CI does NOT substitute for this smoke.
+- **Part 3 (settings UI, renderer):** the packaged app's **renderer loads prod `corelive.app`**, so
+  the branch's capture UI will **NOT** appear in the packaged build — that's expected, not a bug.
+  Verify Part 3 via **unit tests** (pure `keydown`→accelerator, no Electron) + **web E2E** on CI.
+  End-to-end global re-registration needs `electron:dev` + Playwright CDP (deferred; not gating).
+
+## Decisions auto-made (no questions — user asleep)
+
+- **D1 — App menu untouched.** App-menu accelerators are live bindings → would double-register.
+  Tray (display-only) is the requested + safe surface.
+- **D2 — Live accelerators, not hardcoded.** Part 3 makes rebinding first-class, so the tray reads
+  `getCurrentShortcuts()` live and refreshes on both mutation paths. (Hardcoding would go stale.)
+- **D3 — Shared capture component in BOTH settings UIs.** Consistency + near-zero marginal cost; also
+  closes the pre-existing "two UIs, two styles" gap.
+- **D4 — `event.code` (physical) over `event.key`.** Layout/shift-stable; matches how VSCode captures.
+- **D5 — Require ≥1 modifier except F-keys.** Prevents binding a bare letter as a global shortcut.
+- **D6 — ⌘ → `CommandOrControl`.** Matches existing defaults + Electron's cross-platform guidance.
+- **D7 — No version bump in the feature PR.** corelive lands features unbumped; the release bump is a
+  separate `chore(release)` + `v*` tag (per `electron-release-sequence`).
+
+## Risks
+
+- **Construction-order**: setter injection (not constructor) — verified tray builds before shortcuts.
+- **Refresh coverage**: must hook BOTH `shortcuts.update` AND `braindump-config-set-shortcut`, else
+  the displayed hotkey drifts depending on which panel set it.
+- **IME/dead keys**: `event.code` + `preventDefault` during recording avoids composing diacritics.
+- **Empty accelerator**: omit the menu `accelerator` key entirely (don't pass `''`).
+
+---
+
+## Implementation reconciliation (as shipped — supersedes the plan where they differ)
+
+A 5-agent adversarial design review ran **before** Part 3 was implemented. It surfaced a
+load-bearing pre-existing bug and several specifics the plan above had wrong. The deltas as
+actually built:
+
+- **R1 — PRELOAD ARITY BUG (the load-bearing fix; not in the plan).** `window.electronAPI.shortcuts.update`
+  is a **single-`Record<string,string>`** contract in `preload.ts` (throws unless arg[0] is an object),
+  but `ShortcutSettings.saveShortcuts` **and** `useElectronShortcuts.updateShortcuts` both looped calling
+  `update(id, accelerator)` (2 positional args) → threw at runtime → the rebind never reached the
+  `shortcuts-update` IPC → **the tray could never track a ShortcutSettings rebind**. Hidden on `main`
+  because the renderer tsconfig pulls in BOTH `src/types/electron.d.ts` (`update(shortcuts:any)`) and
+  `electron/types/electron-api.d.ts` (`update(id,accel)`), which merge into a permissive **overload set**,
+  so the 2-arg call type-checked. Fixed: both type decls collapsed to
+  `update(shortcuts: Record<string,string>) => Promise<boolean>`, both call sites send the full record.
+  This is what makes Goal 2's "Floating-Navigator hotkey tracks a rebind" real on the ShortcutSettings path.
+- **R2 — KeybindingCaptureInput is a native `<Button>`, not `role="button"` on a div.** Labelable, so
+  `<Label htmlFor={id}>` still associates; `aria-label` = the shortcut description, and `getByLabelText`
+  resolves the single button via the aria-label path. Element-level `onKeyDown`/`onClick`/`onBlur` +
+  `useState(isRecording)` — **no window listener, no effect, no `useSyncExternalStore`** (plan's
+  "attach handler while recording / window-listener" framing dropped).
+- **R3 — Recording starts on CLICK (or keyboard Enter/Space activation), NOT on focus.** Auto-recording
+  on focus would **trap keyboard users**: a recording box `preventDefault`s every keydown _including Tab_,
+  so focus could never leave by keyboard. **Escape** is the deliberate keyboard exit (cancels, keeps focus,
+  restores normal Tab) — unit-tested. The Enter/Space that _enters_ recording fires the button's onClick and
+  is never captured as the binding (guarded: keydown is ignored until `isRecording`).
+- **R4 — IME guard mirrors `useKeyboardNav` (`isComposing || keyCode === 229`)** in BOTH the util and the
+  component handler (early-return _before_ `preventDefault`, so a composing key reaches the OS — the JP
+  voice-input flow).
+- **R5 — Data-tier font size uses the `text-sm` token, not `text-[13px]`.** DESIGN.md's Data tier is 13px,
+  but `tailwind.config.ts` defines no 13px token and `text-[13px]` is an arbitrary value → `dslint/token-only`
+  **warns** → husky (`--max-warnings 0`) blocks the commit. The existing data-tier component
+  (`AppUpdateSettings.tsx`) uses `font-mono tabular-nums` on a token size; matched that (1px off spec,
+  token-clean). Recording emphasis uses the `ring-2` scale token, not `ring-[3px]` (the arbitrary ring is
+  dslint-exempt only inside `src/components/ui/**`).
+- **R6 — Pinned microcopy** (`src/lib/constants/keybinding.ts`): empty `Click to set`, recording
+  `Press keys…`, conflict `That combo's already in use — try another.` (gentle, no-shame per DESIGN.md).
+- **R7 — BrainDump rollback migrated into the immediate `onChange`.** The old type-then-`onBlur`
+  register/rollback (`lastGoodShortcutRef`) now runs on capture: optimistic set → `setShortcut` IPC →
+  on `false`, show the conflict copy and revert to the last accepted value.
+- **R8 — Test plan additions (beyond the plan):** `BrainDumpSettings.test.tsx` rewritten (glyph assertion +
+  register-failure→revert→conflict-copy); `KeybindingCaptureInput.test.tsx` covers Tab-trap-then-Escape-release,
+  IME-guard, bare-Space-keeps-recording, activation-keypress-not-captured, Backspace/Delete-clear, disabled;
+  util tests gained unmapped-code→null and a capture→display round-trip. Suite green (`pnpm validate`).
+
+### Verification correction (per reviewer) — **route Part 3 visual checks to `electron:dev`, not the packaged smoke**
+
+The "Verification plan" above says Part 3 is renderer code; sharpen it: the **packaged build loads prod
+`corelive.app`**, so the capture UI (glyph coverage `⎋⇥⏎` in Geist Mono, amber focus ring, `Click to set` /
+`Press keys…` microcopy) does **NOT** render there — verify all of that on **`electron:dev`** (local branch).
+Reserve the **macOS computer-use tray smoke** for **Parts 1+2 only** (main-process — actually in the build:
+"Toggle BrainDump" label + toggle behavior + `⌥Space`/`⌘3` live glyphs + Floating-Navigator hotkey tracking a
+rebind, with the no-rebind first-paint showing `⌘3`/`⌥Space` since the accelerator provider is injected at
+`main.ts:848`, before the first tray paint inside `initializeSystemIntegration` at `main.ts:866`).

--- a/src/components/electron/BrainDumpSettings.test.tsx
+++ b/src/components/electron/BrainDumpSettings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BrainDumpSettings } from './BrainDumpSettings'
@@ -105,12 +105,39 @@ describe('BrainDumpSettings', () => {
     // Assert: the ready UI renders; the old conditional useMemo crash would abort here.
     expect(await screen.findByText('Window opacity')).toBeInTheDocument()
     expect(screen.getByText('70%')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('Alt+Space')).toBeInTheDocument()
+    // The capture box renders the bound chord as a macOS glyph, not the raw
+    // "Alt+Space" accelerator string.
+    expect(screen.getByLabelText('Toggle shortcut')).toHaveTextContent('⌥Space')
     expect(consoleErrorSpy).not.toHaveBeenCalledWith(
       expect.stringContaining(
         'React has detected a change in the order of Hooks',
       ),
     )
+  })
+
+  it('reverts the binding and explains why when the captured chord is already in use', async () => {
+    // Arrange: load with Alt+Space bound, then make the next register attempt fail.
+    installBrainDumpBridge({
+      syncMode: false,
+      opacity: 0.7,
+      shortcut: 'Alt+Space',
+    })
+    render(<BrainDumpSettings />)
+    const box = await screen.findByLabelText('Toggle shortcut')
+    expect(box).toHaveTextContent('⌥Space')
+    // The main process rejects the next accelerator as already registered.
+    setShortcutMock.mockResolvedValueOnce(false)
+
+    // Act: record a new chord (⌘3) that gets refused.
+    fireEvent.click(box)
+    fireEvent.keyDown(box, { code: 'Digit3', metaKey: true })
+
+    // Assert: the conflict copy appears and the box rolls back to the last
+    // accepted binding rather than keeping the rejected ⌘3.
+    expect(
+      await screen.findByText("That combo's already in use — try another."),
+    ).toBeInTheDocument()
+    expect(box).toHaveTextContent('⌥Space')
   })
 
   it('degrades gracefully when an old preload exposes brainDump but not the settings getters', async () => {

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -10,6 +10,7 @@ import React, {
   useState,
 } from 'react'
 
+import { KeybindingCaptureInput } from '@/components/electron/KeybindingCaptureInput'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -18,7 +19,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Slider } from '@/components/ui/slider'
 import { Switch } from '@/components/ui/switch'
@@ -32,6 +32,7 @@ import {
   BRAINDUMP_OPACITY_MIN,
   BRAINDUMP_OPACITY_STEP,
 } from '@/lib/constants/braindump'
+import { KEYBINDING_CONFLICT_MESSAGE } from '@/lib/constants/keybinding'
 import { log } from '@/lib/logger'
 
 /**
@@ -180,22 +181,30 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
     [],
   )
 
-  const handleShortcutBlur = useCallback(async (): Promise<void> => {
-    setError(null)
-    try {
-      const ok = await window.electronAPI?.brainDump?.setShortcut(shortcut)
-      if (ok === false) {
-        setError('Shortcut could not be registered (it may already be in use).')
+  const handleShortcutCapture = useCallback(
+    async (nextAccelerator: string): Promise<void> => {
+      // The capture box commits immediately (no blur step), so the optimistic
+      // update + registration + rollback that used to live in onBlur run here.
+      setShortcut(nextAccelerator)
+      setError(null)
+      try {
+        const ok =
+          await window.electronAPI?.brainDump?.setShortcut(nextAccelerator)
+        if (ok === false) {
+          // Already registered elsewhere — revert to the last accepted value.
+          setError(KEYBINDING_CONFLICT_MESSAGE)
+          setShortcut(lastGoodShortcutRef.current)
+          return
+        }
+        lastGoodShortcutRef.current = nextAccelerator
+      } catch (err) {
+        log.error('Failed to update BrainDump shortcut:', err)
         setShortcut(lastGoodShortcutRef.current)
-        return
+        setError('Failed to update shortcut')
       }
-      lastGoodShortcutRef.current = shortcut
-    } catch (err) {
-      log.error('Failed to update BrainDump shortcut:', err)
-      setShortcut(lastGoodShortcutRef.current)
-      setError('Failed to update shortcut')
-    }
-  }, [shortcut])
+    },
+    [],
+  )
 
   const handleOpenBrainDump = useCallback(async (): Promise<void> => {
     try {
@@ -206,12 +215,6 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
     }
   }, [])
 
-  const handleShortcutChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      setShortcut(event.target.value)
-    },
-    [],
-  )
   const opacityValue = useMemo(() => [opacity], [opacity])
 
   // Defer the non-Electron fallback until after hydration so server and
@@ -345,16 +348,15 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
             <Keyboard className="h-4 w-4" />
             Toggle shortcut
           </Label>
-          <Input
+          <KeybindingCaptureInput
             id={shortcutId}
             value={shortcut}
-            placeholder="e.g. CommandOrControl+Shift+B"
-            onChange={handleShortcutChange}
-            onBlur={handleShortcutBlur}
+            ariaLabel="Toggle shortcut"
+            onChange={handleShortcutCapture}
           />
           <p className="text-xs text-muted-foreground">
-            Leave empty to disable the global shortcut. Use Electron accelerator
-            syntax (e.g. <code>CommandOrControl+Shift+B</code>).
+            Click, then press the keys you want. Esc cancels; Backspace clears
+            it to disable the global shortcut.
           </p>
         </div>
 

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -181,6 +181,14 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
     [],
   )
 
+  /**
+   * Commit a captured BrainDump accelerator: apply optimistically, persist over
+   * IPC, then roll back to the last accepted value on conflict (`ok === false`)
+   * or error. Wired to the capture box's onChange (fires on key-press, not blur).
+   * @param nextAccelerator - Captured accelerator string, or `''` to unbind.
+   * @returns Resolves once the binding is persisted or rolled back.
+   * @example handleShortcutCapture('Alt+Space') // persists, or reverts + shows conflict copy if taken
+   */
   const handleShortcutCapture = useCallback(
     async (nextAccelerator: string): Promise<void> => {
       // The capture box commits immediately (no blur step), so the optimistic

--- a/src/components/electron/KeybindingCaptureInput.test.tsx
+++ b/src/components/electron/KeybindingCaptureInput.test.tsx
@@ -1,0 +1,188 @@
+import { createEvent, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { KeybindingCaptureInput } from './KeybindingCaptureInput'
+
+/**
+ * Render the capture box as a controlled field so the displayed glyph reflects
+ * captured chords, while still exposing the raw onChange payload for assertions.
+ * @param initialValue - Starting accelerator (`''` = unbound).
+ * @returns The onChange spy and the box's button element (resolved by aria-label).
+ * @example const { onChange, button } = renderCaptureBox()
+ */
+function renderCaptureBox(initialValue = ''): {
+  onChange: ReturnType<typeof vi.fn>
+  button: HTMLElement
+} {
+  const onChange = vi.fn()
+  function Harness(): React.ReactElement {
+    const [value, setValue] = useState(initialValue)
+    return (
+      <KeybindingCaptureInput
+        value={value}
+        ariaLabel="Toggle BrainDump"
+        onChange={(accelerator) => {
+          onChange(accelerator)
+          setValue(accelerator)
+        }}
+      />
+    )
+  }
+  render(<Harness />)
+  return { onChange, button: screen.getByLabelText('Toggle BrainDump') }
+}
+
+describe('KeybindingCaptureInput', () => {
+  it('shows the empty invite, then the recording prompt once activated', () => {
+    // Arrange
+    const { button } = renderCaptureBox()
+
+    // Assert: unbound state invites the click that starts recording.
+    expect(button).toHaveTextContent('Click to set')
+
+    // Act
+    fireEvent.click(button)
+
+    // Assert: clicking enters recording and prompts for the chord.
+    expect(button).toHaveTextContent('Press keys…')
+  })
+
+  it('captures ⌘+3 as a CommandOrControl accelerator', () => {
+    // Arrange
+    const { onChange, button } = renderCaptureBox()
+
+    // Act: enter recording, then press the chord.
+    fireEvent.click(button)
+    fireEvent.keyDown(button, { code: 'Digit3', metaKey: true })
+
+    // Assert: metaKey maps to CommandOrControl (matches the app's defaults).
+    expect(onChange).toHaveBeenCalledWith('CommandOrControl+3')
+  })
+
+  it('captures Alt+Space even though Space would otherwise activate the button', () => {
+    // Arrange
+    const { onChange, button } = renderCaptureBox()
+
+    // Act
+    fireEvent.click(button)
+    fireEvent.keyDown(button, { code: 'Space', altKey: true })
+
+    // Assert: the recording box owns Space, so Alt+Space binds rather than clicking.
+    expect(onChange).toHaveBeenCalledWith('Alt+Space')
+  })
+
+  it('keeps recording when an incomplete chord (bare Space, no modifier) is pressed', () => {
+    // Arrange
+    const { onChange, button } = renderCaptureBox()
+
+    // Act
+    fireEvent.click(button)
+    fireEvent.keyDown(button, { code: 'Space' })
+
+    // Assert: a modifier-less key is not bindable, so nothing commits and the
+    // box stays in recording mode waiting for a real chord.
+    expect(onChange).not.toHaveBeenCalled()
+    expect(button).toHaveTextContent('Press keys…')
+  })
+
+  it('does not capture the activation keypress that precedes recording', () => {
+    // Arrange
+    const { onChange, button } = renderCaptureBox()
+
+    // Act: a keydown BEFORE recording (the Enter/Space that triggers the click
+    // which starts recording) must be left for the native button.
+    const enter = createEvent.keyDown(button, { code: 'Enter' })
+    fireEvent(button, enter)
+
+    // Assert: nothing captured, and the event is not swallowed.
+    expect(onChange).not.toHaveBeenCalled()
+    expect(enter.defaultPrevented).toBe(false)
+  })
+
+  it('traps Tab while recording but releases it after Escape (keyboard escape hatch)', () => {
+    // Arrange
+    const { onChange, button } = renderCaptureBox('Alt+Space')
+    fireEvent.click(button)
+
+    // Act + Assert: while recording, Tab is swallowed so focus can't silently
+    // leave mid-capture and Shift+Tab-style chords stay capturable.
+    const tabWhileRecording = createEvent.keyDown(button, { code: 'Tab' })
+    fireEvent(button, tabWhileRecording)
+    expect(tabWhileRecording.defaultPrevented).toBe(true)
+
+    // Escape ends recording without changing the binding.
+    fireEvent.keyDown(button, { code: 'Escape' })
+    expect(onChange).not.toHaveBeenCalled()
+    expect(button).toHaveTextContent('⌥Space')
+
+    // After Escape, Tab is no longer trapped — the user can leave by keyboard.
+    const tabAfterEscape = createEvent.keyDown(button, { code: 'Tab' })
+    fireEvent(button, tabAfterEscape)
+    expect(tabAfterEscape.defaultPrevented).toBe(false)
+  })
+
+  it('clears the binding when Backspace is pressed while recording', () => {
+    // Arrange
+    const { onChange, button } = renderCaptureBox('Alt+Space')
+
+    // Act
+    fireEvent.click(button)
+    fireEvent.keyDown(button, { code: 'Backspace' })
+
+    // Assert: Backspace unbinds (emits the empty accelerator).
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('clears the binding when Delete is pressed while recording', () => {
+    // Arrange
+    const { onChange, button } = renderCaptureBox('Alt+Space')
+
+    // Act
+    fireEvent.click(button)
+    fireEvent.keyDown(button, { code: 'Delete' })
+
+    // Assert: Delete unbinds (emits the empty accelerator).
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('ignores keydowns while an IME is composing so it never hijacks voice/IME input', () => {
+    // Arrange
+    const { onChange, button } = renderCaptureBox()
+    fireEvent.click(button)
+
+    // Act: a composing keydown must pass through untouched (the JP voice-input
+    // user relies on the composition reaching the OS).
+    const composing = createEvent.keyDown(button, {
+      code: 'Digit3',
+      metaKey: true,
+      isComposing: true,
+    })
+    fireEvent(button, composing)
+
+    // Assert: nothing captured and the key is not swallowed.
+    expect(onChange).not.toHaveBeenCalled()
+    expect(composing.defaultPrevented).toBe(false)
+  })
+
+  it('does not start recording when disabled', () => {
+    // Arrange
+    const onChange = vi.fn()
+    render(
+      <KeybindingCaptureInput
+        value=""
+        ariaLabel="Toggle BrainDump"
+        disabled
+        onChange={onChange}
+      />,
+    )
+    const button = screen.getByLabelText('Toggle BrainDump')
+
+    // Act
+    fireEvent.click(button)
+    fireEvent.keyDown(button, { code: 'Digit3', metaKey: true })
+
+    // Assert: a disabled box captures nothing.
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/electron/KeybindingCaptureInput.tsx
+++ b/src/components/electron/KeybindingCaptureInput.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { memo, useCallback, useState, type KeyboardEvent } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  KEYBINDING_CAPTURE_EMPTY_LABEL,
+  KEYBINDING_CAPTURE_RECORDING_LABEL,
+} from '@/lib/constants/keybinding'
+import { cn } from '@/lib/utils'
+
+import { formatAcceleratorForDisplay } from './utils/formatAcceleratorForDisplay'
+import { keyboardEventToAccelerator } from './utils/keyboardEventToAccelerator'
+
+/** A keydown fired mid-IME-composition reports this sentinel keyCode (legacy but still emitted). */
+const IME_COMPOSITION_KEYCODE = 229
+
+interface KeybindingCaptureInputProps {
+  /** Current accelerator string; `''` means unbound. Controlled by the parent. */
+  value: string
+  /**
+   * Emits the captured accelerator, or `''` when the user clears the binding.
+   * The parent owns persistence (buffer-then-Save, or commit-and-rollback).
+   */
+  onChange: (accelerator: string) => void
+  /** Accessible name — set to the shortcut's human description so `getByLabelText` resolves here. */
+  ariaLabel: string
+  /** Stable id so a sibling `<Label htmlFor>` associates with this control. */
+  id?: string
+  /** Display platform; defaults to `'darwin'` (CoreLive ships macOS-only). */
+  platform?: 'darwin' | 'other'
+  /** Disables capture (e.g. while a save is in flight). */
+  disabled?: boolean
+  /** Extra classes merged onto the button (e.g. width overrides per call site). */
+  className?: string
+}
+
+/**
+ * Pick the button's visible label for the current state — recording prompt wins,
+ * then the bound chord as macOS glyphs, then the empty-state invite.
+ * @param isRecording - Whether the box is actively capturing a chord.
+ * @param value - The bound accelerator string (`''` when unbound).
+ * @param platform - Glyph platform passed through to {@link formatAcceleratorForDisplay}.
+ * @returns
+ * - `'Press keys…'` while recording
+ * - the glyph string (e.g. `'⌥Space'`) when a chord is bound
+ * - `'Click to set'` when unbound
+ * @example
+ * getCaptureLabel(true, 'Alt+Space', 'darwin')  // 'Press keys…'
+ * getCaptureLabel(false, 'Alt+Space', 'darwin') // '⌥Space'
+ * getCaptureLabel(false, '', 'darwin')          // 'Click to set'
+ */
+function getCaptureLabel(
+  isRecording: boolean,
+  value: string,
+  platform: 'darwin' | 'other',
+): string {
+  if (isRecording) return KEYBINDING_CAPTURE_RECORDING_LABEL
+  if (value) return formatAcceleratorForDisplay(value, platform)
+  return KEYBINDING_CAPTURE_EMPTY_LABEL
+}
+
+/**
+ * VSCode-style keybinding capture: click (or focus + Enter/Space) to start
+ * recording, then press a key combination to bind it. Exists so users set
+ * shortcuts by pressing the keys instead of typing Electron accelerator syntax;
+ * rendered in the Electron keyboard-shortcut and BrainDump settings panels.
+ * Built on the native-button primitive so a `<Label htmlFor>` still associates,
+ * and reads `event.code` (physical key) so capture is keyboard-layout-independent.
+ *
+ * @param props - See {@link KeybindingCaptureInputProps}.
+ * @returns A button showing the bound keys as glyphs (`⌥Space`), `Click to set`
+ *   when unbound, or `Press keys…` while recording.
+ * @example
+ * <KeybindingCaptureInput value="Alt+Space" ariaLabel="Toggle BrainDump" onChange={setAccel} />
+ */
+export const KeybindingCaptureInput = memo(function KeybindingCaptureInput({
+  value,
+  onChange,
+  ariaLabel,
+  id,
+  platform = 'darwin',
+  disabled = false,
+  className,
+}: KeybindingCaptureInputProps) {
+  const [isRecording, setIsRecording] = useState(false)
+
+  // Recording starts on explicit activation — a click, or keyboard Enter/Space,
+  // both of which fire the button's onClick. Deliberately NOT on focus: auto-
+  // recording on focus would trap keyboard users, because a recording box
+  // preventDefaults Tab (Escape is the only keyboard exit).
+  const startRecording = useCallback(() => {
+    if (disabled) return
+    setIsRecording(true)
+  }, [disabled])
+
+  const stopRecording = useCallback(() => {
+    setIsRecording(false)
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      const nativeEvent = event.nativeEvent
+      // Mirror useKeyboardNav: never swallow a key while an IME is composing —
+      // the JP voice-input flow needs the composition to reach the OS.
+      if (
+        nativeEvent.isComposing ||
+        nativeEvent.keyCode === IME_COMPOSITION_KEYCODE
+      ) {
+        return
+      }
+      // Not recording yet: let the native button handle Enter/Space so it can
+      // fire onClick → startRecording. This is the keypress that ENTERS
+      // recording, so it must never be captured as the binding itself.
+      if (!isRecording) return
+
+      // Recording: trap every key — including Tab — so the chord is captured and
+      // focus cannot escape mid-recording. Escape is the deliberate exit.
+      event.preventDefault()
+      event.stopPropagation()
+
+      // OS auto-repeat is a held key, not a fresh chord.
+      if (event.repeat) return
+
+      // Escape cancels without changing the binding; focus stays so Tab resumes.
+      if (event.code === 'Escape') {
+        stopRecording()
+        return
+      }
+      // Backspace/Delete clears the binding (unbinds the shortcut).
+      if (event.code === 'Backspace' || event.code === 'Delete') {
+        onChange('')
+        stopRecording()
+        return
+      }
+
+      // A complete chord commits and ends recording; an incomplete one (a bare
+      // modifier, or an unmapped key) returns null and keeps the box recording.
+      const accelerator = keyboardEventToAccelerator(nativeEvent)
+      if (accelerator) {
+        onChange(accelerator)
+        stopRecording()
+      }
+    },
+    [isRecording, onChange, stopRecording],
+  )
+
+  return (
+    <Button
+      type="button"
+      id={id}
+      aria-label={ariaLabel}
+      aria-keyshortcuts={value || undefined}
+      variant="outline"
+      disabled={disabled}
+      onClick={startRecording}
+      onBlur={stopRecording}
+      onKeyDown={handleKeyDown}
+      data-recording={isRecording || undefined}
+      className={cn(
+        'w-36 font-mono font-medium tabular-nums',
+        // Recording emphasis uses scale ring tokens (ring-2), not an arbitrary
+        // ring-[3px] — the latter is dslint-exempt only inside components/ui/**.
+        isRecording && 'ring-ring/50 border-ring ring-2',
+        className,
+      )}
+    >
+      {getCaptureLabel(isRecording, value, platform)}
+    </Button>
+  )
+})

--- a/src/components/electron/ShortcutSettings.test.tsx
+++ b/src/components/electron/ShortcutSettings.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -69,7 +75,7 @@ describe('ShortcutSettings defaults', () => {
     installShortcutsBridge()
   })
 
-  it('resets Floating Navigator and BrainDump inputs to the new default accelerators', async () => {
+  it('shows the default accelerators as macOS glyphs after Reset to Defaults', async () => {
     // Arrange
     const user = userEvent.setup()
     render(<ShortcutSettings />)
@@ -80,12 +86,40 @@ describe('ShortcutSettings defaults', () => {
     // Act
     await user.click(resetButton)
 
-    // Assert
+    // Assert: the capture boxes render the bound chord as Apple glyphs (⌘3 /
+    // ⌥Space), not the raw "CommandOrControl+3" accelerator string.
     await waitFor(() => {
-      expect(screen.getByLabelText('Toggle floating navigator')).toHaveValue(
-        'CommandOrControl+3',
-      )
+      expect(
+        screen.getByLabelText('Toggle floating navigator'),
+      ).toHaveTextContent('⌘3')
     })
-    expect(screen.getByLabelText('Toggle BrainDump')).toHaveValue('Alt+Space')
+    expect(screen.getByLabelText('Toggle BrainDump')).toHaveTextContent(
+      '⌥Space',
+    )
+  })
+
+  it('enables a shortcut’s Test button once it is bound and disables it when cleared', async () => {
+    // Arrange: reset so BrainDump starts bound to its default accelerator.
+    const user = userEvent.setup()
+    render(<ShortcutSettings />)
+    const resetButton = await screen.findByRole('button', {
+      name: 'Reset to Defaults',
+    })
+    await user.click(resetButton)
+    const brainDumpBox = await screen.findByLabelText('Toggle BrainDump')
+    const controls = brainDumpBox.parentElement
+    if (!controls) throw new Error('expected the shortcut row controls wrapper')
+    const testButton = within(controls).getByRole('button', { name: 'Test' })
+
+    // Assert: a bound shortcut can be tested.
+    expect(testButton).toBeEnabled()
+
+    // Act: clear the binding by recording then pressing Delete.
+    fireEvent.click(brainDumpBox)
+    fireEvent.keyDown(brainDumpBox, { code: 'Delete' })
+
+    // Assert: with nothing bound there is nothing to test, so Test is disabled.
+    expect(brainDumpBox).toHaveTextContent('Click to set')
+    expect(testButton).toBeDisabled()
   })
 })

--- a/src/components/electron/ShortcutSettings.tsx
+++ b/src/components/electron/ShortcutSettings.tsx
@@ -123,6 +123,13 @@ export const ShortcutSettings = memo(function ShortcutSettings({
     setError(null)
   }, [])
 
+  /**
+   * Persist every pending shortcut edit to the main process in one batch, then
+   * surface success/failure. Sends the full id→accelerator record to update()
+   * (the preload bridge rejects a per-shortcut loop — see the body comment).
+   * @returns Resolves when the batch save settles; sets error state on any failure.
+   * @example saveShortcuts() // flushes pending edits, clears the unsaved-changes flag on success
+   */
   const saveShortcuts = useCallback(async () => {
     if (!isElectron) return
 

--- a/src/components/electron/ShortcutSettings.tsx
+++ b/src/components/electron/ShortcutSettings.tsx
@@ -1,14 +1,9 @@
 'use client'
 
 import { Keyboard, RotateCcw, Save, AlertCircle } from 'lucide-react'
-import {
-  memo,
-  useCallback,
-  useState,
-  type ChangeEvent,
-  type MouseEvent,
-} from 'react'
+import { memo, useCallback, useState, type MouseEvent } from 'react'
 
+import { KeybindingCaptureInput } from '@/components/electron/KeybindingCaptureInput'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -18,7 +13,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { useCycleEffect } from '@/hooks/use-cycle-effect'
@@ -139,17 +133,10 @@ export const ShortcutSettings = memo(function ShortcutSettings({
       if (!window.electronAPI?.shortcuts) {
         throw new Error('Electron API not available')
       }
-      // Update each shortcut individually
-      let allSuccess = true
-      for (const [id, accelerator] of Object.entries(shortcuts)) {
-        const success = await window.electronAPI.shortcuts.update(
-          id,
-          accelerator,
-        )
-        if (!success) {
-          allSuccess = false
-        }
-      }
+      // Persist every shortcut in one batch — the preload bridge takes the full
+      // id→accelerator record. A per-shortcut loop calling update(id, accel)
+      // throws in preload, which expects a Record, not positional args.
+      const allSuccess = await window.electronAPI.shortcuts.update(shortcuts)
 
       if (allSuccess) {
         setHasChanges(false)
@@ -228,14 +215,6 @@ export const ShortcutSettings = memo(function ShortcutSettings({
       }
     },
     [isElectron, shortcuts],
-  )
-
-  const handleShortcutChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const shortcutId = event.currentTarget.dataset.shortcutId
-      if (shortcutId) updateShortcut(shortcutId, event.target.value)
-    },
-    [updateShortcut],
   )
 
   const handleTestShortcutClick = useCallback(
@@ -331,33 +310,18 @@ export const ShortcutSettings = memo(function ShortcutSettings({
               <div className="space-y-3">
                 {Object.entries(SHORTCUT_DESCRIPTIONS).map(
                   ([id, description]) => (
-                    <div key={id} className="flex items-center gap-3">
-                      <div className="flex-1">
-                        <Label htmlFor={`shortcut-${id}`} className="text-sm">
-                          {description}
-                        </Label>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Input
-                          id={`shortcut-${id}`}
-                          value={shortcuts[id] || ''}
-                          data-shortcut-id={id}
-                          onChange={handleShortcutChange}
-                          placeholder="e.g. Ctrl+N"
-                          className="w-32 text-sm"
-                          disabled={isSaving}
-                        />
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          data-shortcut-id={id}
-                          onClick={handleTestShortcutClick}
-                          disabled={isSaving || !shortcuts[id]}
-                        >
-                          Test
-                        </Button>
-                      </div>
-                    </div>
+                    <ShortcutRow
+                      key={id}
+                      id={id}
+                      description={description}
+                      value={shortcuts[id] || ''}
+                      platform={
+                        stats?.platform === 'darwin' ? 'darwin' : 'other'
+                      }
+                      disabled={isSaving}
+                      onChange={updateShortcut}
+                      onTest={handleTestShortcutClick}
+                    />
                   ),
                 )}
               </div>
@@ -369,12 +333,8 @@ export const ShortcutSettings = memo(function ShortcutSettings({
                 <p>Platform: {stats.platform}</p>
                 <p>Registered shortcuts: {stats.totalRegistered}</p>
                 <p className="mt-2">
-                  <strong>Tip:</strong> Use{' '}
-                  {stats.platform === 'darwin' ? 'Cmd' : 'Ctrl'} as the main
-                  modifier key. Examples:{' '}
-                  {stats.platform === 'darwin'
-                    ? 'Cmd+N, Cmd+Shift+F'
-                    : 'Ctrl+N, Ctrl+Shift+F'}
+                  <strong>Tip:</strong> Click a shortcut, then press the key
+                  combination you want — Esc cancels, Backspace clears it.
                 </p>
               </div>
             )}
@@ -404,5 +364,77 @@ export const ShortcutSettings = memo(function ShortcutSettings({
         )}
       </CardContent>
     </Card>
+  )
+})
+
+interface ShortcutRowProps {
+  /** Shortcut id (map key); also builds the stable `shortcut-${id}` control id. */
+  id: string
+  /** Human-readable shortcut name shown in the Label and as the box's aria-label. */
+  description: string
+  /** Bound accelerator string (`''` when unbound). */
+  value: string
+  /** Glyph platform forwarded to the capture box. */
+  platform: 'darwin' | 'other'
+  /** Whether a save is in flight — disables capture and the Test button. */
+  disabled: boolean
+  /** Buffers a captured accelerator into the parent's pending edits. */
+  onChange: (id: string, accelerator: string) => void
+  /** Fires the Test action; reads `data-shortcut-id` off the clicked button. */
+  onTest: (event: MouseEvent<HTMLButtonElement>) => void
+}
+
+/**
+ * One configurable shortcut line — label, VSCode-style capture box, and Test button.
+ * Extracted so each row owns a stable per-id onChange (useCallback): an inline
+ * `(accel) => onChange(id, accel)` in the parent's .map would allocate a fresh
+ * function every render and trip the prefer-usecallback lint.
+ * @param props - See {@link ShortcutRowProps}.
+ * @returns The shortcut's settings row.
+ * @example <ShortcutRow id="toggleBrainDump" description="Toggle BrainDump" value="Alt+Space" platform="darwin" disabled={false} onChange={updateShortcut} onTest={handleTestShortcutClick} />
+ */
+const ShortcutRow = memo(function ShortcutRow({
+  id,
+  description,
+  value,
+  platform,
+  disabled,
+  onChange,
+  onTest,
+}: ShortcutRowProps) {
+  // Bind the parent's (id, accelerator) handler to this row's id so the capture
+  // box receives a stable reference instead of a fresh inline closure each render.
+  const handleChange = useCallback(
+    (accelerator: string) => onChange(id, accelerator),
+    [id, onChange],
+  )
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-1">
+        <Label htmlFor={`shortcut-${id}`} className="text-sm">
+          {description}
+        </Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <KeybindingCaptureInput
+          id={`shortcut-${id}`}
+          value={value}
+          ariaLabel={description}
+          platform={platform}
+          disabled={disabled}
+          onChange={handleChange}
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          data-shortcut-id={id}
+          onClick={onTest}
+          disabled={disabled || !value}
+        >
+          Test
+        </Button>
+      </div>
+    </div>
   )
 })

--- a/src/components/electron/utils/formatAcceleratorForDisplay.test.ts
+++ b/src/components/electron/utils/formatAcceleratorForDisplay.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatAcceleratorForDisplay } from './formatAcceleratorForDisplay'
+import { keyboardEventToAccelerator } from './keyboardEventToAccelerator'
+
+describe('formatAcceleratorForDisplay', () => {
+  it('renders Cmd + digit as a tight ⌘ glyph group on macOS', () => {
+    // Arrange + Act
+    const display = formatAcceleratorForDisplay('CommandOrControl+3', 'darwin')
+
+    // Assert
+    expect(display).toBe('⌘3')
+  })
+
+  it('renders Option + Space with the ⌥ glyph on macOS', () => {
+    // Arrange + Act
+    const display = formatAcceleratorForDisplay('Alt+Space', 'darwin')
+
+    // Assert
+    expect(display).toBe('⌥Space')
+  })
+
+  it('orders modifiers Shift-before-Command per Apple HIG', () => {
+    // Arrange + Act: capture util emits Command first; display must reorder.
+    const display = formatAcceleratorForDisplay(
+      'CommandOrControl+Shift+N',
+      'darwin',
+    )
+
+    // Assert
+    expect(display).toBe('⇧⌘N')
+  })
+
+  it('renders Control as the ⌃ caret glyph on macOS', () => {
+    // Arrange + Act
+    const display = formatAcceleratorForDisplay('Control+Shift+A', 'darwin')
+
+    // Assert
+    expect(display).toBe('⌃⇧A')
+  })
+
+  it('renders an arrow key as its glyph on macOS', () => {
+    // Arrange + Act
+    const display = formatAcceleratorForDisplay('CommandOrControl+Up', 'darwin')
+
+    // Assert
+    expect(display).toBe('⌘↑')
+  })
+
+  it('renders ASCII labels joined with plus off macOS', () => {
+    // Arrange + Act
+    const display = formatAcceleratorForDisplay('CommandOrControl+3', 'other')
+
+    // Assert
+    expect(display).toBe('Ctrl+3')
+  })
+
+  it('returns an empty string for an unbound accelerator', () => {
+    // Arrange + Act
+    const display = formatAcceleratorForDisplay('', 'darwin')
+
+    // Assert
+    expect(display).toBe('')
+  })
+
+  it('round-trips a captured chord from keydown to display glyphs', () => {
+    // Arrange: the exact handoff the capture box relies on — whatever
+    // keyboardEventToAccelerator emits must render cleanly here.
+    const event = new KeyboardEvent('keydown', {
+      code: 'KeyN',
+      metaKey: true,
+      shiftKey: true,
+    })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+    const display = accelerator
+      ? formatAcceleratorForDisplay(accelerator, 'darwin')
+      : ''
+
+    // Assert
+    expect(accelerator).toBe('CommandOrControl+Shift+N')
+    expect(display).toBe('⇧⌘N')
+  })
+})

--- a/src/components/electron/utils/formatAcceleratorForDisplay.ts
+++ b/src/components/electron/utils/formatAcceleratorForDisplay.ts
@@ -1,0 +1,59 @@
+import {
+  ACCELERATOR_MODIFIER_TOKENS,
+  ASCII_MODIFIER_LABELS,
+  MAC_KEY_GLYPHS,
+  MAC_MODIFIER_DISPLAY_ORDER,
+  MAC_MODIFIER_GLYPHS,
+} from '@/lib/constants/keybinding'
+
+/**
+ * Render an Electron accelerator as readable keys — macOS glyphs in Apple HIG
+ * order (⌃⌥⇧⌘, Command nearest the key, joined tight) or ASCII (`Ctrl+…`) — for
+ * the keybinding settings UI and any tray-hotkey mirroring.
+ *
+ * @param accelerator - An Electron accelerator string, e.g. `'CommandOrControl+Shift+N'`. An empty string means "unbound".
+ * @param platform - `'darwin'` renders mac glyphs joined with no separator; anything else renders ASCII labels joined with `'+'`.
+ * @returns
+ * - The display string, e.g. `'⇧⌘N'` (darwin) or `'Ctrl+Shift+N'` (other)
+ * - `''` when `accelerator` is empty (the unbound state)
+ * @example
+ * formatAcceleratorForDisplay('CommandOrControl+3', 'darwin')       // '⌘3'
+ * formatAcceleratorForDisplay('Alt+Space', 'darwin')               // '⌥Space'
+ * formatAcceleratorForDisplay('CommandOrControl+Shift+N', 'darwin') // '⇧⌘N'
+ * formatAcceleratorForDisplay('CommandOrControl+3', 'other')        // 'Ctrl+3'
+ */
+export function formatAcceleratorForDisplay(
+  accelerator: string,
+  platform: 'darwin' | 'other',
+): string {
+  if (!accelerator) return ''
+
+  const segments = accelerator.split('+')
+  const modifiers = segments.filter((segment) =>
+    ACCELERATOR_MODIFIER_TOKENS.has(segment),
+  )
+  const keys = segments.filter(
+    (segment) =>
+      segment.length > 0 && !ACCELERATOR_MODIFIER_TOKENS.has(segment),
+  )
+
+  // macOS: glyphs in HIG order, no separator (⇧⌘N).
+  if (platform === 'darwin') {
+    const orderedModifierGlyphs = modifiers
+      .slice()
+      .sort(
+        (left, right) =>
+          (MAC_MODIFIER_DISPLAY_ORDER[left] ?? Number.MAX_SAFE_INTEGER) -
+          (MAC_MODIFIER_DISPLAY_ORDER[right] ?? Number.MAX_SAFE_INTEGER),
+      )
+      .map((modifier) => MAC_MODIFIER_GLYPHS[modifier] ?? modifier)
+    const keyGlyphs = keys.map((key) => MAC_KEY_GLYPHS[key] ?? key)
+    return [...orderedModifierGlyphs, ...keyGlyphs].join('')
+  }
+
+  // Other platforms: ASCII labels joined with '+'.
+  const modifierLabels = modifiers.map(
+    (modifier) => ASCII_MODIFIER_LABELS[modifier] ?? modifier,
+  )
+  return [...modifierLabels, ...keys].join('+')
+}

--- a/src/components/electron/utils/keyboardEventToAccelerator.test.ts
+++ b/src/components/electron/utils/keyboardEventToAccelerator.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+
+import { keyboardEventToAccelerator } from './keyboardEventToAccelerator'
+
+/**
+ * Build a `keydown` event with the given physical code + modifier state.
+ * @param init - `code` plus any KeyboardEvent flags (metaKey, repeat, …).
+ * @returns A real KeyboardEvent for the converter under test.
+ * @example keydown({ code: 'Digit3', metaKey: true })
+ */
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent('keydown', init)
+}
+
+describe('keyboardEventToAccelerator', () => {
+  it('maps Cmd + digit to a CommandOrControl accelerator', () => {
+    // Arrange
+    const event = keydown({ code: 'Digit3', metaKey: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBe('CommandOrControl+3')
+  })
+
+  it('maps Option + Space to the BrainDump-style accelerator', () => {
+    // Arrange
+    const event = keydown({ code: 'Space', altKey: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBe('Alt+Space')
+  })
+
+  it('emits modifiers in canonical Command-then-Shift order', () => {
+    // Arrange
+    const event = keydown({ code: 'KeyN', metaKey: true, shiftKey: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBe('CommandOrControl+Shift+N')
+  })
+
+  it('captures a function key pressed with no modifier', () => {
+    // Arrange
+    const event = keydown({ code: 'F5' })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBe('F5')
+  })
+
+  it('rejects a bare letter with no modifier so it cannot grab the keyboard', () => {
+    // Arrange
+    const event = keydown({ code: 'KeyA' })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBeNull()
+  })
+
+  it('stays incomplete while only a modifier is held down', () => {
+    // Arrange: MetaLeft is the physical Cmd key — not a bindable accelerator key.
+    const event = keydown({ code: 'MetaLeft', metaKey: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBeNull()
+  })
+
+  it('ignores keys pressed during IME composition', () => {
+    // Arrange
+    const event = keydown({ code: 'KeyN', metaKey: true, isComposing: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBeNull()
+  })
+
+  it('ignores OS auto-repeat so a held key is captured only once', () => {
+    // Arrange
+    const event = keydown({ code: 'KeyN', metaKey: true, repeat: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBeNull()
+  })
+
+  it('uses the physical key so Shift + Equal stays "=" and never "+"', () => {
+    // Arrange
+    const event = keydown({ code: 'Equal', shiftKey: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBe('Shift+=')
+  })
+
+  it('maps a numpad key to its Electron num token', () => {
+    // Arrange
+    const event = keydown({ code: 'Numpad5', metaKey: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBe('CommandOrControl+num5')
+  })
+
+  it('returns null for an unmapped physical key even with a modifier held', () => {
+    // Arrange: 'IntlBackslash' has no accelerator mapping, so holding Cmd must
+    // still resolve to null — never a bogus "CommandOrControl+undefined".
+    const event = keydown({ code: 'IntlBackslash', metaKey: true })
+
+    // Act
+    const accelerator = keyboardEventToAccelerator(event)
+
+    // Assert
+    expect(accelerator).toBeNull()
+  })
+})

--- a/src/components/electron/utils/keyboardEventToAccelerator.ts
+++ b/src/components/electron/utils/keyboardEventToAccelerator.ts
@@ -1,0 +1,45 @@
+import {
+  CODE_TO_ACCELERATOR_KEY,
+  FUNCTION_KEY_TOKENS,
+} from '@/lib/constants/keybinding'
+
+/**
+ * Convert a captured `keydown` into an Electron accelerator string, or `null`
+ * while the chord is incomplete/invalid — powers the VSCode-style "press the
+ * keys" capture in keybinding settings. Reads `event.code` (physical key) so the
+ * result is layout- and shift-independent (Shift+3 stays `Shift+3`, not `#`);
+ * `event.metaKey` maps to `CommandOrControl` to match the existing defaults.
+ *
+ * @param event - The `keydown` event captured while a binding box is recording.
+ * @returns
+ * - A valid accelerator string when a non-modifier key is held with the required modifiers (e.g. `'CommandOrControl+Shift+N'`)
+ * - `null` when the chord is not yet bindable: only modifiers are down, an IME composition is active, the event is an auto-repeat, the key is unmapped, or a non-function key is pressed with no modifier
+ * @example
+ * keyboardEventToAccelerator(cmdThree)   // ⌘ + 3      → 'CommandOrControl+3'
+ * keyboardEventToAccelerator(altSpace)   // ⌥ + Space  → 'Alt+Space'
+ * keyboardEventToAccelerator(f5)         // F5 (no mod) → 'F5'
+ * keyboardEventToAccelerator(letterA)    // A  (no mod) → null
+ */
+export function keyboardEventToAccelerator(
+  event: KeyboardEvent,
+): string | null {
+  // IME composition and OS auto-repeat are not deliberate new chords — ignore.
+  if (event.isComposing || event.repeat) return null
+
+  const key = CODE_TO_ACCELERATOR_KEY[event.code]
+  // A bare modifier press (or an unmapped key) is not yet a complete chord.
+  if (!key) return null
+
+  // Canonical internal order; display reorders to Apple HIG separately.
+  const modifiers: string[] = []
+  if (event.metaKey) modifiers.push('CommandOrControl')
+  if (event.ctrlKey) modifiers.push('Control')
+  if (event.altKey) modifiers.push('Alt')
+  if (event.shiftKey) modifiers.push('Shift')
+
+  // Require a modifier for everything except F-keys, so a stray letter can't be
+  // bound as a global shortcut that swallows normal typing.
+  if (modifiers.length === 0 && !FUNCTION_KEY_TOKENS.has(key)) return null
+
+  return [...modifiers, key].join('+')
+}

--- a/src/hooks/useElectronShortcuts.ts
+++ b/src/hooks/useElectronShortcuts.ts
@@ -81,17 +81,10 @@ export function useElectronShortcuts(): UseElectronShortcutsReturn {
       if (!isElectron || !window.electronAPI?.shortcuts) return false
 
       try {
-        // Update each shortcut individually
-        let allSuccess = true
-        for (const [id, accelerator] of Object.entries(newShortcuts)) {
-          const success = await window.electronAPI.shortcuts.update(
-            id,
-            accelerator,
-          )
-          if (!success) {
-            allSuccess = false
-          }
-        }
+        // Persist the whole record in one call — the preload bridge's update()
+        // expects a Record, not positional (id, accelerator) args (a loop throws).
+        const allSuccess =
+          await window.electronAPI.shortcuts.update(newShortcuts)
         if (allSuccess) {
           await loadShortcuts() // Refresh after update
         }

--- a/src/hooks/useElectronShortcuts.ts
+++ b/src/hooks/useElectronShortcuts.ts
@@ -76,6 +76,14 @@ export function useElectronShortcuts(): UseElectronShortcutsReturn {
     }
   }, [isElectron])
 
+  /**
+   * Batch-persist a full shortcut record via the preload bridge, refreshing local
+   * state on success. One update() call with the whole map — the bridge rejects
+   * positional (id, accelerator) args, so a per-shortcut loop would throw.
+   * @param newShortcuts - Full `{ shortcutId: accelerator }` map to persist (`''` unbinds).
+   * @returns Resolves to `true` when the batch persisted, `false` on failure or non-Electron.
+   * @example await updateShortcuts({ toggleBrainDump: 'Alt+Space' })
+   */
   const updateShortcuts = useCallback(
     async (newShortcuts: Record<string, string>) => {
       if (!isElectron || !window.electronAPI?.shortcuts) return false

--- a/src/lib/constants/keybinding.ts
+++ b/src/lib/constants/keybinding.ts
@@ -1,0 +1,199 @@
+/**
+ * @fileoverview Keybinding capture + display constants.
+ *
+ * Source-of-truth maps for converting a browser `KeyboardEvent` into an Electron
+ * accelerator string (`keyboardEventToAccelerator`) and rendering an accelerator
+ * back as human-readable keys (`formatAcceleratorForDisplay`). Kept here — not
+ * inline in the utils — per the repo rule that magic values live in `constants/`.
+ *
+ * Electron accelerator format reference (modifiers + key tokens):
+ * https://www.electronjs.org/docs/latest/api/accelerator
+ *
+ * @module lib/constants/keybinding
+ */
+
+// Intrinsic alphabet/number ranges — named so the generated maps below carry no
+// bare magic numbers.
+const LETTER_COUNT = 26
+const DIGIT_COUNT = 10
+const FUNCTION_KEY_COUNT = 24
+const UPPERCASE_A_CHARCODE = 65 // 'A'
+
+/**
+ * `KeyboardEvent.code` (physical key, layout/shift-independent) → Electron
+ * accelerator key token. Letters/digits/function/numpad ranges are generated;
+ * navigation, whitespace, and punctuation are explicit. Modifier keys are
+ * intentionally absent — they are read from `event.metaKey/ctrlKey/altKey/shiftKey`.
+ */
+export const CODE_TO_ACCELERATOR_KEY: Record<string, string> = {
+  // A–Z → 'A'–'Z'
+  ...Object.fromEntries(
+    Array.from({ length: LETTER_COUNT }, (_unused, index) => {
+      const letter = String.fromCharCode(UPPERCASE_A_CHARCODE + index)
+      return [`Key${letter}`, letter]
+    }),
+  ),
+  // Digit0–Digit9 (top row) → '0'–'9'
+  ...Object.fromEntries(
+    Array.from({ length: DIGIT_COUNT }, (_unused, index) => [
+      `Digit${index}`,
+      String(index),
+    ]),
+  ),
+  // F1–F24 → same token
+  ...Object.fromEntries(
+    Array.from({ length: FUNCTION_KEY_COUNT }, (_unused, index) => {
+      const token = `F${index + 1}`
+      return [token, token]
+    }),
+  ),
+  // Numpad0–Numpad9 → 'num0'–'num9'
+  ...Object.fromEntries(
+    Array.from({ length: DIGIT_COUNT }, (_unused, index) => [
+      `Numpad${index}`,
+      `num${index}`,
+    ]),
+  ),
+  // Numpad operators
+  NumpadDecimal: 'numdec',
+  NumpadAdd: 'numadd',
+  NumpadSubtract: 'numsub',
+  NumpadMultiply: 'nummult',
+  NumpadDivide: 'numdiv',
+  // Whitespace / editing keys that are valid accelerator keys
+  Space: 'Space',
+  Enter: 'Return',
+  Tab: 'Tab',
+  // Navigation
+  ArrowUp: 'Up',
+  ArrowDown: 'Down',
+  ArrowLeft: 'Left',
+  ArrowRight: 'Right',
+  Home: 'Home',
+  End: 'End',
+  PageUp: 'PageUp',
+  PageDown: 'PageDown',
+  // Punctuation (physical keys → literal accelerator chars; '=' not 'Plus' since
+  // '+' is the accelerator separator).
+  Minus: '-',
+  Equal: '=',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backslash: '\\',
+  Semicolon: ';',
+  Quote: "'",
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  Backquote: '`',
+}
+
+/**
+ * Accelerator key tokens that need no modifier to be valid (F1–F24). Every other
+ * key requires at least one modifier so a stray letter can't grab the keyboard
+ * as a global shortcut.
+ */
+export const FUNCTION_KEY_TOKENS: ReadonlySet<string> = new Set(
+  Array.from(
+    { length: FUNCTION_KEY_COUNT },
+    (_unused, index) => `F${index + 1}`,
+  ),
+)
+
+/** Every Electron modifier token, used to split an accelerator into modifiers vs key. */
+export const ACCELERATOR_MODIFIER_TOKENS: ReadonlySet<string> = new Set([
+  'CommandOrControl',
+  'CmdOrCtrl',
+  'Command',
+  'Cmd',
+  'Control',
+  'Ctrl',
+  'Alt',
+  'Option',
+  'AltGr',
+  'Shift',
+  'Super',
+  'Meta',
+])
+
+/** Modifier token → macOS glyph. */
+export const MAC_MODIFIER_GLYPHS: Record<string, string> = {
+  CommandOrControl: '⌘',
+  CmdOrCtrl: '⌘',
+  Command: '⌘',
+  Cmd: '⌘',
+  Super: '⌘',
+  Meta: '⌘',
+  Control: '⌃',
+  Ctrl: '⌃',
+  Alt: '⌥',
+  Option: '⌥',
+  AltGr: '⌥',
+  Shift: '⇧',
+}
+
+/**
+ * Apple HIG modifier display order — Control, Option, Shift, Command (⌃⌥⇧⌘),
+ * Command nearest the key. The capture util may emit modifiers in a different
+ * order, so display sorts by this index.
+ */
+export const MAC_MODIFIER_DISPLAY_ORDER: Record<string, number> = {
+  Control: 0,
+  Ctrl: 0,
+  Alt: 1,
+  Option: 1,
+  AltGr: 1,
+  Shift: 2,
+  CommandOrControl: 3,
+  CmdOrCtrl: 3,
+  Command: 3,
+  Cmd: 3,
+  Meta: 3,
+  Super: 3,
+}
+
+/** Accelerator key token → macOS glyph (keys without an entry display literally). */
+export const MAC_KEY_GLYPHS: Record<string, string> = {
+  Return: '⏎',
+  Enter: '⏎',
+  Escape: '⎋',
+  Esc: '⎋',
+  Tab: '⇥',
+  Up: '↑',
+  Down: '↓',
+  Left: '←',
+  Right: '→',
+  Backspace: '⌫',
+  Delete: '⌦',
+}
+
+/** Modifier token → ASCII label for non-macOS display (the app is macOS-only; this keeps the util pure + testable). */
+export const ASCII_MODIFIER_LABELS: Record<string, string> = {
+  CommandOrControl: 'Ctrl',
+  CmdOrCtrl: 'Ctrl',
+  Control: 'Ctrl',
+  Ctrl: 'Ctrl',
+  Command: 'Cmd',
+  Cmd: 'Cmd',
+  Super: 'Super',
+  Meta: 'Meta',
+  Alt: 'Alt',
+  Option: 'Alt',
+  AltGr: 'Alt',
+  Shift: 'Shift',
+}
+
+// ---------------------------------------------------------------------------
+// KeybindingCaptureInput microcopy — gentle, no-shame voice per DESIGN.md. The
+// box is a button whose label cycles through these three states.
+// ---------------------------------------------------------------------------
+
+/** Shown when a binding box is unbound — invites the click that starts recording. */
+export const KEYBINDING_CAPTURE_EMPTY_LABEL = 'Click to set'
+
+/** Shown while a binding box is recording — prompts the user to press the chord. */
+export const KEYBINDING_CAPTURE_RECORDING_LABEL = 'Press keys…'
+
+/** Surfaced when the captured chord is already registered elsewhere (register returned false). */
+export const KEYBINDING_CONFLICT_MESSAGE =
+  "That combo's already in use — try another."

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -101,7 +101,7 @@ interface ElectronAPI {
   shortcuts?: {
     getRegistered: () => Promise<any>
     getDefaults: () => Promise<any>
-    update: (shortcuts: any) => Promise<any>
+    update: (shortcuts: Record<string, string>) => Promise<boolean>
     register: (accelerator: string, id: string) => Promise<boolean>
     unregister: (id: string) => Promise<boolean>
     isRegistered: (accelerator: string) => Promise<boolean>


### PR DESCRIPTION
## What & why

Three hotkey-UX improvements to the Electron desktop chrome, from the design doc
in `plans/2026-06-14-hotkey-ux.md`:

### 1. BrainDump tray item → Toggle
The tray's BrainDump entry was a one-way **Open BrainDump**. It's now **Toggle
BrainDump** (shows/hides the window), matching the existing Floating Navigator
item. Routes through `WindowManager.toggleBrainDump`.

### 2. Live hotkey display in the tray menu
Each toggle item now renders its **live accelerator**, supplied by the
`ShortcutManager` through an injected provider on `SystemTrayManager` and
refreshed on every rebind. No hardcoded glyphs — the accelerator is **omitted
entirely** when a shortcut is unbound, and the tray falls back to no hotkey when
no provider is wired (e.g. boot before ShortcutManager).

### 3. VSCode-style keybinding capture
Settings keybindings are now captured by **pressing the chord** instead of typing
an accelerator string. New `KeybindingCaptureInput`:
- Physical-key based (`event.code`) for keyboard-layout safety
- IME-safe (guards `isComposing` / keyCode 229 before `preventDefault`)
- **Escape** cancels (keeps focus), **Backspace/Delete** clears the binding
- `metaKey` → `CommandOrControl`; recording starts on click / Enter / Space

### Fix: `shortcuts.update` preload arity
The preload contract is a single `Record<string, string>`. Two callers looped
`update(id, accel)` (2 args), which **throws in preload**. Collapsed both call
sites (`ShortcutSettings.saveShortcuts`, `useElectronShortcuts.updateShortcuts`)
to a single-record call and aligned both `.d.ts` declarations.

## New modules
- `KeybindingCaptureInput.tsx` — the capture box (native `<Button>` primitive, no
  window listener / effect)
- `utils/keyboardEventToAccelerator.ts` — physical key + modifiers → Electron accelerator
- `utils/formatAcceleratorForDisplay.ts` — accelerator → macOS glyphs (`⇧⌘N`)
- `lib/constants/keybinding.ts` — keybinding constants

## Testing
- `pnpm validate` green: **502 web unit tests** + build + typecheck + lint + theme + dslint package tests
- **36** feature unit tests (capture box, both utils, both settings panels)
- **5** tray-menu tests (`electron/__tests__/SystemTrayManager.tray-menu.test.ts`,
  run under `pnpm test:electron`): toggle label, live ⌥Space/⌘3 glyphs, unbound
  omission, no-provider fallback, rebind refresh keeping recent tasks

## Release note
Touches Electron main-process / native tray code, so the **mandatory macOS
computer-use tray smoke** (per `CLAUDE.md` → "Electron Native QA") must run before
the release tag — the renderer-only Playwright/Linux-xvfb suites can't reach the
native tray. Patch bump **v0.10.0 → v0.10.1** to follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click-to-record VSCode-style shortcut capture UI with macOS glyph rendering.
  * System tray shows live hotkey labels for BrainDump and Floating Navigator; BrainDump is now a toggle.
  * Shortcuts saved/updated in batch for consistent persistence.

* **Bug Fixes**
  * Prevented stale hotkey glyphs in the system tray after rebinding.

* **Documentation**
  * Added hotkey UX design doc.

* **Tests**
  * Expanded tests covering capture UI, display formatting, and tray behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->