### PR TITLE
chore: follow-up cleanup (docs, prefs type-safety, settings card dedup, theme E2E guard)

### DIFF
--- a/docs/plans/2026-05-29-paste-import-plan.md
+++ b/docs/plans/2026-05-29-paste-import-plan.md
@@ -1,11 +1,11 @@
 # Plan: Paste-to-import + AI auto-labeling (Issue #53)
 
-|            |                                                                                                            |
-| ---------- | ---------------------------------------------------------------------------------------------------------- |
-| **Status** | In review — PRs #54 (server) + #55 (UI); design + eng + devex cleared, implementation-ready                |
-| **Issue**  | [#53](https://github.com/laststance/corelive/issues/53)                                                    |
-| **Date**   | 2026-05-29 (office-hours + CEO review) · revised 2026-05-30 after an independent (cross-model) plan review |
-| **Origin** | office-hours design session → CEO strategy/scope review → Codex outside-voice review                       |
+|            |                                                                                                                                                             |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status** | Shipped (Slice 1) — PRs #54 (server) + #55 (UI) merged. Slice 2 (AI auto-labeling) deferred → Issue [#53](https://github.com/laststance/corelive/issues/53) |
+| **Issue**  | [#53](https://github.com/laststance/corelive/issues/53)                                                                                                     |
+| **Date**   | 2026-05-29 (office-hours + CEO review) · revised 2026-05-30 after an independent (cross-model) plan review                                                  |
+| **Origin** | office-hours design session → CEO strategy/scope review → Codex outside-voice review                                                                        |
 
 ## Vision
 

--- a/e2e/web/theme.spec.ts
+++ b/e2e/web/theme.spec.ts
@@ -58,21 +58,9 @@ test.describe('Theme Visual Test', () => {
     })
     const lightBackground = await readBackgroundColor(page)
 
-    // Act — open the user menu and switch to dark theme
-    const sidebarHeader = page.locator('[data-sidebar="header"]').first()
-    await expect(sidebarHeader).toBeVisible({ timeout: 5000 })
-    const avatarButton = sidebarHeader.locator('button').first()
-    await expect(avatarButton).toBeVisible({ timeout: 5000 })
-    await avatarButton.click()
-    const changeThemeTrigger = page.getByText('Change Theme', { exact: false })
-    await expect(changeThemeTrigger).toBeVisible()
-    await changeThemeTrigger.click()
-    const darkThemeOption = page
-      .locator('[role="menuitem"]')
-      .filter({ hasText: 'Dark' })
-      .first()
-    await expect(darkThemeOption).toBeVisible()
-    await darkThemeOption.click()
+    // Act — switch to dark theme the way a user does (sidebar menu → Change
+    // Theme → Dark), via the shared helper so all theme switches share one path.
+    await switchToTheme(page, 'Dark')
 
     // Assert — `data-theme` flipped to dark, and the body background-color
     // (driven by the `--background` CSS variable in src/globals.css) actually

--- a/e2e/web/theme.spec.ts
+++ b/e2e/web/theme.spec.ts
@@ -1,6 +1,8 @@
 import { setupClerkTestingToken } from '@clerk/testing/playwright'
 import { expect, test, type Page } from '@playwright/test'
 
+import { THEME_CROSSFADE_DURATION_MS } from '@/lib/constants/theme'
+
 import { resetDatabase } from './_helpers/db'
 
 test.describe('Theme Visual Test', () => {
@@ -81,6 +83,64 @@ test.describe('Theme Visual Test', () => {
       .poll(async () => readBackgroundColor(page), { timeout: 5000 })
       .not.toBe(lightBackground)
   })
+
+  // Regression guard for the PR #71 theme crossfade (DESIGN.md Motion → "Theme
+  // toggle: crossfade, no flash"). How it LOOKS was verified once by recorded
+  // video frames at build time; these tests are the durable contract guard — the
+  // <ThemeTransition> machinery must arm the transient `theme-transition` class
+  // ONLY for the switch window and never leak it onto hover/focus. Assertions are
+  // pure DOM-class state (+ the frozen clock from beforeEach), so they stay
+  // deterministic on CI rather than sampling opacity mid-animation.
+  test('arms the crossfade class only during a theme switch, then drops it', async ({
+    page,
+  }) => {
+    // Arrange — the crossfade is keyed off a transient <html> class that must be
+    // absent at rest, so hover/focus repaints stay instant.
+    const html = page.locator('html')
+    await expect(html).toHaveAttribute('data-theme', 'light', { timeout: 5000 })
+    await expect(html).not.toHaveClass(/theme-transition/)
+
+    // Act — switch theme the way a user does (sidebar menu → Change Theme → Dark).
+    await switchToTheme(page, 'Dark')
+
+    // Assert — the switch arms the crossfade: <html> gains `theme-transition` so
+    // globals.css animates colors across the whole UI for this one window.
+    await expect(html).toHaveAttribute('data-theme', 'dark', { timeout: 5000 })
+    await expect(html).toHaveClass(/theme-transition/)
+
+    // Act — advance the frozen clock past the crossfade window.
+    await page.clock.fastForward(THEME_CROSSFADE_DURATION_MS + 50)
+
+    // Assert — the class is dropped once the fade completes, so later hover/focus
+    // repaint instantly with no lingering global transition.
+    await expect(html).not.toHaveClass(/theme-transition/)
+  })
+
+  test('does not arm the crossfade when hovering cards or the sidebar', async ({
+    page,
+  }) => {
+    // Arrange — at rest the crossfade class is absent and <html> carries no
+    // crossfade transition, so per-element hover color changes are instant. This
+    // guards the regression where the global color transition leaked onto every
+    // hover (making the whole UI feel laggy).
+    const html = page.locator('html')
+    await expect(html).not.toHaveClass(/theme-transition/)
+    expect(await readTransitionDuration(page)).toBe('0s')
+
+    // Act — hover real token-bearing surfaces (a card, then the sidebar).
+    const card = page.locator('[data-slot="card"]').first()
+    await expect(card).toBeVisible({ timeout: 10000 })
+    await card.hover()
+    const sidebar = page.locator('[data-sidebar="sidebar"]').first()
+    if (await sidebar.isVisible()) {
+      await sidebar.hover()
+    }
+
+    // Assert — hovering never arms the crossfade (it is gated to data-theme
+    // changes), so <html> stays class-free and transition-free.
+    await expect(html).not.toHaveClass(/theme-transition/)
+    expect(await readTransitionDuration(page)).toBe('0s')
+  })
 })
 
 /**
@@ -99,4 +159,52 @@ async function readBackgroundColor(page: Page): Promise<string> {
   return page.evaluate(
     () => window.getComputedStyle(document.body).backgroundColor,
   )
+}
+
+/**
+ * Returns the computed `transition-duration` of the `<html>` element. The
+ * crossfade rule in globals.css targets `html.theme-transition`, so `<html>`
+ * (which carries no Tailwind transition utility of its own) reads `"0s"` at rest
+ * and the crossfade duration only while the transient class is present — letting
+ * the no-hover-leak test prove the transition is scoped, not global.
+ *
+ * @param page - The Playwright Page instance.
+ * @returns The `<html>` computed `transition-duration` (e.g. `"0s"`).
+ * @example
+ * expect(await readTransitionDuration(page)).toBe('0s') // at rest
+ */
+async function readTransitionDuration(page: Page): Promise<string> {
+  return page.evaluate(
+    () => window.getComputedStyle(document.documentElement).transitionDuration,
+  )
+}
+
+/**
+ * Switches the active theme the way a user does — opening the sidebar avatar
+ * menu, the "Change Theme" submenu, then picking an option. Used by the crossfade
+ * regression tests so they drive the real next-themes + ThemeTransition path
+ * instead of poking `data-theme` directly (which would bypass the machinery
+ * under test).
+ *
+ * @param page - The Playwright Page instance.
+ * @param optionLabel - The visible theme name to select (e.g. `"Dark"`).
+ * @returns Resolves once the theme option has been clicked.
+ * @example
+ * await switchToTheme(page, 'Dark')
+ */
+async function switchToTheme(page: Page, optionLabel: string): Promise<void> {
+  const sidebarHeader = page.locator('[data-sidebar="header"]').first()
+  await expect(sidebarHeader).toBeVisible({ timeout: 5000 })
+  const avatarButton = sidebarHeader.locator('button').first()
+  await expect(avatarButton).toBeVisible({ timeout: 5000 })
+  await avatarButton.click()
+  const changeThemeTrigger = page.getByText('Change Theme', { exact: false })
+  await expect(changeThemeTrigger).toBeVisible()
+  await changeThemeTrigger.click()
+  const themeOption = page
+    .locator('[role="menuitem"]')
+    .filter({ hasText: optionLabel })
+    .first()
+  await expect(themeOption).toBeVisible()
+  await themeOption.click()
 }

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -11,6 +11,7 @@ import React, {
 } from 'react'
 
 import { KeybindingCaptureInput } from '@/components/electron/KeybindingCaptureInput'
+import { SettingsStateCard } from '@/components/electron/SettingsStateCard'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -230,17 +231,12 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
   // true we keep rendering the "Loading" branch below.
   if (hasMounted && !window.electronAPI?.brainDump) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Brain className="h-5 w-5" />
-            BrainDump Note
-          </CardTitle>
-          <CardDescription>
-            BrainDump Note is only available in the desktop application.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Brain}
+        title="BrainDump Note"
+        description="BrainDump Note is only available in the desktop application."
+        className={className}
+      />
     )
   }
 
@@ -253,31 +249,23 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
       typeof window.electronAPI?.brainDump?.getShortcut !== 'function')
   ) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Brain className="h-5 w-5" />
-            BrainDump Note
-          </CardTitle>
-          <CardDescription>
-            Update CoreLive to the latest version to manage BrainDump Note.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Brain}
+        title="BrainDump Note"
+        description="Update CoreLive to the latest version to manage BrainDump Note."
+        className={className}
+      />
     )
   }
 
   if (!isReady) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Brain className="h-5 w-5" />
-            BrainDump Note
-          </CardTitle>
-          <CardDescription>Loading BrainDump settings…</CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Brain}
+        title="BrainDump Note"
+        description="Loading BrainDump settings…"
+        className={className}
+      />
     )
   }
 

--- a/src/components/electron/FloatingWindowSettings.test.tsx
+++ b/src/components/electron/FloatingWindowSettings.test.tsx
@@ -105,7 +105,7 @@ describe('FloatingWindowSettings', () => {
 
     // Assert: the loading copy shows and no switch has rendered yet.
     expect(
-      await screen.findByText('Loading floating window settings...'),
+      await screen.findByText('Loading floating window settings…'),
     ).toBeInTheDocument()
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
   })

--- a/src/components/electron/FloatingWindowSettings.tsx
+++ b/src/components/electron/FloatingWindowSettings.tsx
@@ -13,6 +13,7 @@ import { Monitor } from 'lucide-react'
 import { memo, useCallback, type ReactElement } from 'react'
 import { useId, useState } from 'react'
 
+import { SettingsStateCard } from '@/components/electron/SettingsStateCard'
 import {
   Card,
   CardContent,
@@ -123,18 +124,12 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
 
   if (hasMounted && !window.electronAPI?.floatingPanels) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Monitor className="h-5 w-5" />
-            Floating windows
-          </CardTitle>
-          <CardDescription>
-            Floating window settings are only available in the desktop
-            application.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Monitor}
+        title="Floating windows"
+        description="Floating window settings are only available in the desktop application."
+        className={className}
+      />
     )
   }
 
@@ -146,31 +141,23 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
       'function'
   ) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Monitor className="h-5 w-5" />
-            Floating windows
-          </CardTitle>
-          <CardDescription>
-            Update CoreLive to the latest version to manage floating windows.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Monitor}
+        title="Floating windows"
+        description="Update CoreLive to the latest version to manage floating windows."
+        className={className}
+      />
     )
   }
 
   if (!isReady) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Monitor className="h-5 w-5" />
-            Floating windows
-          </CardTitle>
-          <CardDescription>Loading floating window settings...</CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Monitor}
+        title="Floating windows"
+        description="Loading floating window settings…"
+        className={className}
+      />
     )
   }
 

--- a/src/components/electron/SettingsStateCard.test.tsx
+++ b/src/components/electron/SettingsStateCard.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { Sunrise } from 'lucide-react'
+import { describe, expect, it } from 'vitest'
+
+import { SettingsStateCard } from './SettingsStateCard'
+
+describe('SettingsStateCard', () => {
+  it('shows the feature title and the one-line status copy', () => {
+    // Arrange / Act
+    render(
+      <SettingsStateCard
+        icon={Sunrise}
+        title="On launch"
+        description="Loading startup window settings…"
+      />,
+    )
+
+    // Assert: both the title and the status description render for the reader.
+    expect(screen.getByText('On launch')).toBeInTheDocument()
+    expect(
+      screen.getByText('Loading startup window settings…'),
+    ).toBeInTheDocument()
+  })
+
+  it('forwards className to the card so the parent keeps control of spacing', () => {
+    // Arrange / Act
+    const { container } = render(
+      <SettingsStateCard
+        icon={Sunrise}
+        title="On launch"
+        description="Startup window settings are only available in the desktop application."
+        className="custom-outer-spacing"
+      />,
+    )
+
+    // Assert: the parent-supplied class lands on the rendered card.
+    expect(container.querySelector('.custom-outer-spacing')).not.toBeNull()
+  })
+})

--- a/src/components/electron/SettingsStateCard.tsx
+++ b/src/components/electron/SettingsStateCard.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+/**
+ * @fileoverview Shared status-card scaffold for the Electron Settings page.
+ *
+ * The Startup / Floating / BrainDump settings cards each render the SAME small
+ * header-only Card in three non-interactive states — desktop-app-only, an
+ * "update CoreLive" version-skew notice, and a loading placeholder. This extracts
+ * that repeated `<Card><CardHeader>` scaffold so the three components stay in
+ * lockstep (one icon + title + one-line description) and their degraded/loading
+ * copy renders identically instead of drifting apart per component.
+ *
+ * @module components/electron/SettingsStateCard
+ */
+import type { LucideIcon } from 'lucide-react'
+import { memo, type ReactElement } from 'react'
+
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+interface SettingsStateCardProps {
+  /** Lucide icon shown beside the title (the same glyph the live card uses). */
+  icon: LucideIcon
+  /** Card title — the feature name (e.g. "On launch", "BrainDump Note"). */
+  title: string
+  /** One-line status message (desktop-only / update-prompt / loading). */
+  description: string
+  /** Forwarded to the Card so the parent keeps control of outer spacing. */
+  className?: string
+}
+
+/**
+ * Header-only settings Card for a non-interactive state (desktop-only,
+ * version-skew update prompt, or loading). Extracted from the three Electron
+ * settings cards so their degraded/loading states render identically and the
+ * copy stays consistent. Purely presentational — the parent still owns the
+ * guard logic that decides WHICH state to show; this only draws it.
+ *
+ * @param props - icon, title, description, and optional className
+ * @returns A Card with an icon + title header and a one-line description
+ * @example
+ * <SettingsStateCard icon={Sunrise} title="On launch" description="Loading startup window settings…" />
+ */
+export const SettingsStateCard = memo(function SettingsStateCard({
+  icon: Icon,
+  title,
+  description,
+  className,
+}: SettingsStateCardProps): ReactElement {
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Icon className="h-5 w-5" />
+          {title}
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+    </Card>
+  )
+})
+
+export default SettingsStateCard

--- a/src/components/electron/StartupWindowSettings.test.tsx
+++ b/src/components/electron/StartupWindowSettings.test.tsx
@@ -196,7 +196,7 @@ describe('StartupWindowSettings', () => {
 
     // Assert: the loading copy shows and no toggles have rendered yet.
     expect(
-      await screen.findByText('Loading startup window settings...'),
+      await screen.findByText('Loading startup window settings…'),
     ).toBeInTheDocument()
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
   })

--- a/src/components/electron/StartupWindowSettings.tsx
+++ b/src/components/electron/StartupWindowSettings.tsx
@@ -15,6 +15,7 @@
 import { Sunrise } from 'lucide-react'
 import { memo, useCallback, useId, useState, type ReactElement } from 'react'
 
+import { SettingsStateCard } from '@/components/electron/SettingsStateCard'
 import {
   Card,
   CardContent,
@@ -164,18 +165,12 @@ export const StartupWindowSettings = memo(function StartupWindowSettings({
 
   if (hasMounted && !window.electronAPI?.settings) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Sunrise className="h-5 w-5" />
-            On launch
-          </CardTitle>
-          <CardDescription>
-            Startup window settings are only available in the desktop
-            application.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Sunrise}
+        title="On launch"
+        description="Startup window settings are only available in the desktop application."
+        className={className}
+      />
     )
   }
 
@@ -187,32 +182,23 @@ export const StartupWindowSettings = memo(function StartupWindowSettings({
     typeof window.electronAPI?.settings?.getStartupConfig !== 'function'
   ) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Sunrise className="h-5 w-5" />
-            On launch
-          </CardTitle>
-          <CardDescription>
-            Update CoreLive to the latest version to choose which windows greet
-            you at launch.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Sunrise}
+        title="On launch"
+        description="Update CoreLive to the latest version to choose which windows greet you at launch."
+        className={className}
+      />
     )
   }
 
   if (!isReady) {
     return (
-      <Card className={className}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Sunrise className="h-5 w-5" />
-            On launch
-          </CardTitle>
-          <CardDescription>Loading startup window settings...</CardDescription>
-        </CardHeader>
-      </Card>
+      <SettingsStateCard
+        icon={Sunrise}
+        title="On launch"
+        description="Loading startup window settings…"
+        className={className}
+      />
     )
   }
 

--- a/src/lib/preferences-sync-channel.ts
+++ b/src/lib/preferences-sync-channel.ts
@@ -1,7 +1,14 @@
 import type { Middleware } from '@reduxjs/toolkit'
 
 import { foldLegacyCompletionSoundIntoMoments } from '@/lib/redux/foldLegacyCompletionSoundIntoMoments'
-import { hydratePreferences } from '@/lib/redux/slices/preferencesSlice'
+import {
+  hydratePreferences,
+  setCompletionSound,
+  setRetainCompletedInList,
+  setSoundMoment,
+  setSoundTimbre,
+  setSoundVolume,
+} from '@/lib/redux/slices/preferencesSlice'
 import {
   type PreferencesState,
   PreferencesStateSchema,
@@ -19,15 +26,18 @@ type PreferencesSyncMessage = Readonly<{
 
 // The local, user-initiated toggles that should propagate to other windows.
 // hydratePreferences is deliberately excluded so an applied broadcast never
-// re-broadcasts (the loop guard). Keep in lockstep with the slice's set* reducers
-// — a NEW set* action is silent cross-window until it is added here (the Zod
-// schema validates payloads but does NOT decide which actions broadcast).
+// re-broadcasts (the loop guard). Referenced via each action creator's `.type`
+// (RTK sets it to `'preferences/<name>'`) instead of hardcoded strings, so a
+// reducer rename can't silently desync this set. Still a MANUAL allowlist of
+// WHICH actions broadcast — a NEW set* action stays silent cross-window until
+// added here (the Zod schema validates payloads but does NOT decide which
+// actions broadcast).
 const BROADCASTABLE_ACTION_TYPES = new Set<string>([
-  'preferences/setCompletionSound',
-  'preferences/setRetainCompletedInList',
-  'preferences/setSoundMoment',
-  'preferences/setSoundTimbre',
-  'preferences/setSoundVolume',
+  setCompletionSound.type,
+  setRetainCompletedInList.type,
+  setSoundMoment.type,
+  setSoundTimbre.type,
+  setSoundVolume.type,
 ])
 
 /**


### PR DESCRIPTION
## Why

Clears the backlog of small, low-risk follow-up items that had accumulated across recent feature work. No behavior change for users — this is doc/type-safety/dedup hygiene plus a durable regression guard.

## What

| # | Change | Notes |
|---|--------|-------|
| **A1** | `docs/plans/2026-05-29-paste-import-plan.md` — status `In review` → **Shipped (Slice 1)** | Slice 1 (PRs #54 + #55) merged; Slice 2 (AI auto-labeling) tracked in #53 |
| **A2** | `preferences-sync-channel.ts` — broadcast allowlist now built from action `.type` | Rename-safe; **behavior-preserving** (`.type` equals the same literal strings). Still a manual allowlist of *which* actions broadcast |
| **B1** | New `SettingsStateCard` — collapses the header-only Card duplicated 3× across BrainDump/Floating/Startup settings (desktop-only / update-prompt / loading = 9 blocks) into one `memo`'d component | **Guard logic untouched** — only the presentational scaffold was deduped. Loading copy normalized to `…` |
| **B2** | `e2e/web/theme.spec.ts` — 2 regression tests for the PR #71 theme crossfade | Pure DOM-class-state assertions + frozen clock (deterministic on CI), not opacity sampling. How it *looks* was video-verified at build time; this is the durable contract guard |

## Verification

- `pnpm validate` (Node 24.13.0, CI parity) green: **test 551 pass / 29 skip · typecheck 0 · build OK · lint 0**.
- ⚠️ **`pnpm validate` does not run e2e**, and web E2E can't boot locally on this Mac (known localhost/IPv6 webServer blocker). **B2 has only been parse/discovery-checked (`playwright test --list`) — its first real execution is this PR's CI run.** Both B2 selector assumptions were verified against source: `card.tsx:11` emits `data-slot="card"` and `AddTodoForm` renders a `<Card>` unconditionally on `/home`; globals.css has no bare-`html`/universal transition rule, so `<html>` reads `transition-duration: 0s` at rest.

## Out of scope (deferred follow-ups, intentionally not in this PR)

- Slice 2 AI auto-labeling (#53), test DB isolation (#56)
- Native macOS smoke, /sync-gbrain refresh, GitHub Actions dep bumps — manual/user actions

## Test plan

- [ ] CI green (esp. the new `e2e/web/theme.spec.ts` cases — this is B2's real verification)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Theme transitions now apply only during actual theme switches, preventing unintended animations on hover
  * Electron settings screens redesigned for consistent layout using a shared SettingsStateCard for loading and fallback states
  * Preference synchronization logic updated to derive broadcastable action types from the real RTK action creators for improved cross-window reliability
* **Tests**
  * Updated loading-state assertions to use ellipsis characters; added unit tests for SettingsStateCard
* **Documentation**
  * Updated plan shipment progress status (Slice 1 shipped; Slice 2 deferred)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->