### PR TITLE
refactor(ui): unify "Settings" labels to "Preferences"

### DIFF
--- a/electron/SystemTrayManager.ts
+++ b/electron/SystemTrayManager.ts
@@ -561,7 +561,7 @@ export class SystemTrayManager {
         },
         { type: 'separator' },
         {
-          label: 'Settings',
+          label: 'Preferences',
           click: () => {
             try {
               this.windowManager.openSettings()

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -17,7 +17,7 @@ import { SettingsBackButton } from '@/components/settings/SettingsBackButton'
 import { ThemeSelector } from '@/components/ThemeSelector'
 
 export const metadata: Metadata = {
-  title: 'Settings',
+  title: 'Preferences',
   description: 'CoreLive preferences and desktop application settings',
 }
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -220,13 +220,13 @@ export const AppSidebar = memo(function AppSidebar() {
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
-                {/* Settings is web-reachable (D15): the shared Preferences
+                {/* Preferences is web-reachable (D15): the shared Preferences
                     section is shown to everyone; Electron window-chrome settings
                     self-gate to the desktop app. */}
                 <SidebarMenuItem>
                   <SidebarMenuButton onClick={handleOpenSettings}>
                     <Settings className="h-4 w-4" />
-                    <span>Settings</span>
+                    <span>Preferences</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
                 <SidebarMenuItem>

--- a/src/components/electron/ElectronSettingsPage.tsx
+++ b/src/components/electron/ElectronSettingsPage.tsx
@@ -191,7 +191,7 @@ export const ElectronSettingsPage = memo(
 
         <Card className="border-0 bg-transparent shadow-none">
           <CardHeader className="px-2 pb-2 pt-0">
-            <CardTitle className="text-lg">Settings</CardTitle>
+            <CardTitle className="text-lg">Application</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4 px-2">
             {/* Hide App Icon */}

--- a/src/components/electron/NotificationSettings.tsx
+++ b/src/components/electron/NotificationSettings.tsx
@@ -238,7 +238,7 @@ export const NotificationSettings = memo(function NotificationSettings({
             <Bell className="h-5 w-5" />
             Notifications
           </CardTitle>
-          <CardDescription>Loading notification settings...</CardDescription>
+          <CardDescription>Loading notification preferences...</CardDescription>
         </CardHeader>
       </Card>
     )

--- a/src/components/electron/ShortcutSettings.tsx
+++ b/src/components/electron/ShortcutSettings.tsx
@@ -256,7 +256,7 @@ export const ShortcutSettings = memo(function ShortcutSettings({
             <Keyboard className="h-5 w-5" />
             Keyboard Shortcuts
           </CardTitle>
-          <CardDescription>Loading shortcut settings...</CardDescription>
+          <CardDescription>Loading shortcut preferences...</CardDescription>
         </CardHeader>
       </Card>
     )


### PR DESCRIPTION
## What & why

The data/state layer already said **"Preferences"** (`preferencesSlice`, `PreferencesSettings`, the macOS app menu's `Preferences...`), but the nav, page title, tray, and one settings card still said **"Settings"** — so clicking **Settings** opened **Preferences** content. This unifies every user-visible label on **Preferences**.

> Task 1 of a 7-task consistency/UX batch.

## What changed (user-visible copy only)

| Surface | Before → After |
|---|---|
| Sidebar nav item (`AppSidebar.tsx`) | Settings → **Preferences** |
| Page `<title>` metadata (`app/settings/page.tsx`) | Settings → **Preferences** |
| System tray menu item (`SystemTrayManager.ts`) | Settings → **Preferences** (now matches the app menu's `Preferences...`) |
| Electron desktop card (`ElectronSettingsPage.tsx`) | Settings → **Application** ¹ |
| Loading copy (`ShortcutSettings.tsx`, `NotificationSettings.tsx`) | "...settings..." → "...preferences..." |

¹ That card (Hide App Icon / Show in Menu Bar / Start at Login) sits **below** a sibling card already titled "Preferences", so it couldn't duplicate that name — **"Application"** names its OS-presence toggles precisely.

## Scope decisions

- **Kept the `/settings` route on purpose.** Renaming it would 404 already-installed Electron clients whose frozen `WindowManager` builds `${baseUrl}/settings` (documented preload version-skew gotcha), for ~zero benefit (the Electron webview has no address bar).
- **Internal symbols/files unchanged** (`electronSettingsSlice`, `electronAPI.settings` preload namespace, component identifiers) — invisible churn, no user benefit, and the preload namespace is version-skew-sensitive.

## Test plan

- `pnpm validate` green: **test 551 passed** / typecheck / lint (`--max-warnings 0`) / build — all exit 0 (run under Node 24.13.0 to match CI).
- Swept `src/` + `electron/` + tests: no remaining user-visible "Settings" label; **no test/story asserts on the old label** (the only `Settings` matches are generic shadcn demos + the untouched `electronAPI.settings` API).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated terminology throughout the application from "Settings" to "Preferences" across menu items, page titles, sidebar actions, and loading messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->