### PR TITLE
feat(braindump): add editor font family, size, and color to Preferences

### DIFF
--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -1,8 +1,14 @@
+import { configureStore } from '@reduxjs/toolkit'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
 import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import preferencesReducer, {
+  initialState as preferencesInitialState,
+} from '@/lib/redux/slices/preferencesSlice'
+import type { PreferencesState } from '@/lib/schemas/preferences'
 import type { CategoryWithCount } from '@/server/schemas/category'
 
 import { BrainDumpEditor } from './BrainDumpEditor'
@@ -116,6 +122,29 @@ function installBrainDumpAPI(spaces: BrainDumpSpacesBridge): void {
   })
 }
 
+/**
+ * Renders the editor under a real preferences store (so its inline text styling
+ * reads the actual slice) with the given preference overrides spread over the
+ * slice defaults. Required now that BrainDumpEditor reads the preferences slice.
+ * @param preferenceOverrides - Fields to override on top of the slice defaults.
+ * @returns The Testing Library render result.
+ * @example
+ * renderEditor({ braindumpFontSize: 20 })
+ */
+function renderEditor(preferenceOverrides: Partial<PreferencesState> = {}) {
+  const store = configureStore({
+    reducer: { preferences: preferencesReducer },
+    preloadedState: {
+      preferences: { ...preferencesInitialState, ...preferenceOverrides },
+    },
+  })
+  return render(
+    <Provider store={store}>
+      <BrainDumpEditor categories={categories} />
+    </Provider>,
+  )
+}
+
 describe('BrainDumpEditor Spaces tracking switch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -131,7 +160,7 @@ describe('BrainDumpEditor Spaces tracking switch', () => {
     })
 
     // Act
-    render(<BrainDumpEditor categories={categories} />)
+    renderEditor()
     const spacesSwitch = screen.getByRole('switch', {
       name: 'Show BrainDump on all Mac desktops',
     })
@@ -152,7 +181,7 @@ describe('BrainDumpEditor Spaces tracking switch', () => {
       setVisibleOnAllWorkspaces,
     })
     const user = userEvent.setup()
-    render(<BrainDumpEditor categories={categories} />)
+    renderEditor()
     const spacesSwitch = screen.getByRole('switch', {
       name: 'Show BrainDump on all Mac desktops',
     })
@@ -181,7 +210,7 @@ describe('BrainDumpEditor Spaces tracking switch', () => {
       setVisibleOnAllWorkspaces,
     })
     const user = userEvent.setup()
-    render(<BrainDumpEditor categories={categories} />)
+    renderEditor()
     const spacesSwitch = screen.getByRole('switch', {
       name: 'Show BrainDump on all Mac desktops',
     })
@@ -213,7 +242,7 @@ describe('BrainDumpEditor Spaces tracking switch', () => {
       getVisibleOnAllWorkspaces,
       setVisibleOnAllWorkspaces,
     })
-    render(<BrainDumpEditor categories={categories} />)
+    renderEditor()
     const spacesSwitch = screen.getByRole('switch', {
       name: 'Show BrainDump on all Mac desktops',
     })
@@ -234,5 +263,53 @@ describe('BrainDumpEditor Spaces tracking switch', () => {
       expect(spacesSwitch).toBeChecked()
     })
     expect(spacesSwitch).not.toBeDisabled()
+  })
+})
+
+describe('BrainDumpEditor text styling preferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the note in the saved font family, size, and color', async () => {
+    // Arrange
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+
+    // Act — open the editor with serif / 20px / amber text saved in preferences.
+    // findByRole settles the editor's async mount effects under act() before asserting.
+    renderEditor({
+      braindumpFontFamily: 'serif',
+      braindumpFontSize: 20,
+      braindumpTextColor: 'var(--primary)',
+    })
+    const noteField = await screen.findByRole('textbox')
+
+    // Assert — the saved presentation is applied inline to the writing surface.
+    expect(noteField.style.fontFamily).toBe('var(--font-serif)')
+    expect(noteField.style.fontSize).toBe('20px')
+    expect(noteField.style.color).toBe('var(--primary)')
+  })
+
+  it('falls back to the default look (mono / 14px) when no preference is saved', async () => {
+    // Arrange
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+
+    // Act — a fresh install (slice defaults) preserves the prior textarea look.
+    renderEditor()
+    const noteField = await screen.findByRole('textbox')
+
+    // Assert — monospace at 14px, matching the removed `font-mono text-sm`.
+    expect(noteField.style.fontFamily).toBe('var(--font-mono)')
+    expect(noteField.style.fontSize).toBe('14px')
   })
 })

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -21,6 +21,8 @@ import { useMounted } from '@/hooks/use-mounted'
 import { useClerkQueryReady } from '@/hooks/useClerkQueryReady'
 import { useSelectedCategory } from '@/hooks/useSelectedCategory'
 import {
+  BRAINDUMP_FONT_FAMILY_CSS,
+  BRAINDUMP_LINE_HEIGHT,
   BRAINDUMP_NOTE_LINES_PER_CAP,
   BRAINDUMP_OPACITY_MAX,
   BRAINDUMP_OPACITY_MIN,
@@ -28,6 +30,12 @@ import {
 } from '@/lib/constants/braindump'
 import { log } from '@/lib/logger'
 import { orpc } from '@/lib/orpc/client-query'
+import { useAppSelector } from '@/lib/redux/hooks'
+import {
+  selectBraindumpFontFamily,
+  selectBraindumpFontSize,
+  selectBraindumpTextColor,
+} from '@/lib/redux/slices/preferencesSlice'
 import { broadcastTodoSync } from '@/lib/todo-sync-channel'
 import type { Category, CategoryWithCount } from '@/server/schemas/category'
 import type { Completed } from '@/server/schemas/completed'
@@ -152,6 +160,13 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
   const syncInputId = useId()
   const categoryInputId = useId()
   const spacesInputId = useId()
+
+  // BrainDump text-presentation preferences (shared via the preferences slice,
+  // hydrated from localStorage + live-synced across windows by the prefs sync
+  // middleware). Read here and applied inline to the editor surface.
+  const braindumpFontFamily = useAppSelector(selectBraindumpFontFamily)
+  const braindumpFontSize = useAppSelector(selectBraindumpFontSize)
+  const braindumpTextColor = useAppSelector(selectBraindumpTextColor)
 
   const activeCategoryId = syncEnabled ? floatingCategoryId : localCategoryId
   const checkedRowsRef = useRef<Map<BrainDumpLineIndex, CheckedRowMemory>>(
@@ -741,8 +756,18 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
         disabled={activeCategoryId === null}
         maxLength={NOTE_MAX_LENGTH}
         spellCheck
-        className="bg-background/60 flex-1 resize-none rounded-lg border p-3 font-mono text-sm shadow-sm focus:outline-none disabled:opacity-50"
-        style={NO_DRAG_REGION_STYLE}
+        className="bg-background/60 flex-1 resize-none rounded-lg border p-3 shadow-sm focus:outline-none disabled:opacity-50"
+        // Inline (not a useMemo) — a fresh style object on an intrinsic element is
+        // free. Spread NO_DRAG_REGION_STYLE first (load-bearing: keeps the
+        // textarea outside the frameless drag region), then layer the saved
+        // presentation. lineHeight is unitless so spacing scales with the size.
+        style={{
+          ...NO_DRAG_REGION_STYLE,
+          fontFamily: BRAINDUMP_FONT_FAMILY_CSS[braindumpFontFamily],
+          fontSize: `${braindumpFontSize}px`,
+          lineHeight: BRAINDUMP_LINE_HEIGHT,
+          color: braindumpTextColor,
+        }}
       />
     </div>
   )

--- a/src/components/settings/PreferencesSettings.test.tsx
+++ b/src/components/settings/PreferencesSettings.test.tsx
@@ -88,8 +88,13 @@ describe('PreferencesSettings — sound palette', () => {
     // Arrange / Act — the default master volume is 0.6.
     renderPreferences()
 
-    // Assert — the single slider reflects the saved fraction directly (not 0–100).
-    const volumeSlider = screen.getByRole('slider')
+    // Assert — the volume slider reflects the saved fraction directly (not 0–100).
+    // Two sliders now exist (volume + BrainDump font size); the volume track is the
+    // one bounded to [0,1] (font size is [12,24]), so scope by its max.
+    const volumeSlider = screen
+      .getAllByRole('slider')
+      .find((slider) => slider.getAttribute('aria-valuemax') === '1')
+    expect(volumeSlider).toBeDefined()
     expect(volumeSlider).toHaveAttribute('aria-valuenow', '0.6')
     expect(volumeSlider).toHaveAttribute('aria-valuemin', '0')
     expect(volumeSlider).toHaveAttribute('aria-valuemax', '1')

--- a/src/components/settings/PreferencesSettings.test.tsx
+++ b/src/components/settings/PreferencesSettings.test.tsx
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -98,5 +98,89 @@ describe('PreferencesSettings — sound palette', () => {
     expect(volumeSlider).toHaveAttribute('aria-valuenow', '0.6')
     expect(volumeSlider).toHaveAttribute('aria-valuemin', '0')
     expect(volumeSlider).toHaveAttribute('aria-valuemax', '1')
+  })
+})
+
+describe('PreferencesSettings — BrainDump editor presentation', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('saves the chosen BrainDump font family when a face is picked', async () => {
+    // Arrange — the default editor face is monospace.
+    const { store, user } = renderPreferences()
+
+    // Act — pick the Serif face.
+    await user.click(screen.getByRole('radio', { name: 'Serif' }))
+
+    // Assert — the serif font is saved to preferences.
+    expect(store.getState().preferences.braindumpFontFamily).toBe('serif')
+  })
+
+  it('shows the BrainDump font-size slider at the saved size on its [12,24] track', () => {
+    // Arrange / Act — a non-default saved size.
+    renderPreferences({ braindumpFontSize: 20 })
+
+    // Assert — the font-size slider (the one bounded to [12,24], unlike the [0,1]
+    // volume track) reflects the saved px directly.
+    const fontSizeSlider = screen
+      .getAllByRole('slider')
+      .find((slider) => slider.getAttribute('aria-valuemax') === '24')
+    expect(fontSizeSlider).toBeDefined()
+    expect(fontSizeSlider).toHaveAttribute('aria-valuenow', '20')
+    expect(fontSizeSlider).toHaveAttribute('aria-valuemin', '12')
+  })
+
+  it('saves the chosen BrainDump text color when a preset is picked', async () => {
+    // Arrange — the default editor color is the theme foreground.
+    const { store, user } = renderPreferences()
+
+    // Act — pick the Amber preset.
+    await user.click(screen.getByRole('radio', { name: 'Amber' }))
+
+    // Assert — the amber theme token is saved.
+    expect(store.getState().preferences.braindumpTextColor).toBe(
+      'var(--primary)',
+    )
+  })
+
+  it('saves a custom BrainDump text color chosen from the native color picker', () => {
+    // Arrange
+    const { store } = renderPreferences()
+    const customColorInput = screen.getByLabelText(
+      'Custom BrainDump text color',
+    )
+
+    // Act — the native picker emits a 6-digit hex.
+    fireEvent.change(customColorInput, { target: { value: '#abcdef' } })
+
+    // Assert — the hex is stored verbatim as the custom color.
+    expect(store.getState().preferences.braindumpTextColor).toBe('#abcdef')
+  })
+
+  it('shows a saved custom hex in the BrainDump color picker', () => {
+    // Arrange / Act — a saved 6-digit hex should populate the native picker.
+    renderPreferences({ braindumpTextColor: '#123456' })
+
+    // Assert — the picker reflects the saved hex, not the fallback.
+    expect(screen.getByLabelText('Custom BrainDump text color')).toHaveValue(
+      '#123456',
+    )
+  })
+
+  it('falls the color picker back to #000000 with no preset selected for a non-hex custom color', () => {
+    // Arrange / Act — a theme token that is NOT one of the presets makes the
+    // selection "custom": no preset radio is active, and the native picker (which
+    // can only display a hex) cannot render a var() token so it shows #000000.
+    renderPreferences({ braindumpTextColor: 'var(--accent)' })
+
+    // Assert — every preset radio is unselected...
+    expect(screen.getByRole('radio', { name: 'Default' })).not.toBeChecked()
+    expect(screen.getByRole('radio', { name: 'Muted' })).not.toBeChecked()
+    expect(screen.getByRole('radio', { name: 'Amber' })).not.toBeChecked()
+    // ...and the custom picker shows the #000000 fallback for the var() token.
+    expect(screen.getByLabelText('Custom BrainDump text color')).toHaveValue(
+      '#000000',
+    )
   })
 })

--- a/src/components/settings/PreferencesSettings.tsx
+++ b/src/components/settings/PreferencesSettings.tsx
@@ -419,7 +419,7 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
                     />
                     <Label
                       htmlFor={`braindump-text-color-${preset.id}`}
-                      className="flex items-center gap-1.5 text-sm font-normal"
+                      className="flex items-center gap-2 text-sm font-normal"
                     >
                       <span
                         aria-hidden

--- a/src/components/settings/PreferencesSettings.tsx
+++ b/src/components/settings/PreferencesSettings.tsx
@@ -10,6 +10,14 @@ import { Slider } from '@/components/ui/slider'
 import { Switch } from '@/components/ui/switch'
 import { previewTimbre } from '@/lib/audio/soundEngine'
 import {
+  BRAINDUMP_FONT_FAMILIES,
+  BRAINDUMP_FONT_FAMILY_CSS,
+  BRAINDUMP_FONT_SIZE_MAX_PX,
+  BRAINDUMP_FONT_SIZE_MIN_PX,
+  BRAINDUMP_FONT_SIZE_STEP_PX,
+  BRAINDUMP_TEXT_COLOR_PRESETS,
+} from '@/lib/constants/braindump'
+import {
   SOUND_MOMENTS,
   SOUND_TIMBRE_LIST,
   type SoundMomentId,
@@ -17,10 +25,16 @@ import {
 } from '@/lib/constants/sound'
 import { useAppDispatch, useAppSelector } from '@/lib/redux/hooks'
 import {
+  selectBraindumpFontFamily,
+  selectBraindumpFontSize,
+  selectBraindumpTextColor,
   selectRetainCompletedInList,
   selectSoundMoment,
   selectSoundTimbre,
   selectSoundVolume,
+  setBraindumpFontFamily,
+  setBraindumpFontSize,
+  setBraindumpTextColor,
   setRetainCompletedInList,
   setSoundMoment,
   setSoundTimbre,
@@ -31,6 +45,11 @@ import {
 const SOUND_VOLUME_SLIDER_STEP = 0.05
 /** Multiplier turning the 0–1 stored volume into the percentage shown beside the slider. */
 const VOLUME_PERCENT_SCALE = 100
+/** A 6-digit `#rrggbb` — the only shape a native `<input type="color">` accepts, so
+ * a preset (theme `var()`) or a 3/8-digit hex can't seed the picker's swatch. */
+const SIX_DIGIT_HEX_PATTERN = /^#[0-9a-fA-F]{6}$/
+/** Picker swatch shown when the active color isn't a 6-digit hex (i.e. a preset is on). */
+const BRAINDUMP_CUSTOM_COLOR_FALLBACK = '#000000'
 
 /**
  * One per-moment sound toggle row (label + quiet-companion description + Switch).
@@ -111,6 +130,9 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
   )
   const soundTimbre = useAppSelector(selectSoundTimbre)
   const soundVolume = useAppSelector(selectSoundVolume)
+  const braindumpFontFamily = useAppSelector(selectBraindumpFontFamily)
+  const braindumpFontSize = useAppSelector(selectBraindumpFontSize)
+  const braindumpTextColor = useAppSelector(selectBraindumpTextColor)
 
   // Lookup so the SOUND_MOMENTS render map (the single source of moment copy) can
   // index its checked state without per-item hook calls.
@@ -122,6 +144,23 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
 
   // Radix Slider wants a stable array; rebuild it only when the volume changes.
   const sliderValue = useMemo(() => [soundVolume], [soundVolume])
+  // Same for the font-size slider — its own stable single-thumb array.
+  const fontSizeSliderValue = useMemo(
+    () => [braindumpFontSize],
+    [braindumpFontSize],
+  )
+  // The active color is "custom" when it matches none of the themed presets — then
+  // no preset radio is selected and the native picker owns the choice.
+  const isCustomBraindumpColor = !BRAINDUMP_TEXT_COLOR_PRESETS.some(
+    (preset) => preset.cssValue === braindumpTextColor,
+  )
+  // `<input type="color">` can only display a 6-digit hex; fall back to a neutral
+  // swatch while a (non-hex) preset is active so the control still renders.
+  const braindumpCustomColorValue = SIX_DIGIT_HEX_PATTERN.test(
+    braindumpTextColor,
+  )
+    ? braindumpTextColor
+    : BRAINDUMP_CUSTOM_COLOR_FALLBACK
 
   const handleRetainChange = useCallback(
     (checked: boolean): void => {
@@ -160,6 +199,36 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
       if (typeof nextVolume === 'number') {
         dispatch(setSoundVolume(nextVolume))
       }
+    },
+    [dispatch],
+  )
+
+  const handleBraindumpFontFamilyChange = useCallback(
+    (value: string): void => {
+      // RadioGroup yields a bare string; resolve it against the registry so the id
+      // narrows to a BrainDumpFontFamilyId without an unsafe cast.
+      const family = BRAINDUMP_FONT_FAMILIES.find((entry) => entry.id === value)
+      if (!family) return
+      dispatch(setBraindumpFontFamily(family.id))
+    },
+    [dispatch],
+  )
+
+  const handleBraindumpFontSizeChange = useCallback(
+    (values: number[]): void => {
+      // Guard the first thumb value (same as the volume slider) before dispatching.
+      const nextSize = values[0]
+      if (typeof nextSize === 'number') {
+        dispatch(setBraindumpFontSize(nextSize))
+      }
+    },
+    [dispatch],
+  )
+
+  const handleBraindumpTextColorPresetChange = useCallback(
+    (value: string): void => {
+      // RadioGroup values ARE the preset cssValue strings, stored verbatim.
+      dispatch(setBraindumpTextColor(value))
     },
     [dispatch],
   )
@@ -262,6 +331,128 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
                 value={sliderValue}
                 onValueChange={handleVolumeChange}
               />
+            </div>
+          </div>
+
+          {/* BrainDump editor text presentation (font, size, color). */}
+          <div className="space-y-4">
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">BrainDump</p>
+              <p className="text-xs text-muted-foreground">
+                How the text looks in the BrainDump editor.
+              </p>
+            </div>
+
+            {/* Font family — the three brand fonts; each label previews its face. */}
+            <div className="space-y-2">
+              <span className="text-sm font-medium">Font</span>
+              <RadioGroup
+                aria-label="BrainDump font family"
+                value={braindumpFontFamily}
+                onValueChange={handleBraindumpFontFamilyChange}
+                className="grid grid-cols-3 gap-2"
+              >
+                {BRAINDUMP_FONT_FAMILIES.map((family) => (
+                  <div key={family.id} className="flex items-center gap-2">
+                    <RadioGroupItem
+                      id={`braindump-font-${family.id}`}
+                      value={family.id}
+                    />
+                    <Label
+                      htmlFor={`braindump-font-${family.id}`}
+                      className="text-sm font-normal"
+                    >
+                      {/* Preview each option in its own face. Inline style sits on
+                          this intrinsic span (not the Label component) — a fresh
+                          object on a DOM element is free and needs no useMemo. */}
+                      <span
+                        style={{
+                          fontFamily: BRAINDUMP_FONT_FAMILY_CSS[family.id],
+                        }}
+                      >
+                        {family.label}
+                      </span>
+                    </Label>
+                  </div>
+                ))}
+              </RadioGroup>
+            </div>
+
+            {/* Font size — px slider; default 14 matches the prior text-sm. */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label
+                  htmlFor="braindump-font-size"
+                  className="text-sm font-medium"
+                >
+                  Font size
+                </Label>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {braindumpFontSize}px
+                </span>
+              </div>
+              <Slider
+                id="braindump-font-size"
+                aria-label="BrainDump font size"
+                min={BRAINDUMP_FONT_SIZE_MIN_PX}
+                max={BRAINDUMP_FONT_SIZE_MAX_PX}
+                step={BRAINDUMP_FONT_SIZE_STEP_PX}
+                value={fontSizeSliderValue}
+                onValueChange={handleBraindumpFontSizeChange}
+              />
+            </div>
+
+            {/* Text color — theme-aware presets, or a custom color (Presets First). */}
+            <div className="space-y-2">
+              <span className="text-sm font-medium">Text color</span>
+              <RadioGroup
+                aria-label="BrainDump text color"
+                value={isCustomBraindumpColor ? '' : braindumpTextColor}
+                onValueChange={handleBraindumpTextColorPresetChange}
+                className="grid grid-cols-3 gap-2"
+              >
+                {BRAINDUMP_TEXT_COLOR_PRESETS.map((preset) => (
+                  <div key={preset.id} className="flex items-center gap-2">
+                    <RadioGroupItem
+                      id={`braindump-text-color-${preset.id}`}
+                      value={preset.cssValue}
+                    />
+                    <Label
+                      htmlFor={`braindump-text-color-${preset.id}`}
+                      className="flex items-center gap-1.5 text-sm font-normal"
+                    >
+                      <span
+                        aria-hidden
+                        className="inline-block h-3 w-3 rounded-full border"
+                        style={{ backgroundColor: preset.cssValue }}
+                      />
+                      {preset.label}
+                    </Label>
+                  </div>
+                ))}
+              </RadioGroup>
+              {/* Custom color — native picker; choosing one overrides the presets. */}
+              <div className="flex items-center gap-2">
+                <Label
+                  htmlFor="braindump-text-color-custom"
+                  className="text-sm font-normal"
+                >
+                  Custom
+                </Label>
+                <input
+                  id="braindump-text-color-custom"
+                  type="color"
+                  aria-label="Custom BrainDump text color"
+                  value={braindumpCustomColorValue}
+                  // Inline (not useCallback) — a fresh handler on an intrinsic
+                  // element is free. The native picker emits a 6-digit hex; store
+                  // it verbatim as the (custom) color.
+                  onChange={(event) =>
+                    dispatch(setBraindumpTextColor(event.target.value))
+                  }
+                  className="h-7 w-10 cursor-pointer rounded border bg-transparent"
+                />
+              </div>
             </div>
           </div>
         </CardContent>

--- a/src/lib/constants/braindump.ts
+++ b/src/lib/constants/braindump.ts
@@ -57,3 +57,101 @@ export type BrainDumpShortcut = string
  * const sync: BrainDumpSyncMode = true
  */
 export type BrainDumpSyncMode = boolean
+
+/* -------------------------------------------------------------------------- */
+/* BrainDump editor text presentation (font family / size / color)            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Selectable BrainDump editor font-family ids. `as const` so the union type AND
+ * `z.enum(BRAINDUMP_FONT_FAMILY_IDS)` both derive from this one tuple (no drift),
+ * mirroring the sound-palette `TIMBRE_IDS` pattern.
+ */
+export const BRAINDUMP_FONT_FAMILY_IDS = ['mono', 'sans', 'serif'] as const
+
+/** A selectable BrainDump editor font family. */
+export type BrainDumpFontFamilyId = (typeof BRAINDUMP_FONT_FAMILY_IDS)[number]
+
+/**
+ * id → CSS value (the globals.css font vars, which resolve to the brand 3-font
+ * stack on every route). The SINGLE source for the font CSS — read by both the
+ * Settings preview label and the editor's inline style — so the mapping can't
+ * drift between picker and surface.
+ */
+export const BRAINDUMP_FONT_FAMILY_CSS: Record<BrainDumpFontFamilyId, string> =
+  {
+    mono: 'var(--font-mono)',
+    sans: 'var(--font-sans)',
+    serif: 'var(--font-serif)',
+  }
+
+/** Settings-selector metadata for a font family (label only; CSS via the map). */
+export interface BrainDumpFontFamilyOption {
+  id: BrainDumpFontFamilyId
+  label: string
+}
+
+/** The ordered font-family options for the Settings selector. */
+export const BRAINDUMP_FONT_FAMILIES: readonly BrainDumpFontFamilyOption[] = [
+  { id: 'mono', label: 'Monospace' },
+  { id: 'sans', label: 'Sans-serif' },
+  { id: 'serif', label: 'Serif' },
+]
+
+/** Default editor font — monospace, preserving the prior `font-mono` look. */
+export const DEFAULT_BRAINDUMP_FONT_FAMILY: BrainDumpFontFamilyId = 'mono'
+
+/** Smallest selectable editor font size. */
+export const BRAINDUMP_FONT_SIZE_MIN_PX = 12
+
+/** Largest selectable editor font size. */
+export const BRAINDUMP_FONT_SIZE_MAX_PX = 24
+
+/** Font-size slider granularity (whole px — finer steps aren't worth the jitter). */
+export const BRAINDUMP_FONT_SIZE_STEP_PX = 1
+
+/** Default editor font size — 14px, preserving the prior `text-sm` (0.875rem). */
+export const DEFAULT_BRAINDUMP_FONT_SIZE_PX = 14
+
+/**
+ * Unitless line-height for the editor textarea. Unitless (not the old fixed
+ * `text-sm` 1.25rem) so line spacing scales WITH the chosen font size instead of
+ * staying glued to a single px height.
+ */
+export const BRAINDUMP_LINE_HEIGHT = 1.5
+
+/** Settings-swatch metadata for a text-color preset (label + themed CSS value). */
+export interface BrainDumpTextColorPreset {
+  id: string
+  label: string
+  /** A theme token via CSS var so the preset follows the active light/dark theme. */
+  cssValue: string
+}
+
+/**
+ * On-brand, theme-aware text-color presets — CSS vars (not fixed hex) so each
+ * follows the active theme. A custom hex (native color input) layers on top as
+ * the user-owned deviation (DESIGN.md "Presets First, Then Options").
+ */
+export const BRAINDUMP_TEXT_COLOR_PRESETS: readonly BrainDumpTextColorPreset[] =
+  [
+    { id: 'default', label: 'Default', cssValue: 'var(--foreground)' },
+    { id: 'muted', label: 'Muted', cssValue: 'var(--muted-foreground)' },
+    { id: 'amber', label: 'Amber', cssValue: 'var(--primary)' },
+  ]
+
+/** Default editor text color — the theme foreground (preserves the prior inherited color). */
+export const DEFAULT_BRAINDUMP_TEXT_COLOR = 'var(--foreground)'
+
+/**
+ * Accepted text-color shapes: a theme token `var(--name)` (the presets) or a
+ * `#hex` (3/6/8 digits, from the native color input). The schema's `.catch`
+ * self-heals anything else to {@link DEFAULT_BRAINDUMP_TEXT_COLOR}.
+ *
+ * @example
+ * BRAINDUMP_TEXT_COLOR_PATTERN.test('var(--primary)') // => true
+ * BRAINDUMP_TEXT_COLOR_PATTERN.test('#1a2b3c')        // => true
+ * BRAINDUMP_TEXT_COLOR_PATTERN.test('red')            // => false
+ */
+export const BRAINDUMP_TEXT_COLOR_PATTERN =
+  /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|var\(--[a-z-]+\))$/

--- a/src/lib/constants/braindump.ts
+++ b/src/lib/constants/braindump.ts
@@ -162,14 +162,16 @@ export const BRAINDUMP_TEXT_COLOR_PRESETS: readonly BrainDumpTextColorPreset[] =
 export const DEFAULT_BRAINDUMP_TEXT_COLOR = 'var(--foreground)'
 
 /**
- * Accepted text-color shapes: a theme token `var(--name)` (the presets) or a
- * `#hex` (3/6/8 digits, from the native color input). The schema's `.catch`
- * self-heals anything else to {@link DEFAULT_BRAINDUMP_TEXT_COLOR}.
+ * Accepted text-color shapes: a theme token `var(--name)` (the presets; the
+ * name may contain digits, e.g. the `--chart-1` family) or a `#hex` (3/6/8
+ * digits, from the native color input). The schema's `.catch` self-heals
+ * anything else to {@link DEFAULT_BRAINDUMP_TEXT_COLOR}.
  *
  * @example
  * BRAINDUMP_TEXT_COLOR_PATTERN.test('var(--primary)') // => true
+ * BRAINDUMP_TEXT_COLOR_PATTERN.test('var(--chart-1)') // => true
  * BRAINDUMP_TEXT_COLOR_PATTERN.test('#1a2b3c')        // => true
  * BRAINDUMP_TEXT_COLOR_PATTERN.test('red')            // => false
  */
 export const BRAINDUMP_TEXT_COLOR_PATTERN =
-  /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|var\(--[a-z-]+\))$/
+  /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|var\(--[a-z0-9-]+\))$/

--- a/src/lib/constants/braindump.ts
+++ b/src/lib/constants/braindump.ts
@@ -91,12 +91,30 @@ export interface BrainDumpFontFamilyOption {
   label: string
 }
 
-/** The ordered font-family options for the Settings selector. */
-export const BRAINDUMP_FONT_FAMILIES: readonly BrainDumpFontFamilyOption[] = [
-  { id: 'mono', label: 'Monospace' },
-  { id: 'sans', label: 'Sans-serif' },
-  { id: 'serif', label: 'Serif' },
-]
+/**
+ * id → human label. The label source of truth; the ordered options list below
+ * derives from the id tuple, so adding a font to {@link BRAINDUMP_FONT_FAMILY_IDS}
+ * can't silently miss the Settings selector (no drift — same guarantee the tuple
+ * docstring promises, mirroring `sound.ts`'s `SOUND_TIMBRE_LIST`).
+ */
+export const BRAINDUMP_FONT_FAMILY_LABELS: Record<
+  BrainDumpFontFamilyId,
+  string
+> = {
+  mono: 'Monospace',
+  sans: 'Sans-serif',
+  serif: 'Serif',
+}
+
+/**
+ * The ordered font-family options for the Settings selector, derived from the id
+ * tuple so ids and order live in exactly one place.
+ */
+export const BRAINDUMP_FONT_FAMILIES: readonly BrainDumpFontFamilyOption[] =
+  BRAINDUMP_FONT_FAMILY_IDS.map((id) => ({
+    id,
+    label: BRAINDUMP_FONT_FAMILY_LABELS[id],
+  }))
 
 /** Default editor font — monospace, preserving the prior `font-mono` look. */
 export const DEFAULT_BRAINDUMP_FONT_FAMILY: BrainDumpFontFamilyId = 'mono'

--- a/src/lib/preferences-sync-channel.test.ts
+++ b/src/lib/preferences-sync-channel.test.ts
@@ -187,11 +187,17 @@ describe('preferences cross-window sync', () => {
     // Act — push a payload whose BrainDump fields are out of range / off-shape.
     sender.postMessage({
       type: PREFERENCES_SYNC_EVENT_TYPE,
-      state: { braindumpFontSize: 99, braindumpTextColor: 'red' },
+      state: {
+        braindumpFontFamily: 'comic-sans',
+        braindumpFontSize: 99,
+        braindumpTextColor: 'red',
+      },
     })
 
-    // Assert — the receiver applies the CLAMPED size (24, the max) and the HEALED
-    // color (the default token), never the raw 99 / 'red'.
+    // Assert — the receiver applies the HEALED family (the default 'mono'),
+    // CLAMPED size (24, the max), and HEALED color (the default token), never
+    // the raw 'comic-sans' / 99 / 'red'.
+    expect(windowB.getState().preferences.braindumpFontFamily).toBe('mono')
     expect(windowB.getState().preferences.braindumpFontSize).toBe(24)
     expect(windowB.getState().preferences.braindumpTextColor).toBe(
       'var(--foreground)',

--- a/src/lib/preferences-sync-channel.test.ts
+++ b/src/lib/preferences-sync-channel.test.ts
@@ -179,6 +179,25 @@ describe('preferences cross-window sync', () => {
     expect(windowB.getState().preferences.soundVolume).toBe(1)
   })
 
+  it('clamps and heals out-of-range inbound BrainDump fields when applying a raw broadcast', () => {
+    // Arrange — a window plus a raw sender on the same wire protocol.
+    const windowB = makeWindowStore()
+    const sender = new FakeBroadcastChannel(PREFERENCES_SYNC_CHANNEL_NAME)
+
+    // Act — push a payload whose BrainDump fields are out of range / off-shape.
+    sender.postMessage({
+      type: PREFERENCES_SYNC_EVENT_TYPE,
+      state: { braindumpFontSize: 99, braindumpTextColor: 'red' },
+    })
+
+    // Assert — the receiver applies the CLAMPED size (24, the max) and the HEALED
+    // color (the default token), never the raw 99 / 'red'.
+    expect(windowB.getState().preferences.braindumpFontSize).toBe(24)
+    expect(windowB.getState().preferences.braindumpTextColor).toBe(
+      'var(--foreground)',
+    )
+  })
+
   it('folds a legacy-only inbound payload so the completion cue is not silently lost', () => {
     // Arrange — a window plus a raw sender posting a pre-palette snapshot that
     // carries ONLY the legacy completionSound flag (no soundMoments at all),

--- a/src/lib/preferences-sync-channel.test.ts
+++ b/src/lib/preferences-sync-channel.test.ts
@@ -9,6 +9,9 @@ import {
 import preferencesReducer, {
   hydratePreferences,
   initialState,
+  setBraindumpFontFamily,
+  setBraindumpFontSize,
+  setBraindumpTextColor,
   setSoundMoment,
   setSoundTimbre,
   setSoundVolume,
@@ -120,6 +123,45 @@ describe('preferences cross-window sync', () => {
 
     // Assert
     expect(windowB.getState().preferences.soundVolume).toBe(0.25)
+  })
+
+  it('propagates a BrainDump font-family change to another window', () => {
+    // Arrange
+    const windowA = makeWindowStore()
+    const windowB = makeWindowStore()
+
+    // Act — switch the editor face away from the default 'mono' in window A.
+    windowA.dispatch(setBraindumpFontFamily('serif'))
+
+    // Assert — window B reflects the chosen face without a reload (the action is
+    // in the broadcast allowlist).
+    expect(windowB.getState().preferences.braindumpFontFamily).toBe('serif')
+  })
+
+  it('propagates a BrainDump font-size change to another window', () => {
+    // Arrange
+    const windowA = makeWindowStore()
+    const windowB = makeWindowStore()
+
+    // Act — bump the editor size off the default 14px in window A.
+    windowA.dispatch(setBraindumpFontSize(20))
+
+    // Assert — window B reflects the new size without a reload.
+    expect(windowB.getState().preferences.braindumpFontSize).toBe(20)
+  })
+
+  it('propagates a BrainDump text-color change to another window', () => {
+    // Arrange
+    const windowA = makeWindowStore()
+    const windowB = makeWindowStore()
+
+    // Act — pick a non-default editor color in window A.
+    windowA.dispatch(setBraindumpTextColor('var(--primary)'))
+
+    // Assert — window B reflects the new color without a reload.
+    expect(windowB.getState().preferences.braindumpTextColor).toBe(
+      'var(--primary)',
+    )
   })
 
   it('clamps an out-of-range inbound volume when applying a raw broadcast', () => {

--- a/src/lib/preferences-sync-channel.ts
+++ b/src/lib/preferences-sync-channel.ts
@@ -3,6 +3,9 @@ import type { Middleware } from '@reduxjs/toolkit'
 import { foldLegacyCompletionSoundIntoMoments } from '@/lib/redux/foldLegacyCompletionSoundIntoMoments'
 import {
   hydratePreferences,
+  setBraindumpFontFamily,
+  setBraindumpFontSize,
+  setBraindumpTextColor,
   setCompletionSound,
   setRetainCompletedInList,
   setSoundMoment,
@@ -38,6 +41,9 @@ const BROADCASTABLE_ACTION_TYPES = new Set<string>([
   setSoundMoment.type,
   setSoundTimbre.type,
   setSoundVolume.type,
+  setBraindumpFontFamily.type,
+  setBraindumpFontSize.type,
+  setBraindumpTextColor.type,
 ])
 
 /**

--- a/src/lib/redux/slices/preferencesSlice.test.ts
+++ b/src/lib/redux/slices/preferencesSlice.test.ts
@@ -248,6 +248,19 @@ describe('preferencesSlice', () => {
     expect(next.braindumpFontFamily).toBe('serif')
   })
 
+  it('self-heals an unknown BrainDump font family to the default instead of storing it', () => {
+    // Act — a payload outside the known ids (a corrupt blob or stray dispatch)
+    // must not poison the font-family key. A raw action bypasses the typed creator
+    // to exercise the reducer's runtime guard the way malformed input would.
+    const next = reducer(initialState, {
+      type: setBraindumpFontFamily.type,
+      payload: 'comic-sans',
+    })
+
+    // Assert — the reducer falls back to the default face.
+    expect(next.braindumpFontFamily).toBe('mono')
+  })
+
   it('clamps an out-of-range BrainDump font size into the slider bounds [12,24]', () => {
     // Act — above-range clamps to the ceiling, below-range to the floor, in-range passes.
     const tooBig = reducer(initialState, setBraindumpFontSize(99))

--- a/src/lib/redux/slices/preferencesSlice.test.ts
+++ b/src/lib/redux/slices/preferencesSlice.test.ts
@@ -276,6 +276,15 @@ describe('preferencesSlice', () => {
     expect(next.braindumpTextColor).toBe('#123abc')
   })
 
+  it('self-heals an off-shape BrainDump text color to the default instead of storing it', () => {
+    // Act — a value that is neither a theme token nor a hex (e.g. a corrupt
+    // persisted blob or stray programmatic call) must not reach the inline style.
+    const next = reducer(initialState, setBraindumpTextColor('not-a-color'))
+
+    // Assert — the reducer shares the schema's validation boundary and falls back.
+    expect(next.braindumpTextColor).toBe('var(--foreground)')
+  })
+
   it('falls back to the default font, size, and color for a slice that predates those fields', () => {
     // Arrange — a persisted slice from before the BrainDump text-style fields existed.
     const legacyState = stateWith({ completionSound: false })

--- a/src/lib/redux/slices/preferencesSlice.test.ts
+++ b/src/lib/redux/slices/preferencesSlice.test.ts
@@ -8,12 +8,18 @@ import reducer, {
   hydratePreferences,
   initialState,
   resetPreferences,
+  selectBraindumpFontFamily,
+  selectBraindumpFontSize,
+  selectBraindumpTextColor,
   selectCompletionSound,
   selectPreferences,
   selectRetainCompletedInList,
   selectSoundMoment,
   selectSoundTimbre,
   selectSoundVolume,
+  setBraindumpFontFamily,
+  setBraindumpFontSize,
+  setBraindumpTextColor,
   setCompletionSound,
   setRetainCompletedInList,
   setSoundMoment,
@@ -31,13 +37,17 @@ function stateWith(preferences: Partial<PreferencesState>): RootState {
 
 describe('preferencesSlice', () => {
   it('defaults every preference to silent/neutral so a fresh install makes no sound', () => {
-    // Assert — all sound moments OFF, default timbre + volume, both legacy flags OFF.
+    // Assert — all sound moments OFF, default timbre + volume, both legacy flags OFF,
+    // and the BrainDump editor at its prior look (mono / 14px / theme foreground).
     expect(initialState).toEqual({
       completionSound: false,
       retainCompletedInList: false,
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,
+      braindumpFontFamily: 'mono',
+      braindumpFontSize: 14,
+      braindumpTextColor: 'var(--foreground)',
     })
   })
 
@@ -126,6 +136,9 @@ describe('preferencesSlice', () => {
       soundMoments: { 'task-create': true, complete: true, clear: true },
       soundTimbre: 'paper',
       soundVolume: 0.8,
+      braindumpFontFamily: 'serif',
+      braindumpFontSize: 20,
+      braindumpTextColor: 'var(--primary)',
     }
 
     // Act
@@ -143,6 +156,9 @@ describe('preferencesSlice', () => {
       soundMoments: { 'task-create': true, complete: true, clear: true },
       soundTimbre: 'paper',
       soundVolume: 0.9,
+      braindumpFontFamily: 'serif',
+      braindumpFontSize: 24,
+      braindumpTextColor: '#abcdef',
     }
 
     // Act
@@ -155,6 +171,9 @@ describe('preferencesSlice', () => {
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,
+      braindumpFontFamily: 'mono',
+      braindumpFontSize: 14,
+      braindumpTextColor: 'var(--foreground)',
     })
   })
 
@@ -215,6 +234,55 @@ describe('preferencesSlice', () => {
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,
+      braindumpFontFamily: 'mono',
+      braindumpFontSize: 14,
+      braindumpTextColor: 'var(--foreground)',
     })
+  })
+
+  it('sets the BrainDump editor font family when setBraindumpFontFamily is dispatched', () => {
+    // Act
+    const next = reducer(initialState, setBraindumpFontFamily('serif'))
+
+    // Assert
+    expect(next.braindumpFontFamily).toBe('serif')
+  })
+
+  it('clamps an out-of-range BrainDump font size into the slider bounds [12,24]', () => {
+    // Act — above-range clamps to the ceiling, below-range to the floor, in-range passes.
+    const tooBig = reducer(initialState, setBraindumpFontSize(99))
+    const tooSmall = reducer(initialState, setBraindumpFontSize(2))
+    const inRange = reducer(initialState, setBraindumpFontSize(18))
+
+    // Assert
+    expect(tooBig.braindumpFontSize).toBe(24)
+    expect(tooSmall.braindumpFontSize).toBe(12)
+    expect(inRange.braindumpFontSize).toBe(18)
+  })
+
+  it('guards a NaN BrainDump font size to the default instead of poisoning the slider', () => {
+    // Act — a non-finite value (e.g. a stray empty slider event) must not stick.
+    const next = reducer(initialState, setBraindumpFontSize(Number.NaN))
+
+    // Assert
+    expect(next.braindumpFontSize).toBe(14)
+  })
+
+  it('stores a custom BrainDump text color when setBraindumpTextColor is dispatched', () => {
+    // Act — the native color picker emits a 6-digit hex.
+    const next = reducer(initialState, setBraindumpTextColor('#123abc'))
+
+    // Assert
+    expect(next.braindumpTextColor).toBe('#123abc')
+  })
+
+  it('falls back to the default font, size, and color for a slice that predates those fields', () => {
+    // Arrange — a persisted slice from before the BrainDump text-style fields existed.
+    const legacyState = stateWith({ completionSound: false })
+
+    // Act / Assert — every BrainDump selector coalesces to its default (Finding 5).
+    expect(selectBraindumpFontFamily(legacyState)).toBe('mono')
+    expect(selectBraindumpFontSize(legacyState)).toBe(14)
+    expect(selectBraindumpTextColor(legacyState)).toBe('var(--foreground)')
   })
 })

--- a/src/lib/redux/slices/preferencesSlice.ts
+++ b/src/lib/redux/slices/preferencesSlice.ts
@@ -26,6 +26,7 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import {
   BRAINDUMP_FONT_SIZE_MAX_PX,
   BRAINDUMP_FONT_SIZE_MIN_PX,
+  BRAINDUMP_TEXT_COLOR_PATTERN,
   type BrainDumpFontFamilyId,
 } from '@/lib/constants/braindump'
 import { DEFAULT_PREFERENCES } from '@/lib/constants/preferences'
@@ -146,12 +147,21 @@ export const preferencesSlice = createSlice({
     },
 
     /**
-     * Sets the BrainDump editor text color (a theme `var(--token)` or a `#hex`).
+     * Sets the BrainDump editor text color (a theme `var(--token)` or a `#hex`),
+     * self-healing an off-shape value to the default so the reducer path shares
+     * the same validation boundary as the schema/cross-window path (mirrors the
+     * in-reducer guard on setBraindumpFontSize). The UI only ever emits valid
+     * values; this hardens against a stray programmatic/persisted string.
      * @param state - Current state
      * @param action - Payload containing the new CSS color string.
      */
     setBraindumpTextColor: (state, action: PayloadAction<string>) => {
-      state.braindumpTextColor = action.payload
+      const requestedColor = action.payload
+      state.braindumpTextColor = BRAINDUMP_TEXT_COLOR_PATTERN.test(
+        requestedColor,
+      )
+        ? requestedColor
+        : DEFAULT_PREFERENCES.braindumpTextColor
     },
 
     /**

--- a/src/lib/redux/slices/preferencesSlice.ts
+++ b/src/lib/redux/slices/preferencesSlice.ts
@@ -24,6 +24,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
 import {
+  BRAINDUMP_FONT_FAMILY_IDS,
   BRAINDUMP_FONT_SIZE_MAX_PX,
   BRAINDUMP_FONT_SIZE_MIN_PX,
   BRAINDUMP_TEXT_COLOR_PATTERN,
@@ -118,7 +119,11 @@ export const preferencesSlice = createSlice({
     },
 
     /**
-     * Sets the BrainDump editor font family (one of the brand fonts).
+     * Sets the BrainDump editor font family, self-healing an unknown id to the
+     * default face so the reducer shares the same validation boundary as the
+     * schema/cross-window path (mirrors the guards on the other BrainDump
+     * setters). The UI only ever emits valid ids; this hardens against a stray
+     * programmatic/persisted value.
      * @param state - Current state
      * @param action - Payload containing the new font-family id.
      */
@@ -126,7 +131,12 @@ export const preferencesSlice = createSlice({
       state,
       action: PayloadAction<BrainDumpFontFamilyId>,
     ) => {
-      state.braindumpFontFamily = action.payload
+      const requestedFamily = action.payload
+      state.braindumpFontFamily = BRAINDUMP_FONT_FAMILY_IDS.includes(
+        requestedFamily,
+      )
+        ? requestedFamily
+        : DEFAULT_PREFERENCES.braindumpFontFamily
     },
 
     /**

--- a/src/lib/redux/slices/preferencesSlice.ts
+++ b/src/lib/redux/slices/preferencesSlice.ts
@@ -23,6 +23,11 @@
  */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
+import {
+  BRAINDUMP_FONT_SIZE_MAX_PX,
+  BRAINDUMP_FONT_SIZE_MIN_PX,
+  type BrainDumpFontFamilyId,
+} from '@/lib/constants/braindump'
 import { DEFAULT_PREFERENCES } from '@/lib/constants/preferences'
 import { type SoundMomentId, type TimbreId } from '@/lib/constants/sound'
 import { type PreferencesState } from '@/lib/schemas/preferences'
@@ -112,6 +117,44 @@ export const preferencesSlice = createSlice({
     },
 
     /**
+     * Sets the BrainDump editor font family (one of the brand fonts).
+     * @param state - Current state
+     * @param action - Payload containing the new font-family id.
+     */
+    setBraindumpFontFamily: (
+      state,
+      action: PayloadAction<BrainDumpFontFamilyId>,
+    ) => {
+      state.braindumpFontFamily = action.payload
+    },
+
+    /**
+     * Sets the BrainDump editor font size (px), clamped to the slider range so a
+     * stray programmatic value can't exceed it; guards NaN/±Infinity to the
+     * default (mirrors setSoundVolume).
+     * @param state - Current state
+     * @param action - Payload containing the new font size in px.
+     */
+    setBraindumpFontSize: (state, action: PayloadAction<number>) => {
+      const requestedSize = action.payload
+      state.braindumpFontSize = Number.isFinite(requestedSize)
+        ? Math.min(
+            BRAINDUMP_FONT_SIZE_MAX_PX,
+            Math.max(BRAINDUMP_FONT_SIZE_MIN_PX, requestedSize),
+          )
+        : DEFAULT_PREFERENCES.braindumpFontSize
+    },
+
+    /**
+     * Sets the BrainDump editor text color (a theme `var(--token)` or a `#hex`).
+     * @param state - Current state
+     * @param action - Payload containing the new CSS color string.
+     */
+    setBraindumpTextColor: (state, action: PayloadAction<string>) => {
+      state.braindumpTextColor = action.payload
+    },
+
+    /**
      * Replaces the whole preferences state. Used by the cross-window sync to
      * apply preferences received from another window without re-broadcasting.
      * @param _state - Current state (unused, returns new state)
@@ -138,6 +181,9 @@ export const {
   setSoundMoment,
   setSoundTimbre,
   setSoundVolume,
+  setBraindumpFontFamily,
+  setBraindumpFontSize,
+  setBraindumpTextColor,
   hydratePreferences,
   resetPreferences,
 } = preferencesSlice.actions
@@ -212,6 +258,33 @@ export const selectSoundVolume = (state: RootState): number =>
   state.preferences.soundVolume ?? DEFAULT_PREFERENCES.soundVolume
 
 /**
+ * Selects the BrainDump editor font family.
+ * @param state - Root state
+ * @returns The selected font-family id (default mono)
+ */
+export const selectBraindumpFontFamily = (
+  state: RootState,
+): BrainDumpFontFamilyId =>
+  state.preferences.braindumpFontFamily ??
+  DEFAULT_PREFERENCES.braindumpFontFamily
+
+/**
+ * Selects the BrainDump editor font size (px).
+ * @param state - Root state
+ * @returns The font size in px (default 14)
+ */
+export const selectBraindumpFontSize = (state: RootState): number =>
+  state.preferences.braindumpFontSize ?? DEFAULT_PREFERENCES.braindumpFontSize
+
+/**
+ * Selects the BrainDump editor text color (a theme var() token or a #hex).
+ * @param state - Root state
+ * @returns The CSS color string (default var(--foreground))
+ */
+export const selectBraindumpTextColor = (state: RootState): string =>
+  state.preferences.braindumpTextColor ?? DEFAULT_PREFERENCES.braindumpTextColor
+
+/**
  * Selects the full preferences state (every field coalesced/migrated to its
  * effective value) — the snapshot the cross-window sync broadcasts.
  * @param state - Root state
@@ -227,6 +300,9 @@ export const selectPreferences = (state: RootState): PreferencesState => ({
   },
   soundTimbre: selectSoundTimbre(state),
   soundVolume: selectSoundVolume(state),
+  braindumpFontFamily: selectBraindumpFontFamily(state),
+  braindumpFontSize: selectBraindumpFontSize(state),
+  braindumpTextColor: selectBraindumpTextColor(state),
 })
 
 export default preferencesSlice.reducer

--- a/src/lib/schemas/preferences.test.ts
+++ b/src/lib/schemas/preferences.test.ts
@@ -127,4 +127,19 @@ describe('PreferencesStateSchema', () => {
     expect(hex.braindumpTextColor).toBe('#1A2B3C')
     expect(bogus.braindumpTextColor).toBe('var(--foreground)')
   })
+
+  it('accepts the 3-digit and 8-digit hex shapes the color pattern allows', () => {
+    // Act — the pattern admits #rgb (shorthand) and #rrggbbaa (with alpha), not
+    // only the 6-digit form the native picker emits.
+    const shorthand = PreferencesStateSchema.parse({
+      braindumpTextColor: '#abc',
+    })
+    const withAlpha = PreferencesStateSchema.parse({
+      braindumpTextColor: '#1A2B3C80',
+    })
+
+    // Assert — both are preserved verbatim, not healed away.
+    expect(shorthand.braindumpTextColor).toBe('#abc')
+    expect(withAlpha.braindumpTextColor).toBe('#1A2B3C80')
+  })
 })

--- a/src/lib/schemas/preferences.test.ts
+++ b/src/lib/schemas/preferences.test.ts
@@ -117,6 +117,11 @@ describe('PreferencesStateSchema', () => {
     const themed = PreferencesStateSchema.parse({
       braindumpTextColor: 'var(--primary)',
     })
+    // A digit-bearing theme token (e.g. a future chart-color preset) must pass —
+    // the narrow [a-z-] charset would have silently healed it away.
+    const digitToken = PreferencesStateSchema.parse({
+      braindumpTextColor: 'var(--chart-1)',
+    })
     const hex = PreferencesStateSchema.parse({ braindumpTextColor: '#1A2B3C' })
     const bogus = PreferencesStateSchema.parse({
       braindumpTextColor: 'rgba(0,0,0,0.5)',
@@ -124,6 +129,7 @@ describe('PreferencesStateSchema', () => {
 
     // Assert
     expect(themed.braindumpTextColor).toBe('var(--primary)')
+    expect(digitToken.braindumpTextColor).toBe('var(--chart-1)')
     expect(hex.braindumpTextColor).toBe('#1A2B3C')
     expect(bogus.braindumpTextColor).toBe('var(--foreground)')
   })

--- a/src/lib/schemas/preferences.test.ts
+++ b/src/lib/schemas/preferences.test.ts
@@ -7,13 +7,17 @@ describe('PreferencesStateSchema', () => {
     // Act
     const result = PreferencesStateSchema.parse({})
 
-    // Assert — every moment OFF, default timbre + volume, both legacy flags OFF.
+    // Assert — every moment OFF, default timbre + volume, both legacy flags OFF,
+    // and the BrainDump editor at its prior look (mono / 14px / theme foreground).
     expect(result).toEqual({
       completionSound: false,
       retainCompletedInList: false,
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,
+      braindumpFontFamily: 'mono',
+      braindumpFontSize: 14,
+      braindumpTextColor: 'var(--foreground)',
     })
   })
 
@@ -31,6 +35,9 @@ describe('PreferencesStateSchema', () => {
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,
+      braindumpFontFamily: 'mono',
+      braindumpFontSize: 14,
+      braindumpTextColor: 'var(--foreground)',
     })
   })
 
@@ -73,5 +80,51 @@ describe('PreferencesStateSchema', () => {
       complete: true,
       clear: false,
     })
+  })
+
+  it('clamps an out-of-range BrainDump font size into the slider bounds [12,24]', () => {
+    // Act
+    const tooBig = PreferencesStateSchema.parse({ braindumpFontSize: 99 })
+    const tooSmall = PreferencesStateSchema.parse({ braindumpFontSize: 8 })
+
+    // Assert
+    expect(tooBig.braindumpFontSize).toBe(24)
+    expect(tooSmall.braindumpFontSize).toBe(12)
+  })
+
+  it('self-heals a non-finite BrainDump font size to the default (no poisoned hydrate)', () => {
+    // Act — a NaN that slipped into a persisted/synced blob must not survive.
+    const result = PreferencesStateSchema.parse({
+      braindumpFontSize: Number.NaN,
+    })
+
+    // Assert
+    expect(result.braindumpFontSize).toBe(14)
+  })
+
+  it('self-heals an unknown BrainDump font family to the default instead of rejecting', () => {
+    // Act
+    const result = PreferencesStateSchema.parse({
+      braindumpFontFamily: 'comic-sans',
+    })
+
+    // Assert
+    expect(result.braindumpFontFamily).toBe('mono')
+  })
+
+  it('keeps a valid BrainDump text color (theme token or hex) and self-heals anything else', () => {
+    // Act — a themed preset and a custom hex both pass; an unsupported shape heals.
+    const themed = PreferencesStateSchema.parse({
+      braindumpTextColor: 'var(--primary)',
+    })
+    const hex = PreferencesStateSchema.parse({ braindumpTextColor: '#1A2B3C' })
+    const bogus = PreferencesStateSchema.parse({
+      braindumpTextColor: 'rgba(0,0,0,0.5)',
+    })
+
+    // Assert
+    expect(themed.braindumpTextColor).toBe('var(--primary)')
+    expect(hex.braindumpTextColor).toBe('#1A2B3C')
+    expect(bogus.braindumpTextColor).toBe('var(--foreground)')
   })
 })

--- a/src/lib/schemas/preferences.ts
+++ b/src/lib/schemas/preferences.ts
@@ -12,6 +12,15 @@
 import { z } from 'zod'
 
 import {
+  BRAINDUMP_FONT_FAMILY_IDS,
+  BRAINDUMP_FONT_SIZE_MAX_PX,
+  BRAINDUMP_FONT_SIZE_MIN_PX,
+  BRAINDUMP_TEXT_COLOR_PATTERN,
+  DEFAULT_BRAINDUMP_FONT_FAMILY,
+  DEFAULT_BRAINDUMP_FONT_SIZE_PX,
+  DEFAULT_BRAINDUMP_TEXT_COLOR,
+} from '@/lib/constants/braindump'
+import {
   DEFAULT_SOUND_VOLUME,
   DEFAULT_TIMBRE_ID,
   type SoundMomentId,
@@ -60,6 +69,30 @@ export const PreferencesStateSchema = z.object({
     .number()
     .transform((value) => Math.min(1, Math.max(0, value)))
     .default(DEFAULT_SOUND_VOLUME),
+  /** BrainDump editor font family. `.catch` (not `.default`) so a MISSING *or*
+   * unknown id self-heals to the default rather than rejecting the whole payload. */
+  braindumpFontFamily: z
+    .enum(BRAINDUMP_FONT_FAMILY_IDS)
+    .catch(DEFAULT_BRAINDUMP_FONT_FAMILY),
+  /** BrainDump editor font size (px). A finite number is clamped to the slider
+   * range; a non-finite or non-number (corrupt blob, bad sync) self-heals to the
+   * default via `.catch` instead of throwing the whole parse. */
+  braindumpFontSize: z
+    .number()
+    .finite()
+    .transform((value) =>
+      Math.min(
+        BRAINDUMP_FONT_SIZE_MAX_PX,
+        Math.max(BRAINDUMP_FONT_SIZE_MIN_PX, value),
+      ),
+    )
+    .catch(DEFAULT_BRAINDUMP_FONT_SIZE_PX),
+  /** BrainDump editor text color — a theme `var(--token)` (preset) or a `#hex`
+   * (custom). Anything outside those shapes self-heals to the default. */
+  braindumpTextColor: z
+    .string()
+    .regex(BRAINDUMP_TEXT_COLOR_PATTERN)
+    .catch(DEFAULT_BRAINDUMP_TEXT_COLOR),
 })
 
 /** The validated core user-preferences shape (inferred from the schema SSoT). */


### PR DESCRIPTION
## Summary

Adds three BrainDump editor presentation controls to **Preferences → BrainDump**, all persisted and synced live across windows:

- **Font family** — a RadioGroup over the brand 3-font stack (Monospace / Sans-serif / Serif), mapped through `BRAINDUMP_FONT_FAMILY_CSS` to the `--font-mono/sans/serif` vars.
- **Font size** — a Slider over `[12, 24]px` (1px steps), unitless line-height (1.5) so spacing scales with size.
- **Text color** — themed presets (Default / Muted / Amber → `var(--foreground)` / `var(--muted-foreground)` / `var(--primary)`) plus a native color picker for a custom hex (DESIGN.md "Presets First, Then Options").

State shape lives in the Zod SSoT (`PreferencesStateSchema`): font-family `z.enum(...).catch(DEFAULT)`, font-size `z.number().finite().transform(clamp).catch(DEFAULT)`, text-color `z.string().regex(...).catch(DEFAULT)`. Each new field flows registry → schema → slice (with `?? DEFAULT` defensive selectors) → BroadcastChannel allowlist → UI, mirroring the existing sound-palette pattern.

## Design decisions

- **Default font kept as Monospace (D1).** The textarea was already `font-mono`; DESIGN.md's prose default is Inter Tight (sans). I deliberately preserved `mono` as the default to avoid silently restyling every existing user's notes — the face is now user-switchable, so anyone who prefers sans/serif can opt in. Switching the default would be a visible regression for zero added control.
- **No `STORAGE_SCHEMA_VERSION` bump.** All three fields are additive and defaulted; a pre-existing persisted blob coalesces to defaults via the `?? DEFAULT` selectors — same call made for the sound fields.

## Hardening

- In-reducer self-heal on all three setters (font-size clamps + NaN-guards; text-color and font-family fall back to default on an off-shape value) so the reducer shares the schema's validation boundary against a stray programmatic/persisted value.
- Widened the text-color `var()` token charset to `[a-z0-9-]` so digit-bearing theme tokens (e.g. `var(--chart-1)`) are accepted rather than healed away.

## Testing

- Schema: empty/legacy parse, font-size clamp + non-finite heal, font-family unknown-id heal, text-color token/hex accept + off-shape heal, 3/8-digit hex + digit-bearing token accept.
- Slice: per-setter behavior incl. clamp/NaN/off-shape/unknown-id self-heal, legacy-field coalescing, `selectPreferences` aggregate.
- Cross-window sync: per-action propagation for all three fields + an out-of-range inbound heal (clamps font-size, heals bad color).
- Component: font-family pick, font-size slider at saved value, color preset pick, custom-hex change, saved-hex display, non-hex → presets unchecked + picker `#000000` fallback.
- `pnpm validate` green: test + typecheck + build + lint all exit 0.

## Follow-up (deferred, pre-existing)

- **F1 — hydrate path doesn't re-validate.** The persistence middleware shallow-merges the raw persisted blob and `migratePersistedState` only folds legacy `completionSound`; it never re-parses through Zod, so a present-but-invalid persisted value reaches runtime unhealed (the `?? DEFAULT` selectors catch `undefined`, not invalid). This is the same shared-hydration behavior the sound fields already have (benign: CSSOM rejects bad colors, JSON drops NaN/Inf, only finite-out-of-range font-size survives and self-recovers on next edit). Worth a follow-up to fold a full `safeParse` into the migrate step for all preference fields at once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * BrainDump editor now follows your saved text styling preferences: choose a font family, set font size (12–24px), and pick text color from presets or a custom color picker.
  * BrainDump text styling controls are added to Preferences, and updates sync automatically across windows.
* **Improvements / Bug Fixes**
  * Stored BrainDump preferences are validated on load; invalid or out-of-range values automatically fall back to defaults, keeping the editor consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->