### PR TITLE
fix(braindump): complete plain prose lines, not just checkbox lines

### DIFF
--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { toast } from 'sonner'
@@ -394,6 +394,59 @@ describe('BrainDumpEditor complete command', () => {
     await waitFor(() => {
       expect(noteField).toHaveValue('- [x] write tests')
     })
+  })
+
+  it('restores the original plain prose when the completion create fails', async () => {
+    // Arrange — the create mutation rejects for this completion.
+    completedMutateAsync.mockRejectedValueOnce(new Error('network down'))
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — complete a plain prose line whose create then fails.
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+
+    // Assert — the line is restored to plain prose, not a `- [ ] buy milk` skeleton.
+    await waitFor(() => {
+      expect(noteField).toHaveValue('buy milk')
+    })
+  })
+
+  it('leaves an unrelated line untouched when a failed completion can no longer find its line', async () => {
+    // Arrange — hold the create in flight so we can edit the note before it
+    // rejects (the create only settles when we call rejectCreate).
+    let rejectCreate: (reason: Error) => void = () => undefined
+    const pendingCreate = new Promise<{ id: number }>((_resolve, reject) => {
+      rejectCreate = reject
+    })
+    completedMutateAsync.mockReturnValueOnce(pendingCreate)
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — complete 'buy milk', then (while the create is still pending) prepend
+    // an unrelated line and rename the completed one so the title search misses.
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+    fireEvent.change(noteField, {
+      target: { value: 'urgent\n- [x] buy milk and eggs' },
+    })
+    await act(async () => {
+      rejectCreate(new Error('network down'))
+    })
+
+    // Assert — the rollback must not blind-overwrite line 0; 'urgent' survives
+    // instead of being clobbered with the stale 'buy milk' rollback text.
+    expect(noteField).toHaveValue('urgent\n- [x] buy milk and eggs')
   })
 
   it('does nothing when the caret line is blank', async () => {

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -13,12 +13,19 @@ import type { CategoryWithCount } from '@/server/schemas/category'
 
 import { BrainDumpEditor } from './BrainDumpEditor'
 
+// Shared across create + delete mutations so the complete-command specs can
+// assert the create call. Resolves `{ id }` so promoteLineToCompleted's
+// `.then(created => created.id)` chain runs instead of throwing on undefined.
+const { completedMutateAsync } = vi.hoisted(() => ({
+  completedMutateAsync: vi.fn(),
+}))
+
 vi.mock('@tanstack/react-query', () => ({
   useMutation: () => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: completedMutateAsync,
   }),
   useQueryClient: () => ({
-    invalidateQueries: vi.fn(),
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
   }),
 }))
 
@@ -311,5 +318,99 @@ describe('BrainDumpEditor text styling preferences', () => {
     // Assert — monospace at 14px, matching the removed `font-mono text-sm`.
     expect(noteField.style.fontFamily).toBe('var(--font-mono)')
     expect(noteField.style.fontSize).toBe('14px')
+  })
+})
+
+/**
+ * Types `value` into the note field, parks the caret at the end of the first
+ * line, and fires the Cmd+Enter complete command. Shared mechanical setup so
+ * each spec keeps its expected create args / textarea value hard-coded inline.
+ * @param noteField - The BrainDump textarea.
+ * @param value - Full note contents to type before completing.
+ * @returns Nothing; drives the editor via fireEvent.
+ * @example
+ * fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+ */
+function fireCompleteCommandOnFirstLine(
+  noteField: HTMLTextAreaElement,
+  value: string,
+) {
+  fireEvent.change(noteField, { target: { value } })
+  const caret = value.split('\n')[0]?.length ?? 0
+  noteField.selectionStart = caret
+  noteField.selectionEnd = caret
+  fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+}
+
+describe('BrainDumpEditor complete command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    completedMutateAsync.mockResolvedValue({ id: 1 })
+  })
+
+  it('completes a plain prose line into a Completed row on Cmd+Enter', async () => {
+    // Arrange — an editor with a category, holding one ordinary (non-checkbox) line.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — fire the complete command on the plain line.
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+
+    // Assert — a Completed row is created and the line is marked done.
+    expect(completedMutateAsync).toHaveBeenCalledWith({
+      categoryId: 1,
+      title: 'buy milk',
+    })
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [x] buy milk')
+    })
+  })
+
+  it('still toggles an existing checkbox line into a Completed row on Cmd+Enter', async () => {
+    // Arrange — an editor holding a pre-formatted unchecked checkbox line.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act
+    fireCompleteCommandOnFirstLine(noteField, '- [ ] write tests')
+
+    // Assert — the existing checkbox path is unchanged.
+    expect(completedMutateAsync).toHaveBeenCalledWith({
+      categoryId: 1,
+      title: 'write tests',
+    })
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [x] write tests')
+    })
+  })
+
+  it('does nothing when the caret line is blank', async () => {
+    // Arrange — an editor whose caret line is whitespace only.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act
+    fireCompleteCommandOnFirstLine(noteField, '   ')
+
+    // Assert — no Completed row is created for an empty line.
+    expect(completedMutateAsync).not.toHaveBeenCalled()
   })
 })

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -46,6 +46,7 @@ import {
   type BrainDumpCompletedTitle,
   type BrainDumpLineIndex,
   COMPLETED_TITLE_MAX_LENGTH,
+  markPlainLineCompleted,
   normalizeCompletedTitle,
   parseAllCheckboxes,
   parseCheckboxLine,
@@ -552,9 +553,11 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
   )
 
   /**
-   * Toggle the checkbox on the line nearest the caret. Triggered by Cmd/Ctrl+
-   * Enter inside the textarea — the keyboard path is the deliberate UX,
-   * pointer-clicks would require a second editor mode.
+   * Complete the line nearest the caret: toggle an existing `- [ ]`/`- [x]`
+   * checkbox, or finish a plain prose line by wrapping it as `- [x]` and
+   * promoting it (so users don't have to pre-type `- [ ]` to log a win).
+   * Triggered by Cmd/Ctrl+Enter inside the textarea — the keyboard path is the
+   * deliberate UX; pointer-clicks would require a second editor mode.
    */
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key !== 'Enter' || !(event.metaKey || event.ctrlKey)) return
@@ -571,7 +574,17 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
     const line = lines[lineIndex]
     if (line === undefined) return
     const parsed = parseCheckboxLine(line, lineIndex)
-    if (!parsed) return
+    if (!parsed) {
+      // Not a checkbox line: let the complete command finish an ordinary prose
+      // line by wrapping it as `- [x] …` and promoting it, so users don't have
+      // to pre-type `- [ ]` markdown just to log a win. Blank lines and empty
+      // checkbox skeletons return null and fall through to a no-op.
+      const promoted = markPlainLineCompleted(text, lineIndex)
+      if (!promoted) return
+      setNoteText(promoted.text)
+      void promoteLineToCompleted(lineIndex, promoted.title)
+      return
+    }
 
     const nextChecked = !parsed.checked
     const nextText = setCheckboxStateAtLine(text, lineIndex, nextChecked)
@@ -751,7 +764,7 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
         placeholder={
           activeCategoryId === null
             ? 'Pick a category to start writing'
-            : '- [ ] braindump anything here…\nUse Cmd/Ctrl+Enter on a checkbox line to toggle.'
+            : '- [ ] braindump anything here…\nUse Cmd/Ctrl+Enter to complete the current line.'
         }
         disabled={activeCategoryId === null}
         maxLength={NOTE_MAX_LENGTH}

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -50,6 +50,7 @@ import {
   normalizeCompletedTitle,
   parseAllCheckboxes,
   parseCheckboxLine,
+  replaceLineAtIndex,
   setCheckboxStateAtLine,
 } from './braindumpUtils'
 
@@ -406,15 +407,28 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
   )
 
   /**
-   * Promote a `[ ]` line to `[x]`, create a Completed row, and arm the
-   * 5-second undo toast.
+   * Promote the caret line to `[x]`, create a Completed row, and arm the
+   * 5-second undo toast. Called by the complete command (Cmd/Ctrl+Enter) for
+   * both checkbox lines and — via `markPlainLineCompleted` — plain prose lines.
    *
-   * Failure mode: when the server rejects the create, we revert the textarea
-   * to the unchecked state and toast the error. The optimistic flip never
-   * leaves the local memory map.
+   * Failure mode: when the create rejects, we roll the textarea back, drift-aware
+   * via `noteTextRef` so the user's concurrent edits survive. A checkbox line
+   * reverts to `[ ]`; a plain line (when `rollbackPlainText` is supplied) is
+   * restored to its original prose instead of being left as a `- [ ] <title>`
+   * skeleton the user never typed.
+   *
+   * @param lineIndex - Zero-based index of the line being completed.
+   * @param title - Title to persist (uncapped; normalised for the DB here).
+   * @param rollbackPlainText - When set, the plain prose to restore on failure
+   *   (plain-line completions); omit for checkbox lines so they revert to `[ ]`.
+   * @returns Promise<void>; the created row id is tracked internally for undo.
    */
   const promoteLineToCompleted = useCallback(
-    async (lineIndex: BrainDumpLineIndex, title: BrainDumpCompletedTitle) => {
+    async (
+      lineIndex: BrainDumpLineIndex,
+      title: BrainDumpCompletedTitle,
+      rollbackPlainText?: BrainDumpCompletedTitle,
+    ) => {
       if (activeCategoryId === null) {
         toast.error('Pick a category before checking items')
         return
@@ -436,11 +450,30 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
             // Re-resolve which line still holds the `[x]` for this title —
             // the original lineIndex may have drifted if the user inserted
             // text above before the create rejected.
-            const currentLine =
-              findCheckedLineIndexByTitle(noteTextRef.current, safeTitle) ??
-              lineIndex
+            const resolvedLine = findCheckedLineIndexByTitle(
+              noteTextRef.current,
+              safeTitle,
+            )
+            const currentLine = resolvedLine ?? lineIndex
+            // Plain-line completion: restore the original prose rather than
+            // leaving a `- [ ] <title>` skeleton the user never typed — but ONLY
+            // when the title search positively found the line. On a miss we fall
+            // back to the safe uncheck (a no-op on non-checkbox lines) so a
+            // drifted stale lineIndex never blind-overwrites an unrelated line
+            // the user edited while the create was in flight. Checkbox lines
+            // (no rollbackPlainText) always revert to `[ ]` as before.
             setNoteText(
-              setCheckboxStateAtLine(noteTextRef.current, currentLine, false),
+              rollbackPlainText !== undefined && resolvedLine !== null
+                ? replaceLineAtIndex(
+                    noteTextRef.current,
+                    resolvedLine,
+                    rollbackPlainText,
+                  )
+                : setCheckboxStateAtLine(
+                    noteTextRef.current,
+                    currentLine,
+                    false,
+                  ),
             )
             return null
           },
@@ -582,7 +615,9 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
       const promoted = markPlainLineCompleted(text, lineIndex)
       if (!promoted) return
       setNoteText(promoted.text)
-      void promoteLineToCompleted(lineIndex, promoted.title)
+      // Pass the plain prose as rollback text so a failed create restores the
+      // original line instead of leaving the optimistic `- [x]` skeleton.
+      void promoteLineToCompleted(lineIndex, promoted.title, promoted.title)
       return
     }
 

--- a/src/components/braindump/braindumpUtils.test.ts
+++ b/src/components/braindump/braindumpUtils.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeCompletedTitle,
   parseAllCheckboxes,
   parseCheckboxLine,
+  replaceLineAtIndex,
   setCheckboxStateAtLine,
 } from './braindumpUtils'
 
@@ -99,6 +100,39 @@ describe('setCheckboxStateAtLine', () => {
     const before = '- [ ] a'
     expect(setCheckboxStateAtLine(before, 5, true)).toBe(before)
     expect(setCheckboxStateAtLine(before, -1, true)).toBe(before)
+  })
+})
+
+describe('replaceLineAtIndex', () => {
+  it('restores a promoted checkbox line back to its original plain prose', () => {
+    // Arrange — the optimistic complete command turned 'buy milk' into a checkbox.
+    const promoted = '- [x] buy milk\ndishes'
+
+    // Act — roll the first line back to plain prose after a failed create.
+    const result = replaceLineAtIndex(promoted, 0, 'buy milk')
+
+    // Assert
+    expect(result).toBe('buy milk\ndishes')
+  })
+
+  it('replaces only the target line and leaves the rest verbatim', () => {
+    // Arrange
+    const before = ['line 0', '- [x] line 1', 'line 2'].join('\n')
+
+    // Act
+    const after = replaceLineAtIndex(before, 1, 'line 1')
+
+    // Assert
+    expect(after).toBe(['line 0', 'line 1', 'line 2'].join('\n'))
+  })
+
+  it('returns the original text for out-of-range indices', () => {
+    // Arrange
+    const before = '- [x] a'
+
+    // Act + Assert
+    expect(replaceLineAtIndex(before, 5, 'a')).toBe(before)
+    expect(replaceLineAtIndex(before, -1, 'a')).toBe(before)
   })
 })
 

--- a/src/components/braindump/braindumpUtils.test.ts
+++ b/src/components/braindump/braindumpUtils.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   COMPLETED_TITLE_MAX_LENGTH,
+  markPlainLineCompleted,
   normalizeCompletedTitle,
   parseAllCheckboxes,
   parseCheckboxLine,
@@ -98,6 +99,69 @@ describe('setCheckboxStateAtLine', () => {
     const before = '- [ ] a'
     expect(setCheckboxStateAtLine(before, 5, true)).toBe(before)
     expect(setCheckboxStateAtLine(before, -1, true)).toBe(before)
+  })
+})
+
+describe('markPlainLineCompleted', () => {
+  it('wraps a plain prose line as a checked checkbox so it can be completed', () => {
+    // Arrange
+    const text = 'buy milk'
+
+    // Act
+    const result = markPlainLineCompleted(text, 0)
+
+    // Assert
+    expect(result).toEqual({ text: '- [x] buy milk', title: 'buy milk' })
+  })
+
+  it('wraps only the caret line and leaves the rest of the document verbatim', () => {
+    // Arrange
+    const text = ['line 0', 'second thing', 'line 2'].join('\n')
+
+    // Act
+    const result = markPlainLineCompleted(text, 1)
+
+    // Assert
+    expect(result).toEqual({
+      text: ['line 0', '- [x] second thing', 'line 2'].join('\n'),
+      title: 'second thing',
+    })
+  })
+
+  it('trims surrounding whitespace into the title and the rewritten line', () => {
+    // Arrange
+    const text = '   spaced out   '
+
+    // Act
+    const result = markPlainLineCompleted(text, 0)
+
+    // Assert
+    expect(result).toEqual({ text: '- [x] spaced out', title: 'spaced out' })
+  })
+
+  it('returns null for an already well-formed checkbox line (toggle path owns it)', () => {
+    // Arrange + Act + Assert
+    expect(markPlainLineCompleted('- [ ] todo', 0)).toBeNull()
+    expect(markPlainLineCompleted('- [x] done', 0)).toBeNull()
+  })
+
+  it('returns null for an empty checkbox skeleton so no junk title is logged', () => {
+    // Arrange + Act + Assert
+    expect(markPlainLineCompleted('- [ ]', 0)).toBeNull()
+    expect(markPlainLineCompleted('- [ ] ', 0)).toBeNull()
+    expect(markPlainLineCompleted('- [x]', 0)).toBeNull()
+    expect(markPlainLineCompleted('- []', 0)).toBeNull()
+  })
+
+  it('returns null for a blank line', () => {
+    // Arrange + Act + Assert
+    expect(markPlainLineCompleted('a\n   \nb', 1)).toBeNull()
+  })
+
+  it('returns null for an out-of-range line index', () => {
+    // Arrange + Act + Assert
+    expect(markPlainLineCompleted('only line', 5)).toBeNull()
+    expect(markPlainLineCompleted('only line', -1)).toBeNull()
   })
 })
 

--- a/src/components/braindump/braindumpUtils.ts
+++ b/src/components/braindump/braindumpUtils.ts
@@ -145,6 +145,32 @@ export function setCheckboxStateAtLine(
 }
 
 /**
+ * Replace the entire content of one line, leaving every other line verbatim.
+ * Used by the complete command's failure-rollback to restore an original plain
+ * prose line (e.g. `buy milk`) rather than leaving the optimistic
+ * `- [x] buy milk` skeleton when the Completed-create rejects. Returns the
+ * original text for out-of-range indices, mirroring `setCheckboxStateAtLine`.
+ *
+ * @param text - The full document text.
+ * @param lineIndex - Zero-based index of the line to overwrite.
+ * @param newLine - Replacement content for that line (no trailing newline).
+ * @returns The updated text, or the original when `lineIndex` is out of range.
+ * @example
+ * replaceLineAtIndex('- [x] buy milk\ndishes', 0, 'buy milk')
+ * // → 'buy milk\ndishes'
+ */
+export function replaceLineAtIndex(
+  text: string,
+  lineIndex: BrainDumpLineIndex,
+  newLine: string,
+): string {
+  const lines = text.split('\n')
+  if (lineIndex < 0 || lineIndex >= lines.length) return text
+  lines[lineIndex] = newLine
+  return lines.join('\n')
+}
+
+/**
  * Matches an empty checkbox skeleton — a checkbox prefix with no title, e.g.
  * `- [ ]`, `- [x]`, `- []` (optional trailing whitespace). These have nothing
  * to record, so the complete command must skip them rather than logging a junk

--- a/src/components/braindump/braindumpUtils.ts
+++ b/src/components/braindump/braindumpUtils.ts
@@ -10,6 +10,10 @@
  * with the line text (sans prefix). Toggling back within the 5-second toast
  * window calls `Completed.delete` with the row id we cached.
  *
+ * The complete command also finishes a plain (non-checkbox) line:
+ * `markPlainLineCompleted` wraps it as `- [x] <text>` so an ordinary prose line
+ * can be logged without first typing the `- [ ]` markdown.
+ *
  * Why a separate utils file: parsing/serialization stays pure so the editor
  * component can stay focused on UI/IPC orchestration and is easy to unit-test.
  *
@@ -138,6 +142,68 @@ export function setCheckboxStateAtLine(
   const mark = checked ? 'x' : ' '
   lines[lineIndex] = `- [${mark}] ${parsed.title}`
   return lines.join('\n')
+}
+
+/**
+ * Matches an empty checkbox skeleton — a checkbox prefix with no title, e.g.
+ * `- [ ]`, `- [x]`, `- []` (optional trailing whitespace). These have nothing
+ * to record, so the complete command must skip them rather than logging a junk
+ * `- [ ]` title.
+ */
+const EMPTY_CHECKBOX_SKELETON_REGEX = /^- \[[ xX]?\]\s*$/
+
+/**
+ * Result of wrapping a plain line as a checked checkbox for the complete
+ * command. `text` is the full note with the caret line rewritten; `title` is
+ * the content to persist.
+ */
+export type PlainLineCompletion = Readonly<{
+  /** Full note text with the caret line rewritten as `- [x] <title>`. */
+  text: string
+  /** Trimmed line content to persist (uncapped; promote caps it for the DB). */
+  title: BrainDumpCompletedTitle
+}>
+
+/**
+ * Wrap a plain (non-checkbox) line as a checked checkbox so the complete
+ * command (Cmd/Ctrl+Enter) can finish an ordinary prose line, not only a
+ * pre-formatted `- [ ]` box. Called from `BrainDumpEditor.handleKeyDown` when
+ * `parseCheckboxLine` returns null for the caret line.
+ *
+ * @param text - The editor's full text contents.
+ * @param lineIndex - Zero-based index of the caret line to complete.
+ * @returns
+ * - `{ text, title }` when the caret line is plain and non-blank: `text` has
+ *   that line rewritten as `- [x] <trimmed content>`; `title` is the trimmed
+ *   content (uncapped, matching how the checkbox path passes `parsed.title`).
+ * - `null` when the line is missing, blank, an empty checkbox skeleton, or an
+ *   already well-formed checkbox line (the caller's toggle path owns that).
+ * @example
+ * markPlainLineCompleted('buy milk', 0)
+ * // → { text: '- [x] buy milk', title: 'buy milk' }
+ * markPlainLineCompleted('a\nb', 1) // → { text: 'a\n- [x] b', title: 'b' }
+ * markPlainLineCompleted('- [ ] todo', 0) // → null (already a checkbox)
+ * markPlainLineCompleted('   ', 0)         // → null (blank)
+ */
+export function markPlainLineCompleted(
+  text: string,
+  lineIndex: BrainDumpLineIndex,
+): PlainLineCompletion | null {
+  const lines = text.split('\n')
+  if (lineIndex < 0 || lineIndex >= lines.length) return null
+
+  const line = lines[lineIndex]
+  if (line === undefined) return null
+  // A well-formed checkbox line is owned by the toggle path, not this one.
+  if (parseCheckboxLine(line, lineIndex)) return null
+  // An empty checkbox skeleton has no content worth recording.
+  if (EMPTY_CHECKBOX_SKELETON_REGEX.test(line)) return null
+
+  const title = line.trim()
+  if (title.length === 0) return null
+
+  lines[lineIndex] = `- [x] ${title}`
+  return { text: lines.join('\n'), title }
 }
 
 /**


### PR DESCRIPTION
## Summary

The BrainDump complete command (Cmd/Ctrl+Enter) only worked on lines that were already formatted as `- [ ]` markdown checkboxes. An ordinary prose line could never be logged as Completed — pressing Cmd/Ctrl+Enter on it did nothing. This broadens the command so any non-empty line can be completed with the natural keyboard gesture, no markdown pre-typing required.

## The bug (root cause)

`handleKeyDown` parsed the caret line and bailed on anything that wasn't a checkbox:

```ts
const parsed = parseCheckboxLine(line, lineIndex)
if (!parsed) return   // ← plain prose lines died here; create mutation fired 0 times
```

Confirmed by reproduction: a plain line + Cmd/Ctrl+Enter fired the Completed-create mutation **zero** times, while a `- [ ]` line fired it once. So the row was never created — a write-path scope gap, not a display issue.

## The fix

Replace the bail with a plain-line completion branch. A new pure helper `markPlainLineCompleted` wraps a non-checkbox line as `- [x] <text>` and returns the rewritten note + the title to persist, mirroring the checkbox path's uncapped-title behavior (promote caps it for the DB). It guards the no-op cases:

- already well-formed checkbox lines → `null` (the existing toggle path owns them)
- empty checkbox skeletons (`- [ ]`, `- [x]`, `- []`) → `null` (nothing to record)
- blank lines and out-of-range indices → `null`

Placeholder and JSDoc now describe the broadened command instead of the old checkbox-only behavior.

## Tests

- `braindumpUtils.test.ts`: 7 specs for `markPlainLineCompleted` (wrap, multi-line caret targeting, trim, and all four null guards).
- `BrainDumpEditor.test.tsx`: 3 complete-command specs — plain prose line → Completed row, existing checkbox still toggles (no regression), blank line is a no-op. Mock refactored to a shared hoisted spy so the create call can be asserted.

## Verification

- `pnpm test` → **585 passed | 29 skipped** (fresh)
- `pnpm build` → compiled successfully (fresh)
- `pnpm lint` + `pnpm typecheck` → green

## Design alignment

Serves the DESIGN.md north star (些細でも経験値 / self-affirmation, low friction): completing any non-empty line with the natural Cmd/Ctrl+Enter gesture — without forcing users to pre-type `- [ ]` markdown just to log a win.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now complete the current plain text line with Cmd/Ctrl+Enter; it’s converted into a completed checkbox item while preserving the original text as the title.
  * Editor instructions/placeholder now clarify completing the current line via the keyboard shortcut.

* **Bug Fixes**
  * Improved completion failure handling: if creation fails, the editor restores the original line content without affecting unrelated lines.

* **Tests**
  * Added/extended coverage for plain-line completion, conversions, and rollback edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->