### PR TITLE
feat(braindump): add clear-on-complete preference

### DIFF
--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -566,4 +566,60 @@ describe('BrainDumpEditor clear-on-complete', () => {
     expect(autoClose).toBeUndefined()
     expect(noteField).toHaveValue('- [x] buy milk')
   })
+
+  it('still deletes the right Completed row after an earlier line was auto-cleared', async () => {
+    // Arrange — clear-on-complete on, with two finished lines whose Completed
+    // rows have distinct ids (titles repeat by design — repetition is a feature).
+    completedMutateAsync.mockReset()
+    completedMutateAsync
+      .mockResolvedValueOnce({ id: 1 }) // create: buy milk
+      .mockResolvedValueOnce({ id: 2 }) // create: wash car
+      .mockResolvedValue({ id: 99 }) // any later delete (return ignored)
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Complete the first line ('buy milk', id 1).
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk\nwash car')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [x] buy milk\nwash car')
+    })
+    // Complete the second line ('wash car', id 2) — caret at end of line 2.
+    noteField.selectionStart = noteField.value.length
+    noteField.selectionEnd = noteField.value.length
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [x] buy milk\n- [x] wash car')
+    })
+
+    // Act — the FIRST line's undo window elapses, auto-clearing 'buy milk' so
+    // 'wash car' shifts up to line 0 (its ref entry key now drifted). Then
+    // uncheck 'wash car'.
+    const autoCloseBuyMilk = vi
+      .mocked(toast.success)
+      .mock.calls.find(
+        (call) => call[0] === 'Completed: buy milk',
+      )?.[1]?.onAutoClose
+    act(() => {
+      autoCloseBuyMilk?.({} as ToastT)
+    })
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [x] wash car')
+    })
+    noteField.selectionStart = 1
+    noteField.selectionEnd = 1
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+
+    // Assert — the uncheck deletes 'wash car' (id 2), NOT the auto-cleared
+    // 'buy milk' (id 1) whose stale ref entry would otherwise be mis-targeted.
+    await waitFor(() => {
+      expect(completedMutateAsync).toHaveBeenCalledWith({ id: 2 })
+    })
+    expect(completedMutateAsync).not.toHaveBeenCalledWith({ id: 1 })
+  })
 })

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { toast } from 'sonner'
+import type { ToastT } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import preferencesReducer, {
@@ -465,5 +466,104 @@ describe('BrainDumpEditor complete command', () => {
 
     // Assert — no Completed row is created for an empty line.
     expect(completedMutateAsync).not.toHaveBeenCalled()
+  })
+})
+
+describe('BrainDumpEditor clear-on-complete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    completedMutateAsync.mockResolvedValue({ id: 1 })
+  })
+
+  it('clears a finished line once its undo window closes when clear-on-complete is on', async () => {
+    // Arrange — the editor with clear-on-complete opted in.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — complete the line, then simulate the undo window elapsing with no
+    // Undo (Sonner fires the success toast's onAutoClose on the timeout).
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [x] buy milk')
+    })
+    const autoClose = vi
+      .mocked(toast.success)
+      .mock.calls.at(-1)?.[1]?.onAutoClose
+    // onAutoClose ignores its ToastT arg (it re-resolves the line from the ref),
+    // so an empty stub stands in for the unused parameter.
+    act(() => {
+      autoClose?.({} as ToastT)
+    })
+
+    // Assert — the finished line is dropped, leaving the scratchpad clean.
+    expect(noteField).toHaveValue('')
+  })
+
+  it('keeps a finished line that was undone before its window closed (clear self-suppresses)', async () => {
+    // Arrange — clear-on-complete on; complete a line, then manually uncheck it
+    // (Cmd+Enter on the `- [x]` line) before the undo window elapses.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [x] buy milk')
+    })
+
+    // Act — manually uncheck (re-fire Cmd+Enter on the checked line), then fire
+    // the original toast's onAutoClose as the window would.
+    noteField.selectionStart = 1
+    noteField.selectionEnd = 1
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [ ] buy milk')
+    })
+    const autoClose = vi
+      .mocked(toast.success)
+      .mock.calls.at(-1)?.[1]?.onAutoClose
+    act(() => {
+      autoClose?.({} as ToastT)
+    })
+
+    // Assert — the now-unchecked line is NOT a checked match, so it survives
+    // instead of being cleared out from under the user.
+    expect(noteField).toHaveValue('- [ ] buy milk')
+  })
+
+  it('keeps every finished line in place by default (no auto-close hook wired)', async () => {
+    // Arrange — a fresh install (clear-on-complete OFF) keeps the prior behavior.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — complete a plain line under the default preference.
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [x] buy milk')
+    })
+
+    // Assert — the success toast carries NO onAutoClose hook, so the finished
+    // line stays put (the clear is strictly opt-in).
+    const autoClose = vi
+      .mocked(toast.success)
+      .mock.calls.at(-1)?.[1]?.onAutoClose
+    expect(autoClose).toBeUndefined()
+    expect(noteField).toHaveValue('- [x] buy milk')
   })
 })

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -526,11 +526,31 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
         // without an Undo), drop the finished line so the scratchpad clears as
         // you go. Sonner fires onAutoClose ONLY on the timeout — an Undo click
         // dismisses (onDismiss) instead, so undone completions are never cleared.
-        // Re-resolve by title against the freshest text (the index may have
-        // drifted) and remove ONLY a line that is STILL checked: a manual uncheck
-        // leaves it `- [ ]`, which won't match, so the clear self-suppresses.
         onAutoClose: clearOnComplete
           ? () => {
+              // Tie the clear to THIS completion via its completedId entry in
+              // checkedRowsRef. If the entry is gone, the completion was already
+              // reverted (toast Undo / manual uncheck both delete it) or the
+              // category was switched (which clears the whole map) — skip, so we
+              // never strip a same-title line belonging to a different
+              // completion or category.
+              let memoryKey: BrainDumpLineIndex | null = null
+              for (const [key, value] of checkedRowsRef.current.entries()) {
+                if (value.completedId === completedId) {
+                  memoryKey = key
+                  break
+                }
+              }
+              if (memoryKey === null) return
+              // Drop the now-defunct entry BEFORE mutating text so no stale
+              // {lineIndex → completedId} lingers: a leftover entry would let the
+              // uncheck path's index/title fallback later delete the WRONG
+              // Completed row (titles repeat by design — repetition is a feature).
+              checkedRowsRef.current.delete(memoryKey)
+
+              // Re-resolve by title against the freshest text (the index may have
+              // drifted) and remove ONLY a line that is STILL checked: a manual
+              // uncheck leaves it `- [ ]`, which won't match, so this self-suppresses.
               const lineToClear = findCheckedLineIndexByTitle(
                 noteTextRef.current,
                 safeTitle,

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -32,6 +32,7 @@ import { log } from '@/lib/logger'
 import { orpc } from '@/lib/orpc/client-query'
 import { useAppSelector } from '@/lib/redux/hooks'
 import {
+  selectBraindumpClearOnComplete,
   selectBraindumpFontFamily,
   selectBraindumpFontSize,
   selectBraindumpTextColor,
@@ -50,6 +51,7 @@ import {
   normalizeCompletedTitle,
   parseAllCheckboxes,
   parseCheckboxLine,
+  removeLineAtIndex,
   replaceLineAtIndex,
   setCheckboxStateAtLine,
 } from './braindumpUtils'
@@ -169,6 +171,9 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
   const braindumpFontFamily = useAppSelector(selectBraindumpFontFamily)
   const braindumpFontSize = useAppSelector(selectBraindumpFontSize)
   const braindumpTextColor = useAppSelector(selectBraindumpTextColor)
+  // When ON, a finished line is dropped once its undo window closes (see the
+  // toast's onAutoClose in promoteLineToCompleted). Default OFF keeps every line.
+  const clearOnComplete = useAppSelector(selectBraindumpClearOnComplete)
 
   const activeCategoryId = syncEnabled ? floatingCategoryId : localCategoryId
   const checkedRowsRef = useRef<Map<BrainDumpLineIndex, CheckedRowMemory>>(
@@ -517,9 +522,26 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
             toast.dismiss(undoToastId)
           },
         },
+        // Clear-on-complete: when the toast auto-closes (the undo window elapsed
+        // without an Undo), drop the finished line so the scratchpad clears as
+        // you go. Sonner fires onAutoClose ONLY on the timeout — an Undo click
+        // dismisses (onDismiss) instead, so undone completions are never cleared.
+        // Re-resolve by title against the freshest text (the index may have
+        // drifted) and remove ONLY a line that is STILL checked: a manual uncheck
+        // leaves it `- [ ]`, which won't match, so the clear self-suppresses.
+        onAutoClose: clearOnComplete
+          ? () => {
+              const lineToClear = findCheckedLineIndexByTitle(
+                noteTextRef.current,
+                safeTitle,
+              )
+              if (lineToClear === null) return
+              setNoteText(removeLineAtIndex(noteTextRef.current, lineToClear))
+            }
+          : undefined,
       })
     },
-    [activeCategoryId, createCompletedMutation, queryClient],
+    [activeCategoryId, createCompletedMutation, queryClient, clearOnComplete],
   )
 
   /**

--- a/src/components/braindump/braindumpUtils.test.ts
+++ b/src/components/braindump/braindumpUtils.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeCompletedTitle,
   parseAllCheckboxes,
   parseCheckboxLine,
+  removeLineAtIndex,
   replaceLineAtIndex,
   setCheckboxStateAtLine,
 } from './braindumpUtils'
@@ -133,6 +134,39 @@ describe('replaceLineAtIndex', () => {
     // Act + Assert
     expect(replaceLineAtIndex(before, 5, 'a')).toBe(before)
     expect(replaceLineAtIndex(before, -1, 'a')).toBe(before)
+  })
+})
+
+describe('removeLineAtIndex', () => {
+  it('drops a finished checkbox line so clear-on-complete leaves the rest verbatim', () => {
+    // Arrange — clear-on-complete fires once the undo window closes on a finished line.
+    const before = '- [x] buy milk\ndishes'
+
+    // Act — drop the completed first line.
+    const result = removeLineAtIndex(before, 0)
+
+    // Assert
+    expect(result).toBe('dishes')
+  })
+
+  it('removes only the target line and joins the surrounding lines', () => {
+    // Arrange
+    const before = ['line 0', 'line 1', 'line 2'].join('\n')
+
+    // Act
+    const after = removeLineAtIndex(before, 1)
+
+    // Assert
+    expect(after).toBe(['line 0', 'line 2'].join('\n'))
+  })
+
+  it('returns the original text for out-of-range indices', () => {
+    // Arrange
+    const before = '- [x] a'
+
+    // Act + Assert
+    expect(removeLineAtIndex(before, 5)).toBe(before)
+    expect(removeLineAtIndex(before, -1)).toBe(before)
   })
 })
 

--- a/src/components/braindump/braindumpUtils.ts
+++ b/src/components/braindump/braindumpUtils.ts
@@ -171,6 +171,30 @@ export function replaceLineAtIndex(
 }
 
 /**
+ * Remove one line entirely, joining the surrounding lines. Used by the
+ * clear-on-complete preference: once a finished line's undo window closes, the
+ * `- [x] <title>` line is dropped so the BrainDump scratchpad stays clean.
+ * Returns the original text for out-of-range indices, mirroring
+ * `replaceLineAtIndex`.
+ *
+ * @param text - The full document text.
+ * @param lineIndex - Zero-based index of the line to delete.
+ * @returns The text with that line removed, or the original when out of range.
+ * @example
+ * removeLineAtIndex('- [x] buy milk\ndishes', 0) // → 'dishes'
+ * removeLineAtIndex('a\nb\nc', 1)                 // → 'a\nc'
+ */
+export function removeLineAtIndex(
+  text: string,
+  lineIndex: BrainDumpLineIndex,
+): string {
+  const lines = text.split('\n')
+  if (lineIndex < 0 || lineIndex >= lines.length) return text
+  lines.splice(lineIndex, 1)
+  return lines.join('\n')
+}
+
+/**
  * Matches an empty checkbox skeleton — a checkbox prefix with no title, e.g.
  * `- [ ]`, `- [x]`, `- []` (optional trailing whitespace). These have nothing
  * to record, so the complete command must skip them rather than logging a junk

--- a/src/components/settings/PreferencesSettings.test.tsx
+++ b/src/components/settings/PreferencesSettings.test.tsx
@@ -183,4 +183,27 @@ describe('PreferencesSettings — BrainDump editor presentation', () => {
       '#000000',
     )
   })
+
+  it('keeps finished BrainDump lines in place by default — clear-on-complete starts off', () => {
+    // Arrange / Act — a fresh install keeps the on-concept behavior.
+    renderPreferences()
+
+    // Assert — the clear-on-complete switch is off (lines stay put by default).
+    expect(
+      screen.getByRole('switch', { name: 'Clear finished lines' }),
+    ).not.toBeChecked()
+  })
+
+  it('opts into clearing finished BrainDump lines when its switch is turned on', async () => {
+    // Arrange
+    const { store, user } = renderPreferences()
+
+    // Act — turn on "Clear finished lines".
+    await user.click(
+      screen.getByRole('switch', { name: 'Clear finished lines' }),
+    )
+
+    // Assert — the preference is now enabled in the slice.
+    expect(store.getState().preferences.braindumpClearOnComplete).toBe(true)
+  })
 })

--- a/src/components/settings/PreferencesSettings.tsx
+++ b/src/components/settings/PreferencesSettings.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/lib/constants/sound'
 import { useAppDispatch, useAppSelector } from '@/lib/redux/hooks'
 import {
+  selectBraindumpClearOnComplete,
   selectBraindumpFontFamily,
   selectBraindumpFontSize,
   selectBraindumpTextColor,
@@ -32,6 +33,7 @@ import {
   selectSoundMoment,
   selectSoundTimbre,
   selectSoundVolume,
+  setBraindumpClearOnComplete,
   setBraindumpFontFamily,
   setBraindumpFontSize,
   setBraindumpTextColor,
@@ -133,6 +135,9 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
   const braindumpFontFamily = useAppSelector(selectBraindumpFontFamily)
   const braindumpFontSize = useAppSelector(selectBraindumpFontSize)
   const braindumpTextColor = useAppSelector(selectBraindumpTextColor)
+  const braindumpClearOnComplete = useAppSelector(
+    selectBraindumpClearOnComplete,
+  )
 
   // Lookup so the SOUND_MOMENTS render map (the single source of moment copy) can
   // index its checked state without per-item hook calls.
@@ -165,6 +170,13 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
   const handleRetainChange = useCallback(
     (checked: boolean): void => {
       dispatch(setRetainCompletedInList(checked))
+    },
+    [dispatch],
+  )
+
+  const handleBraindumpClearOnCompleteChange = useCallback(
+    (checked: boolean): void => {
+      dispatch(setBraindumpClearOnComplete(checked))
     },
     [dispatch],
   )
@@ -334,13 +346,34 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
             </div>
           </div>
 
-          {/* BrainDump editor text presentation (font, size, color). */}
+          {/* BrainDump editor behavior + text presentation (font, size, color). */}
           <div className="space-y-4">
             <div className="space-y-0.5">
               <p className="text-sm font-medium">BrainDump</p>
               <p className="text-xs text-muted-foreground">
-                How the text looks in the BrainDump editor.
+                How the BrainDump editor looks and behaves.
               </p>
+            </div>
+
+            {/* Clear-on-complete — tuck a finished line away after the undo window. */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label
+                  htmlFor="braindump-clear-on-complete"
+                  className="text-sm font-medium"
+                >
+                  Clear finished lines
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Once you finish a line, tuck it away after the undo moment —
+                  so the page clears as you go. Off keeps every line in place.
+                </p>
+              </div>
+              <Switch
+                id="braindump-clear-on-complete"
+                checked={braindumpClearOnComplete}
+                onCheckedChange={handleBraindumpClearOnCompleteChange}
+              />
             </div>
 
             {/* Font family — the three brand fonts; each label previews its face. */}

--- a/src/lib/preferences-sync-channel.test.ts
+++ b/src/lib/preferences-sync-channel.test.ts
@@ -9,6 +9,7 @@ import {
 import preferencesReducer, {
   hydratePreferences,
   initialState,
+  setBraindumpClearOnComplete,
   setBraindumpFontFamily,
   setBraindumpFontSize,
   setBraindumpTextColor,
@@ -162,6 +163,19 @@ describe('preferences cross-window sync', () => {
     expect(windowB.getState().preferences.braindumpTextColor).toBe(
       'var(--primary)',
     )
+  })
+
+  it('propagates a BrainDump clear-on-complete toggle to another window', () => {
+    // Arrange
+    const windowA = makeWindowStore()
+    const windowB = makeWindowStore()
+
+    // Act — opt into clearing finished lines in window A.
+    windowA.dispatch(setBraindumpClearOnComplete(true))
+
+    // Assert — window B reflects the toggle without a reload (the action is in
+    // the broadcast allowlist; a NEW set* action would stay silent until added).
+    expect(windowB.getState().preferences.braindumpClearOnComplete).toBe(true)
   })
 
   it('clamps an out-of-range inbound volume when applying a raw broadcast', () => {

--- a/src/lib/preferences-sync-channel.ts
+++ b/src/lib/preferences-sync-channel.ts
@@ -3,6 +3,7 @@ import type { Middleware } from '@reduxjs/toolkit'
 import { foldLegacyCompletionSoundIntoMoments } from '@/lib/redux/foldLegacyCompletionSoundIntoMoments'
 import {
   hydratePreferences,
+  setBraindumpClearOnComplete,
   setBraindumpFontFamily,
   setBraindumpFontSize,
   setBraindumpTextColor,
@@ -44,6 +45,7 @@ const BROADCASTABLE_ACTION_TYPES = new Set<string>([
   setBraindumpFontFamily.type,
   setBraindumpFontSize.type,
   setBraindumpTextColor.type,
+  setBraindumpClearOnComplete.type,
 ])
 
 /**

--- a/src/lib/redux/slices/preferencesSlice.test.ts
+++ b/src/lib/redux/slices/preferencesSlice.test.ts
@@ -8,6 +8,7 @@ import reducer, {
   hydratePreferences,
   initialState,
   resetPreferences,
+  selectBraindumpClearOnComplete,
   selectBraindumpFontFamily,
   selectBraindumpFontSize,
   selectBraindumpTextColor,
@@ -17,6 +18,7 @@ import reducer, {
   selectSoundMoment,
   selectSoundTimbre,
   selectSoundVolume,
+  setBraindumpClearOnComplete,
   setBraindumpFontFamily,
   setBraindumpFontSize,
   setBraindumpTextColor,
@@ -48,6 +50,7 @@ describe('preferencesSlice', () => {
       braindumpFontFamily: 'mono',
       braindumpFontSize: 14,
       braindumpTextColor: 'var(--foreground)',
+      braindumpClearOnComplete: false,
     })
   })
 
@@ -139,6 +142,7 @@ describe('preferencesSlice', () => {
       braindumpFontFamily: 'serif',
       braindumpFontSize: 20,
       braindumpTextColor: 'var(--primary)',
+      braindumpClearOnComplete: true,
     }
 
     // Act
@@ -159,6 +163,7 @@ describe('preferencesSlice', () => {
       braindumpFontFamily: 'serif',
       braindumpFontSize: 24,
       braindumpTextColor: '#abcdef',
+      braindumpClearOnComplete: true,
     }
 
     // Act
@@ -174,6 +179,7 @@ describe('preferencesSlice', () => {
       braindumpFontFamily: 'mono',
       braindumpFontSize: 14,
       braindumpTextColor: 'var(--foreground)',
+      braindumpClearOnComplete: false,
     })
   })
 
@@ -237,6 +243,7 @@ describe('preferencesSlice', () => {
       braindumpFontFamily: 'mono',
       braindumpFontSize: 14,
       braindumpTextColor: 'var(--foreground)',
+      braindumpClearOnComplete: false,
     })
   })
 
@@ -306,5 +313,21 @@ describe('preferencesSlice', () => {
     expect(selectBraindumpFontFamily(legacyState)).toBe('mono')
     expect(selectBraindumpFontSize(legacyState)).toBe(14)
     expect(selectBraindumpTextColor(legacyState)).toBe('var(--foreground)')
+  })
+
+  it('turns on BrainDump clear-on-complete when setBraindumpClearOnComplete(true) is dispatched', () => {
+    // Act
+    const next = reducer(initialState, setBraindumpClearOnComplete(true))
+
+    // Assert
+    expect(next.braindumpClearOnComplete).toBe(true)
+  })
+
+  it('falls back to clear-on-complete OFF for a slice that predates the field', () => {
+    // Arrange — a persisted slice from before clear-on-complete existed.
+    const legacyState = stateWith({ completionSound: false })
+
+    // Act / Assert — the selector coalesces to the default, never undefined (Finding 5).
+    expect(selectBraindumpClearOnComplete(legacyState)).toBe(false)
   })
 })

--- a/src/lib/redux/slices/preferencesSlice.ts
+++ b/src/lib/redux/slices/preferencesSlice.ts
@@ -175,6 +175,16 @@ export const preferencesSlice = createSlice({
     },
 
     /**
+     * Toggles BrainDump clear-on-complete (drop a finished line once its undo
+     * window closes). Plain boolean, so no value-healing is needed.
+     * @param state - Current state
+     * @param action - Payload containing the new braindumpClearOnComplete value
+     */
+    setBraindumpClearOnComplete: (state, action: PayloadAction<boolean>) => {
+      state.braindumpClearOnComplete = action.payload
+    },
+
+    /**
      * Replaces the whole preferences state. Used by the cross-window sync to
      * apply preferences received from another window without re-broadcasting.
      * @param _state - Current state (unused, returns new state)
@@ -204,6 +214,7 @@ export const {
   setBraindumpFontFamily,
   setBraindumpFontSize,
   setBraindumpTextColor,
+  setBraindumpClearOnComplete,
   hydratePreferences,
   resetPreferences,
 } = preferencesSlice.actions
@@ -305,6 +316,15 @@ export const selectBraindumpTextColor = (state: RootState): string =>
   state.preferences.braindumpTextColor ?? DEFAULT_PREFERENCES.braindumpTextColor
 
 /**
+ * Selects the BrainDump clear-on-complete preference.
+ * @param state - Root state
+ * @returns Whether finished BrainDump lines clear after the undo window (default false)
+ */
+export const selectBraindumpClearOnComplete = (state: RootState): boolean =>
+  state.preferences.braindumpClearOnComplete ??
+  DEFAULT_PREFERENCES.braindumpClearOnComplete
+
+/**
  * Selects the full preferences state (every field coalesced/migrated to its
  * effective value) — the snapshot the cross-window sync broadcasts.
  * @param state - Root state
@@ -323,6 +343,7 @@ export const selectPreferences = (state: RootState): PreferencesState => ({
   braindumpFontFamily: selectBraindumpFontFamily(state),
   braindumpFontSize: selectBraindumpFontSize(state),
   braindumpTextColor: selectBraindumpTextColor(state),
+  braindumpClearOnComplete: selectBraindumpClearOnComplete(state),
 })
 
 export default preferencesSlice.reducer

--- a/src/lib/schemas/preferences.test.ts
+++ b/src/lib/schemas/preferences.test.ts
@@ -8,7 +8,8 @@ describe('PreferencesStateSchema', () => {
     const result = PreferencesStateSchema.parse({})
 
     // Assert — every moment OFF, default timbre + volume, both legacy flags OFF,
-    // and the BrainDump editor at its prior look (mono / 14px / theme foreground).
+    // the BrainDump editor at its prior look (mono / 14px / theme foreground),
+    // and clear-on-complete OFF (finished lines stay put by default).
     expect(result).toEqual({
       completionSound: false,
       retainCompletedInList: false,
@@ -18,6 +19,7 @@ describe('PreferencesStateSchema', () => {
       braindumpFontFamily: 'mono',
       braindumpFontSize: 14,
       braindumpTextColor: 'var(--foreground)',
+      braindumpClearOnComplete: false,
     })
   })
 
@@ -38,7 +40,20 @@ describe('PreferencesStateSchema', () => {
       braindumpFontFamily: 'mono',
       braindumpFontSize: 14,
       braindumpTextColor: 'var(--foreground)',
+      braindumpClearOnComplete: false,
     })
+  })
+
+  it('keeps an explicit BrainDump clear-on-complete opt-in and defaults it OFF when absent', () => {
+    // Act — an explicit true is preserved; a payload omitting it defaults to OFF.
+    const optedIn = PreferencesStateSchema.parse({
+      braindumpClearOnComplete: true,
+    })
+    const omitted = PreferencesStateSchema.parse({})
+
+    // Assert
+    expect(optedIn.braindumpClearOnComplete).toBe(true)
+    expect(omitted.braindumpClearOnComplete).toBe(false)
   })
 
   it('clamps an out-of-range master volume number into [0,1]', () => {

--- a/src/lib/schemas/preferences.ts
+++ b/src/lib/schemas/preferences.ts
@@ -93,6 +93,11 @@ export const PreferencesStateSchema = z.object({
     .string()
     .regex(BRAINDUMP_TEXT_COLOR_PATTERN)
     .catch(DEFAULT_BRAINDUMP_TEXT_COLOR),
+  /** BrainDump clear-on-complete — when ON, a finished `- [x] <title>` line is
+   * dropped once its undo window closes so the scratchpad clears as you go.
+   * Default OFF keeps the on-concept behavior (every line stays in place); the
+   * clear is the opt-in deviation ("Presets First, Then Options"). */
+  braindumpClearOnComplete: z.boolean().default(false),
 })
 
 /** The validated core user-preferences shape (inferred from the schema SSoT). */


### PR DESCRIPTION
## What

Adds a **"Clear finished lines"** preference to the BrainDump section of Preferences. When ON, a finished `- [x] <title>` line is tucked away once its undo window closes, so the scratchpad clears as you go. **Default OFF** — every line stays in place (the on-concept behavior).

## Why

BrainDump is a quick scratchpad. Some people want finished lines to linger (a record of what they did today); others want the page to clear so only open work remains. This makes it a per-user choice instead of a baked-in default.

Per `DESIGN.md` **"Presets First, Then Options"**: keep-every-line ships as the default (self-affirming — the day's work stays visible), and clearing is the opt-in deviation.

## How it works

The clear is tied to the success toast's `onAutoClose`:

- Sonner fires `onAutoClose` **only on the timeout** (the undo window elapsing). An **Undo click** fires `onDismiss` instead — so undone completions are **never** cleared.
- The callback re-resolves the line **by title** against the freshest editor text (the index may have drifted) and removes **only a line that is still checked**. A manual uncheck (or undo) flips the line back to `- [ ]`, which the checked-title lookup won't match — so the clear **self-suppresses**.

No timers, no re-insertion logic, undo flow completely untouched.

## Files

- `schemas/preferences.ts` — `braindumpClearOnComplete: z.boolean().default(false)`
- `redux/slices/preferencesSlice.ts` — reducer + selector + `selectPreferences` broadcast snapshot
- `preferences-sync-channel.ts` — added to the cross-window broadcast allowlist
- `braindump/braindumpUtils.ts` — `removeLineAtIndex` pure helper
- `braindump/BrainDumpEditor.tsx` — `onAutoClose` clear wiring
- `settings/PreferencesSettings.tsx` — the "Clear finished lines" Switch

## Testing

`pnpm validate` green — **602 unit tests pass**, build + typecheck + lint all clean. New behavior coverage:

- **Editor** (3): clears a finished line on auto-close when ON; **keeps** a line that was undone before its window closed (self-suppress); no auto-close hook wired by default. The two non-trivial tests were RED-proven (broke prod code → test failed → restored).
- **Preferences UI** (2): default OFF; opts in when the switch is toggled.
- **Schema / slice / sync** (4): default + explicit opt-in; reducer/selector; cross-window propagation.
- **Util** (3): drops the target line; out-of-range returns original.

## Notes

- No version bump (corelive convention: features land unbumped; release bump is a separate chore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Clear finished lines” preference for the BrainDump editor. When enabled, completed lines are automatically removed after the success notification closes.
* **Bug Fixes**
  * Improved auto-clear behavior to avoid clearing the wrong line when multiple lines are completed or when an undo occurs before the notification closes.
* **Tests**
  * Added/updated unit and integration tests to cover the new preference, default behavior, cross-window syncing, and line-removal edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->