### PR TITLE
fix(heatmap): show the full year at content-width instead of scrolling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -115,6 +115,9 @@ export default defineConfig([
             'peer-*',
             'data-*',
             'container',
+            // Grid column span — structural layout utility; `gridColumn` isn't in
+            // the token source (only `gridTemplateColumns` → `grid-cols-*` is).
+            'col-span-*',
             // Typography
             'antialiased',
             'subpixel-antialiased',

--- a/src/app/(main)/home/_components/ContributionGraph.test.ts
+++ b/src/app/(main)/home/_components/ContributionGraph.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateHeatmapLayout } from './ContributionGraph'
+
+/**
+ * The Activity heatmap shows a trailing one year, which lays out as 53 Sunday-
+ * aligned week columns. These specs lock the sizing contract that lets the
+ * heatmap sit full-content-width without a horizontal scrollbar (the bug Task 5
+ * fixed by promoting it out of the half-width column) while still honoring the
+ * DESIGN.md "Heatmap Cathedral D6" cell-size lock (12px min, 32px max).
+ */
+const WEEKS_IN_TRAILING_YEAR = 53
+
+describe('Activity heatmap sizing', () => {
+  it('fits the whole year inside the card at desktop content width, so no horizontal scrollbar appears', () => {
+    // Arrange — the home page now gives the heatmap the full ~1180px content width.
+    const containerWidth = 1180
+
+    // Act
+    const layout = calculateHeatmapLayout(
+      containerWidth,
+      WEEKS_IN_TRAILING_YEAR,
+    )
+
+    // Assert — the rendered grid is no wider than its card, so it never overflows.
+    expect(layout.rectSize).toBe(19)
+    expect(layout.width).toBe(1141)
+    expect(layout.width).toBeLessThanOrEqual(containerWidth)
+  })
+
+  it('never grows cells past the 32px Cathedral maximum even in an unusually wide card', () => {
+    // Arrange — a very wide container that could otherwise over-grow the cells.
+    const containerWidth = 3000
+
+    // Act
+    const layout = calculateHeatmapLayout(
+      containerWidth,
+      WEEKS_IN_TRAILING_YEAR,
+    )
+
+    // Assert — cells cap at the DESIGN.md D6 maximum.
+    expect(layout.rectSize).toBe(32)
+  })
+
+  it('holds the 12px minimum cell and lets the grid overflow when the card is narrower than a full year', () => {
+    // Arrange — the old half-width column (~578px) cannot fit 53 weeks at the 12px floor.
+    const containerWidth = 578
+
+    // Act
+    const layout = calculateHeatmapLayout(
+      containerWidth,
+      WEEKS_IN_TRAILING_YEAR,
+    )
+
+    // Assert — the cell holds the floor and the grid stays wider than the card,
+    // so overflow-x-auto scrolls it (the only D6-legal behavior below ~770px).
+    expect(layout.rectSize).toBe(12)
+    expect(layout.width).toBe(770)
+    expect(layout.width).toBeGreaterThan(containerWidth)
+  })
+
+  it('falls back to the minimum-size layout before the container width has been measured', () => {
+    // Arrange — width is null on the first render, before the ResizeObserver fires.
+    const unmeasuredWidth = null
+
+    // Act
+    const layout = calculateHeatmapLayout(
+      unmeasuredWidth,
+      WEEKS_IN_TRAILING_YEAR,
+    )
+
+    // Assert — a stable minimum-size layout avoids a layout jump on first paint.
+    expect(layout.rectSize).toBe(12)
+    expect(layout.width).toBe(770)
+  })
+})

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -467,7 +467,7 @@ type HeatmapLayout = {
  * calculateHeatmapLayout(720, 53) // => { rectSize: 11, width: 717 }
  * calculateHeatmapLayout(480, 53) // => { rectSize: 8, width: 558 }
  */
-function calculateHeatmapLayout(
+export function calculateHeatmapLayout(
   containerWidth: number | null,
   weekCount: number,
 ): HeatmapLayout {

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -494,6 +494,34 @@ export const TodoList = memo(function TodoList() {
 
   return (
     <div className="grid h-full grid-cols-1 gap-6 lg:grid-cols-2">
+      {/* Activity Heatmap — promoted to span both columns so it gets the full
+          content-width DESIGN.md mandates for the centerpiece. At full width the
+          trailing-year grid fits the card, removing the horizontal scroll the
+          old half-width placement forced on desktop (sub-770px still scrolls via
+          ContributionGraph's own overflow-x-auto — unavoidable at the 12px floor). */}
+      <div className="lg:col-span-2">
+        {/* Suspense required because ContributionGraph + YearInReviewModal read URL params via Next.js 16's useSearchParams — fallback matches its own isLoading skeleton so the prerender phase is shape-identical. */}
+        <Suspense
+          fallback={
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  Activity
+                </CardTitle>
+                <CardDescription>Loading activity data...</CardDescription>
+              </CardHeader>
+            </Card>
+          }
+        >
+          <ContributionGraph />
+          <YearInReviewModal
+            dataByDate={heatmapByDate}
+            isLoading={heatmapLoading}
+            isRestoring={isRestoring}
+          />
+        </Suspense>
+      </div>
+
       {/* Pending Tasks Column */}
       <div className="space-y-6">
         <Card>
@@ -574,26 +602,6 @@ export const TodoList = memo(function TodoList() {
 
       {/* Completed Tasks Column */}
       <div className="space-y-6">
-        {/* Suspense required because ContributionGraph + YearInReviewModal read URL params via Next.js 16's useSearchParams — fallback matches its own isLoading skeleton so the prerender phase is shape-identical. */}
-        <Suspense
-          fallback={
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  Activity
-                </CardTitle>
-                <CardDescription>Loading activity data...</CardDescription>
-              </CardHeader>
-            </Card>
-          }
-        >
-          <ContributionGraph />
-          <YearInReviewModal
-            dataByDate={heatmapByDate}
-            isLoading={heatmapLoading}
-            isRestoring={isRestoring}
-          />
-        </Suspense>
         <WeeklySummaryCard
           dataByDate={heatmapByDate}
           isLoading={heatmapLoading}


### PR DESCRIPTION
## What & why

The Activity heatmap lived in the **right half** of the home page's two-column grid (`lg:grid-cols-2`). At the 1180px content max that column is ~578px — below the **770px** a 53-week year needs at the **12px cell floor** — so the heatmap **scrolled horizontally on every desktop**.

DESIGN.md mandates the heatmap be **full content-width** — it's the centerpiece, *"never demoted to a half-width column"* (L207). So this promotes it to **span both columns** (`lg:col-span-2`, as the first grid row). At full width the trailing year fits inside the card and the horizontal scroll is gone.

## Notes

- **`overflow-x-auto` is kept** on `ContributionGraph` for the irreducible **sub-770px** case (mobile / very narrow windows). Below the 12px D6 cell floor a full year *cannot* fit without scroll — that's the only D6-legal behavior, so the scrollbar correctly survives only there.
- Exported `calculateHeatmapLayout` and added a **DAMP unit test** locking the sizing contract: fits within the card at 1180px (rectSize 19, width 1141), caps at the 32px Cathedral max, holds the 12px floor (+ overflows) below 770px. RED-proven.
- Allowed `col-span-*` in the `dslint/token-only` ignore list — it's a structural grid utility; `gridColumn` isn't in the token source (only `gridTemplateColumns` → `grid-cols-*` is), so this fills a resolver gap, consistent with the rule's intent.

## Test plan

- `pnpm validate` green locally (test 607 pass / packages 22 / typecheck / build / lint / theme — all exit 0).
- Visual diff (Argos) on the home page is **expected** — the heatmap moves to a full-width hero row; not a regression.
- `heatmap-day-detail.spec.ts` should stay green on CI (cells remain clickable). Local web E2E can't boot on this machine, so it verifies on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the activity contribution graph to display at the top of the home page as the primary section
  * Contribution graph now spans full width on large screens while maintaining responsive behavior on smaller devices

* **Tests**
  * Added comprehensive test coverage for contribution graph sizing across various screen dimensions

* **Chores**
  * Updated ESLint configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->