### PR TITLE
fix: focus BrainDump note editor on window show

### DIFF
--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -322,6 +322,62 @@ describe('BrainDumpEditor text styling preferences', () => {
   })
 })
 
+describe('BrainDumpEditor focus on window show', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('focuses the note editor when the BrainDump window first opens, so a quick capture can start typing right away', async () => {
+    // Arrange — open the editor with an active category, so the note field is enabled.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+
+    // Act — findByRole settles the mount effects (including the focus effect) under act().
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Assert — keyboard focus lands in the editor, not on a header control.
+    expect(noteField).toHaveFocus()
+  })
+
+  it('returns focus to the note editor when the window is shown again, instead of leaving it on the Follow Spaces switch', async () => {
+    // Arrange — editor open with an active category; reproduce the reported bug's
+    // starting point by parking focus on the first focusable header control.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    const spacesSwitch = screen.getByRole('switch', {
+      name: 'Show BrainDump on all Mac desktops',
+    })
+    act(() => {
+      spacesSwitch.focus()
+    })
+    expect(spacesSwitch).toHaveFocus()
+
+    // Act — the window is shown again: BrowserWindow.show() drives a Page
+    // Visibility transition to 'visible' in the renderer.
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    // Assert — focus is back in the note editor, ready for the next capture.
+    expect(noteField).toHaveFocus()
+  })
+})
+
 /**
  * Types `value` into the note field, parks the caret at the end of the first
  * line, and fires the Cmd+Enter complete command. Shared mechanical setup so

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -251,6 +251,32 @@ export const BrainDumpEditor = memo(function BrainDumpEditor({
     })
   }, [isMounted])
 
+  // Move keyboard focus into the note editor whenever the BrainDump window is
+  // shown, so a quick global-shortcut capture lands in the textarea instead of
+  // the first focusable control (the "Follow Spaces" switch). The window is
+  // hidden — not destroyed — between toggles, so the textarea can't lean on a
+  // mount-time autoFocus to refocus on re-show; we listen for the Page
+  // Visibility transition to 'visible' that BrowserWindow.show() drives, and
+  // also focus once on mount for the first open. focus() is a no-op while the
+  // textarea is disabled (no active category) — picking a category first is the
+  // expected flow there.
+  useCycleEffect(() => {
+    if (!isMounted || !isBrainDumpEnvironment()) return
+    const focusNoteEditor = () => {
+      textareaRef.current?.focus()
+    }
+    // First open: show() already fired before this effect subscribed, so the
+    // visibilitychange we would catch has passed — focus directly.
+    focusNoteEditor()
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') focusNoteEditor()
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [isMounted])
+
   // Whenever the active category flips, load that category's note text.
   useCycleEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment() || activeCategoryId === null) {


### PR DESCRIPTION
## Problem

Triggering the BrainDump window with its global shortcut and immediately typing dropped the capture: the keystrokes went nowhere instead of into the note editor.

Root cause: `hideBrainDump()` **hides** the window, it does not destroy it. So the React tree stays mounted across toggles, and on re-show the textarea cannot lean on a mount-time `autoFocus` to refocus. `showBrainDump()` calls `BrowserWindow.show()` + `.focus()`, which focuses the *window* — DOM focus then lands on the first focusable control, the **"Follow Spaces"** switch, not the editor.

## Fix

Renderer-only (`BrainDumpEditor.tsx`): a lifecycle effect focuses the note `textarea`

- **on mount** — covers the very first open, and
- **on every Page Visibility transition to `visible`** — `BrowserWindow.show()` drives `visibilitychange` in the renderer because the braindump window leaves `backgroundThrottling` at its `true` default.

`focus()` is a deliberate no-op while the textarea is disabled (no active category yet) — picking a category first is the expected flow there.

### Why renderer-only (Approach A) over an IPC `braindump-shown` event (Approach B)

`visibilitychange` already carries the show/hide signal into the renderer, so an IPC event would add a main↔renderer round-trip with no new capability. Using `visibilitychange` (not window `focus`) also avoids stealing DOM focus when the user merely click-to-fronts an already-visible window. Fewer dependencies, easier to test (per `ts-rules.md`).

## Tests

`BrainDumpEditor.test.tsx` — 2 DAMP specs:
1. focuses the note editor when the window first opens, and
2. returns focus to the editor on re-show (parks focus on the Follow Spaces switch first to reproduce the bug's starting point).

`pnpm validate` green (test + lint + build + typecheck + theme:check).

## Verification scope ⚠️

The renderer focus logic is **unit-tested**. The native `BrowserWindow.show()` → `visibilitychange` trigger that the re-show path depends on is confirmed by **Electron docs only** (backgroundThrottling default `true`), not yet exercised against the packaged app. That integration assertion is reserved for the **mandated release macOS smoke** (the unit test cannot drive a real `show()`):

- [ ] **macOS release smoke**: open BrainDump → hide via global shortcut → re-show via shortcut → confirm the caret is in the note textarea, ready to type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced focus management for the note editor. When the BrainDump window opens or returns to focus, the cursor now automatically returns to the note area for a seamless editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->