### PR TITLE
feat: add master "All cues" toggle to Preferences Sound section

### DIFF
--- a/src/components/settings/PreferencesSettings.test.tsx
+++ b/src/components/settings/PreferencesSettings.test.tsx
@@ -72,6 +72,58 @@ describe('PreferencesSettings — sound palette', () => {
     expect(store.getState().preferences.soundMoments['task-create']).toBe(true)
   })
 
+  it('shows the master All cues switch on when every moment cue is already enabled', () => {
+    // Arrange / Act — a palette with all three cues on.
+    renderPreferences({
+      soundMoments: { 'task-create': true, complete: true, clear: true },
+    })
+
+    // Assert — the master switch reads on (it mirrors an all-on palette).
+    expect(screen.getByRole('switch', { name: 'All cues' })).toBeChecked()
+  })
+
+  it('shows the master All cues switch off when only some moment cues are enabled', () => {
+    // Arrange / Act — a partial palette: task-create on, the other two off.
+    renderPreferences({
+      soundMoments: { 'task-create': true, complete: false, clear: false },
+    })
+
+    // Assert — the master switch reads off; it never claims a partial palette is "all".
+    expect(screen.getByRole('switch', { name: 'All cues' })).not.toBeChecked()
+  })
+
+  it('enables every moment cue when the master All cues switch is turned on', async () => {
+    // Arrange — a fresh, silent install (every cue off).
+    const { store, user } = renderPreferences()
+
+    // Act — turn on the master "All cues" switch.
+    await user.click(screen.getByRole('switch', { name: 'All cues' }))
+
+    // Assert — all three cues are now enabled in the preferences slice.
+    expect(store.getState().preferences.soundMoments).toEqual({
+      'task-create': true,
+      complete: true,
+      clear: true,
+    })
+  })
+
+  it('silences every moment cue when the master All cues switch is turned off', async () => {
+    // Arrange — a palette with all three cues currently on.
+    const { store, user } = renderPreferences({
+      soundMoments: { 'task-create': true, complete: true, clear: true },
+    })
+
+    // Act — turn off the master "All cues" switch.
+    await user.click(screen.getByRole('switch', { name: 'All cues' }))
+
+    // Assert — every cue is now off (a silent palette).
+    expect(store.getState().preferences.soundMoments).toEqual({
+      'task-create': false,
+      complete: false,
+      clear: false,
+    })
+  })
+
   it('saves and auditions the chosen timbre when a different one is picked', async () => {
     // Arrange — the defaults are the 'felt' timbre at 0.6 master volume.
     const { store, user } = renderPreferences()

--- a/src/components/settings/PreferencesSettings.tsx
+++ b/src/components/settings/PreferencesSettings.tsx
@@ -33,6 +33,7 @@ import {
   selectSoundMoment,
   selectSoundTimbre,
   selectSoundVolume,
+  setAllSoundMoments,
   setBraindumpClearOnComplete,
   setBraindumpFontFamily,
   setBraindumpFontSize,
@@ -147,6 +148,13 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
     clear: isClearSoundOn,
   }
 
+  // The master "All cues" toggle reflects the palette only when EVERY cue is on
+  // (read through the effective-state selectors, so a legacy completionSound user
+  // counts as having the complete cue on). From any partial/all-off state it reads
+  // OFF and one tap turns them all on; from all-on, one tap silences the palette.
+  const areAllSoundMomentsOn =
+    isTaskCreateSoundOn && isCompleteSoundOn && isClearSoundOn
+
   // Radix Slider wants a stable array; rebuild it only when the volume changes.
   const sliderValue = useMemo(() => [soundVolume], [soundVolume])
   // Same for the font-size slider — its own stable single-thumb array.
@@ -184,6 +192,13 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
   const handleMomentChange = useCallback(
     (momentId: SoundMomentId, enabled: boolean): void => {
       dispatch(setSoundMoment({ moment: momentId, enabled }))
+    },
+    [dispatch],
+  )
+
+  const handleAllSoundMomentsChange = useCallback(
+    (enabled: boolean): void => {
+      dispatch(setAllSoundMoments(enabled))
     },
     [dispatch],
   )
@@ -281,6 +296,25 @@ export const PreferencesSettings = memo(function PreferencesSettings() {
                 Off by default. Pick where a soft, warm cue plays — a quiet
                 companion, never a chime.
               </p>
+            </div>
+
+            {/* Master toggle — flips all three cues together. Checked only when
+                every cue is on, so it never misrepresents a partial palette; a
+                quiet divider sets it above the cues it governs. */}
+            <div className="flex items-center justify-between border-b pb-4">
+              <div className="space-y-0.5">
+                <Label htmlFor="sound-all-cues" className="text-sm font-medium">
+                  All cues
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Turn every cue on or off at once.
+                </p>
+              </div>
+              <Switch
+                id="sound-all-cues"
+                checked={areAllSoundMomentsOn}
+                onCheckedChange={handleAllSoundMomentsChange}
+              />
             </div>
 
             {/* Per-moment toggles (SOUND_MOMENTS is the source of the copy). */}

--- a/src/lib/preferences-sync-channel.test.ts
+++ b/src/lib/preferences-sync-channel.test.ts
@@ -9,6 +9,7 @@ import {
 import preferencesReducer, {
   hydratePreferences,
   initialState,
+  setAllSoundMoments,
   setBraindumpClearOnComplete,
   setBraindumpFontFamily,
   setBraindumpFontSize,
@@ -100,6 +101,22 @@ describe('preferences cross-window sync', () => {
 
     // Assert — window B sees the same toggle without a reload.
     expect(windowB.getState().preferences.soundMoments.clear).toBe(true)
+  })
+
+  it('propagates a master all-cues toggle to another window', () => {
+    // Arrange — two windows, each with its own store + sync middleware.
+    const windowA = makeWindowStore()
+    const windowB = makeWindowStore()
+
+    // Act — flip every cue ON via the master toggle in window A.
+    windowA.dispatch(setAllSoundMoments(true))
+
+    // Assert — window B sees all three cues enabled without a reload.
+    expect(windowB.getState().preferences.soundMoments).toEqual({
+      'task-create': true,
+      complete: true,
+      clear: true,
+    })
   })
 
   it('propagates a timbre change to another window', () => {

--- a/src/lib/preferences-sync-channel.ts
+++ b/src/lib/preferences-sync-channel.ts
@@ -3,6 +3,7 @@ import type { Middleware } from '@reduxjs/toolkit'
 import { foldLegacyCompletionSoundIntoMoments } from '@/lib/redux/foldLegacyCompletionSoundIntoMoments'
 import {
   hydratePreferences,
+  setAllSoundMoments,
   setBraindumpClearOnComplete,
   setBraindumpFontFamily,
   setBraindumpFontSize,
@@ -40,6 +41,7 @@ const BROADCASTABLE_ACTION_TYPES = new Set<string>([
   setCompletionSound.type,
   setRetainCompletedInList.type,
   setSoundMoment.type,
+  setAllSoundMoments.type,
   setSoundTimbre.type,
   setSoundVolume.type,
   setBraindumpFontFamily.type,

--- a/src/lib/redux/slices/preferencesSlice.test.ts
+++ b/src/lib/redux/slices/preferencesSlice.test.ts
@@ -25,6 +25,7 @@ import reducer, {
   setCompletionSound,
   setRetainCompletedInList,
   setSoundMoment,
+  setAllSoundMoments,
   setSoundTimbre,
   setSoundVolume,
   type PreferencesState,
@@ -104,6 +105,36 @@ describe('preferencesSlice', () => {
     // Assert — the object is rebuilt from defaults with only task-create flipped.
     expect(next.soundMoments).toEqual({
       'task-create': true,
+      complete: false,
+      clear: false,
+    })
+  })
+
+  it('turns on every sound moment at once when the master toggle is enabled', () => {
+    // Act — flip the master "All cues" switch on from a silent default.
+    const next = reducer(initialState, setAllSoundMoments(true))
+
+    // Assert — all three cues are now on.
+    expect(next.soundMoments).toEqual({
+      'task-create': true,
+      complete: true,
+      clear: true,
+    })
+  })
+
+  it('silences every sound moment at once when the master toggle is disabled', () => {
+    // Arrange — a palette with all three cues currently on.
+    const allCuesOnState: PreferencesState = {
+      ...initialState,
+      soundMoments: { 'task-create': true, complete: true, clear: true },
+    }
+
+    // Act — flip the master "All cues" switch off.
+    const next = reducer(allCuesOnState, setAllSoundMoments(false))
+
+    // Assert — every cue is now off (a silent palette).
+    expect(next.soundMoments).toEqual({
+      'task-create': false,
       complete: false,
       clear: false,
     })

--- a/src/lib/redux/slices/preferencesSlice.ts
+++ b/src/lib/redux/slices/preferencesSlice.ts
@@ -95,6 +95,26 @@ export const preferencesSlice = createSlice({
     },
 
     /**
+     * Flips EVERY sound moment on or off in one write — the master "All cues"
+     * toggle. Writes the explicit literal (not a spread over the current object)
+     * so a stale/missing `soundMoments` can't leave a moment behind; the
+     * `satisfies Record<SoundMomentId, boolean>` mirrors the schema default and
+     * fails compilation if the moment set ever drifts from SOUND_MOMENT_IDS.
+     * @param state - Current state
+     * @param action - Payload: whether all cues should play.
+     * @example
+     * dispatch(setAllSoundMoments(true))  // every cue ON
+     * dispatch(setAllSoundMoments(false)) // every cue OFF (a silent palette)
+     */
+    setAllSoundMoments: (state, action: PayloadAction<boolean>) => {
+      state.soundMoments = {
+        'task-create': action.payload,
+        complete: action.payload,
+        clear: action.payload,
+      } satisfies Record<SoundMomentId, boolean>
+    },
+
+    /**
      * Selects the active timbre for every enabled moment.
      * @param state - Current state
      * @param action - Payload containing the new timbre id.
@@ -209,6 +229,7 @@ export const {
   setCompletionSound,
   setRetainCompletedInList,
   setSoundMoment,
+  setAllSoundMoments,
   setSoundTimbre,
   setSoundVolume,
   setBraindumpFontFamily,


### PR DESCRIPTION
## What

Adds a master **"All cues"** Switch at the top of the Preferences → Sound section that flips all three sound-moment cues (`task-create`, `complete`, `clear`) on or off in one tap.

## Why

The sound palette has three independent per-moment toggles, so turning the whole palette on or off meant three taps. This is the requested one-switch affordance (`PreferenceのSoundに全Sound項目を一括でトグルするSwitchを設置する`).

## How

- **`preferencesSlice`** — new `setAllSoundMoments(enabled: boolean)` reducer. Writes the explicit `{ 'task-create', complete, clear }` literal with `satisfies Record<SoundMomentId, boolean>` (mirrors the schema default, so adding a 4th moment fails compilation here instead of silently leaving it behind).
- **`preferences-sync-channel`** — registers `setAllSoundMoments.type` in the broadcast allowlist so the master toggle propagates across windows like the per-moment toggles (the allowlist is manual — a new action stays window-local until added).
- **`PreferencesSettings`** — master "All cues" row above the per-moment toggles, set apart by a quiet divider. `checked` is derived from the **effective-state** selectors (`isTaskCreateSoundOn && isCompleteSoundOn && isClearSoundOn`), so a legacy `completionSound` user still counts as having the complete cue on.

### Semantics

`checked` = **all three on**. From a partial or all-off state the master reads OFF and one tap turns everything on; from all-on, one tap silences the palette. It never claims a partially-on palette is "all".

Default stays OFF — the palette still ships silent (DESIGN.md "Presets First, Then Options"; quiet-companion voice, no reward/achievement language).

## Tests

- `preferencesSlice.test.ts` — 2 specs: master enables all three; master disables all three.
- `PreferencesSettings.test.tsx` — 4 specs: reflects all-on; reads OFF on a partial palette; click-on enables all; click-off silences all.
- `preferences-sync-channel.test.ts` — 1 spec: master toggle propagates to another window.

`pnpm validate` green (test 616 pass / typecheck / build / lint:fix / theme:check).

No version bump (corelive convention — features land unbumped; the release bump is a separate chore + `v*` tag).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a master "All cues" toggle in sound preferences that controls all individual sound moment cues simultaneously
  * Toggle reflects the combined state of all cues and syncs changes across browser windows/tabs

* **Tests**
  * Added comprehensive test coverage for the master toggle behavior, state synchronization, and cross-window sync functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->