### PR TITLE
feat(electron): Keep-on-top preference for Floating Navigator + BrainDump

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -233,6 +233,22 @@ function that will pull it off the deferred list.
       gap), unlike the proven-live `getStartupConfig` crash. A web deploy protects old
       apps once live; users still must update the app to USE the startup settings.
 
+## Electron floating windows
+
+- [ ] **Cross-window live sync for the Keep-on-top toggles.** (deferred — feat/keep-on-top-preference)
+      Surfaced by `/ship` adversarial review (F1). When BOTH the Settings "Keep on
+      top" card AND a floating panel's in-window pin button are open at the same
+      time, toggling one does NOT live-update the other's displayed state (the
+      Settings switch / the pin glyph) until that surface is reopened. PERSISTENCE
+      is always correct — all three layers (config, WindowStateManager.isAlwaysOnTop,
+      live window) are written synchronously on every toggle; only the OTHER open
+      surface's LABEL is stale. Accepted as T2-minimal (plan-approved): the realistic
+      flow opens one surface at a time, and a cross-window broadcast is disproportionate
+      to a label refresh. Full fix: echo each pin write over the existing preferences
+      BroadcastChannel (or a main→renderer push) so every open surface re-reads.
+      Forcing function: a user report of a stale toggle, or the next feature needing
+      main→all-renderers preference mirroring. Effort: ~1-2h CC + a multi-window E2E.
+
 - [x] **error.tsx / global-error.tsx design sign-off + reset() escape hatch.** ✅ 2026-06-11 (feat/deferred-a11y-polish-and-tz)
       The two error boundaries shipped with placeholder copy/styling and only a
       `reset()` affordance, which DEAD-ENDS on a deterministic error (e.g. the

--- a/electron/ConfigManager.ts
+++ b/electron/ConfigManager.ts
@@ -83,6 +83,8 @@ export interface BrainDumpConfig {
   height: number
   /** Keep the BrainDump panel visible while macOS Spaces change. */
   visibleOnAllWorkspaces: boolean
+  /** Keep the BrainDump panel pinned above other windows (default off). */
+  alwaysOnTop: boolean
   /** Window opacity, clamped 0.30–1.00 to keep the window discoverable. */
   opacity: number
   /** When true, BrainDump mirrors FloatingNavigator's selected category. */
@@ -377,6 +379,8 @@ export class ConfigManager {
         width: 480,
         height: 640,
         visibleOnAllWorkspaces: false,
+        // Default OFF: BrainDump stays unpinned unless the user opts in.
+        alwaysOnTop: false,
         opacity: 0.95,
         syncMode: true,
         shortcut: 'Alt+Space',

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -585,6 +585,13 @@ export class WindowManager {
         ),
       },
       frame: floatingConfig.frame,
+      // Sole pin-source for users upgrading from a build that predates this
+      // preference: their saved window-state has no isAlwaysOnTop field, so
+      // applyWindowState's `typeof === 'boolean'` guard skips it and CANNOT
+      // re-pin. This line must stay AFTER the ...windowOptions spread (which
+      // carries getWindowOptions' `alwaysOnTop: undefined` on upgrade) and must
+      // NOT be folded into it — doing so hands the ctor `undefined` (unpinned).
+      // Locked by the upgrade test in WindowManager.always-on-top.test.ts.
       alwaysOnTop: floatingConfig.alwaysOnTop,
       skipTaskbar: true,
       resizable: floatingConfig.resizable,

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -196,6 +196,22 @@ export class WindowManager {
   }
 
   /**
+   * Applies the always-on-top flag to a live panel window (no-op when the window
+   * is absent or destroyed). Sibling of {@link applyVisibleOnAllWorkspaces}.
+   * @param browserWindow - Target panel window, or null when not open.
+   * @param enabled - true pins the window above others; false unpins it.
+   */
+  private applyAlwaysOnTop(
+    browserWindow: BrowserWindow | null,
+    enabled: boolean,
+  ): void {
+    if (!browserWindow || browserWindow.isDestroyed()) return
+    // setAlwaysOnTop defaults to the 'floating' window level when enabled —
+    // the correct level for these utility panels.
+    browserWindow.setAlwaysOnTop(enabled)
+  }
+
+  /**
    * Reads whether both floating panels should follow macOS Spaces.
    *
    * The Settings UI presents this as a single switch, while the config stores
@@ -243,6 +259,71 @@ export class WindowManager {
     this.applyVisibleOnAllWorkspaces(this.floatingNavigator, enabled)
     this.applyVisibleOnAllWorkspaces(this.brainDumpWindow, enabled)
 
+    return enabled
+  }
+
+  /**
+   * Reads BrainDump's always-on-top preference (config-backed, default off).
+   * BrainDump has no in-window pin control, so config is the single source of truth.
+   * @returns true when the BrainDump panel is pinned above other windows.
+   */
+  getBrainDumpAlwaysOnTop(): boolean {
+    return (
+      this.configManager?.get<boolean>('braindump.alwaysOnTop', false) ?? false
+    )
+  }
+
+  /**
+   * Persists + applies BrainDump's always-on-top preference.
+   * @param enabled - true pins BrainDump above other windows; false unpins it.
+   * @returns The applied value (echoed for optimistic-UI confirmation).
+   */
+  setBrainDumpAlwaysOnTop(enabled: boolean): boolean {
+    if (this.configManager) {
+      this.configManager.set('braindump.alwaysOnTop', enabled)
+    }
+    this.applyAlwaysOnTop(this.brainDumpWindow, enabled)
+    return enabled
+  }
+
+  /**
+   * Reads FloatingNavigator's effective always-on-top state.
+   * @returns
+   * - the live window's `isAlwaysOnTop()` when the panel is open
+   * - else the persisted WindowStateManager value (what relaunch will re-apply)
+   * - else the config default (true)
+   */
+  getFloatingNavigatorAlwaysOnTop(): boolean {
+    if (this.floatingNavigator && !this.floatingNavigator.isDestroyed()) {
+      return this.floatingNavigator.isAlwaysOnTop()
+    }
+    const persisted =
+      this.windowStateManager?.getWindowState('floating')?.isAlwaysOnTop
+    if (typeof persisted === 'boolean') return persisted
+    return (
+      this.configManager?.get<boolean>('window.floating.alwaysOnTop', true) ??
+      true
+    )
+  }
+
+  /**
+   * Persists + applies FloatingNavigator's always-on-top preference across all
+   * three layers that decide its relaunch state — config seed, window-state.json,
+   * and the live window. The window-state write is load-bearing: `getWindowOptions`
+   * reads `state.isAlwaysOnTop` at create and main re-applies it post-create, so a
+   * config-only write would be silently overridden after the first launch.
+   * @param enabled - true pins FloatingNavigator above others; false unpins it.
+   * @returns The applied value (echoed for optimistic-UI confirmation).
+   */
+  setFloatingNavigatorAlwaysOnTop(enabled: boolean): boolean {
+    if (this.configManager) {
+      this.configManager.set('window.floating.alwaysOnTop', enabled)
+    }
+    // Load-bearing — without this, relaunch re-pins from the persisted state.
+    this.windowStateManager?.setWindowState('floating', {
+      isAlwaysOnTop: enabled,
+    })
+    this.applyAlwaysOnTop(this.floatingNavigator, enabled)
     return enabled
   }
 
@@ -602,7 +683,7 @@ export class WindowManager {
           minHeight: 320,
           maxWidth: 1200,
           frame: false,
-          alwaysOnTop: true,
+          alwaysOnTop: this.getBrainDumpAlwaysOnTop(),
           resizable: true,
           skipTaskbar: true,
         }
@@ -638,7 +719,7 @@ export class WindowManager {
         ),
       },
       frame: false,
-      alwaysOnTop: true,
+      alwaysOnTop: this.getBrainDumpAlwaysOnTop(),
       skipTaskbar: true,
       resizable: true,
       show: false,

--- a/electron/WindowStateManager.ts
+++ b/electron/WindowStateManager.ts
@@ -689,7 +689,13 @@ export class WindowStateManager {
         y: state.y,
         show: false,
         frame: false,
-        alwaysOnTop: true,
+        // Honor the BrainDump always-on-top preference (default off) instead of
+        // hardcoding true — pairs with the createBrainDumpWindow ctor read so the
+        // options path and the constructor agree.
+        alwaysOnTop: this.configManager.get<boolean>(
+          'braindump.alwaysOnTop',
+          false,
+        ),
         resizable: true,
         skipTaskbar: true,
       } satisfies WindowOptions

--- a/electron/__tests__/ConfigManager.always-on-top.test.ts
+++ b/electron/__tests__/ConfigManager.always-on-top.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview BrainDump always-on-top config default + migration tests.
+ *
+ * Locks the contract that BrainDump ships UNPINNED (`alwaysOnTop=false`) and that
+ * a pre-feature `config.json` lacking the key migrates to false — never
+ * resurrects a stale `true`. Guards the 「固定しない」 default this preference exists
+ * to deliver.
+ *
+ * Triggered when: `pnpm test:electron` (Vitest).
+ *
+ * @example
+ *   pnpm test:electron -- ConfigManager.always-on-top
+ */
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// A mutable holder so the hoisted electron mock resolves a fresh temp userData
+// directory per test (vi.mock factories cannot close over later-declared vars).
+const userDataDir = vi.hoisted(() => ({ current: '' }))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => userDataDir.current),
+  },
+}))
+
+// Silence the real pino logger so config-load warnings never spew into output.
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+// Imported after the mock so ConfigManager's `import { app }` is stubbed.
+import { ConfigManager } from '../ConfigManager'
+
+/**
+ * Writes a raw config.json into the active temp userData dir so the next
+ * `new ConfigManager()` loads (and migrates/merges) it from disk.
+ *
+ * @param rawConfig - Partial config object to persist verbatim.
+ */
+function writeConfigFile(rawConfig: Record<string, unknown>): void {
+  fs.writeFileSync(
+    path.join(userDataDir.current, 'config.json'),
+    JSON.stringify(rawConfig),
+    'utf8',
+  )
+}
+
+describe('ConfigManager BrainDump always-on-top', () => {
+  beforeEach(() => {
+    // Arrange: isolate every test in its own temp userData directory.
+    userDataDir.current = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'corelive-config-'),
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(userDataDir.current, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it('ships BrainDump unpinned by default', () => {
+    // Arrange
+    const configManager = new ConfigManager()
+
+    // Act
+    const braindump = configManager.getDefaultConfig().braindump
+
+    // Assert: a `true` default would pin BrainDump on a fresh install — the exact
+    // behavior this preference was added to avoid.
+    expect(braindump.alwaysOnTop).toBe(false)
+  })
+
+  it('migrates a pre-feature config without braindump.alwaysOnTop to false, never stale-true', () => {
+    // Arrange: a config.json written before the field existed — its braindump
+    // block carries every sibling key BUT alwaysOnTop.
+    writeConfigFile({
+      braindump: {
+        width: 480,
+        height: 640,
+        visibleOnAllWorkspaces: false,
+        opacity: 0.95,
+        syncMode: true,
+        shortcut: 'Alt+Space',
+        lastCategoryId: null,
+        notes: {},
+      },
+    })
+
+    // Act: loading merges the partial config over the defaults.
+    const configManager = new ConfigManager()
+
+    // Assert: the absent key resolves to the false default (passing `true` as the
+    // lookup default proves the value is genuinely present-and-false, not falling
+    // back) — the merge seeds from defaults and only overlays present keys.
+    expect(configManager.get('braindump.alwaysOnTop', true)).toBe(false)
+  })
+
+  it('preserves an explicit braindump.alwaysOnTop=true opt-in from a saved config', () => {
+    // Arrange: a user who turned BrainDump pinning on persists true.
+    writeConfigFile({ braindump: { alwaysOnTop: true } })
+
+    // Act
+    const configManager = new ConfigManager()
+
+    // Assert: the migration fills absences only — an explicit opt-in survives.
+    expect(configManager.get('braindump.alwaysOnTop', false)).toBe(true)
+  })
+})

--- a/electron/__tests__/ConfigManager.always-on-top.test.ts
+++ b/electron/__tests__/ConfigManager.always-on-top.test.ts
@@ -3,8 +3,8 @@
  *
  * Locks the contract that BrainDump ships UNPINNED (`alwaysOnTop=false`) and that
  * a pre-feature `config.json` lacking the key migrates to false — never
- * resurrects a stale `true`. Guards the 「固定しない」 default this preference exists
- * to deliver.
+ * resurrects a stale `true`. Guards the "off by default" (unpinned) behavior
+ * this preference exists to deliver.
  *
  * Triggered when: `pnpm test:electron` (Vitest).
  *

--- a/electron/__tests__/WindowManager.always-on-top.test.ts
+++ b/electron/__tests__/WindowManager.always-on-top.test.ts
@@ -1,0 +1,278 @@
+/**
+ * @fileoverview FloatingNavigator + BrainDump always-on-top WindowManager tests.
+ *
+ * The crux sentinel: FloatingNavigator's always-on-top must persist to the
+ * WindowStateManager, not just config — otherwise the preference is a silent
+ * no-op after the first launch, because `window-state.json` overrides config at
+ * relaunch. A config-only setter would pass typecheck and look correct, yet
+ * re-pin the window on the next boot. These tests fail if that regression
+ * returns. They also lock the BrainDump window's constructor to a config read
+ * (no hardcoded `alwaysOnTop: true` shadow) and the getters to the right source
+ * of truth.
+ *
+ * Triggered when: `pnpm test:electron` (Vitest).
+ *
+ * @example
+ *   pnpm test:electron -- WindowManager.always-on-top
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Spy = ReturnType<typeof vi.fn>
+
+/** The slice of the BrowserWindow surface these always-on-top paths touch. */
+interface MockBrowserWindow {
+  setAlwaysOnTop: Spy
+  isAlwaysOnTop: Spy
+  isDestroyed: Spy
+  setOpacity: Spy
+  getOpacity: Spy
+  setVisibleOnAllWorkspaces: Spy
+  loadURL: Spy
+  on: Spy
+  webContents: { on: Spy }
+}
+
+/** Every constructed window plus the options it was constructed with. */
+interface CapturedMockWindow {
+  win: MockBrowserWindow
+  options: Record<string, unknown>
+}
+
+const createdWindows: CapturedMockWindow[] = []
+
+// BrowserWindow mock: records constructor options so the shadow-trap test can
+// assert the `alwaysOnTop` the window was actually built with.
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(function (options: Record<string, unknown>) {
+    const win: MockBrowserWindow = {
+      setAlwaysOnTop: vi.fn(),
+      // Mirrors the constructed flag so a "live window" reports what it was built with.
+      isAlwaysOnTop: vi.fn(() => Boolean(options.alwaysOnTop)),
+      isDestroyed: vi.fn(() => false),
+      setOpacity: vi.fn(),
+      getOpacity: vi.fn(() => 1),
+      setVisibleOnAllWorkspaces: vi.fn(),
+      loadURL: vi.fn(),
+      on: vi.fn(),
+      webContents: { on: vi.fn() },
+    }
+    createdWindows.push({ win, options })
+    return win
+  }),
+  screen: {
+    getPrimaryDisplay: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+    getDisplayNearestPoint: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+  },
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+// Imported after the mocks so WindowManager's `import { BrowserWindow }` is stubbed.
+import type { ConfigManager } from '../ConfigManager'
+import { WindowManager } from '../WindowManager'
+import type { WindowStateManager } from '../WindowStateManager'
+
+const SERVER_URL = 'https://corelive.app'
+
+/**
+ * Builds a ConfigManager stub backed by an in-memory store so `set` followed by
+ * `get` round-trips, and both are observable spies.
+ *
+ * @param values - Initial config values keyed by dotted path.
+ * @returns The stub plus its `get`/`set` spies for assertions.
+ */
+function createConfigStub(values: Record<string, unknown> = {}): {
+  configManager: ConfigManager
+  get: Spy
+  set: Spy
+} {
+  const store: Record<string, unknown> = { ...values }
+  const get = vi.fn((key: string, fallback?: unknown) =>
+    key in store ? store[key] : fallback,
+  )
+  const set = vi.fn((key: string, value: unknown) => {
+    store[key] = value
+  })
+  const configManager = {
+    get,
+    set,
+    getSection: vi.fn(() => ({})),
+  } as unknown as ConfigManager
+  return { configManager, get, set }
+}
+
+/**
+ * Builds a WindowStateManager stub whose `getWindowState('floating')` returns a
+ * fixed state, with an observable `setWindowState` spy.
+ *
+ * @param floatingState - The persisted floating state, or null when none saved.
+ * @returns The stub plus its `getWindowState`/`setWindowState` spies.
+ */
+function createWindowStateStub(
+  floatingState: { isAlwaysOnTop?: boolean } | null = null,
+): {
+  windowStateManager: WindowStateManager
+  getWindowState: Spy
+  setWindowState: Spy
+} {
+  const getWindowState = vi.fn(() => floatingState)
+  const setWindowState = vi.fn(() => true)
+  const windowStateManager = {
+    getWindowState,
+    setWindowState,
+  } as unknown as WindowStateManager
+  return { windowStateManager, getWindowState, setWindowState }
+}
+
+describe('WindowManager always-on-top', () => {
+  beforeEach(() => {
+    createdWindows.length = 0
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('setFloatingNavigatorAlwaysOnTop', () => {
+    it('persists to BOTH config and window-state so the choice survives relaunch', () => {
+      // Arrange: floating window closed, so only the persisted layers are written.
+      const { configManager, set } = createConfigStub()
+      const { windowStateManager, setWindowState } = createWindowStateStub()
+      const windowManager = new WindowManager(
+        SERVER_URL,
+        configManager,
+        windowStateManager,
+      )
+
+      // Act: the user turns OFF always-on-top from Settings.
+      const applied = windowManager.setFloatingNavigatorAlwaysOnTop(false)
+
+      // Assert: the window-state write is the load-bearing one — getWindowOptions
+      // reads `state.isAlwaysOnTop` at relaunch, so a config-only setter would
+      // silently re-pin on the next boot. A regression to config-only fails here.
+      expect(applied).toBe(false)
+      expect(set).toHaveBeenCalledWith('window.floating.alwaysOnTop', false)
+      expect(setWindowState).toHaveBeenCalledWith('floating', {
+        isAlwaysOnTop: false,
+      })
+    })
+  })
+
+  describe('setBrainDumpAlwaysOnTop', () => {
+    it('persists to config and applies to the open BrainDump window', () => {
+      // Arrange: BrainDump starts unpinned, then is opened.
+      const { configManager, set } = createConfigStub({
+        'braindump.alwaysOnTop': false,
+      })
+      const windowManager = new WindowManager(SERVER_URL, configManager, null)
+      windowManager.createBrainDumpWindow()
+      const brainDumpWindow = createdWindows[0]
+      if (!brainDumpWindow) throw new Error('Expected a BrainDump window')
+
+      // Act: the user pins BrainDump.
+      const applied = windowManager.setBrainDumpAlwaysOnTop(true)
+
+      // Assert: config is updated AND the live window is re-pinned immediately.
+      expect(applied).toBe(true)
+      expect(set).toHaveBeenCalledWith('braindump.alwaysOnTop', true)
+      expect(brainDumpWindow.win.setAlwaysOnTop).toHaveBeenCalledWith(true)
+    })
+  })
+
+  describe('getBrainDumpAlwaysOnTop', () => {
+    it('reads the persisted BrainDump pin from config', () => {
+      // Arrange: a user who opted in.
+      const { configManager } = createConfigStub({
+        'braindump.alwaysOnTop': true,
+      })
+      const windowManager = new WindowManager(SERVER_URL, configManager, null)
+
+      // Act + Assert
+      expect(windowManager.getBrainDumpAlwaysOnTop()).toBe(true)
+    })
+
+    it('defaults to unpinned when config has no BrainDump pin', () => {
+      // Arrange: a fresh install with no saved value.
+      const { configManager } = createConfigStub()
+      const windowManager = new WindowManager(SERVER_URL, configManager, null)
+
+      // Act + Assert: the false default serves the 「固定しない」 behavior.
+      expect(windowManager.getBrainDumpAlwaysOnTop()).toBe(false)
+    })
+  })
+
+  describe('getFloatingNavigatorAlwaysOnTop', () => {
+    it('prefers the persisted window-state over config when the window is closed', () => {
+      // Arrange: config says pinned, but the saved window-state says unpinned —
+      // the saved state is what relaunch will re-apply, so it must win.
+      const { configManager } = createConfigStub({
+        'window.floating.alwaysOnTop': true,
+      })
+      const { windowStateManager } = createWindowStateStub({
+        isAlwaysOnTop: false,
+      })
+      const windowManager = new WindowManager(
+        SERVER_URL,
+        configManager,
+        windowStateManager,
+      )
+
+      // Act + Assert: the persisted state (false) wins over the config (true).
+      expect(windowManager.getFloatingNavigatorAlwaysOnTop()).toBe(false)
+    })
+
+    it('defaults to pinned when nothing is persisted (preserves current behavior)', () => {
+      // Arrange: no saved window-state and no config value.
+      const { configManager } = createConfigStub()
+      const { windowStateManager } = createWindowStateStub(null)
+      const windowManager = new WindowManager(
+        SERVER_URL,
+        configManager,
+        windowStateManager,
+      )
+
+      // Act + Assert: Floating Navigator defaults ON, matching its pre-feature behavior.
+      expect(windowManager.getFloatingNavigatorAlwaysOnTop()).toBe(true)
+    })
+  })
+
+  describe('createBrainDumpWindow', () => {
+    it('constructs the BrainDump window unpinned when config is off (no hardcoded shadow)', () => {
+      // Arrange: BrainDump pin OFF in config; no WindowStateManager, so the
+      // constructor path (not getWindowOptions) decides alwaysOnTop.
+      const { configManager } = createConfigStub({
+        'braindump.alwaysOnTop': false,
+      })
+      const windowManager = new WindowManager(SERVER_URL, configManager, null)
+
+      // Act
+      windowManager.createBrainDumpWindow()
+
+      // Assert: the window was built unpinned — proving the constructor reads
+      // config and the old hardcoded `alwaysOnTop: true` no longer shadows it.
+      expect(createdWindows).toHaveLength(1)
+      expect(createdWindows[0]?.options.alwaysOnTop).toBe(false)
+    })
+
+    it('constructs the BrainDump window pinned when config opts in', () => {
+      // Arrange: BrainDump pin ON in config.
+      const { configManager } = createConfigStub({
+        'braindump.alwaysOnTop': true,
+      })
+      const windowManager = new WindowManager(SERVER_URL, configManager, null)
+
+      // Act
+      windowManager.createBrainDumpWindow()
+
+      // Assert: the opt-in flows through to the constructed window.
+      expect(createdWindows).toHaveLength(1)
+      expect(createdWindows[0]?.options.alwaysOnTop).toBe(true)
+    })
+  })
+})

--- a/electron/__tests__/WindowManager.always-on-top.test.ts
+++ b/electron/__tests__/WindowManager.always-on-top.test.ts
@@ -85,9 +85,16 @@ const SERVER_URL = 'https://corelive.app'
  * `get` round-trips, and both are observable spies.
  *
  * @param values - Initial config values keyed by dotted path.
+ * @param windowSection - What `getSection('window')` returns; pass
+ *   `{ floating: {...} }` for the `createFloatingNavigator` construction tests,
+ *   which read `getSection('window').floating`. Defaults to `{}` so the
+ *   non-construction callers stay unaffected.
  * @returns The stub plus its `get`/`set` spies for assertions.
  */
-function createConfigStub(values: Record<string, unknown> = {}): {
+function createConfigStub(
+  values: Record<string, unknown> = {},
+  windowSection: Record<string, unknown> = {},
+): {
   configManager: ConfigManager
   get: Spy
   set: Spy
@@ -102,32 +109,50 @@ function createConfigStub(values: Record<string, unknown> = {}): {
   const configManager = {
     get,
     set,
-    getSection: vi.fn(() => ({})),
+    getSection: vi.fn(() => windowSection),
   } as unknown as ConfigManager
   return { configManager, get, set }
 }
 
 /**
  * Builds a WindowStateManager stub whose `getWindowState('floating')` returns a
- * fixed state, with an observable `setWindowState` spy.
+ * fixed state, with observable spies. Also stubs `getWindowOptions` (spread into
+ * the BrowserWindow ctor) and `applyWindowState` so the `createFloatingNavigator`
+ * construction tests can build a window through this manager.
  *
  * @param floatingState - The persisted floating state, or null when none saved.
- * @returns The stub plus its `getWindowState`/`setWindowState` spies.
+ * @param windowOptions - What `getWindowOptions('floating')` returns; the
+ *   construction tests pass bounds with `alwaysOnTop: undefined` to model a
+ *   saved state that predates the always-on-top field (the upgrade path).
+ * @returns The stub plus its observable spies.
  */
 function createWindowStateStub(
   floatingState: { isAlwaysOnTop?: boolean } | null = null,
+  windowOptions: Record<string, unknown> = {},
 ): {
   windowStateManager: WindowStateManager
   getWindowState: Spy
   setWindowState: Spy
+  getWindowOptions: Spy
+  applyWindowState: Spy
 } {
   const getWindowState = vi.fn(() => floatingState)
   const setWindowState = vi.fn(() => true)
+  const getWindowOptions = vi.fn(() => windowOptions)
+  const applyWindowState = vi.fn(() => true)
   const windowStateManager = {
     getWindowState,
     setWindowState,
+    getWindowOptions,
+    applyWindowState,
   } as unknown as WindowStateManager
-  return { windowStateManager, getWindowState, setWindowState }
+  return {
+    windowStateManager,
+    getWindowState,
+    setWindowState,
+    getWindowOptions,
+    applyWindowState,
+  }
 }
 
 describe('WindowManager always-on-top', () => {
@@ -161,6 +186,56 @@ describe('WindowManager always-on-top', () => {
       expect(setWindowState).toHaveBeenCalledWith('floating', {
         isAlwaysOnTop: false,
       })
+    })
+
+    it('applies to the open floating window alongside the config and window-state writes', () => {
+      // Arrange: a floating window is open. getSection feeds the ctor a pinned
+      // floating config; getWindowOptions feeds matching bounds.
+      const { configManager, set } = createConfigStub(
+        {},
+        {
+          floating: {
+            frame: false,
+            alwaysOnTop: true,
+            resizable: true,
+            maxWidth: 400,
+          },
+        },
+      )
+      const { windowStateManager, setWindowState } = createWindowStateStub(
+        { isAlwaysOnTop: true },
+        {
+          width: 300,
+          height: 400,
+          maxWidth: 400,
+          frame: false,
+          alwaysOnTop: true,
+          resizable: true,
+          skipTaskbar: true,
+        },
+      )
+      const windowManager = new WindowManager(
+        SERVER_URL,
+        configManager,
+        windowStateManager,
+      )
+      windowManager.createFloatingNavigator()
+      const floatingWindow = createdWindows[0]
+      if (!floatingWindow) throw new Error('Expected a floating window')
+
+      // Act: the user turns OFF always-on-top while the window is open.
+      const applied = windowManager.setFloatingNavigatorAlwaysOnTop(false)
+
+      // Assert: all three layers update together — config, the load-bearing
+      // window-state, AND the live window — so the unpin is visible immediately,
+      // not only after the next relaunch. A setter that skipped the live window
+      // would leave the open panel pinned until restart.
+      expect(applied).toBe(false)
+      expect(set).toHaveBeenCalledWith('window.floating.alwaysOnTop', false)
+      expect(setWindowState).toHaveBeenCalledWith('floating', {
+        isAlwaysOnTop: false,
+      })
+      expect(floatingWindow.win.setAlwaysOnTop).toHaveBeenCalledWith(false)
     })
   })
 
@@ -240,6 +315,46 @@ describe('WindowManager always-on-top', () => {
       // Act + Assert: Floating Navigator defaults ON, matching its pre-feature behavior.
       expect(windowManager.getFloatingNavigatorAlwaysOnTop()).toBe(true)
     })
+
+    it('reads the live floating window over config and persisted state when it is open', () => {
+      // Arrange: an open floating window built UNPINNED (the floating section's
+      // alwaysOnTop is false), while BOTH the config value and the persisted
+      // window-state say pinned. Only the live-window branch can return false.
+      const { configManager } = createConfigStub(
+        { 'window.floating.alwaysOnTop': true },
+        {
+          floating: {
+            frame: false,
+            alwaysOnTop: false,
+            resizable: true,
+            maxWidth: 400,
+          },
+        },
+      )
+      const { windowStateManager } = createWindowStateStub(
+        { isAlwaysOnTop: true },
+        {
+          width: 300,
+          height: 400,
+          maxWidth: 400,
+          frame: false,
+          alwaysOnTop: false,
+          resizable: true,
+          skipTaskbar: true,
+        },
+      )
+      const windowManager = new WindowManager(
+        SERVER_URL,
+        configManager,
+        windowStateManager,
+      )
+      windowManager.createFloatingNavigator()
+
+      // Act + Assert: the live window (false) wins over config (true) and the
+      // persisted state (true) — the open-window branch short-circuits before
+      // either is consulted, so the Settings switch mirrors the real window.
+      expect(windowManager.getFloatingNavigatorAlwaysOnTop()).toBe(false)
+    })
   })
 
   describe('createBrainDumpWindow', () => {
@@ -271,6 +386,55 @@ describe('WindowManager always-on-top', () => {
       windowManager.createBrainDumpWindow()
 
       // Assert: the opt-in flows through to the constructed window.
+      expect(createdWindows).toHaveLength(1)
+      expect(createdWindows[0]?.options.alwaysOnTop).toBe(true)
+    })
+  })
+
+  describe('createFloatingNavigator', () => {
+    it('constructs the floating window PINNED on upgrade when the saved state predates always-on-top', () => {
+      // Arrange: an upgrading user. window-state.json has saved bounds but no
+      // `isAlwaysOnTop` (it predates this feature), so getWindowOptions yields
+      // `alwaysOnTop: undefined`; config still carries the default true.
+      const { configManager } = createConfigStub(
+        {},
+        {
+          floating: {
+            frame: false,
+            alwaysOnTop: true,
+            resizable: true,
+            maxWidth: 400,
+          },
+        },
+      )
+      const { windowStateManager } = createWindowStateStub(
+        {},
+        {
+          width: 300,
+          height: 400,
+          x: 100,
+          y: 100,
+          maxWidth: 400,
+          frame: false,
+          alwaysOnTop: undefined,
+          resizable: true,
+          skipTaskbar: true,
+        },
+      )
+      const windowManager = new WindowManager(
+        SERVER_URL,
+        configManager,
+        windowStateManager,
+      )
+
+      // Act
+      windowManager.createFloatingNavigator()
+
+      // Assert: built PINNED. The ctor spreads getWindowOptions (alwaysOnTop:
+      // undefined) FIRST, then sets `alwaysOnTop: floatingConfig.alwaysOnTop`
+      // (config default true) explicitly AFTER. A regression reordering the
+      // spread or dropping that explicit line silently unpins every upgrading
+      // user's floating window on first relaunch — this test fails if so.
       expect(createdWindows).toHaveLength(1)
       expect(createdWindows[0]?.options.alwaysOnTop).toBe(true)
     })

--- a/electron/__tests__/WindowManager.always-on-top.test.ts
+++ b/electron/__tests__/WindowManager.always-on-top.test.ts
@@ -277,7 +277,7 @@ describe('WindowManager always-on-top', () => {
       const { configManager } = createConfigStub()
       const windowManager = new WindowManager(SERVER_URL, configManager, null)
 
-      // Act + Assert: the false default serves the 「固定しない」 behavior.
+      // Act + Assert: the false default serves the "unpinned by default" behavior.
       expect(windowManager.getBrainDumpAlwaysOnTop()).toBe(false)
     })
   })

--- a/electron/__tests__/ipc-contract.test.ts
+++ b/electron/__tests__/ipc-contract.test.ts
@@ -133,6 +133,25 @@ describe('IPC contract', () => {
       expect(() => setVisibleOnAllWorkspaces.parse([])).toThrow(ZodError)
     })
 
+    it('requires boolean for floating-window-set-always-on-top', () => {
+      const setAlwaysOnTop =
+        IPC_ARG_SCHEMAS['floating-window-set-always-on-top']
+      expect(() => setAlwaysOnTop.parse([true])).not.toThrow()
+      expect(() => setAlwaysOnTop.parse([false])).not.toThrow()
+      // A malicious renderer cannot smuggle a non-boolean past the trust boundary.
+      expect(() => setAlwaysOnTop.parse(['true'])).toThrow(ZodError)
+      expect(() => setAlwaysOnTop.parse([])).toThrow(ZodError)
+    })
+
+    it('requires boolean for braindump-window-set-always-on-top', () => {
+      const setAlwaysOnTop =
+        IPC_ARG_SCHEMAS['braindump-window-set-always-on-top']
+      expect(() => setAlwaysOnTop.parse([true])).not.toThrow()
+      expect(() => setAlwaysOnTop.parse([false])).not.toThrow()
+      expect(() => setAlwaysOnTop.parse(['true'])).toThrow(ZodError)
+      expect(() => setAlwaysOnTop.parse([])).toThrow(ZodError)
+    })
+
     it('accepts enum-constrained window state channel names', () => {
       const windowStateGet = IPC_ARG_SCHEMAS['window-state-get']
       expect(() => windowStateGet.parse(['main'])).not.toThrow()

--- a/electron/ipc/ipc-schemas.ts
+++ b/electron/ipc/ipc-schemas.ts
@@ -286,6 +286,8 @@ export const IPC_ARG_SCHEMAS: Record<IPCChannel, z.ZodTypeAny> = {
     }),
   ]),
   'floating-window-is-always-on-top': z.tuple([]),
+  'floating-window-get-always-on-top': z.tuple([]),
+  'floating-window-set-always-on-top': z.tuple([z.boolean()]),
 
   // ──────────────────────────────────────────────────────────────────────────
   // Window State Management
@@ -343,6 +345,8 @@ export const IPC_ARG_SCHEMAS: Record<IPCChannel, z.ZodTypeAny> = {
   // Opacity is clamped in main; we only validate the bounded range here.
   'braindump-window-set-opacity': z.tuple([z.number().min(0).max(1)]),
   'braindump-window-get-opacity': z.tuple([]),
+  'braindump-window-get-always-on-top': z.tuple([]),
+  'braindump-window-set-always-on-top': z.tuple([z.boolean()]),
   'braindump-window-get-bounds': z.tuple([]),
   'braindump-window-set-bounds': z.tuple([
     z.object({

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1324,12 +1324,13 @@ function setupIPCHandlers(): void {
   typedHandle('floating-window-toggle-always-on-top', () => {
     try {
       if (windowManager && windowManager.hasFloatingNavigator()) {
-        const floatingWindow = windowManager.getFloatingNavigator()
-        if (floatingWindow && !floatingWindow.isDestroyed()) {
-          const isAlwaysOnTop = floatingWindow.isAlwaysOnTop()
-          floatingWindow.setAlwaysOnTop(!isAlwaysOnTop)
-          return !isAlwaysOnTop
-        }
+        // Toggle through the persisting setter (not a bare live-window flip) so
+        // the in-window pin button writes config + window-state + the live
+        // window, exactly like the Settings toggle. Floating isn't saved on
+        // close (only on move/resize), so a bare flip here would be lost on the
+        // next relaunch — contradicting the "survives relaunch" guarantee.
+        const next = !windowManager.getFloatingNavigatorAlwaysOnTop()
+        return windowManager.setFloatingNavigatorAlwaysOnTop(next)
       }
       return false
     } catch (error) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1266,6 +1266,30 @@ function setupIPCHandlers(): void {
     },
   )
 
+  // Always-on-top preference (persisted Settings toggles, per window). The
+  // floating setter writes config + window-state + the live window atomically
+  // inside WindowManager — so relaunch honors it — which is why these handlers
+  // only delegate and never touch WindowStateManager directly.
+  typedHandle('floating-window-get-always-on-top', () => {
+    if (!windowManager) return false
+    return windowManager.getFloatingNavigatorAlwaysOnTop()
+  })
+
+  typedHandle('floating-window-set-always-on-top', (_event, enabled) => {
+    if (!windowManager) return false
+    return windowManager.setFloatingNavigatorAlwaysOnTop(enabled)
+  })
+
+  typedHandle('braindump-window-get-always-on-top', () => {
+    if (!windowManager) return false
+    return windowManager.getBrainDumpAlwaysOnTop()
+  })
+
+  typedHandle('braindump-window-set-always-on-top', (_event, enabled) => {
+    if (!windowManager) return false
+    return windowManager.setBrainDumpAlwaysOnTop(enabled)
+  })
+
   // Floating window control IPC handlers (Zod-validated)
   typedHandle('floating-window-close', () => {
     try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -414,6 +414,55 @@ contextBridge.exposeInMainWorld('electronAPI', {
         throw error
       }
     },
+    /**
+     * Read FloatingNavigator's always-on-top preference (effective state: the
+     * live window when open, else the persisted relaunch value).
+     */
+    getFloatingNavigatorAlwaysOnTop: async (): Promise<boolean> => {
+      try {
+        return await typedInvoke('floating-window-get-always-on-top')
+      } catch (error) {
+        log.error('Failed to get floating navigator always-on-top:', error)
+        // Floating defaults to pinned — fail to its config default.
+        return true
+      }
+    },
+    /** Persist and apply FloatingNavigator's always-on-top preference. */
+    setFloatingNavigatorAlwaysOnTop: async (
+      enabled: boolean,
+    ): Promise<boolean> => {
+      if (typeof enabled !== 'boolean') {
+        throw new Error('FloatingNavigator alwaysOnTop must be a boolean')
+      }
+      try {
+        return await typedInvoke('floating-window-set-always-on-top', enabled)
+      } catch (error) {
+        log.error('Failed to set floating navigator always-on-top:', error)
+        throw error
+      }
+    },
+    /** Read BrainDump's always-on-top preference (config-backed, default off). */
+    getBrainDumpAlwaysOnTop: async (): Promise<boolean> => {
+      try {
+        return await typedInvoke('braindump-window-get-always-on-top')
+      } catch (error) {
+        log.error('Failed to get braindump always-on-top:', error)
+        // BrainDump defaults to unpinned.
+        return false
+      }
+    },
+    /** Persist and apply BrainDump's always-on-top preference. */
+    setBrainDumpAlwaysOnTop: async (enabled: boolean): Promise<boolean> => {
+      if (typeof enabled !== 'boolean') {
+        throw new Error('BrainDump alwaysOnTop must be a boolean')
+      }
+      try {
+        return await typedInvoke('braindump-window-set-always-on-top', enabled)
+      } catch (error) {
+        log.error('Failed to set braindump always-on-top:', error)
+        throw error
+      }
+    },
   },
 
   // System integration APIs

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -303,6 +303,14 @@ export interface ElectronAPI {
     getVisibleOnAllWorkspaces: () => Promise<boolean>
     /** Persist and apply whether both panels follow macOS Spaces. */
     setVisibleOnAllWorkspaces: (enabled: boolean) => Promise<boolean>
+    /** Read FloatingNavigator's always-on-top preference (effective state). */
+    getFloatingNavigatorAlwaysOnTop: () => Promise<boolean>
+    /** Persist and apply FloatingNavigator's always-on-top preference. */
+    setFloatingNavigatorAlwaysOnTop: (enabled: boolean) => Promise<boolean>
+    /** Read BrainDump's always-on-top preference (config-backed, default off). */
+    getBrainDumpAlwaysOnTop: () => Promise<boolean>
+    /** Persist and apply BrainDump's always-on-top preference. */
+    setBrainDumpAlwaysOnTop: (enabled: boolean) => Promise<boolean>
   }
 
   /**

--- a/electron/types/ipc.ts
+++ b/electron/types/ipc.ts
@@ -432,6 +432,20 @@ export interface IPCChannels {
     request: void
     response: boolean
   }
+  /**
+   * Persisted Settings preference for FloatingNavigator's always-on-top state —
+   * distinct from the live `is`/`toggle` pair above. `get` returns the effective
+   * value (live window when open, else the persisted relaunch state); `set`
+   * persists across config + window-state + the live window so relaunch honors it.
+   */
+  'floating-window-get-always-on-top': {
+    request: void
+    response: boolean
+  }
+  'floating-window-set-always-on-top': {
+    request: boolean
+    response: boolean
+  }
 
   // ──────────────────────────────────────────────────────────────────────────
   // BrainDump Window
@@ -457,6 +471,15 @@ export interface IPCChannels {
   'braindump-window-get-opacity': {
     request: void
     response: number
+  }
+  /** Persisted Settings preference: keep BrainDump pinned above other windows. */
+  'braindump-window-get-always-on-top': {
+    request: void
+    response: boolean
+  }
+  'braindump-window-set-always-on-top': {
+    request: boolean
+    response: boolean
   }
   'braindump-window-get-bounds': {
     request: void

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -279,8 +279,8 @@ export const BrainDumpSettings = memo(function BrainDumpSettings({
           BrainDump Note
         </CardTitle>
         <CardDescription>
-          A frameless, always-on-top scratchpad for the active category. Checked
-          items become Completed entries with a 5-second undo window.
+          A frameless scratchpad for the active category. Checked items become
+          Completed entries with a 5-second undo window.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">

--- a/src/components/electron/FloatingWindowSettings.test.tsx
+++ b/src/components/electron/FloatingWindowSettings.test.tsx
@@ -82,7 +82,7 @@ describe('FloatingWindowSettings', () => {
 
   it('reflects saved always-on-top preferences: Floating pinned, BrainDump unpinned', async () => {
     // Arrange: the persisted choice pins Floating Navigator but not BrainDump —
-    // the exact 「固定しない」 default this preference ships for BrainDump.
+    // the exact "off by default" behavior this preference ships for BrainDump.
     installElectronAPI({
       floatingPanels: createBridge({
         getFloatingNavigatorAlwaysOnTop: vi.fn().mockResolvedValue(true),

--- a/src/components/electron/FloatingWindowSettings.test.tsx
+++ b/src/components/electron/FloatingWindowSettings.test.tsx
@@ -96,9 +96,11 @@ describe('FloatingWindowSettings', () => {
     // Assert: each pin switch reads its own saved value, independently — a
     // shared/leaked value would flip one of these.
     const floatingSwitch = await screen.findByRole('switch', {
-      name: 'Floating Navigator',
+      name: 'Keep Floating Navigator on top',
     })
-    const brainDumpSwitch = screen.getByRole('switch', { name: 'BrainDump' })
+    const brainDumpSwitch = screen.getByRole('switch', {
+      name: 'Keep BrainDump on top',
+    })
     expect(floatingSwitch).toBeChecked()
     expect(brainDumpSwitch).not.toBeChecked()
   })
@@ -218,7 +220,7 @@ describe('FloatingWindowSettings', () => {
     const user = userEvent.setup()
     render(<FloatingWindowSettings />)
     const brainDumpSwitch = await screen.findByRole('switch', {
-      name: 'BrainDump',
+      name: 'Keep BrainDump on top',
     })
     expect(brainDumpSwitch).not.toBeChecked()
 
@@ -228,7 +230,7 @@ describe('FloatingWindowSettings', () => {
     // Assert: the switch reverts to unpinned and an error surfaces.
     await waitFor(() => {
       expect(
-        screen.getByRole('switch', { name: 'BrainDump' }),
+        screen.getByRole('switch', { name: 'Keep BrainDump on top' }),
       ).not.toBeChecked()
     })
     expect(

--- a/src/components/electron/FloatingWindowSettings.test.tsx
+++ b/src/components/electron/FloatingWindowSettings.test.tsx
@@ -1,20 +1,47 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { FloatingWindowSettings } from './FloatingWindowSettings'
 
-// Stand-ins for the typed `floatingPanels` preload bridge the component talks to.
-const getVisibleOnAllWorkspacesMock = vi.fn()
-const setVisibleOnAllWorkspacesMock = vi.fn()
-
+/**
+ * The full floating-panels preload bridge this card drives. A CURRENT desktop
+ * preload exposes all six methods; older builds may expose only a subset, which
+ * the component's completeness guard treats as an outdated preload.
+ */
 type FloatingPanelsBridge = {
   getVisibleOnAllWorkspaces: () => Promise<boolean>
   setVisibleOnAllWorkspaces: (value: boolean) => Promise<boolean>
+  getFloatingNavigatorAlwaysOnTop: () => Promise<boolean>
+  setFloatingNavigatorAlwaysOnTop: (value: boolean) => Promise<boolean>
+  getBrainDumpAlwaysOnTop: () => Promise<boolean>
+  setBrainDumpAlwaysOnTop: (value: boolean) => Promise<boolean>
 }
 
 /**
- * Define `window.electronAPI` for a test. Passing `undefined` simulates a web
+ * Builds a complete six-method bridge of resolved spies; a test overrides only
+ * the methods it exercises (a rejecting setter, a never-resolving getter). The
+ * resolved defaults mirror the config defaults: Floating pinned, BrainDump not.
+ *
+ * @param overrides - Per-method spies that replace the resolved defaults.
+ * @returns The bridge object of vi spies.
+ */
+function createBridge(
+  overrides: Partial<FloatingPanelsBridge> = {},
+): FloatingPanelsBridge {
+  return {
+    getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+    setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    getFloatingNavigatorAlwaysOnTop: vi.fn().mockResolvedValue(true),
+    setFloatingNavigatorAlwaysOnTop: vi.fn().mockResolvedValue(true),
+    getBrainDumpAlwaysOnTop: vi.fn().mockResolvedValue(false),
+    setBrainDumpAlwaysOnTop: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  }
+}
+
+/**
+ * Defines `window.electronAPI` for a test. Passing `undefined` simulates a web
  * (non-Electron) renderer where the bridge is missing entirely; a partial
  * `floatingPanels` simulates an outdated desktop preload.
  *
@@ -31,21 +58,16 @@ function installElectronAPI(
 }
 
 describe('FloatingWindowSettings', () => {
-  beforeEach(() => {
-    getVisibleOnAllWorkspacesMock.mockReset()
-    setVisibleOnAllWorkspacesMock.mockReset()
-    // Default: saves succeed; individual tests override when exercising failure.
-    setVisibleOnAllWorkspacesMock.mockResolvedValue(true)
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('reflects the saved macOS Spaces preference once the bridge responds', async () => {
     // Arrange: the saved preference keeps both panels on all desktops.
-    getVisibleOnAllWorkspacesMock.mockResolvedValue(true)
     installElectronAPI({
-      floatingPanels: {
-        getVisibleOnAllWorkspaces: getVisibleOnAllWorkspacesMock,
-        setVisibleOnAllWorkspaces: setVisibleOnAllWorkspacesMock,
-      },
+      floatingPanels: createBridge({
+        getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+      }),
     })
 
     // Act
@@ -56,6 +78,29 @@ describe('FloatingWindowSettings', () => {
       name: 'Show on all Mac desktops',
     })
     expect(desktopSwitch).toBeChecked()
+  })
+
+  it('reflects saved always-on-top preferences: Floating pinned, BrainDump unpinned', async () => {
+    // Arrange: the persisted choice pins Floating Navigator but not BrainDump —
+    // the exact 「固定しない」 default this preference ships for BrainDump.
+    installElectronAPI({
+      floatingPanels: createBridge({
+        getFloatingNavigatorAlwaysOnTop: vi.fn().mockResolvedValue(true),
+        getBrainDumpAlwaysOnTop: vi.fn().mockResolvedValue(false),
+      }),
+    })
+
+    // Act
+    render(<FloatingWindowSettings />)
+
+    // Assert: each pin switch reads its own saved value, independently — a
+    // shared/leaked value would flip one of these.
+    const floatingSwitch = await screen.findByRole('switch', {
+      name: 'Floating Navigator',
+    })
+    const brainDumpSwitch = screen.getByRole('switch', { name: 'BrainDump' })
+    expect(floatingSwitch).toBeChecked()
+    expect(brainDumpSwitch).not.toBeChecked()
   })
 
   it('shows a desktop-only message when the floatingPanels bridge is absent', async () => {
@@ -74,30 +119,47 @@ describe('FloatingWindowSettings', () => {
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
   })
 
-  it('degrades gracefully when an old preload exposes floatingPanels but not getVisibleOnAllWorkspaces', async () => {
-    // Arrange: an OUTDATED desktop app exposes the floatingPanels namespace but
-    // predates the getVisibleOnAllWorkspaces method the load effect calls.
+  it('degrades to an update prompt when the preload predates always-on-top', async () => {
+    // Arrange: an OUTDATED desktop app exposes the original Spaces pair but NOT
+    // the always-on-top methods this card now calls — the realistic preload skew
+    // (frozen installed preload, newer web bundle) the guard exists to survive.
+    installElectronAPI({
+      floatingPanels: {
+        getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+        setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+      },
+    })
+
+    // Act + Assert: mounting must NOT throw a TypeError from calling a missing
+    // method inside the load effect (which would bubble to Next.js global-error
+    // and blank the page). A graceful update card renders, with no switch.
+    render(<FloatingWindowSettings />)
+    expect(
+      await screen.findByText(/Update CoreLive to the latest version/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
+
+  it('degrades to an update prompt when floatingPanels is an empty namespace', async () => {
+    // Arrange: an even older preload exposes the namespace with no methods.
     installElectronAPI({ floatingPanels: {} })
 
-    // Act + Assert: mounting must NOT throw a synchronous TypeError from the load
-    // effect (which would bubble out of useEffect to Next.js global-error and
-    // blank the whole page). A graceful update card must render instead.
+    // Act + Assert: still the update card, never a crash.
     render(<FloatingWindowSettings />)
     expect(
       await screen.findByText(/Update CoreLive to the latest version/i),
     ).toBeInTheDocument()
   })
 
-  it('shows a loading state until the saved Spaces preference arrives', async () => {
-    // Arrange: a never-resolving fetch keeps the card in its loading state.
-    getVisibleOnAllWorkspacesMock.mockReturnValue(
-      new Promise<boolean>(() => {}),
-    )
+  it('shows a loading state until the saved preferences arrive', async () => {
+    // Arrange: a never-resolving getter keeps the card in its loading state,
+    // while the other methods are present so the completeness guard passes.
     installElectronAPI({
-      floatingPanels: {
-        getVisibleOnAllWorkspaces: getVisibleOnAllWorkspacesMock,
-        setVisibleOnAllWorkspaces: setVisibleOnAllWorkspacesMock,
-      },
+      floatingPanels: createBridge({
+        getVisibleOnAllWorkspaces: vi
+          .fn()
+          .mockReturnValue(new Promise<boolean>(() => {})),
+      }),
     })
 
     // Act
@@ -110,18 +172,15 @@ describe('FloatingWindowSettings', () => {
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
   })
 
-  it('rolls the switch back when the main process fails to persist it', async () => {
-    // Arrange: the saved preference is off, and the save will reject — mirroring
-    // StartupWindowSettings' rollback test so both share the same safety net.
-    getVisibleOnAllWorkspacesMock.mockResolvedValue(false)
-    setVisibleOnAllWorkspacesMock.mockRejectedValue(
-      new Error('main process unavailable'),
-    )
+  it('rolls the Spaces switch back when the main process fails to persist it', async () => {
+    // Arrange: the saved preference is off, and the save will reject.
     installElectronAPI({
-      floatingPanels: {
-        getVisibleOnAllWorkspaces: getVisibleOnAllWorkspacesMock,
-        setVisibleOnAllWorkspaces: setVisibleOnAllWorkspacesMock,
-      },
+      floatingPanels: createBridge({
+        getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+        setVisibleOnAllWorkspaces: vi
+          .fn()
+          .mockRejectedValue(new Error('main process unavailable')),
+      }),
     })
     const user = userEvent.setup()
     render(<FloatingWindowSettings />)
@@ -137,6 +196,39 @@ describe('FloatingWindowSettings', () => {
     await waitFor(() => {
       expect(
         screen.getByRole('switch', { name: 'Show on all Mac desktops' }),
+      ).not.toBeChecked()
+    })
+    expect(
+      screen.getByText('Failed to update floating window settings'),
+    ).toBeInTheDocument()
+  })
+
+  it('rolls the BrainDump pin back when the main process fails to persist it', async () => {
+    // Arrange: BrainDump starts unpinned; pinning it will reject in the main
+    // process. Proves the per-key optimistic rollback covers the new pins, not
+    // just the original Spaces toggle.
+    installElectronAPI({
+      floatingPanels: createBridge({
+        getBrainDumpAlwaysOnTop: vi.fn().mockResolvedValue(false),
+        setBrainDumpAlwaysOnTop: vi
+          .fn()
+          .mockRejectedValue(new Error('main process unavailable')),
+      }),
+    })
+    const user = userEvent.setup()
+    render(<FloatingWindowSettings />)
+    const brainDumpSwitch = await screen.findByRole('switch', {
+      name: 'BrainDump',
+    })
+    expect(brainDumpSwitch).not.toBeChecked()
+
+    // Act: try to pin BrainDump; persistence rejects.
+    await user.click(brainDumpSwitch)
+
+    // Assert: the switch reverts to unpinned and an error surfaces.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('switch', { name: 'BrainDump' }),
       ).not.toBeChecked()
     })
     expect(

--- a/src/components/electron/FloatingWindowSettings.tsx
+++ b/src/components/electron/FloatingWindowSettings.tsx
@@ -3,9 +3,10 @@
 /**
  * @fileoverview Floating utility window settings for the Electron Settings page.
  *
- * Surfaces cross-window behavior shared by Floating Navigator and BrainDump.
- * The main process owns the actual BrowserWindow calls so this component only
- * reads and writes the typed preload API.
+ * Surfaces cross-window behavior shared by Floating Navigator and BrainDump:
+ * whether they follow macOS Spaces, and whether each one stays pinned above
+ * other windows. The main process owns the actual BrowserWindow calls so this
+ * component only reads and writes the typed preload API.
  *
  * @module components/electron/FloatingWindowSettings
  */
@@ -31,11 +32,56 @@ interface FloatingWindowSettingsProps {
   className?: string
 }
 
+/** The preload bridge this card drives (reused from the electron-api source of truth). */
+type FloatingPanelsBridge = NonNullable<
+  NonNullable<Window['electronAPI']>['floatingPanels']
+>
+
+/** The three independent preferences this card persists. */
+type PreferenceKey =
+  | 'visibleOnAllWorkspaces'
+  | 'floatingAlwaysOnTop'
+  | 'brainDumpAlwaysOnTop'
+
+/** Persists + applies each preference through the matching preload method. */
+const PREFERENCE_SETTERS: Record<
+  PreferenceKey,
+  (api: FloatingPanelsBridge, next: boolean) => Promise<boolean>
+> = {
+  visibleOnAllWorkspaces: async (api, next) =>
+    api.setVisibleOnAllWorkspaces(next),
+  floatingAlwaysOnTop: async (api, next) =>
+    api.setFloatingNavigatorAlwaysOnTop(next),
+  brainDumpAlwaysOnTop: async (api, next) => api.setBrainDumpAlwaysOnTop(next),
+}
+
+/**
+ * True only when the preload exposes the COMPLETE floating-panels surface this
+ * card needs (the desktop-Spaces pair AND both always-on-top pairs). An outdated
+ * desktop preload that has `floatingPanels` but predates always-on-top degrades
+ * to the update-prompt card instead of throwing inside the load.
+ * @param api - The floatingPanels bridge, or undefined on web / an old preload.
+ * @returns true when every method this card calls is present.
+ */
+function hasCompleteFloatingPanelsApi(
+  api: FloatingPanelsBridge | undefined,
+): api is FloatingPanelsBridge {
+  return (
+    typeof api?.getVisibleOnAllWorkspaces === 'function' &&
+    typeof api?.setVisibleOnAllWorkspaces === 'function' &&
+    typeof api?.getFloatingNavigatorAlwaysOnTop === 'function' &&
+    typeof api?.setFloatingNavigatorAlwaysOnTop === 'function' &&
+    typeof api?.getBrainDumpAlwaysOnTop === 'function' &&
+    typeof api?.setBrainDumpAlwaysOnTop === 'function'
+  )
+}
+
 /**
  * Settings card for Floating Navigator + BrainDump desktop behavior.
  *
- * Loads the persisted macOS Spaces preference from Electron on mount. Toggling
- * the switch persists the value and applies it to any already-open panels.
+ * Loads the persisted Spaces + always-on-top preferences from Electron on mount.
+ * Toggling any switch optimistically updates, persists the value, and rolls back
+ * if the main process rejects the change.
  *
  * @param props - Component props
  * @param props.className - Optional className forwarded to the Card
@@ -47,32 +93,56 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
   className,
 }: FloatingWindowSettingsProps): ReactElement {
   const desktopTrackingId = useId()
+  const floatingPinId = useId()
+  const brainDumpPinId = useId()
   const hasMounted = useMounted()
   const [isReady, setIsReady] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
-  const [visibleOnAllWorkspaces, setVisibleOnAllWorkspaces] = useState(false)
+  // Which preferences have an in-flight save — drives per-row disabled state so
+  // one toggle never freezes the others.
+  const [savingKeys, setSavingKeys] = useState<ReadonlySet<PreferenceKey>>(
+    () => new Set(),
+  )
+  // Defaults mirror the config defaults (floating pinned, BrainDump not) but are
+  // only shown after the mount load resolves real values.
+  const [values, setValues] = useState<Record<PreferenceKey, boolean>>({
+    visibleOnAllWorkspaces: false,
+    floatingAlwaysOnTop: true,
+    brainDumpAlwaysOnTop: false,
+  })
   const [error, setError] = useState<string | null>(null)
 
-  // Fetch once from the preload bridge after mount; the fallback branch below
-  // handles non-Electron renderers without needing a separate effect path.
+  // Fetch all three preferences once after mount; the fallback branches below
+  // handle non-Electron and outdated-preload renderers without a second path.
   useCycleEffect(() => {
     const api =
       typeof window === 'undefined'
         ? undefined
         : window.electronAPI?.floatingPanels
-    // Guard on the METHOD, not just the namespace, so an outdated desktop
-    // preload that exposes `floatingPanels` without getVisibleOnAllWorkspaces
-    // degrades to the fallback card instead of throwing inside this effect.
-    if (typeof api?.getVisibleOnAllWorkspaces !== 'function') return
+    // Guard on the full method set, not just the namespace, so an outdated
+    // desktop preload degrades to the fallback card instead of throwing.
+    if (!hasCompleteFloatingPanelsApi(api)) return
 
     let cancelled = false
 
-    void api
-      .getVisibleOnAllWorkspaces()
-      .then((enabled) => {
-        if (cancelled) return
-        setVisibleOnAllWorkspaces(enabled)
-      })
+    void Promise.all([
+      api.getVisibleOnAllWorkspaces(),
+      api.getFloatingNavigatorAlwaysOnTop(),
+      api.getBrainDumpAlwaysOnTop(),
+    ])
+      .then(
+        ([
+          visibleOnAllWorkspaces,
+          floatingAlwaysOnTop,
+          brainDumpAlwaysOnTop,
+        ]) => {
+          if (cancelled) return
+          setValues({
+            visibleOnAllWorkspaces,
+            floatingAlwaysOnTop,
+            brainDumpAlwaysOnTop,
+          })
+        },
+      )
       .catch((loadError: unknown) => {
         log.error('Failed to load floating window settings:', loadError)
         if (!cancelled) {
@@ -89,37 +159,41 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
   }, [])
 
   /**
-   * Persists and applies the desktop-following switch.
+   * Optimistically toggles one preference, persists it, and rolls back on error.
    *
-   * @param next - true keeps floating panels visible across macOS desktops
-   * @returns Promise that resolves once the main process confirms the change
+   * @param key - Which preference the switch controls
+   * @param next - The requested value
+   * @returns Promise that resolves once the main process confirms or rejects
    */
-  const handleVisibleOnAllWorkspacesChange = useCallback(
-    async (next: boolean): Promise<void> => {
-      const previous = visibleOnAllWorkspaces
-      setVisibleOnAllWorkspaces(next)
-      setIsSaving(true)
+  const applyPreference = useCallback(
+    async (key: PreferenceKey, next: boolean): Promise<void> => {
+      const api = window.electronAPI?.floatingPanels
+      // If the preload bridge disappears, do nothing rather than show an
+      // un-persisted value.
+      if (!api) return
+
+      const previous = values[key]
+      setValues((current) => ({ ...current, [key]: next }))
+      setSavingKeys((current) => new Set(current).add(key))
       setError(null)
 
       try {
-        const api = window.electronAPI?.floatingPanels
-        // If the preload bridge disappears, rollback instead of showing a saved
-        // value that the main process never applied.
-        if (!api) {
-          throw new Error('Electron floating panels API is not available')
-        }
-
-        const applied = await api.setVisibleOnAllWorkspaces(next)
-        setVisibleOnAllWorkspaces(applied)
+        const applied = await PREFERENCE_SETTERS[key](api, next)
+        setValues((current) => ({ ...current, [key]: applied }))
       } catch (saveError: unknown) {
         log.error('Failed to update floating window settings:', saveError)
-        setVisibleOnAllWorkspaces(previous)
+        // Roll back to the value before the optimistic flip.
+        setValues((current) => ({ ...current, [key]: previous }))
         setError('Failed to update floating window settings')
       } finally {
-        setIsSaving(false)
+        setSavingKeys((current) => {
+          const updated = new Set(current)
+          updated.delete(key)
+          return updated
+        })
       }
     },
-    [visibleOnAllWorkspaces],
+    [values],
   )
 
   if (hasMounted && !window.electronAPI?.floatingPanels) {
@@ -133,12 +207,11 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
     )
   }
 
-  // Outdated desktop app: the floatingPanels bridge exists but predates
-  // getVisibleOnAllWorkspaces. Invite an update instead of crashing the page.
+  // Outdated desktop app: the floatingPanels bridge exists but predates one of
+  // the methods this card needs. Invite an update instead of crashing the page.
   if (
     hasMounted &&
-    typeof window.electronAPI?.floatingPanels?.getVisibleOnAllWorkspaces !==
-      'function'
+    !hasCompleteFloatingPanelsApi(window.electronAPI?.floatingPanels)
   ) {
     return (
       <SettingsStateCard
@@ -183,31 +256,110 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
           </div>
         )}
 
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-0.5">
-            <Label htmlFor={desktopTrackingId} className="text-sm font-medium">
-              Show on all Mac desktops
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              Keep both panels visible while switching Spaces, including
-              fullscreen Spaces.
-            </p>
-          </div>
-          <Switch
-            id={desktopTrackingId}
-            checked={visibleOnAllWorkspaces}
-            disabled={!isMac || isSaving}
-            onCheckedChange={handleVisibleOnAllWorkspacesChange}
-          />
-        </div>
+        <FloatingToggleRow
+          switchId={desktopTrackingId}
+          optionKey="visibleOnAllWorkspaces"
+          label="Show on all Mac desktops"
+          description="Keep both panels visible while switching Spaces, including fullscreen Spaces."
+          checked={values.visibleOnAllWorkspaces}
+          disabled={!isMac || savingKeys.has('visibleOnAllWorkspaces')}
+          onToggleAction={applyPreference}
+        />
 
         {!isMac && (
           <p className="text-xs text-muted-foreground">
             This option only applies on macOS.
           </p>
         )}
+
+        {/* Keep-on-top group: per-window pinning, default on for Floating only. */}
+        <div className="space-y-3 border-t pt-4">
+          <div className="space-y-0.5">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Keep on top
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Pin a panel above your other windows so it stays visible.
+            </p>
+          </div>
+
+          <FloatingToggleRow
+            switchId={floatingPinId}
+            optionKey="floatingAlwaysOnTop"
+            label="Floating Navigator"
+            checked={values.floatingAlwaysOnTop}
+            disabled={savingKeys.has('floatingAlwaysOnTop')}
+            onToggleAction={applyPreference}
+          />
+
+          <FloatingToggleRow
+            switchId={brainDumpPinId}
+            optionKey="brainDumpAlwaysOnTop"
+            label="BrainDump"
+            checked={values.brainDumpAlwaysOnTop}
+            disabled={savingKeys.has('brainDumpAlwaysOnTop')}
+            onToggleAction={applyPreference}
+          />
+        </div>
       </CardContent>
     </Card>
+  )
+})
+
+interface FloatingToggleRowProps {
+  switchId: string
+  optionKey: PreferenceKey
+  label: string
+  /** Optional helper copy under the label; omitted for the compact pin rows. */
+  description?: string
+  checked: boolean
+  disabled?: boolean
+  onToggleAction: (key: PreferenceKey, next: boolean) => Promise<void>
+}
+
+/**
+ * One labeled toggle row in the floating-windows card. Extracted so its
+ * `onCheckedChange` can be a stable `useCallback` keyed by `optionKey` — an
+ * inline arrow in the parent would allocate a fresh handler every render.
+ *
+ * @param props - Row props (ids, copy, current state, and the keyed parent handler)
+ * @returns A label/description paired with its toggle switch
+ */
+const FloatingToggleRow = memo(function FloatingToggleRow({
+  switchId,
+  optionKey,
+  label,
+  description,
+  checked,
+  disabled,
+  onToggleAction,
+}: FloatingToggleRowProps): ReactElement {
+  // Bridge Radix's (checked) callback to the keyed parent handler; `void`
+  // discards the returned promise so this stays a plain void event handler.
+  const handleCheckedChange = useCallback(
+    (next: boolean): void => {
+      void onToggleAction(optionKey, next)
+    },
+    [onToggleAction, optionKey],
+  )
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="space-y-0.5">
+        <Label htmlFor={switchId} className="text-sm font-medium">
+          {label}
+        </Label>
+        {description && (
+          <p className="text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+      <Switch
+        id={switchId}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={handleCheckedChange}
+      />
+    </div>
   )
 })
 

--- a/src/components/electron/FloatingWindowSettings.tsx
+++ b/src/components/electron/FloatingWindowSettings.tsx
@@ -287,6 +287,7 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
             switchId={floatingPinId}
             optionKey="floatingAlwaysOnTop"
             label="Floating Navigator"
+            ariaLabel="Keep Floating Navigator on top"
             checked={values.floatingAlwaysOnTop}
             disabled={savingKeys.has('floatingAlwaysOnTop')}
             onToggleAction={applyPreference}
@@ -296,6 +297,7 @@ export const FloatingWindowSettings = memo(function FloatingWindowSettings({
             switchId={brainDumpPinId}
             optionKey="brainDumpAlwaysOnTop"
             label="BrainDump"
+            ariaLabel="Keep BrainDump on top"
             checked={values.brainDumpAlwaysOnTop}
             disabled={savingKeys.has('brainDumpAlwaysOnTop')}
             onToggleAction={applyPreference}
@@ -312,6 +314,15 @@ interface FloatingToggleRowProps {
   label: string
   /** Optional helper copy under the label; omitted for the compact pin rows. */
   description?: string
+  /**
+   * Optional self-describing accessible name for the Switch. The compact pin
+   * rows show a short visible label ("Floating Navigator") under a "Keep on
+   * top" group caption, but that caption isn't programmatically tied to the
+   * switch — so a screen reader would announce "Floating Navigator, switch, on"
+   * with no verb. Pass the full action here ("Keep Floating Navigator on top");
+   * the visible label stays a substring, satisfying WCAG 2.5.3 Label-in-Name.
+   */
+  ariaLabel?: string
   checked: boolean
   disabled?: boolean
   onToggleAction: (key: PreferenceKey, next: boolean) => Promise<void>
@@ -330,6 +341,7 @@ const FloatingToggleRow = memo(function FloatingToggleRow({
   optionKey,
   label,
   description,
+  ariaLabel,
   checked,
   disabled,
   onToggleAction,
@@ -355,6 +367,7 @@ const FloatingToggleRow = memo(function FloatingToggleRow({
       </div>
       <Switch
         id={switchId}
+        aria-label={ariaLabel}
         checked={checked}
         disabled={disabled}
         onCheckedChange={handleCheckedChange}

--- a/src/components/floating-navigator/FloatingNavigator.test.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview FloatingNavigator pin-button mount-init tests.
+ *
+ * The sentinel: the always-on-top pin button must seed from the window's REAL
+ * state on mount, not from its hardcoded `useState(true)`. Because the pin
+ * preference now survives relaunch, a user who turned it off must see the button
+ * read "off" — otherwise the button lies (shows pinned over an unpinned window).
+ * The unpinned case below fails if that mount-init read regresses.
+ *
+ * Triggered when: `pnpm test` (Vitest, happy-dom).
+ *
+ * @example
+ *   pnpm test -- FloatingNavigator
+ */
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FloatingNavigator } from './FloatingNavigator'
+
+// Force the floating-navigator environment so the window-controls toolbar (and
+// its pin button) renders and the mount-init effect runs.
+vi.mock('@/electron/utils/electron-client', () => ({
+  isFloatingNavigatorEnvironment: () => true,
+}))
+
+const isAlwaysOnTopMock = vi.fn()
+
+/**
+ * Installs a `window.floatingNavigatorAPI` whose `window.isAlwaysOnTop` is the
+ * given spy; the other methods are present (only invoked on user interaction).
+ *
+ * @param isAlwaysOnTop - The spy the mount-init effect awaits.
+ */
+function installFloatingNavigatorAPI(
+  isAlwaysOnTop: () => Promise<boolean>,
+): void {
+  Object.defineProperty(window, 'floatingNavigatorAPI', {
+    configurable: true,
+    writable: true,
+    value: {
+      window: {
+        isAlwaysOnTop,
+        toggleAlwaysOnTop: vi.fn(),
+        minimize: vi.fn(),
+        close: vi.fn(),
+        focusMainWindow: vi.fn(),
+      },
+      brainDump: { toggle: vi.fn() },
+    },
+  })
+}
+
+// Minimal required task callbacks — no todos so no rows/dnd/lazy-row icons render.
+const noopTaskProps = {
+  todos: [],
+  onTaskToggle: vi.fn(),
+  onTaskCreate: vi.fn(),
+  onTaskEdit: vi.fn(),
+  onTaskDelete: vi.fn(),
+}
+
+describe('FloatingNavigator pin button', () => {
+  beforeEach(() => {
+    isAlwaysOnTopMock.mockReset()
+  })
+
+  it('shows the pin button OFF when the window launched unpinned', async () => {
+    // Arrange: the window's real state is NOT pinned — the user turned pinning
+    // off in a prior session and the preference survived relaunch.
+    isAlwaysOnTopMock.mockResolvedValue(false)
+    installFloatingNavigatorAPI(isAlwaysOnTopMock)
+
+    // Act
+    render(<FloatingNavigator {...noopTaskProps} />)
+
+    // Assert: the button reflects the REAL unpinned state (aria-pressed=false),
+    // not the `useState(true)` default. Drop the mount-init read and this button
+    // would lie — labelled "Disable always on top" over an unpinned window.
+    const pinButton = await screen.findByRole('button', {
+      name: 'Enable always on top',
+    })
+    expect(pinButton).toHaveAttribute('aria-pressed', 'false')
+    expect(isAlwaysOnTopMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the pin button ON when the window launched pinned', async () => {
+    // Arrange: the window is pinned (the default-on behavior preserved).
+    isAlwaysOnTopMock.mockResolvedValue(true)
+    installFloatingNavigatorAPI(isAlwaysOnTopMock)
+
+    // Act
+    render(<FloatingNavigator {...noopTaskProps} />)
+
+    // Assert: the mount-init still runs (it read the state) and the button reads
+    // pressed, offering to disable.
+    const pinButton = await screen.findByRole('button', {
+      name: 'Disable always on top',
+    })
+    expect(pinButton).toHaveAttribute('aria-pressed', 'true')
+    expect(isAlwaysOnTopMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/floating-navigator/FloatingNavigator.test.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.test.tsx
@@ -99,4 +99,37 @@ describe('FloatingNavigator pin button', () => {
     expect(pinButton).toHaveAttribute('aria-pressed', 'true')
     expect(isAlwaysOnTopMock).toHaveBeenCalledTimes(1)
   })
+
+  it('does not crash when the preload predates the pin-state method', async () => {
+    // Arrange: preload skew — the floatingNavigatorAPI namespace is present (an
+    // installed app) but its `window` bridge predates `isAlwaysOnTop` (this
+    // preference added it). isFloatingNavigatorEnvironment() only checks the
+    // namespace, so the mount-init effect must method-guard before calling it.
+    Object.defineProperty(window, 'floatingNavigatorAPI', {
+      configurable: true,
+      writable: true,
+      value: {
+        window: {
+          // isAlwaysOnTop intentionally absent — the older preload lacks it.
+          toggleAlwaysOnTop: vi.fn(),
+          minimize: vi.fn(),
+          close: vi.fn(),
+          focusMainWindow: vi.fn(),
+        },
+        brainDump: { toggle: vi.fn() },
+      },
+    })
+
+    // Act: mounting must NOT throw a TypeError from invoking undefined() in the
+    // mount-init effect (which would bubble to the error boundary and blank the
+    // floating window).
+    render(<FloatingNavigator {...noopTaskProps} />)
+
+    // Assert: the pin button still renders, falling back to the default pinned
+    // state instead of crashing.
+    const pinButton = await screen.findByRole('button', {
+      name: 'Disable always on top',
+    })
+    expect(pinButton).toHaveAttribute('aria-pressed', 'true')
+  })
 })

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { isFloatingNavigatorEnvironment } from '@/electron/utils/electron-client'
+import { useInitialEffect } from '@/hooks/use-initial-effect'
 import { useCompletionFeedback } from '@/hooks/useCompletionFeedback'
 import { COLOR_DOT_CLASSES } from '@/lib/category-colors'
 import { todoSortableSensors } from '@/lib/dnd-kit-sensors'
@@ -517,6 +518,26 @@ export const FloatingNavigator = React.memo(function FloatingNavigator({
       }
     }
   }, [])
+
+  // Seed the pin button from the window's real state on mount. The button no
+  // longer assumes the window launched pinned: the always-on-top preference now
+  // survives relaunch, so a user who turned it off must see the button reflect
+  // that. T2-minimal — initialize only; no live main→renderer event sync.
+  useInitialEffect(() => {
+    if (!isFloatingNavigatorEnvironment()) return
+    let cancelled = false
+    void window
+      .floatingNavigatorAPI!.window.isAlwaysOnTop()
+      .then((current) => {
+        if (!cancelled) setIsAlwaysOnTop(current)
+      })
+      .catch((error: unknown) => {
+        log.error('Failed to read always-on-top state:', error)
+      })
+    return () => {
+      cancelled = true
+    }
+  })
 
   const handleFocusMainWindow = useCallback(async () => {
     if (isFloatingNavigatorEnvironment()) {

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -525,9 +525,15 @@ export const FloatingNavigator = React.memo(function FloatingNavigator({
   // that. T2-minimal — initialize only; no live main→renderer event sync.
   useInitialEffect(() => {
     if (!isFloatingNavigatorEnvironment()) return
+    // Guard the METHOD, not just the namespace: a frozen older preload can expose
+    // `floatingNavigatorAPI` yet predate `isAlwaysOnTop` (preload skew — installed
+    // app vs newer remote web bundle). Calling an absent method would throw
+    // synchronously here and break the floating UI, so degrade to the default.
+    const windowApi = window.floatingNavigatorAPI?.window
+    if (typeof windowApi?.isAlwaysOnTop !== 'function') return
     let cancelled = false
-    void window
-      .floatingNavigatorAPI!.window.isAlwaysOnTop()
+    void windowApi
+      .isAlwaysOnTop()
       .then((current) => {
         if (!cancelled) setIsAlwaysOnTop(current)
       })


### PR DESCRIPTION
## What

Adds a user **Preference** controlling whether the **Floating Navigator** and **BrainDump** windows stay pinned above other windows (`alwaysOnTop`), instead of both being hardcoded always-on-top.

- **Settings → Floating windows → "Keep on top"**: two independent toggles (Floating Navigator, BrainDump).
- **In-window pin button** on the Floating Navigator now persists through the same path (it was a bare live flip that reset on relaunch).

### Defaults (deliberate)

| Window | Default | Why |
| --- | --- | --- |
| Floating Navigator | **ON** (pinned) | Preserves pre-feature behavior; upgrading users stay pinned. |
| BrainDump | **OFF** (固定しない) | The requested 「固定しない」 default — BrainDump no longer forces itself on top. |

> ⚠️ **User-visible migration for existing BrainDump users:** BrainDump was previously hardcoded always-on-top; it now defaults **OFF**. After this ships, existing users will find BrainDump no longer pinned (re-enable in Settings). Intended per the feature request; covered by the config-default tests.

## How — three-layer persistence

Always-on-top for the floating window has **three** sources of truth that must agree, or the setting silently reverts on relaunch:

1. **Config** — `window.floating.alwaysOnTop` (default `true`)
2. **WindowStateManager** — `isAlwaysOnTop` in `window-state.json` (the value re-applied on relaunch)
3. **The live `BrowserWindow`**

`WindowManager.setFloatingNavigatorAlwaysOnTop` writes **all three atomically**. A config-only write is a silent no-op after first launch because `window-state.json` drives relaunch. BrainDump is config-as-single-source (it never writes window-state).

### Upgrade-path safety

For users upgrading from a build that predates this preference, their saved `window-state.json` has **no `isAlwaysOnTop` field**. `applyWindowState` guards on `typeof state.isAlwaysOnTop === 'boolean'`, so it **skips** the absent field and cannot re-pin. The explicit `alwaysOnTop: floatingConfig.alwaysOnTop` at `WindowManager.ts:588` (after the `...windowOptions` spread) is therefore the **sole pin-source on upgrade** — it keeps upgrading users pinned. Now commented inline and locked by an upgrade construction test.

> The `/ship` adversarial review suggested dropping that line for "defense-in-depth." That would reintroduce the upgrade regression (the spread hands the ctor `alwaysOnTop: undefined`), so it was **rejected and documented** instead.

### Safety surfaces

- **IPC trust boundary**: every `floatingPanels` channel parses its args through `IPC_ARG_SCHEMAS` (setters `z.tuple([z.boolean()])`, getters `z.tuple([])`) before the handler runs.
- **Preload skew guard**: `hasCompleteFloatingPanelsApi` checks all six bridge methods; an outdated installed preload degrades to an "Update CoreLive" card instead of throwing past the error boundary.
- **a11y**: the compact pin rows carry a self-describing `aria-label` ("Keep Floating Navigator on top") so the visible short label stays a substring (WCAG 2.5.3 Label-in-Name).

## Tests

- `pnpm validate` ✅ green (test + typecheck + build + lint + theme) — **621 web unit tests**.
- `pnpm test:electron` ✅ green — **271 electron tests**, including new coverage:
  - `WindowManager.always-on-top.test.ts` (11) — three-layer writes, live-window application, getter live-precedence, and the **upgrade-path construction** case (saved state predates the field → window still constructed pinned).
  - `ConfigManager.always-on-top.test.ts` — config defaults + round-trip.
  - `FloatingNavigator.test.tsx` (renderer) + `FloatingWindowSettings.test.tsx` — the card, per-key optimistic rollback, preload-skew degradation, and the pin a11y names.
- Per-tool mandate honored: **serena** symbol tools for navigation, **context7** for Electron docs.

## ⚠️ Owed at release: macOS native smoke

The automated suites verify the **plumbing** (config / window-state / IPC writes, and that `setAlwaysOnTop` is called with the right boolean). They do **not** verify the **native Cocoa always-on-top effect** — whether the window actually floats above other apps. Per CLAUDE.md, the floating / braindump windows' native behavior is invisible to Playwright + `mcp__electron__*` (renderer-only) and to the Linux + xvfb CI, and this PR touches main-process code (`WindowManager`, `main.ts`, `preload`). So a **macOS `computer-use` smoke is owed before the release tag** (build the packaged app, toggle each pin, confirm it really floats / drops over another app). Deferred to the release smoke per the UNBUMPED feature-PR convention — it is **not** covered by the green test counts above.

## Version

No version bump (corelive convention: features land unbumped; the release bump is a separate `chore(release)` + `v*` tag).

## Deferral

`TODOS.md` tracks one accepted T2-minimal limitation: cross-window label staleness when both the Settings card and an in-window pin button are open at once (persistence stays correct; only the other open surface's label is stale).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent “always on top” (pin) toggles for both BrainDump and the Floating Navigator, with the preference saved across sessions.

* **Bug Fixes**
  * Resolved out-of-sync pin toggle display when Settings and floating panels are open at the same time.
  * Improved startup behavior so the pin button reflects the real pinned state immediately.
  * Ensured the Floating Navigator/BrainDump pin controls default correctly when no saved preference exists.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->