### PR TITLE
feat(electron): Phase 1 Lane A — Floating window as signed-out OAuth front door

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,47 @@ If local QA genuinely cannot run yet (e.g. a native multi-window path with no lo
 harness), **do not silently defer it and ship anyway, and do not present unverified
 work as shipped**. Say so plainly and get the user's explicit OK before merging.
 
+## Autonomy — self-complete the work (自分で完結させる / NON-NEGOTIABLE)
+
+**Default: complete every task end-to-end yourself — including driving the app and
+doing QA.** You have Computer Use, Playwright/CDP, the CLI, Electron, and MCP
+servers. Use them. "I can plan and write code, but you click the buttons / sign in
+/ press Cmd+3" is **not acceptable** — if a tool can do it, you do it.
+
+**The ONLY things you may hand back to the user:**
+
+1. **Payment / money movement** — purchases, transfers, anything that spends.
+2. **Credential entry** — passwords, card / bank / government IDs (safety-prohibited;
+   the user types these, never you).
+3. A surface that is **genuinely un-automatable after you've tried the autonomous
+   workaround below** — and then you say so plainly and ask, you don't just offload.
+
+**Native macOS QA → drive the PACKAGED app, never make the user click.**
+Computer Use **cannot see or click the `electron:dev` app** (it runs from
+`node_modules` as "Electron" / `com.corelive.app.dev`, is not LaunchServices-
+installed, and is filtered out of every screenshot — see the dev-vs-prod table
+below). That is **not** a reason to offload the click to the user — it is the reason
+to **build and drive the packaged app yourself**:
+
+```bash
+pnpm electron:build:dir && open dist/mac/CoreLive.app
+```
+
+then `mcp__computer-use__request_access` for **CoreLive** (full tier) and drive the
+menu bar / tray / dock / **native dialogs** / traffic-lights / `Cmd+3` floating
+yourself. The packaged main bundle is built from the current branch, so a
+main-process fix (e.g. DT7) IS in it; trigger the failure path (offline / blocked
+host) and exercise the dialog with Computer Use — no human needed.
+
+**OAuth / browser redirects → drive them yourself** via the browser MCP /
+Computer Use. The user's Chrome is already signed into Google, so the redirect leg
+is yours to complete; the only gate is the per-action consent click, allowed once
+the user has authorized the flow.
+
+> When you catch yourself about to type "press Cmd+3" / "click Retry" / "sign in for
+> me", **stop** and route it through the packaged app + Computer Use (or the browser
+> MCP) instead. Asking the user to operate the app is a last resort, not the default.
+
 ## Services
 
 | Service    | Environment   | URL/Identifier                                                                                             |

--- a/electron/OAuthManager.ts
+++ b/electron/OAuthManager.ts
@@ -9,7 +9,8 @@
 
 import crypto from 'crypto'
 
-import { shell } from 'electron'
+import { BrowserWindow, shell } from 'electron'
+import type { WebContents } from 'electron'
 
 import { typedSend } from './ipc/typedSend'
 import { log } from './logger'
@@ -20,9 +21,6 @@ import type { WindowManager } from './WindowManager'
 // ============================================================================
 // Type Definitions
 // ============================================================================
-
-/** Production web app origin used as a safe fallback. */
-const DEFAULT_APP_ORIGIN = 'https://corelive.app'
 
 /** Route that starts the browser-side OAuth flow. */
 const OAUTH_START_PATH = '/oauth/start'
@@ -38,6 +36,12 @@ interface PendingStateData {
   provider: string
   createdAt: number
   verifier?: string
+  /**
+   * The renderer that started this flow. The one-time sign-in ticket is pushed
+   * back to THIS webContents only (single recipient → no cross-window
+   * double-consumption); undefined when the flow had no identifiable initiator.
+   */
+  initiator?: WebContents
 }
 
 /** Pending sign-in token */
@@ -176,28 +180,25 @@ export class OAuthManager {
    * // => 'https://corelive.app'
    */
   private getWebAppOrigin(): string {
-    const mainWindow = this.windowManager.getMainWindow()
-    const currentUrl = mainWindow?.webContents.getURL()
-
-    if (!currentUrl) {
-      return DEFAULT_APP_ORIGIN
-    }
-
-    try {
-      return new URL(currentUrl).origin
-    } catch (error) {
-      log.error('Failed to parse BrowserWindow URL for OAuth origin:', error)
-      return DEFAULT_APP_ORIGIN
-    }
+    // Origin is window-agnostic — delegate to WindowManager, which derives it
+    // from the configured server URL. The main window was retired, so reading a
+    // live window URL is no longer viable (and during a cold OAuth callback a
+    // panel may not even exist yet).
+    return this.windowManager.getWebAppOrigin()
   }
 
   /**
    * Starts the OAuth flow by opening system browser.
    *
    * @param provider - OAuth provider (e.g., 'google', 'github')
+   * @param initiator - The renderer that started the flow; the resulting sign-in
+   *   ticket is pushed back to it (single recipient). Omit when unknown.
    * @returns Result with state for tracking
    */
-  async startOAuthFlow(provider: string): Promise<OAuthFlowResult> {
+  async startOAuthFlow(
+    provider: string,
+    initiator?: WebContents,
+  ): Promise<OAuthFlowResult> {
     try {
       log.info(`Starting OAuth flow for provider: ${provider}`)
 
@@ -206,6 +207,7 @@ export class OAuthManager {
       this.pendingStates.set(state, {
         provider,
         createdAt: Date.now(),
+        initiator,
       })
 
       const oauthUrl = this.buildOAuthURL(provider, state)
@@ -300,13 +302,21 @@ export class OAuthManager {
 
       log.info('OAuth state validated, sending sign-in token to WebView')
 
-      if (this.windowManager && this.windowManager.hasMainWindow()) {
+      // Bring the window that STARTED sign-in back to the front so the in-place
+      // re-render is visible. Fall back to the main window while it still exists
+      // (Phase 1); the initiator is the durable target once main is retired.
+      const { initiator } = pendingFlow
+      if (initiator && !initiator.isDestroyed()) {
+        const initiatorWindow = BrowserWindow.fromWebContents(initiator)
+        initiatorWindow?.show()
+        initiatorWindow?.focus()
+      } else if (this.windowManager && this.windowManager.hasMainWindow()) {
         const mainWindow = this.windowManager.getMainWindow()
         mainWindow?.show()
         mainWindow?.focus()
       }
 
-      this.sendSignInToken(token, pendingFlow.provider)
+      this.sendSignInToken(token, pendingFlow.provider, initiator)
 
       if (this.notificationManager) {
         this.notificationManager.showNotification(
@@ -329,18 +339,30 @@ export class OAuthManager {
   /**
    * Sends the sign-in token to the WebView for session creation.
    *
+   * Stores the token for PULL retrieval (window-agnostic, serialized → atomic)
+   * AND pushes it to a SINGLE recipient — the initiating window — so two windows
+   * never race to consume the one-time ticket. Falls back to the main window
+   * while it still exists (Phase 1).
+   *
    * @param token - Clerk sign-in token
    * @param provider - OAuth provider
+   * @param initiator - The renderer that started the flow; receives the push.
    */
-  sendSignInToken(token: string, provider: string): void {
+  sendSignInToken(
+    token: string,
+    provider: string,
+    initiator?: WebContents,
+  ): void {
     log.info('[OAuth] Sending sign-in token to WebView', {
       provider,
       tokenPrefix: token.slice(0, 10) + '...',
+      hasInitiator: !!(initiator && !initiator.isDestroyed()),
       hasMainWindow: !!(
         this.windowManager && this.windowManager.hasMainWindow()
       ),
     })
 
+    // PULL store — durable fallback for any window that missed the push.
     this.pendingSignInToken = {
       token,
       provider,
@@ -348,7 +370,13 @@ export class OAuthManager {
     }
     log.debug('[OAuth] Stored pending sign-in token for retrieval')
 
-    this.sendToRenderer('clerk-sign-in-token', { token, provider })
+    // PUSH to the single initiating window; fall back to the main window so the
+    // existing main-window flow keeps working through Phase 1.
+    if (initiator && !initiator.isDestroyed()) {
+      typedSend(initiator, 'clerk-sign-in-token', { token, provider })
+    } else {
+      this.sendToRenderer('clerk-sign-in-token', { token, provider })
+    }
     log.debug('[OAuth] Sign-in token sent via IPC')
   }
 

--- a/electron/OAuthManager.ts
+++ b/electron/OAuthManager.ts
@@ -49,6 +49,13 @@ interface PendingSignInToken {
   token: string
   provider: string
   createdAt: number
+  /**
+   * `webContents.id` of the window that STARTED this flow. The PULL fallback
+   * (`getPendingSignInToken`) releases the one-time ticket only to this window,
+   * so a non-initiating renderer can't consume it first. Undefined when the
+   * flow had no identifiable initiator (legacy / main-window push) → unscoped.
+   */
+  initiatorId?: number
 }
 
 /** OAuth flow result */
@@ -266,7 +273,16 @@ export class OAuthManager {
 
       if (error) {
         log.error('OAuth error:', { error, errorDescription })
-        this.sendOAuthError(errorDescription || error)
+        // Route the failure to the window that STARTED the flow (Phase 1: falls
+        // back to the main renderer) so a floating-initiated sign-in can't hang
+        // forever on "Opening browser…" after a provider denial/error.
+        const initiator = state
+          ? this.pendingStates.get(state)?.initiator
+          : undefined
+        if (state) {
+          this.pendingStates.delete(state)
+        }
+        this.sendOAuthError(errorDescription || error, initiator)
         return { success: false, error: errorDescription || error }
       }
 
@@ -278,8 +294,12 @@ export class OAuthManager {
 
       if (!token) {
         log.error('Missing token in OAuth callback')
+        // `state` is present here (checked above); route to its initiator.
+        const initiator = this.pendingStates.get(state)?.initiator
+        this.pendingStates.delete(state)
         this.sendOAuthError(
           'Invalid OAuth callback: missing authentication token',
+          initiator,
         )
         return { success: false, error: 'Missing token' }
       }
@@ -293,8 +313,12 @@ export class OAuthManager {
 
       if (Date.now() - pendingFlow.createdAt > this.stateTTL) {
         log.error('OAuth state expired')
+        const { initiator } = pendingFlow
         this.pendingStates.delete(state)
-        this.sendOAuthError('OAuth session expired. Please try again.')
+        this.sendOAuthError(
+          'OAuth session expired. Please try again.',
+          initiator,
+        )
         return { success: false, error: 'State expired' }
       }
 
@@ -362,11 +386,15 @@ export class OAuthManager {
       ),
     })
 
-    // PULL store — durable fallback for any window that missed the push.
+    // PULL store — durable fallback for any window that missed the push, scoped
+    // to the initiator so a non-initiating window can't pull the one-time ticket
+    // first (the PUSH below targets the initiator; the PULL must match it).
     this.pendingSignInToken = {
       token,
       provider,
       createdAt: Date.now(),
+      initiatorId:
+        initiator && !initiator.isDestroyed() ? initiator.id : undefined,
     }
     log.debug('[OAuth] Stored pending sign-in token for retrieval')
 
@@ -381,13 +409,33 @@ export class OAuthManager {
   }
 
   /**
-   * Retrieves and clears the pending sign-in token.
+   * Retrieves and clears the pending sign-in token, scoped to the initiator.
    *
-   * @returns The pending token or null
+   * @param requester - The window asking for the ticket. When the stored ticket
+   *   is bound to an initiator, only that window receives it (others get null,
+   *   leaving the ticket intact); an unbound ticket is returned to any caller.
+   * @returns The pending token, or null when absent, expired, or claimed by a
+   *   non-initiator window.
    */
-  getPendingSignInToken(): { token: string; provider: string } | null {
+  getPendingSignInToken(
+    requester?: WebContents,
+  ): { token: string; provider: string } | null {
     if (!this.pendingSignInToken) {
       log.debug('[OAuth] No pending sign-in token')
+      return null
+    }
+
+    // Scope the PULL to the initiator: a ticket bound to a specific window is
+    // released only to that window. A non-initiator pull returns null and
+    // leaves the ticket for the rightful initiator. An unbound ticket
+    // (initiatorId undefined) stays window-agnostic — preserves the Phase-1
+    // main-window flow and any legacy push.
+    const { initiatorId } = this.pendingSignInToken
+    if (
+      initiatorId !== undefined &&
+      (!requester || requester.isDestroyed() || requester.id !== initiatorId)
+    ) {
+      log.debug('[OAuth] Pending sign-in token requested by non-initiator')
       return null
     }
 
@@ -459,11 +507,22 @@ export class OAuthManager {
   }
 
   /**
-   * Sends OAuth error event to renderer.
+   * Sends OAuth error event to the renderer that started the flow.
+   *
+   * Mirrors `sendSignInToken`'s initiator-targeting: routes the failure to the
+   * initiating window when known (so a floating-initiated flow surfaces its own
+   * error instead of hanging), and falls back to the main renderer otherwise
+   * (Phase 1, or callbacks with no identifiable initiator).
    *
    * @param error - Error message
+   * @param initiator - The renderer that started the flow; receives the error
+   *   when present and alive. Omit to broadcast to the main renderer.
    */
-  sendOAuthError(error: string): void {
+  sendOAuthError(error: string, initiator?: WebContents): void {
+    if (initiator && !initiator.isDestroyed()) {
+      typedSend(initiator, 'oauth-error', { error })
+      return
+    }
     this.sendToRenderer('oauth-error', { error })
   }
 

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -1047,6 +1047,27 @@ export class WindowManager {
   }
 
   /**
+   * Resolve the web-app origin the renderers point at, independent of any one
+   * window. OAuth URL building uses this so the system-browser flow targets the
+   * correct origin (localhost in dev, corelive.app in prod) even with no main
+   * window — the retired main window can no longer be read for its URL.
+   *
+   * @returns The origin (scheme + host + port) of the configured server URL, or
+   * the production origin when `serverUrl` is unset/unparseable.
+   * @example
+   * windowManager.getWebAppOrigin() // => 'http://localhost:4991' (dev)
+   * windowManager.getWebAppOrigin() // => 'https://corelive.app'    (prod)
+   */
+  getWebAppOrigin(): string {
+    const baseUrl = this.serverUrl || 'https://corelive.app'
+    try {
+      return new URL(baseUrl).origin
+    } catch {
+      return 'https://corelive.app'
+    }
+  }
+
+  /**
    * Whether a navigated URL is a Clerk auth page, i.e. the user is not yet
    * authenticated. A startup panel that lands here was redirected by proxy.ts.
    *

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -97,11 +97,11 @@ export class WindowManager {
   // native dialog) instead of leaving a dead window. Reset per fresh window in
   // `createFloatingNavigator`.
   /** Retry count for the current never-succeeded Floating load. */
-  private floatingLoadFailAttempts = 0
+  private floatingLoadFailAttempts: number = 0
   /** True while a retry timer is queued or the recovery dialog is open. */
-  private floatingLoadRecoveryPending = false
+  private floatingLoadRecoveryPending: boolean = false
   /** Latched on the first successful Floating load; after it the renderer owns errors. */
-  private floatingHasLoadedOnce = false
+  private floatingHasLoadedOnce: boolean = false
 
   /** Frameless transparent BrainDump Note panel */
   private brainDumpWindow: BrowserWindow | null
@@ -751,12 +751,19 @@ export class WindowManager {
       this.floatingLoadRecoveryPending = true
       const backoffMs =
         FLOATING_LOAD_RETRY_BASE_MS * this.floatingLoadFailAttempts
+      // Bind the retry to the window that ACTUALLY failed. If it closes and a
+      // fresh Floating window replaces it during the backoff, this stale timer
+      // must not reload (and corrupt the recovery state of) the new window.
+      const retryTarget = target
       setTimeout(() => {
-        this.floatingLoadRecoveryPending = false
-        const retryTarget = this.floatingNavigator
-        if (retryTarget && !retryTarget.isDestroyed()) {
-          retryTarget.webContents.loadURL(this.getPanelUrl('floating'))
+        if (
+          this.floatingNavigator !== retryTarget ||
+          retryTarget.isDestroyed()
+        ) {
+          return
         }
+        this.floatingLoadRecoveryPending = false
+        retryTarget.webContents.loadURL(this.getPanelUrl('floating'))
       }, backoffMs)
       return
     }
@@ -766,6 +773,10 @@ export class WindowManager {
     // macOS, which would itself be the dead window this recovery exists to kill.
     this.floatingLoadRecoveryPending = true
     target.show()
+    // Cancel the armed startup-pill timeout before the dialog: once recovery
+    // commits, the pill's fallback (restoreFromTray → surface main) must not
+    // fire and pop the main window over the Floating recovery.
+    this.dismissStartupPill()
     void this.promptFloatingLoadFailure(target)
   }
 

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -805,6 +805,8 @@ export class WindowManager {
 
     // Close (button 1): keep the Phase-1 main window alive; the tray re-opens
     // Floating later.
+    // PHASE 2 (main window deleted): Close here would leave zero windows + tray
+    // only — revisit whether to keep the window on a recoverable blank instead.
     target.close()
   }
 

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -17,12 +17,14 @@
 import path from 'path'
 import { fileURLToPath } from 'url'
 
-import { BrowserWindow, screen } from 'electron'
+import { BrowserWindow, dialog, screen } from 'electron'
 
 import type { ConfigManager } from './ConfigManager'
 import {
   AUTH_PATHNAMES,
   ERR_ABORTED,
+  FLOATING_LOAD_MAX_RETRIES,
+  FLOATING_LOAD_RETRY_BASE_MS,
   SETTINGS_POPOVER_DEFAULT_HEIGHT_PX,
   SETTINGS_POPOVER_DEFAULT_WIDTH_PX,
   SETTINGS_POPOVER_MAX_HEIGHT_PX,
@@ -89,6 +91,17 @@ export class WindowManager {
 
   /** Always-on-top utility window */
   private floatingNavigator: BrowserWindow | null
+
+  // DT7 Floating load-failure recovery state. The Floating window is the
+  // signed-out front door, so a main-frame load failure must self-heal (retry +
+  // native dialog) instead of leaving a dead window. Reset per fresh window in
+  // `createFloatingNavigator`.
+  /** Retry count for the current never-succeeded Floating load. */
+  private floatingLoadFailAttempts = 0
+  /** True while a retry timer is queued or the recovery dialog is open. */
+  private floatingLoadRecoveryPending = false
+  /** Latched on the first successful Floating load; after it the renderer owns errors. */
+  private floatingHasLoadedOnce = false
 
   /** Frameless transparent BrainDump Note panel */
   private brainDumpWindow: BrowserWindow | null
@@ -626,6 +639,12 @@ export class WindowManager {
       trafficLightPosition: { x: -100, y: -100 },
     })
 
+    // DT7: fresh window → reset the load-failure recovery machine so a prior
+    // window's exhausted retries don't carry over.
+    this.floatingLoadFailAttempts = 0
+    this.floatingLoadRecoveryPending = false
+    this.floatingHasLoadedOnce = false
+
     const floatingUrl = this.getPanelUrl('floating')
 
     log.debug('Loading floating navigator URL:', floatingUrl)
@@ -661,7 +680,30 @@ export class WindowManager {
 
     this.floatingNavigator.webContents.on('did-finish-load', () => {
       log.debug('Floating navigator content loaded')
+      // DT7: the renderer is alive now and owns its own error states, so stop
+      // the main-process load-failure recovery from firing on later transient
+      // events (e.g. a stale did-fail-load for the settled load).
+      this.floatingHasLoadedOnce = true
+      this.floatingLoadRecoveryPending = false
     })
+
+    // DT7: recover a never-loaded Floating window from a main-frame load
+    // failure (offline/DNS/5xx). Without this the signed-out front door can
+    // boot into a permanently blank window. See `recoverFloatingFromLoadFailure`.
+    this.floatingNavigator.webContents.on(
+      'did-fail-load',
+      (_event, errorCode, _errorDescription, _validatedURL, isMainFrame) => {
+        // Sub-resource failures and intentional cancellations (ERR_ABORTED
+        // fires during a normal redirect chain) are not real document failures.
+        if (!isMainFrame || errorCode === ERR_ABORTED) return
+        // Once the panel has loaded once, its live renderer owns its error UI —
+        // main-process retry is only for a never-loaded (dead) window.
+        if (this.floatingHasLoadedOnce) return
+        // A retry timer or dialog is already in flight — don't stack them.
+        if (this.floatingLoadRecoveryPending) return
+        this.recoverFloatingFromLoadFailure()
+      },
+    )
 
     this.floatingNavigator.webContents.on(
       'render-process-gone',
@@ -685,6 +727,85 @@ export class WindowManager {
     )
 
     return this.floatingNavigator
+  }
+
+  /**
+   * Drive the Floating window back to life after a main-frame load failure:
+   * silently retry with linear backoff, then — once retries are exhausted —
+   * surface a NATIVE recovery dialog. Main-process owned because a never-loaded
+   * renderer can't render its own error page; the dialog is native (not bundled
+   * HTML) because electron-builder can drop asar leaf deps. Wired from the
+   * Floating `did-fail-load` handler in `createFloatingNavigator`.
+   *
+   * @returns nothing — schedules a retry or opens the recovery dialog as a side effect.
+   * @example
+   * // on a real offline boot: retries 3× (800/1600/2400 ms) then shows the dialog
+   */
+  private recoverFloatingFromLoadFailure(): void {
+    const target = this.floatingNavigator
+    if (!target || target.isDestroyed()) return
+
+    // Still within the silent-retry budget: schedule a backed-off reload.
+    if (this.floatingLoadFailAttempts < FLOATING_LOAD_MAX_RETRIES) {
+      this.floatingLoadFailAttempts += 1
+      this.floatingLoadRecoveryPending = true
+      const backoffMs =
+        FLOATING_LOAD_RETRY_BASE_MS * this.floatingLoadFailAttempts
+      setTimeout(() => {
+        this.floatingLoadRecoveryPending = false
+        const retryTarget = this.floatingNavigator
+        if (retryTarget && !retryTarget.isDestroyed()) {
+          retryTarget.webContents.loadURL(this.getPanelUrl('floating'))
+        }
+      }, backoffMs)
+      return
+    }
+
+    // Retries exhausted. Show the (until now hidden) startup panel FIRST: a
+    // window-modal sheet attached to a non-visible window may never render on
+    // macOS, which would itself be the dead window this recovery exists to kill.
+    this.floatingLoadRecoveryPending = true
+    target.show()
+    void this.promptFloatingLoadFailure(target)
+  }
+
+  /**
+   * Native "couldn't reach corelive.app" recovery dialog shown when the Floating
+   * window exhausts its silent reload retries. Retry restarts a fresh recovery
+   * cycle; Close dismisses the window (re-openable from the tray). Deliberately
+   * Close, not Quit: in Phase 1 the main window is still alive and `app.quit()`
+   * would take it down over a companion-window network blip.
+   *
+   * @param target - The Floating window to attach the dialog to and recover.
+   * @returns a promise that settles once the user picks Retry or Close.
+   * @example
+   * void this.promptFloatingLoadFailure(this.floatingNavigator)
+   */
+  private async promptFloatingLoadFailure(
+    target: BrowserWindow,
+  ): Promise<void> {
+    const { response } = await dialog.showMessageBox(target, {
+      type: 'warning',
+      message: "Couldn't reach corelive.app",
+      detail: 'Check your internet connection, then try again.',
+      buttons: ['Retry', 'Close'],
+      defaultId: 0,
+      cancelId: 1,
+    })
+
+    if (target.isDestroyed()) return
+
+    // Retry (button 0): restart the backoff sequence from a clean slate.
+    if (response === 0) {
+      this.floatingLoadFailAttempts = 0
+      this.floatingLoadRecoveryPending = false
+      target.webContents.loadURL(this.getPanelUrl('floating'))
+      return
+    }
+
+    // Close (button 1): keep the Phase-1 main window alive; the tray re-opens
+    // Floating later.
+    target.close()
   }
 
   /**
@@ -1196,6 +1317,11 @@ export class WindowManager {
       // Subresource failures and intentional cancellations (ERR_ABORTED fires
       // during the normal panel -> /login redirect chain) are not real errors.
       if (!isMainFrame || errorCode === ERR_ABORTED) return
+      // Phase 1 / DT7: the Floating window owns its own load-failure recovery
+      // (retry + native dialog in `createFloatingNavigator`), so the startup
+      // gate must NOT suppress it and surface main on a network blip. Braindump
+      // is still main-deferred in Phase 1, so it keeps the surface-main path.
+      if (kind === 'floating') return
       finish(false)
     }
 

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -102,6 +102,13 @@ export class WindowManager {
   private floatingLoadRecoveryPending: boolean = false
   /** Latched on the first successful Floating load; after it the renderer owns errors. */
   private floatingHasLoadedOnce: boolean = false
+  /**
+   * True between a real main-frame `did-fail-load` and the `did-finish-load`
+   * Chromium then fires for the error page it commits. Lets the finish handler
+   * tell an error-page settle (which must NOT latch `floatingHasLoadedOnce`, or
+   * it silences DT7 recovery and strands a blank window) from a genuine app load.
+   */
+  private floatingLoadFailedPendingFinish: boolean = false
 
   /** Frameless transparent BrainDump Note panel */
   private brainDumpWindow: BrowserWindow | null
@@ -644,6 +651,7 @@ export class WindowManager {
     this.floatingLoadFailAttempts = 0
     this.floatingLoadRecoveryPending = false
     this.floatingHasLoadedOnce = false
+    this.floatingLoadFailedPendingFinish = false
 
     const floatingUrl = this.getPanelUrl('floating')
 
@@ -679,6 +687,15 @@ export class WindowManager {
     })
 
     this.floatingNavigator.webContents.on('did-finish-load', () => {
+      // DT7: Chromium fires did-finish-load for the ERROR PAGE too (chrome-error://…)
+      // after a failed load, not only for a real app load. If the most recent
+      // main-frame load failed, THIS finish is that error page settling: consume
+      // the marker and do NOT latch, so recovery keeps retrying instead of being
+      // silenced into a permanently blank window (the bug T20 native QA caught).
+      if (this.floatingLoadFailedPendingFinish) {
+        this.floatingLoadFailedPendingFinish = false
+        return
+      }
       log.debug('Floating navigator content loaded')
       // DT7: the renderer is alive now and owns its own error states, so stop
       // the main-process load-failure recovery from firing on later transient
@@ -696,6 +713,10 @@ export class WindowManager {
         // Sub-resource failures and intentional cancellations (ERR_ABORTED
         // fires during a normal redirect chain) are not real document failures.
         if (!isMainFrame || errorCode === ERR_ABORTED) return
+        // A real main-frame failure: Chromium will now commit an error page and
+        // fire did-finish-load for IT. Mark it so that finish doesn't mistake the
+        // error page for a live app render and latch `floatingHasLoadedOnce`.
+        this.floatingLoadFailedPendingFinish = true
         // Once the panel has loaded once, its live renderer owns its error UI —
         // main-process retry is only for a never-loaded (dead) window.
         if (this.floatingHasLoadedOnce) return

--- a/electron/__tests__/OAuthManager.test.ts
+++ b/electron/__tests__/OAuthManager.test.ts
@@ -9,31 +9,29 @@ vi.mock('electron', () => ({
 }))
 
 /**
- * Creates a minimal WindowManager mock for OAuth URL tests.
+ * Creates a minimal WindowManager mock for OAuth URL tests. OAuthManager now
+ * sources the OAuth origin from `WindowManager.getWebAppOrigin()` (window-
+ * agnostic, so it survives main-window retirement) rather than reading a live
+ * BrowserWindow URL — the mock just returns the resolved origin.
  *
- * @param currentUrl - URL currently loaded in the main BrowserWindow.
+ * @param origin - Web-app origin WindowManager resolves from its server URL
+ *   (localhost in dev, corelive.app in prod).
  * @returns WindowManager-compatible mock object.
  * @example
- * createWindowManagerMock('http://localhost:4991/login')
+ * createWindowManagerMock('http://localhost:4991')
  */
-function createWindowManagerMock(currentUrl?: string) {
+function createWindowManagerMock(origin = 'https://corelive.app') {
   return {
-    getMainWindow: () =>
-      currentUrl
-        ? {
-            webContents: {
-              getURL: () => currentUrl,
-            },
-          }
-        : null,
-    hasMainWindow: () => Boolean(currentUrl),
+    getWebAppOrigin: () => origin,
+    getMainWindow: () => null,
+    hasMainWindow: () => false,
   }
 }
 
 describe('OAuthManager', () => {
-  it('builds the OAuth start URL from the current BrowserWindow origin in development', () => {
+  it('builds the OAuth start URL from the dev web-app origin', () => {
     const oauthManager = new OAuthManager(
-      createWindowManagerMock('http://localhost:4991/login') as never,
+      createWindowManagerMock('http://localhost:4991') as never,
       null,
     )
 
@@ -42,9 +40,9 @@ describe('OAuthManager', () => {
     )
   })
 
-  it('falls back to the production origin when no BrowserWindow URL is available', () => {
+  it('builds the OAuth start URL from the production web-app origin', () => {
     const oauthManager = new OAuthManager(
-      createWindowManagerMock() as never,
+      createWindowManagerMock('https://corelive.app') as never,
       null,
     )
 

--- a/electron/__tests__/OAuthManager.test.ts
+++ b/electron/__tests__/OAuthManager.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { typedSend } from '../ipc/typedSend'
 import { OAuthManager } from '../OAuthManager'
 
 vi.mock('electron', () => ({
   shell: {
     openExternal: vi.fn(),
   },
+}))
+
+// Spy on the per-window IPC send so initiator-targeting (the sign-in-token push
+// and the error routing) is observable without a real Electron WebContents.
+vi.mock('../ipc/typedSend', () => ({
+  typedSend: vi.fn(),
 }))
 
 /**
@@ -26,6 +33,19 @@ function createWindowManagerMock(origin = 'https://corelive.app') {
     getMainWindow: () => null,
     hasMainWindow: () => false,
   }
+}
+
+/**
+ * Builds a stand-in for an Electron renderer (`WebContents`) identified by its
+ * `id` — all the initiator-scoping logic compares. Alive (`isDestroyed: false`).
+ *
+ * @param id - The `webContents.id` the OAuth flow keys its ticket/errors to.
+ * @returns A WebContents-shaped stub accepted by the initiator parameters.
+ * @example
+ * oauthManager.getPendingSignInToken(fakeRenderer(11))
+ */
+function fakeRenderer(id: number) {
+  return { id, isDestroyed: () => false } as never
 }
 
 describe('OAuthManager', () => {
@@ -49,5 +69,74 @@ describe('OAuthManager', () => {
     expect(oauthManager.buildOAuthURL('google', 'state_456')).toBe(
       'https://corelive.app/oauth/start?provider=google&state=state_456',
     )
+  })
+})
+
+// The Floating window can START a sign-in, so the resulting ticket and any
+// failure must come back to THAT window — not leak to the main window or strand
+// the initiator on "Opening browser…" forever. These pin the targeting contract.
+describe('OAuthManager initiator targeting', () => {
+  beforeEach(() => {
+    vi.mocked(typedSend).mockClear()
+  })
+
+  it('routes a provider-denied callback error to the window that started the flow', async () => {
+    // Arrange: the Floating renderer (id 11) starts a Google flow.
+    const oauthManager = new OAuthManager(
+      createWindowManagerMock() as never,
+      null,
+    )
+    const floatingRenderer = fakeRenderer(11)
+    const { state } = await oauthManager.startOAuthFlow(
+      'google',
+      floatingRenderer,
+    )
+
+    // Act: the deep-link callback comes back as a denial for that state.
+    await oauthManager.handleOAuthCallback(
+      new URL(
+        `corelive://oauth/callback?state=${state}&error=access_denied&error_description=User+denied+access`,
+      ),
+    )
+
+    // Assert: the error is delivered to the initiating window — not broadcast to
+    // the main renderer, which would leave the Floating CTA stuck "Opening…".
+    expect(typedSend).toHaveBeenCalledWith(floatingRenderer, 'oauth-error', {
+      error: 'User denied access',
+    })
+  })
+
+  it('hands the pending sign-in ticket only to the window that initiated it', () => {
+    // Arrange: a ticket bound to the Floating renderer (id 11).
+    const oauthManager = new OAuthManager(
+      createWindowManagerMock() as never,
+      null,
+    )
+    const floatingRenderer = fakeRenderer(11)
+    oauthManager.sendSignInToken('tok_floating', 'google', floatingRenderer)
+
+    // Act + Assert: a DIFFERENT window (id 22) cannot consume the one-time
+    // ticket — it gets null, and the ticket stays put for the rightful window.
+    expect(oauthManager.getPendingSignInToken(fakeRenderer(22))).toBeNull()
+    expect(oauthManager.getPendingSignInToken(floatingRenderer)).toEqual({
+      token: 'tok_floating',
+      provider: 'google',
+    })
+  })
+
+  it('keeps an unbound ticket window-agnostic so the main-window pull still works', () => {
+    // Arrange: a push with no initiator (Phase-1 main-window / legacy path).
+    const oauthManager = new OAuthManager(
+      createWindowManagerMock() as never,
+      null,
+    )
+    oauthManager.sendSignInToken('tok_main', 'google')
+
+    // Act + Assert: any window may claim an unbound ticket — no regression to
+    // the existing main-window flow that pulls without an initiator id.
+    expect(oauthManager.getPendingSignInToken(fakeRenderer(99))).toEqual({
+      token: 'tok_main',
+      provider: 'google',
+    })
   })
 })

--- a/electron/__tests__/WindowManager.startup-panel.test.ts
+++ b/electron/__tests__/WindowManager.startup-panel.test.ts
@@ -495,6 +495,56 @@ describe('WindowManager startup panel nav-watch', () => {
       expect(floating.win.close).toHaveBeenCalledTimes(1)
     })
 
+    it('binds the retry timer to the window that failed, not its replacement', () => {
+      // Arrange: a Floating window fails once, scheduling a backed-off reload.
+      const windowManager = new WindowManager(SERVER_URL)
+      windowManager.createFloatingNavigator()
+      const firstFloating = getWindow(0)
+      fireFloatingLoadFailure(firstFloating)
+
+      // The window closes and a fresh Floating window replaces it before the
+      // backoff fires. createFloatingNavigator() bails while the old reference
+      // is still set, and the harness doesn't replay the window-level `closed`
+      // event, so null the reference (what the real `closed` handler does) and
+      // then create the replacement.
+      ;(
+        windowManager as unknown as { floatingNavigator: unknown }
+      ).floatingNavigator = null
+      windowManager.createFloatingNavigator()
+      const secondFloating = getWindow(1)
+
+      // Act: the stale timer from the FIRST window fires.
+      vi.runOnlyPendingTimers()
+
+      // Assert: it does not reload the replacement — a stale retry must never
+      // corrupt the recovery state of a window that never failed.
+      expect(secondFloating.win.webContents.loadURL).not.toHaveBeenCalled()
+    })
+
+    it('dismisses the armed startup pill when it gives up and shows the recovery dialog', async () => {
+      // Arrange: a Floating window whose load keeps failing.
+      const windowManager = new WindowManager(SERVER_URL)
+      windowManager.createFloatingNavigator()
+      const floating = getWindow(0)
+      const dismissStartupPill = vi.spyOn(windowManager, 'dismissStartupPill')
+
+      // Act: exhaust the retries (3) so the 4th failure opens the dialog.
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers()
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers()
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers()
+      dismissStartupPill.mockClear() // isolate the exhaustion-path call
+      fireFloatingLoadFailure(floating)
+      await vi.runOnlyPendingTimersAsync()
+
+      // Assert: the pill's timeout is cancelled when recovery commits, so it
+      // can't later fire restoreFromTray() and pop the main window over the
+      // Floating recovery dialog.
+      expect(dismissStartupPill).toHaveBeenCalledTimes(1)
+    })
+
     it('reloads the panel after a single failure instead of giving up immediately', () => {
       // Arrange
       const windowManager = new WindowManager(SERVER_URL)

--- a/electron/__tests__/WindowManager.startup-panel.test.ts
+++ b/electron/__tests__/WindowManager.startup-panel.test.ts
@@ -11,6 +11,9 @@
  * @example
  *   pnpm test:electron -- WindowManager.startup-panel
  */
+// The mocked electron `dialog`, asserted on by the DT7 recovery tests (the
+// `vi.mock('electron')` factory below is hoisted above this import by Vitest).
+import { dialog } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type Spy = ReturnType<typeof vi.fn>
@@ -29,6 +32,7 @@ interface MockBrowserWindow {
   getOpacity: Spy
   setVisibleOnAllWorkspaces: Spy
   loadURL: Spy
+  close: Spy
   on: Spy
   once: Spy
   webContents: {
@@ -74,6 +78,7 @@ vi.mock('electron', () => ({
       loadURL: vi.fn((url: string) => {
         currentUrl = url
       }),
+      close: vi.fn(),
       on: vi.fn(),
       once: vi.fn(),
       webContents: {
@@ -120,6 +125,11 @@ vi.mock('electron', () => ({
     getDisplayNearestPoint: vi.fn(() => ({
       workArea: { x: 0, y: 0, width: 1920, height: 1080 },
     })),
+  },
+  // DT7 recovery dialog. Defaults to "Close" (response 1) so the exhaustion
+  // path never loops back into a reload unless a test opts into "Retry".
+  dialog: {
+    showMessageBox: vi.fn(async () => ({ response: 1 })),
   },
 }))
 
@@ -242,11 +252,12 @@ describe('WindowManager startup panel nav-watch', () => {
     expect(windowManager.getStartupAuthFallbacks().size).toBe(0)
   })
 
-  it('surfaces the main window when the panel fails to load (offline/5xx)', () => {
-    // Arrange
+  it('surfaces the main window when a braindump panel fails to load (offline/5xx)', () => {
+    // Arrange: braindump still defers to the main window in Phase 1 (only the
+    // Floating window owns its own load-failure recovery via DT7).
     const windowManager = new WindowManager(SERVER_URL)
     windowManager.createMainWindow(false)
-    windowManager.openStartupPanel('floating')
+    windowManager.openStartupPanel('braindump')
     const mainWindow = getWindow(0)
     const panelWindow = getWindow(1)
 
@@ -256,14 +267,14 @@ describe('WindowManager startup panel nav-watch', () => {
       {},
       -105,
       'ERR_NAME_NOT_RESOLVED',
-      `${SERVER_URL}/floating-navigator`,
+      `${SERVER_URL}/braindump`,
       true,
     )
 
     // Assert: failed panel stays hidden, main is surfaced, fallback recorded.
     expect(panelWindow.win.show).not.toHaveBeenCalled()
     expect(mainWindow.win.show).toHaveBeenCalledTimes(1)
-    expect(windowManager.getStartupAuthFallbacks().has('floating')).toBe(true)
+    expect(windowManager.getStartupAuthFallbacks().has('braindump')).toBe(true)
   })
 
   it('ignores an aborted load (ERR_ABORTED) during the redirect chain', () => {
@@ -424,5 +435,146 @@ describe('WindowManager startup panel nav-watch', () => {
 
     // Assert: the re-show bails on the destroyed panel instead of reloading it.
     expect(panelWindow.win.webContents.loadURL).not.toHaveBeenCalled()
+  })
+
+  // DT7: the Floating window is the signed-out front door, so a never-loaded
+  // window must self-heal (retry, then a native recovery dialog) instead of
+  // stranding the user on a blank panel. These exercise the recovery machine in
+  // `createFloatingNavigator` plus the asymmetry vs. braindump's surface-main.
+  describe('Floating load-failure recovery (DT7)', () => {
+    // Fake timers so the backoff reload retries can be driven deterministically;
+    // clear any pending timer between cases so a scheduled retry never leaks.
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    })
+
+    /** Fire a real main-frame load failure (net::ERR_NAME_NOT_RESOLVED). */
+    function fireFloatingLoadFailure(panel: CapturedMockWindow): void {
+      panel.fireWebContents(
+        'did-fail-load',
+        {},
+        -105,
+        'ERR_NAME_NOT_RESOLVED',
+        `${SERVER_URL}/floating-navigator`,
+        true,
+      )
+    }
+
+    it('retries the failed load and surfaces a native recovery dialog once retries are exhausted', async () => {
+      // Arrange: a Floating window whose load keeps failing (offline).
+      const windowManager = new WindowManager(SERVER_URL)
+      windowManager.createFloatingNavigator()
+      const floating = getWindow(0)
+
+      // Act: each failure schedules one backed-off reload; flush it, then fail
+      // again. FLOATING_LOAD_MAX_RETRIES = 3, so the 4th failure exhausts them.
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers() // retry 1
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers() // retry 2
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers() // retry 3
+      fireFloatingLoadFailure(floating) // exhausted → recovery dialog
+      await vi.runOnlyPendingTimersAsync() // settle the awaited dialog promise
+
+      // Assert: it actively retried 3× (positive recovery, not a dead window),
+      // and on exhaustion it SHOWED the window before opening the native dialog
+      // (a sheet on a hidden window may never render on macOS). The default
+      // "Close" choice then dismisses the window without quitting the app.
+      expect(floating.win.webContents.loadURL).toHaveBeenCalledTimes(3)
+      expect(floating.win.webContents.loadURL).toHaveBeenLastCalledWith(
+        `${SERVER_URL}/floating-navigator`,
+      )
+      expect(floating.win.show).toHaveBeenCalledTimes(1)
+      expect(dialog.showMessageBox).toHaveBeenCalledTimes(1)
+      expect(floating.win.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('reloads the panel after a single failure instead of giving up immediately', () => {
+      // Arrange
+      const windowManager = new WindowManager(SERVER_URL)
+      windowManager.createFloatingNavigator()
+      const floating = getWindow(0)
+
+      // Act: one failure, then let the backoff timer fire.
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers()
+
+      // Assert: it reloaded the panel route and did NOT jump straight to the
+      // recovery dialog.
+      expect(floating.win.webContents.loadURL).toHaveBeenCalledWith(
+        `${SERVER_URL}/floating-navigator`,
+      )
+      expect(dialog.showMessageBox).not.toHaveBeenCalled()
+    })
+
+    it('stops main-process retries once the floating window has loaded successfully', () => {
+      // Arrange: the panel loaded once, so its renderer is alive.
+      const windowManager = new WindowManager(SERVER_URL)
+      windowManager.createFloatingNavigator()
+      const floating = getWindow(0)
+      floating.fireWebContents('did-finish-load')
+
+      // Act: a later transient main-frame failure arrives.
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers()
+
+      // Assert: no main-process retry and no dialog — a live renderer owns its
+      // own error states (this also guards against a stale did-fail-load for an
+      // already-settled load triggering a spurious reload).
+      expect(floating.win.webContents.loadURL).not.toHaveBeenCalled()
+      expect(dialog.showMessageBox).not.toHaveBeenCalled()
+    })
+
+    it('does not surface the main window when a startup floating panel fails to load', () => {
+      // Arrange: panel-only cold boot opens the Floating startup panel.
+      const windowManager = new WindowManager(SERVER_URL)
+      windowManager.createMainWindow(false)
+      windowManager.openStartupPanel('floating')
+      const mainWindow = getWindow(0)
+      const panelWindow = getWindow(1)
+
+      // Act: the floating panel's first load fails.
+      fireFloatingLoadFailure(panelWindow)
+
+      // Assert: unlike braindump, the floating startup gate defers to DT7 — it
+      // neither surfaces the main window nor records an auth fallback; recovery
+      // is the Floating window's own job.
+      expect(mainWindow.win.show).not.toHaveBeenCalled()
+      expect(panelWindow.win.show).not.toHaveBeenCalled()
+      expect(windowManager.getStartupAuthFallbacks().has('floating')).toBe(
+        false,
+      )
+    })
+
+    it('restarts the recovery cycle when the user picks Retry in the dialog', async () => {
+      // Arrange: the dialog will return "Retry" (response 0) this time.
+      vi.mocked(dialog.showMessageBox).mockResolvedValueOnce({
+        response: 0,
+        checkboxChecked: false,
+      })
+      const windowManager = new WindowManager(SERVER_URL)
+      windowManager.createFloatingNavigator()
+      const floating = getWindow(0)
+
+      // Act: exhaust the retries to open the dialog, then let the Retry handler run.
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers()
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers()
+      fireFloatingLoadFailure(floating)
+      vi.runOnlyPendingTimers()
+      fireFloatingLoadFailure(floating) // exhausted → dialog opens
+      await vi.runOnlyPendingTimersAsync() // flush the awaited dialog promise
+
+      // Assert: Retry reloaded the panel a 4th time (3 backoff retries + the
+      // explicit user retry), restarting the recovery from a clean slate.
+      expect(floating.win.webContents.loadURL).toHaveBeenCalledTimes(4)
+    })
   })
 })

--- a/electron/__tests__/WindowManager.startup-panel.test.ts
+++ b/electron/__tests__/WindowManager.startup-panel.test.ts
@@ -626,5 +626,40 @@ describe('WindowManager startup panel nav-watch', () => {
       // explicit user retry), restarting the recovery from a clean slate.
       expect(floating.win.webContents.loadURL).toHaveBeenCalledTimes(4)
     })
+
+    it('keeps retrying when Chromium commits an error page (did-finish-load) after each failure', async () => {
+      // Arrange: a Floating window whose load keeps failing (offline). Unlike the
+      // other DT7 cases, the REAL Electron runtime commits a chrome-error page
+      // after every main-frame failure and fires did-finish-load for THAT page.
+      // The error page is not the app, so it must NOT latch floatingHasLoadedOnce
+      // (which would early-return every later did-fail-load and silence recovery,
+      // stranding a permanently blank signed-out front door). Regression for the
+      // bug T20 native QA surfaced: 2 failures then a dead window, no dialog.
+      const windowManager = new WindowManager(SERVER_URL)
+      windowManager.createFloatingNavigator()
+      const floating = getWindow(0)
+
+      // Act: interleave the error-page did-finish-load the runtime emits after
+      // each failure with the backoff retries. 3 retries, then the 4th failure
+      // exhausts the budget and opens the native dialog.
+      fireFloatingLoadFailure(floating)
+      floating.fireWebContents('did-finish-load') // chrome-error page settles
+      vi.runOnlyPendingTimers() // retry 1
+      fireFloatingLoadFailure(floating)
+      floating.fireWebContents('did-finish-load')
+      vi.runOnlyPendingTimers() // retry 2
+      fireFloatingLoadFailure(floating)
+      floating.fireWebContents('did-finish-load')
+      vi.runOnlyPendingTimers() // retry 3
+      fireFloatingLoadFailure(floating) // exhausted → recovery dialog
+      floating.fireWebContents('did-finish-load')
+      await vi.runOnlyPendingTimersAsync() // settle the awaited dialog promise
+
+      // Assert: recovery survived the interleaved error-page finishes — it still
+      // retried 3× and surfaced the native dialog, identical to the no-finish run.
+      expect(floating.win.webContents.loadURL).toHaveBeenCalledTimes(3)
+      expect(floating.win.show).toHaveBeenCalledTimes(1)
+      expect(dialog.showMessageBox).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/electron/__tests__/WindowManager.web-app-origin.test.ts
+++ b/electron/__tests__/WindowManager.web-app-origin.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview WindowManager.getWebAppOrigin resolution tests.
+ *
+ * The sentinel: the native OAuth flow targets whatever `getWebAppOrigin()`
+ * returns, and with the main window retired there is no window URL left to read
+ * — so this getter is the SOLE source of the system-browser sign-in origin. It
+ * must resolve to the dev origin when a server URL is configured, and degrade to
+ * the production origin (never throw, never an empty/relative origin) when the
+ * server URL is unset or unparseable. A regression here would point OAuth at the
+ * wrong origin (or crash the flow), so these pin all three branches.
+ *
+ * Triggered when: `pnpm test:electron` (Vitest, node env).
+ *
+ * @example
+ *   pnpm test:electron -- WindowManager.web-app-origin
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import { WindowManager } from '../WindowManager'
+
+// getWebAppOrigin constructs no window — these mocks exist only so importing
+// WindowManager (which imports `electron` + the logger at module load) resolves
+// in the node test env. The getter itself touches none of them.
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  screen: {
+    getPrimaryDisplay: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+    getDisplayNearestPoint: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+  },
+  dialog: { showMessageBox: vi.fn() },
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+describe('WindowManager.getWebAppOrigin', () => {
+  it('defaults to the production origin when no server URL is configured', () => {
+    // Arrange: no server URL (the packaged app passes null — it points at prod).
+    const windowManager = new WindowManager(null)
+
+    // Act
+    const origin = windowManager.getWebAppOrigin()
+
+    // Assert: OAuth targets the production web app.
+    expect(origin).toBe('https://corelive.app')
+  })
+
+  it("uses the dev server's origin, stripping any path, when a server URL is configured", () => {
+    // Arrange: dev passes the full local URL (with a path) as the server URL.
+    const windowManager = new WindowManager('http://localhost:4991/home')
+
+    // Act
+    const origin = windowManager.getWebAppOrigin()
+
+    // Assert: just the origin (scheme + host + port) — the /home path is dropped,
+    // so OAuth URL building appends its own path to a clean origin.
+    expect(origin).toBe('http://localhost:4991')
+  })
+
+  it('falls back to the production origin when the configured server URL is unparseable', () => {
+    // Arrange: a malformed server URL that `new URL()` cannot parse.
+    const windowManager = new WindowManager('not a url')
+
+    // Act
+    const origin = windowManager.getWebAppOrigin()
+
+    // Assert: degrades to prod rather than throwing or returning a bad origin.
+    expect(origin).toBe('https://corelive.app')
+  })
+})

--- a/electron/__tests__/preload-security.test.mjs
+++ b/electron/__tests__/preload-security.test.mjs
@@ -1,18 +1,22 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 import { log } from '../../src/lib/logger.ts'
+import { sanitizeData } from '../preload-floating.ts'
 
-// Mock Electron modules
-const mockIpcRenderer = {
-  invoke: vi.fn(),
-  on: vi.fn(),
-  removeListener: vi.fn(),
-  removeAllListeners: vi.fn(),
-}
-
-const mockContextBridge = {
-  exposeInMainWorld: vi.fn(),
-}
+// Mock Electron modules. Defined via vi.hoisted so the (hoisted) vi.mock factory
+// can reference them without a TDZ error — needed now that a real preload module
+// (preload-floating) is imported through this mock for the sanitizer test.
+const { mockIpcRenderer, mockContextBridge } = vi.hoisted(() => ({
+  mockIpcRenderer: {
+    invoke: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    removeAllListeners: vi.fn(),
+  },
+  mockContextBridge: {
+    exposeInMainWorld: vi.fn(),
+  },
+}))
 
 vi.mock('electron', () => ({
   contextBridge: mockContextBridge,
@@ -223,6 +227,26 @@ describe('Preload Script Security Tests', () => {
           },
         },
       })
+    })
+  })
+
+  describe('Prototype pollution hardening (floating preload)', () => {
+    it('strips __proto__/constructor/prototype and returns a null-prototype object', () => {
+      // Arrange: a payload carrying an own __proto__ key, as JSON.parse yields —
+      // the attacker shape a naive sanitizer would copy into the result.
+      const malicious = JSON.parse(
+        '{"__proto__":{"polluted":true},"title":"  Plan the week  "}',
+      )
+
+      // Act: the REAL floating-preload sanitizer (now mirrors the main preload).
+      const sanitized = sanitizeData(malicious)
+
+      // Assert: forbidden keys are dropped, the result has a null prototype, the
+      // global Object.prototype is untouched, and ordinary fields still trim.
+      expect(Object.getPrototypeOf(sanitized)).toBeNull()
+      expect('polluted' in sanitized).toBe(false)
+      expect({}.polluted).toBeUndefined()
+      expect(sanitized.title).toBe('Plan the week')
     })
   })
 

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -74,14 +74,14 @@ export const STARTUP_PILL_HEIGHT_PX = 76
  * signed-out front door now, so a never-loaded ("dead") window must self-heal
  * across a brief offline/DNS/5xx blip rather than stranding the user.
  */
-export const FLOATING_LOAD_MAX_RETRIES = 3
+export const FLOATING_LOAD_MAX_RETRIES: number = 3
 
 /**
  * Base backoff before a Floating reload retry; the delay scales linearly with
  * the attempt number (800 → 1600 → 2400 ms). Quick enough to ride out a brief
  * blip, backed off enough not to hammer a still-unreachable origin.
  */
-export const FLOATING_LOAD_RETRY_BASE_MS = 800
+export const FLOATING_LOAD_RETRY_BASE_MS: number = 800
 
 // ============================================================================
 // Auto-update download progress window

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -65,6 +65,25 @@ export const STARTUP_PILL_WIDTH_PX = 260
 export const STARTUP_PILL_HEIGHT_PX = 76
 
 // ============================================================================
+// Floating window load-failure recovery (DT7)
+// ============================================================================
+
+/**
+ * How many times the Floating window silently retries a failed main-frame load
+ * before surfacing the native recovery dialog. The Floating panel is the
+ * signed-out front door now, so a never-loaded ("dead") window must self-heal
+ * across a brief offline/DNS/5xx blip rather than stranding the user.
+ */
+export const FLOATING_LOAD_MAX_RETRIES = 3
+
+/**
+ * Base backoff before a Floating reload retry; the delay scales linearly with
+ * the attempt number (800 → 1600 → 2400 ms). Quick enough to ride out a brief
+ * blip, backed off enough not to hammer a still-unreachable origin.
+ */
+export const FLOATING_LOAD_RETRY_BASE_MS = 800
+
+// ============================================================================
 // Auto-update download progress window
 // ============================================================================
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1980,9 +1980,11 @@ function setupIPCHandlers(): void {
     return true
   })
 
-  typedHandle('oauth-get-pending-token', () => {
+  typedHandle('oauth-get-pending-token', (event) => {
     const oauth = ensureOAuthManager()
-    return oauth ? oauth.getPendingSignInToken() : null
+    // Pass the requesting window so the PULL releases the one-time ticket only
+    // to the window that STARTED the flow (scoped in getPendingSignInToken).
+    return oauth ? oauth.getPendingSignInToken(event.sender) : null
   })
 
   typedHandle('oauth-clear-pending-token', () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1945,7 +1945,7 @@ function setupIPCHandlers(): void {
   // OAuth IPC handlers for browser-based OAuth flows
   // OAuth IPC handlers (Zod-validated)
   // Used when WebView OAuth is blocked (e.g., Google OAuth)
-  typedHandle('oauth-start', async (_event, provider) => {
+  typedHandle('oauth-start', async (event, provider) => {
     try {
       const oauth = ensureOAuthManager()
       if (!oauth) {
@@ -1954,7 +1954,9 @@ function setupIPCHandlers(): void {
       if (!oauth.isProviderSupported(provider)) {
         throw new Error(`Unsupported OAuth provider: ${provider}`)
       }
-      return await oauth.startOAuthFlow(provider)
+      // Pass the initiating renderer so the resulting one-time sign-in ticket is
+      // pushed back to THIS window only (single recipient → no double-consume).
+      return await oauth.startOAuthFlow(provider, event.sender)
     } catch (error) {
       log.error('Failed to start OAuth flow:', error)
       return {

--- a/electron/preload-floating.ts
+++ b/electron/preload-floating.ts
@@ -19,6 +19,10 @@ import type { IpcRendererEvent } from 'electron'
 
 import { typedInvoke } from './ipc/typedInvoke'
 import { log } from './logger'
+import {
+  createAuthBridge,
+  createOAuthBridge,
+} from './preload-shared/auth-oauth-bridge'
 import type { WindowBounds as IPCWindowBounds } from './types/ipc'
 
 // ============================================================================
@@ -286,6 +290,26 @@ contextBridge.exposeInMainWorld('floatingNavigatorAPI', {
       `Floating Navigator: removeListener is deprecated. Use the cleanup function returned by on() instead. Channel: ${channel}`,
     )
   },
+})
+
+/**
+ * Expose the auth + OAuth slice of `electronAPI` so the signed-out Floating
+ * window is a self-contained native-OAuth "front door".
+ *
+ * `ElectronAuthProvider` (root layout, runs in every panel) gates on
+ * `window.electronAPI` via `isElectronEnvironment()`, so exposing it HERE is
+ * what activates the provider in this window — and the full `oauth` surface lets
+ * the panel both START a browser flow and RECEIVE its sign-in ticket with no
+ * main window in the loop.
+ *
+ * Deliberately SCOPED to { auth, oauth }: omitting `settings`/`menu`/etc. keeps
+ * `ElectronStartupSync`'s method guards a clean no-op here (it only touches
+ * `electronAPI.settings`), so activating the provider has zero native side
+ * effects in the floating window.
+ */
+contextBridge.exposeInMainWorld('electronAPI', {
+  auth: createAuthBridge(sanitizeData),
+  oauth: createOAuthBridge(sanitizeData),
 })
 
 /**

--- a/electron/preload-floating.ts
+++ b/electron/preload-floating.ts
@@ -4,8 +4,10 @@
  * In WebView architecture, the Floating Navigator loads https://corelive.app/floating-navigator
  * and uses oRPC (via the web app) for all data operations.
  *
- * This preload script only exposes:
+ * This preload script exposes:
  * - Window control APIs (close, minimize, always-on-top)
+ * - Auth/OAuth bridge slice for signed-out native OAuth
+ *   (createAuthBridge / createOAuthBridge → window.electronAPI.{auth,oauth})
  * - Platform detection (isElectron, isFloatingNavigator)
  *
  * Note: Todo operations are NOT exposed here - they are handled by
@@ -89,7 +91,12 @@ function validateChannel(channel: string): boolean {
  * @param data - Data to sanitize
  * @returns Sanitized data
  */
-function sanitizeData<T>(data: T): T {
+export function sanitizeData<T>(data: T): T {
+  // Keys that could be used for prototype pollution attacks. Mirrors the main
+  // preload's hardening so the floating bridge is not the weaker IPC boundary
+  // now that it also forwards renderer-controlled auth/OAuth payloads.
+  const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype']
+
   if (typeof data === 'string') {
     return data.trim() as T
   }
@@ -97,8 +104,15 @@ function sanitizeData<T>(data: T): T {
     if (Array.isArray(data)) {
       return data.map((item) => sanitizeData(item)) as T
     }
-    const sanitized: Record<string, SanitizedValue> = {}
+    // Deep clone and sanitize object properties
+    // Use null prototype to prevent prototype pollution attacks
+    const sanitized = Object.create(null) as Record<string, SanitizedValue>
     for (const [key, value] of Object.entries(data)) {
+      // Block prototype pollution attacks
+      if (FORBIDDEN_KEYS.includes(key)) {
+        continue
+      }
+
       if (typeof value === 'string') {
         sanitized[key] = value.trim()
       } else if (typeof value === 'number' || typeof value === 'boolean') {

--- a/electron/preload-shared/auth-oauth-bridge.ts
+++ b/electron/preload-shared/auth-oauth-bridge.ts
@@ -1,0 +1,346 @@
+/**
+ * @fileoverview Shared Auth + OAuth contextBridge factories
+ *
+ * The native-OAuth sign-in flow (system browser → `corelive://oauth` deep link →
+ * Clerk ticket) must be drivable from ANY Electron window that hosts the React
+ * app, not just the (now-retired) main window. `ElectronAuthProvider` lives in
+ * the root layout, so it renders in every panel — but it can only act where the
+ * preload has exposed `window.electronAPI.{auth,oauth}`. These factories are that
+ * single source of truth, consumed by both `preload.ts` and `preload-floating.ts`
+ * so the bridge never skews between windows.
+ *
+ * `sanitizeData` is dependency-injected rather than imported so each preload keeps
+ * its own isolated sanitizer instance (the context-isolation boundary is
+ * per-preload); the bridge logic itself stays DRY.
+ *
+ * @module electron/preload-shared/auth-oauth-bridge
+ */
+
+import { ipcRenderer } from 'electron'
+import type { IpcRendererEvent } from 'electron'
+
+import { typedInvoke } from '../ipc/typedInvoke'
+import { log } from '../logger'
+
+/** User data payload pushed from the renderer to the main process. */
+export interface ElectronUserData {
+  clerkId: string
+  [key: string]: unknown
+}
+
+/** OAuth callback payload delivered to renderer event listeners. */
+export interface OAuthCallbackData {
+  [key: string]: unknown
+}
+
+/**
+ * Deep-trim sanitizer signature. Injected by each preload so the bridge reuses
+ * the caller's already-isolated `sanitizeData` instead of importing a third copy.
+ */
+export type SanitizeData = <T>(data: T) => T
+
+/**
+ * Build the `auth` bridge — the renderer↔main auth-sync surface (Clerk user push,
+ * logout, auth-state reads). Identical in every window; exposed wherever
+ * `ElectronAuthProvider` needs to mirror sign-in state to the main process.
+ *
+ * @param sanitizeData - The host preload's deep-trim sanitizer.
+ * @returns The `auth` object exposed at `window.electronAPI.auth`.
+ * @example
+ * contextBridge.exposeInMainWorld('electronAPI', { auth: createAuthBridge(sanitizeData) })
+ */
+export function createAuthBridge(sanitizeData: SanitizeData) {
+  return {
+    /**
+     * Get current user.
+     */
+    getUser: async () => {
+      try {
+        return await typedInvoke('auth-get-user')
+      } catch (error) {
+        log.error('Failed to get user:', error)
+        return null
+      }
+    },
+
+    /**
+     * Set current user.
+     */
+    setUser: async (user: ElectronUserData) => {
+      try {
+        if (!user || typeof user !== 'object') {
+          throw new Error('Invalid auth payload: user object is required')
+        }
+        if (!user.clerkId || typeof user.clerkId !== 'string') {
+          throw new Error('Invalid auth payload: clerkId is required')
+        }
+        // Validate id if present (optional but must be string if provided)
+        if (
+          'id' in user &&
+          user.id !== undefined &&
+          typeof user.id !== 'string'
+        ) {
+          throw new Error('Invalid auth payload: id must be a string')
+        }
+
+        const sanitized = sanitizeData(user) as {
+          clerkId: string
+          emailAddresses?: string[]
+          firstName?: string | null
+        }
+        return await typedInvoke('auth-set-user', sanitized)
+      } catch (error) {
+        log.error('Failed to set user:', error)
+        throw new Error('Failed to set user')
+      }
+    },
+
+    /**
+     * Logout current user.
+     */
+    logout: async (): Promise<boolean> => {
+      try {
+        return await typedInvoke('auth-logout')
+      } catch (error) {
+        log.error('Failed to logout:', error)
+        throw new Error('Failed to logout')
+      }
+    },
+
+    /**
+     * Check if user is authenticated.
+     */
+    isAuthenticated: async (): Promise<boolean> => {
+      try {
+        return await typedInvoke('auth-is-authenticated')
+      } catch (error) {
+        log.error('Failed to check authentication:', error)
+        return false
+      }
+    },
+
+    /**
+     * Sync authentication state from web version.
+     */
+    syncFromWeb: async (authData: ElectronUserData): Promise<boolean> => {
+      try {
+        if (!authData || typeof authData !== 'object') {
+          throw new Error('Invalid auth payload: authData object is required')
+        }
+        if (!authData.clerkId || typeof authData.clerkId !== 'string') {
+          throw new Error('Invalid auth payload: clerkId is required')
+        }
+        // Validate id if present (optional but must be string if provided)
+        if (
+          'id' in authData &&
+          authData.id !== undefined &&
+          typeof authData.id !== 'string'
+        ) {
+          throw new Error('Invalid auth payload: id must be a string')
+        }
+
+        const sanitized = sanitizeData(authData) as {
+          clerkId: string
+          emailAddresses?: string[]
+          firstName?: string | null
+        }
+        return await typedInvoke('auth-sync-from-web', sanitized)
+      } catch (error) {
+        log.error('Failed to sync auth from web:', error)
+        throw new Error('Failed to sync authentication')
+      }
+    },
+  }
+}
+
+/**
+ * Build the `oauth` bridge — the browser-based OAuth surface for providers (e.g.
+ * Google) that block WebView auth. Exposes the FULL surface (start/cancel, the
+ * success/error/exchange/sign-in-token listeners, and the pending-token
+ * store/clear) so a panel can both START a flow and RECEIVE its ticket without a
+ * main window in the loop.
+ *
+ * @param sanitizeData - The host preload's deep-trim sanitizer.
+ * @returns The `oauth` object exposed at `window.electronAPI.oauth`.
+ * @example
+ * contextBridge.exposeInMainWorld('electronAPI', { oauth: createOAuthBridge(sanitizeData) })
+ */
+export function createOAuthBridge(sanitizeData: SanitizeData) {
+  return {
+    /**
+     * Start OAuth flow in system browser.
+     * Used for providers like Google that block WebView authentication.
+     *
+     * @param provider - OAuth provider (e.g., 'google', 'github')
+     * @returns Promise with success status and state or error
+     */
+    start: async (provider: string) => {
+      try {
+        return await typedInvoke('oauth-start', provider)
+      } catch (error) {
+        log.error('Failed to start OAuth flow:', error)
+        return {
+          state: null,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      }
+    },
+
+    /**
+     * Get list of supported OAuth providers.
+     */
+    getSupportedProviders: async () => {
+      try {
+        return await typedInvoke('oauth-get-supported-providers')
+      } catch (error) {
+        log.error('Failed to get supported OAuth providers:', error)
+        return []
+      }
+    },
+
+    /**
+     * Cancel pending OAuth flow.
+     */
+    cancel: async (state?: string | null) => {
+      try {
+        return await typedInvoke('oauth-cancel', state ?? null)
+      } catch (error) {
+        log.error('Failed to cancel OAuth flow:', error)
+        return false
+      }
+    },
+
+    /**
+     * Register callback for OAuth success.
+     */
+    onSuccess: (callback: (data: OAuthCallbackData) => void): (() => void) => {
+      if (typeof callback !== 'function') {
+        throw new Error('Callback must be a function')
+      }
+
+      const wrappedCallback = (
+        _event: IpcRendererEvent,
+        data: OAuthCallbackData,
+      ): void => {
+        try {
+          callback(sanitizeData(data))
+        } catch (error) {
+          log.error('Error in OAuth success callback:', error)
+        }
+      }
+
+      ipcRenderer.on('oauth-success', wrappedCallback)
+      return () => ipcRenderer.removeListener('oauth-success', wrappedCallback)
+    },
+
+    /**
+     * Register callback for OAuth error.
+     */
+    onError: (callback: (data: OAuthCallbackData) => void): (() => void) => {
+      if (typeof callback !== 'function') {
+        throw new Error('Callback must be a function')
+      }
+
+      const wrappedCallback = (
+        _event: IpcRendererEvent,
+        data: OAuthCallbackData,
+      ): void => {
+        try {
+          callback(sanitizeData(data))
+        } catch (error) {
+          log.error('Error in OAuth error callback:', error)
+        }
+      }
+
+      ipcRenderer.on('oauth-error', wrappedCallback)
+      return () => ipcRenderer.removeListener('oauth-error', wrappedCallback)
+    },
+
+    /**
+     * Register callback for OAuth code exchange completion.
+     * (Used by web app to complete the Clerk session setup)
+     */
+    onCompleteExchange: (
+      callback: (data: OAuthCallbackData) => void,
+    ): (() => void) => {
+      if (typeof callback !== 'function') {
+        throw new Error('Callback must be a function')
+      }
+
+      const wrappedCallback = (
+        _event: IpcRendererEvent,
+        data: OAuthCallbackData,
+      ): void => {
+        try {
+          callback(sanitizeData(data))
+        } catch (error) {
+          log.error('Error in OAuth exchange callback:', error)
+        }
+      }
+
+      ipcRenderer.on('oauth-complete-exchange', wrappedCallback)
+      return () =>
+        ipcRenderer.removeListener('oauth-complete-exchange', wrappedCallback)
+    },
+
+    /**
+     * Register callback for Clerk sign-in token from browser OAuth.
+     * This token allows the WebView to create its own Clerk session
+     * using signIn.create({ strategy: 'ticket', ticket: token }).
+     *
+     * @param callback - Function called with { token, provider }
+     * @returns Cleanup function to remove the listener
+     */
+    onSignInToken: (
+      callback: (data: { token: string; provider: string }) => void,
+    ): (() => void) => {
+      if (typeof callback !== 'function') {
+        throw new Error('Callback must be a function')
+      }
+
+      const wrappedCallback = (
+        _event: IpcRendererEvent,
+        data: { token: string; provider: string },
+      ): void => {
+        try {
+          callback(sanitizeData(data))
+        } catch (error) {
+          log.error('Error in OAuth sign-in token callback:', error)
+        }
+      }
+
+      ipcRenderer.on('clerk-sign-in-token', wrappedCallback)
+      return () =>
+        ipcRenderer.removeListener('clerk-sign-in-token', wrappedCallback)
+    },
+
+    /**
+     * Get pending sign-in token (for race condition handling).
+     * This is called when the renderer is ready to process tokens,
+     * in case it missed the IPC event.
+     *
+     * @returns Promise with pending token or null
+     */
+    getPendingToken: async () => {
+      try {
+        return await typedInvoke('oauth-get-pending-token')
+      } catch (error) {
+        log.error('Failed to get pending OAuth token:', error)
+        return null
+      }
+    },
+
+    /**
+     * Clear pending sign-in token (after successful sign-in).
+     */
+    clearPendingToken: async () => {
+      try {
+        return await typedInvoke('oauth-clear-pending-token')
+      } catch (error) {
+        log.error('Failed to clear pending OAuth token:', error)
+        return false
+      }
+    },
+  }
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -29,6 +29,10 @@ import type { IpcRendererEvent } from 'electron'
 
 import { typedInvoke } from './ipc/typedInvoke'
 import { log } from './logger'
+import {
+  createAuthBridge,
+  createOAuthBridge,
+} from './preload-shared/auth-oauth-bridge'
 import type {
   AuxWindowVisibility,
   ConfigSection,
@@ -78,16 +82,9 @@ interface TrayTaskItem {
   completed?: boolean
 }
 
-/** User data */
-interface ElectronUserData {
-  clerkId: string
-  [key: string]: unknown
-}
-
-/** OAuth callback data */
-interface OAuthCallbackData {
-  [key: string]: unknown
-}
+// `ElectronUserData` / `OAuthCallbackData` now live alongside the bridge
+// factories in `./preload-shared/auth-oauth-bridge` (single source for every
+// window's auth/oauth surface).
 
 // ============================================================================
 // Allowed Channels Whitelist
@@ -852,287 +849,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
   },
 
-  // Authentication management
-  auth: {
-    /**
-     * Get current user.
-     */
-    getUser: async () => {
-      try {
-        return await typedInvoke('auth-get-user')
-      } catch (error) {
-        log.error('Failed to get user:', error)
-        return null
-      }
-    },
+  // Authentication management (shared factory — single source for every window)
+  auth: createAuthBridge(sanitizeData),
 
-    /**
-     * Set current user.
-     */
-    setUser: async (user: ElectronUserData) => {
-      try {
-        if (!user || typeof user !== 'object') {
-          throw new Error('Invalid auth payload: user object is required')
-        }
-        if (!user.clerkId || typeof user.clerkId !== 'string') {
-          throw new Error('Invalid auth payload: clerkId is required')
-        }
-        // Validate id if present (optional but must be string if provided)
-        if (
-          'id' in user &&
-          user.id !== undefined &&
-          typeof user.id !== 'string'
-        ) {
-          throw new Error('Invalid auth payload: id must be a string')
-        }
-
-        const sanitized = sanitizeData(user) as {
-          clerkId: string
-          emailAddresses?: string[]
-          firstName?: string | null
-        }
-        return await typedInvoke('auth-set-user', sanitized)
-      } catch (error) {
-        log.error('Failed to set user:', error)
-        throw new Error('Failed to set user')
-      }
-    },
-
-    /**
-     * Logout current user.
-     */
-    logout: async (): Promise<boolean> => {
-      try {
-        return await typedInvoke('auth-logout')
-      } catch (error) {
-        log.error('Failed to logout:', error)
-        throw new Error('Failed to logout')
-      }
-    },
-
-    /**
-     * Check if user is authenticated.
-     */
-    isAuthenticated: async (): Promise<boolean> => {
-      try {
-        return await typedInvoke('auth-is-authenticated')
-      } catch (error) {
-        log.error('Failed to check authentication:', error)
-        return false
-      }
-    },
-
-    /**
-     * Sync authentication state from web version.
-     */
-    syncFromWeb: async (authData: ElectronUserData): Promise<boolean> => {
-      try {
-        if (!authData || typeof authData !== 'object') {
-          throw new Error('Invalid auth payload: authData object is required')
-        }
-        if (!authData.clerkId || typeof authData.clerkId !== 'string') {
-          throw new Error('Invalid auth payload: clerkId is required')
-        }
-        // Validate id if present (optional but must be string if provided)
-        if (
-          'id' in authData &&
-          authData.id !== undefined &&
-          typeof authData.id !== 'string'
-        ) {
-          throw new Error('Invalid auth payload: id must be a string')
-        }
-
-        const sanitized = sanitizeData(authData) as {
-          clerkId: string
-          emailAddresses?: string[]
-          firstName?: string | null
-        }
-        return await typedInvoke('auth-sync-from-web', sanitized)
-      } catch (error) {
-        log.error('Failed to sync auth from web:', error)
-        throw new Error('Failed to sync authentication')
-      }
-    },
-  },
-
-  // OAuth management (browser-based OAuth for providers that block WebView)
-  oauth: {
-    /**
-     * Start OAuth flow in system browser.
-     * Used for providers like Google that block WebView authentication.
-     *
-     * @param provider - OAuth provider (e.g., 'google', 'github')
-     * @returns Promise with success status and state or error
-     */
-    start: async (provider: string) => {
-      try {
-        return await typedInvoke('oauth-start', provider)
-      } catch (error) {
-        log.error('Failed to start OAuth flow:', error)
-        return {
-          state: null,
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
-        }
-      }
-    },
-
-    /**
-     * Get list of supported OAuth providers.
-     */
-    getSupportedProviders: async () => {
-      try {
-        return await typedInvoke('oauth-get-supported-providers')
-      } catch (error) {
-        log.error('Failed to get supported OAuth providers:', error)
-        return []
-      }
-    },
-
-    /**
-     * Cancel pending OAuth flow.
-     */
-    cancel: async (state?: string | null) => {
-      try {
-        return await typedInvoke('oauth-cancel', state ?? null)
-      } catch (error) {
-        log.error('Failed to cancel OAuth flow:', error)
-        return false
-      }
-    },
-
-    /**
-     * Register callback for OAuth success.
-     */
-    onSuccess: (callback: (data: OAuthCallbackData) => void): (() => void) => {
-      if (typeof callback !== 'function') {
-        throw new Error('Callback must be a function')
-      }
-
-      const wrappedCallback = (
-        _event: IpcRendererEvent,
-        data: OAuthCallbackData,
-      ): void => {
-        try {
-          callback(sanitizeData(data))
-        } catch (error) {
-          log.error('Error in OAuth success callback:', error)
-        }
-      }
-
-      ipcRenderer.on('oauth-success', wrappedCallback)
-      return () => ipcRenderer.removeListener('oauth-success', wrappedCallback)
-    },
-
-    /**
-     * Register callback for OAuth error.
-     */
-    onError: (callback: (data: OAuthCallbackData) => void): (() => void) => {
-      if (typeof callback !== 'function') {
-        throw new Error('Callback must be a function')
-      }
-
-      const wrappedCallback = (
-        _event: IpcRendererEvent,
-        data: OAuthCallbackData,
-      ): void => {
-        try {
-          callback(sanitizeData(data))
-        } catch (error) {
-          log.error('Error in OAuth error callback:', error)
-        }
-      }
-
-      ipcRenderer.on('oauth-error', wrappedCallback)
-      return () => ipcRenderer.removeListener('oauth-error', wrappedCallback)
-    },
-
-    /**
-     * Register callback for OAuth code exchange completion.
-     * (Used by web app to complete the Clerk session setup)
-     */
-    onCompleteExchange: (
-      callback: (data: OAuthCallbackData) => void,
-    ): (() => void) => {
-      if (typeof callback !== 'function') {
-        throw new Error('Callback must be a function')
-      }
-
-      const wrappedCallback = (
-        _event: IpcRendererEvent,
-        data: OAuthCallbackData,
-      ): void => {
-        try {
-          callback(sanitizeData(data))
-        } catch (error) {
-          log.error('Error in OAuth exchange callback:', error)
-        }
-      }
-
-      ipcRenderer.on('oauth-complete-exchange', wrappedCallback)
-      return () =>
-        ipcRenderer.removeListener('oauth-complete-exchange', wrappedCallback)
-    },
-
-    /**
-     * Register callback for Clerk sign-in token from browser OAuth.
-     * This token allows the WebView to create its own Clerk session
-     * using signIn.create({ strategy: 'ticket', ticket: token }).
-     *
-     * @param callback - Function called with { token, provider }
-     * @returns Cleanup function to remove the listener
-     */
-    onSignInToken: (
-      callback: (data: { token: string; provider: string }) => void,
-    ): (() => void) => {
-      if (typeof callback !== 'function') {
-        throw new Error('Callback must be a function')
-      }
-
-      const wrappedCallback = (
-        _event: IpcRendererEvent,
-        data: { token: string; provider: string },
-      ): void => {
-        try {
-          callback(sanitizeData(data))
-        } catch (error) {
-          log.error('Error in OAuth sign-in token callback:', error)
-        }
-      }
-
-      ipcRenderer.on('clerk-sign-in-token', wrappedCallback)
-      return () =>
-        ipcRenderer.removeListener('clerk-sign-in-token', wrappedCallback)
-    },
-
-    /**
-     * Get pending sign-in token (for race condition handling).
-     * This is called when the renderer is ready to process tokens,
-     * in case it missed the IPC event.
-     *
-     * @returns Promise with pending token or null
-     */
-    getPendingToken: async () => {
-      try {
-        return await typedInvoke('oauth-get-pending-token')
-      } catch (error) {
-        log.error('Failed to get pending OAuth token:', error)
-        return null
-      }
-    },
-
-    /**
-     * Clear pending sign-in token (after successful sign-in).
-     */
-    clearPendingToken: async () => {
-      try {
-        return await typedInvoke('oauth-clear-pending-token')
-      } catch (error) {
-        log.error('Failed to clear pending OAuth token:', error)
-        return false
-      }
-    },
-  },
+  // OAuth management (shared factory — full browser-based OAuth surface)
+  oauth: createOAuthBridge(sanitizeData),
 
   // Menu management APIs
   menu: {

--- a/src/components/auth/ElectronOAuthButtons.test.tsx
+++ b/src/components/auth/ElectronOAuthButtons.test.tsx
@@ -71,18 +71,27 @@ describe('ElectronOAuthButtons', () => {
     )
 
     // Assert: it starts the native Google flow and reflects the in-flight state
-    // (so the user sees the browser is opening, and can't double-fire it).
+    // (so the user sees the browser is opening).
     expect(start).toHaveBeenCalledWith('google')
-    expect(
-      await screen.findByRole('button', { name: /opening browser/i }),
-    ).toBeDisabled()
+    const openingButton = await screen.findByRole('button', {
+      name: /opening browser/i,
+    })
+    expect(openingButton).toBeDisabled()
+
+    // And it can't be double-fired: a second press on the now-disabled button
+    // starts no second flow (one browser tab, not two).
+    fireEvent.click(openingButton)
+    expect(start).toHaveBeenCalledTimes(1)
   })
 
   it('surfaces a calm error when the native flow fails to start', async () => {
-    // Arrange: the main process reports it could not start the flow.
+    // Arrange: the main process reports it could not start the flow, with a
+    // specific reason. Using a distinct message (not the generic fallback) pins
+    // that we surface the SERVER's reason verbatim — proving this is the
+    // `result.success === false` branch, not the catch-path's hardcoded string.
     plantOAuthBridge({
       success: false,
-      error: 'Failed to start authentication',
+      error: 'No supported browser found',
     })
     render(<ElectronOAuthButtons />)
 
@@ -93,9 +102,7 @@ describe('ElectronOAuthButtons', () => {
 
     // Assert: the failure is announced (role=alert) rather than swallowed, and
     // the button returns to its idle, re-pressable state.
-    const errorMessage = await screen.findByText(
-      /failed to start authentication/i,
-    )
+    const errorMessage = await screen.findByText(/no supported browser found/i)
     expect(errorMessage).toHaveAttribute('role', 'alert')
     expect(
       screen.getByRole('button', { name: /sign in with google/i }),

--- a/src/components/auth/ElectronOAuthButtons.test.tsx
+++ b/src/components/auth/ElectronOAuthButtons.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview ElectronOAuthButtons — the Floating front door's native sign-in CTA.
+ *
+ * The sentinel: this single amber button is the ONLY way a signed-out user
+ * starts the system-browser OAuth flow from the Floating window (the Electron
+ * main window is being retired). If the click ever stops calling
+ * `window.electronAPI.oauth.start('google')`, or stops surfacing a start
+ * failure, the desktop front door silently goes dead — a signed-out user is
+ * stranded with a button that does nothing. These pin the click → start →
+ * loading/error contract.
+ *
+ * Triggered when: `pnpm test` (Vitest, happy-dom).
+ *
+ * @example
+ *   pnpm test -- ElectronOAuthButtons
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ElectronOAuthButtons } from './ElectronOAuthButtons'
+
+// useUser gates the "reset on signed-in" derivation; a signed-out user is the
+// state under test (the card only renders this while signed out).
+vi.mock('@clerk/nextjs', () => ({
+  useUser: () => ({ user: null }),
+}))
+
+// Force the Electron branch so the success/error listeners register exactly as
+// they do in the packaged app (the effect early-returns outside Electron).
+vi.mock('../../../electron/utils/electron-client', () => ({
+  isElectronEnvironment: () => true,
+}))
+
+type OAuthStartResult = { success: boolean; error?: string }
+
+/**
+ * Plants a Floating-preload-shaped `window.electronAPI.oauth` whose `start`
+ * resolves to the given result, returning the spy so the test can assert the
+ * provider it was called with.
+ */
+function plantOAuthBridge(result: OAuthStartResult) {
+  const start = vi.fn(async () => result)
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: {
+      oauth: {
+        start,
+        onSuccess: vi.fn(() => () => {}),
+        onError: vi.fn(() => () => {}),
+      },
+    } as unknown as Window['electronAPI'],
+  })
+  return start
+}
+
+describe('ElectronOAuthButtons', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'electronAPI')
+    vi.clearAllMocks()
+  })
+
+  it('launches the Google system-browser sign-in when the front-door button is pressed', async () => {
+    // Arrange: the Floating preload exposes a working oauth bridge.
+    const start = plantOAuthBridge({ success: true })
+    render(<ElectronOAuthButtons />)
+
+    // Act: the signed-out user presses the only sign-in affordance.
+    fireEvent.click(
+      screen.getByRole('button', { name: /sign in with google/i }),
+    )
+
+    // Assert: it starts the native Google flow and reflects the in-flight state
+    // (so the user sees the browser is opening, and can't double-fire it).
+    expect(start).toHaveBeenCalledWith('google')
+    expect(
+      await screen.findByRole('button', { name: /opening browser/i }),
+    ).toBeDisabled()
+  })
+
+  it('surfaces a calm error when the native flow fails to start', async () => {
+    // Arrange: the main process reports it could not start the flow.
+    plantOAuthBridge({
+      success: false,
+      error: 'Failed to start authentication',
+    })
+    render(<ElectronOAuthButtons />)
+
+    // Act
+    fireEvent.click(
+      screen.getByRole('button', { name: /sign in with google/i }),
+    )
+
+    // Assert: the failure is announced (role=alert) rather than swallowed, and
+    // the button returns to its idle, re-pressable state.
+    const errorMessage = await screen.findByText(
+      /failed to start authentication/i,
+    )
+    expect(errorMessage).toHaveAttribute('role', 'alert')
+    expect(
+      screen.getByRole('button', { name: /sign in with google/i }),
+    ).toBeEnabled()
+  })
+})

--- a/src/components/auth/ElectronOAuthButtons.tsx
+++ b/src/components/auth/ElectronOAuthButtons.tsx
@@ -39,6 +39,9 @@ function oauthReducer(state: OAuthState, action: OAuthAction): OAuthState {
       return { isLoading: false, error: null }
     case 'ERROR':
       return { isLoading: false, error: action.error }
+    // Intentionally unwired in Phase 1 (nothing dispatches RESET yet) — kept as
+    // the recovery scaffold; see the success branch in handleGoogleClick for the
+    // abandonment limitation it will eventually resolve (T20 UX decision).
     case 'RESET':
       return { isLoading: false, error: null }
     default:
@@ -125,6 +128,15 @@ export const ElectronOAuthButtons = memo(function ElectronOAuthButtons() {
         }
         // On success the system browser opens; the onSuccess/onError events (and
         // the in-place Clerk re-render) take over from here.
+        //
+        // KNOWN Phase-1 limitation: if the user ABANDONS the browser flow (closes
+        // the tab / picks no account), no event fires and the CTA stays disabled
+        // at "Opening browser…" until the window is reopened. Non-regressive — the
+        // Electron main window is still a working sign-in path during Phase 1's
+        // strangler-fig, so this is not a dead-ended user. The recovery mechanism
+        // (dispatch RESET on focus-regain vs. a timeout) is a UX decision to settle
+        // during the T20 packaged native-OAuth QA, where the real deep-link timing
+        // can be observed — it must not be guessed at here.
       } catch {
         dispatch({ type: 'ERROR', error: 'Failed to start authentication' })
       }

--- a/src/components/auth/ElectronOAuthButtons.tsx
+++ b/src/components/auth/ElectronOAuthButtons.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useUser } from '@clerk/nextjs'
+import { Loader2 } from 'lucide-react'
 import { memo, useCallback, useSyncExternalStore } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -8,58 +9,75 @@ import { useCycleEffect } from '@/hooks/use-cycle-effect'
 import { useReducerState } from '@/hooks/useReducerState'
 
 import { isElectronEnvironment } from '../../../electron/utils/electron-client'
+
 type OAuthState = {
-  isLoading: string | null
+  isLoading: boolean
   error: string | null
 }
 
 type OAuthAction =
-  | { type: 'START_LOADING'; provider: string }
+  | { type: 'START_LOADING' }
   | { type: 'SUCCESS' }
   | { type: 'ERROR'; error: string }
   | { type: 'RESET' }
 
+/**
+ * Reduces the native-OAuth start gesture's transient UI state (one provider:
+ * Google). START_LOADING on click, SUCCESS/ERROR from the main-process events.
+ * @param state - Current loading/error state.
+ * @param action - Lifecycle event for the in-flight sign-in.
+ * @returns The next state.
+ * @example
+ * oauthReducer({ isLoading: false, error: null }, { type: 'START_LOADING' })
+ * // => { isLoading: true, error: null }
+ */
 function oauthReducer(state: OAuthState, action: OAuthAction): OAuthState {
   switch (action.type) {
     case 'START_LOADING':
-      return { isLoading: action.provider, error: null }
+      return { isLoading: true, error: null }
     case 'SUCCESS':
-      return { isLoading: null, error: null }
+      return { isLoading: false, error: null }
     case 'ERROR':
-      return { isLoading: null, error: action.error }
+      return { isLoading: false, error: action.error }
     case 'RESET':
-      return { isLoading: null, error: null }
+      return { isLoading: false, error: null }
     default:
       return state
   }
 }
 
 /**
- * OAuth buttons for Electron environment.
+ * The signed-out Floating front door's sign-in CTA — a single amber "Sign in
+ * with Google" button that launches the system-browser OAuth flow.
  *
- * Google OAuth blocks WebView authentication, so in Electron we need to:
- * 1. Open system browser for OAuth
- * 2. Receive callback via deep link
- * 3. Complete authentication in Electron
+ * Why Google-only: Google blocks OAuth inside a WebView, so Electron opens the
+ * system browser, receives the `corelive://` deep-link callback, and completes
+ * the sign-in in-process (Clerk re-renders the panel in place — no navigation).
+ * The Electron login forms are already Google-only, so this matches that
+ * convention and the approved single-CTA design. It is the ONLY consumer of
+ * this module; the capability hook below decides whether to render it at all.
  *
- * This component provides buttons that trigger the browser-based OAuth flow.
+ * @returns The amber sign-in button plus a calm trust/error line beneath it.
+ * @example
+ * <ElectronOAuthButtons />
  */
 export const ElectronOAuthButtons = memo(function ElectronOAuthButtons() {
   const [state, dispatch] = useReducerState(oauthReducer, {
-    isLoading: null,
+    isLoading: false,
     error: null,
   })
   const { user } = useUser()
 
-  // When user becomes signed in (from Clerk), reset loading state
-  // This handles successful sign-in via the token exchange
-  const isLoading = user ? null : state.isLoading
+  // Clear transient state the instant Clerk reports a signed-in user (the token
+  // exchange completed) — the card is about to swap to the live navigator.
+  const isLoading = user ? false : state.isLoading
   const error = user ? null : state.error
 
   useCycleEffect(() => {
     if (!isElectronEnvironment()) return
 
-    // Register OAuth event listeners
+    // Main-process OAuth outcome events (success/error) drive the button back
+    // out of its loading state.
     const unsubscribeSuccess = window.electronAPI?.oauth?.onSuccess?.(() => {
       dispatch({ type: 'SUCCESS' })
     })
@@ -68,7 +86,8 @@ export const ElectronOAuthButtons = memo(function ElectronOAuthButtons() {
       dispatch({ type: 'ERROR', error: data.error || 'Authentication failed' })
     })
 
-    // Listen for custom error event from ElectronAuthProvider
+    // The renderer-side provider re-dispatches token-exchange failures through
+    // this custom event (D2's second error source).
     const handleCustomError = (event: Event) => {
       const customEvent = event as CustomEvent<string>
       dispatch({
@@ -85,111 +104,90 @@ export const ElectronOAuthButtons = memo(function ElectronOAuthButtons() {
     }
   }, [])
 
-  const handleOAuthClick = useCallback(
-    async (provider: 'google' | 'github' | 'apple') => {
+  // Sync, stable click handler (the Button needs a stable useCallback ref) that
+  // fires the async native-OAuth start as fire-and-forget.
+  const handleGoogleClick = useCallback(() => {
+    void (async () => {
       if (!window.electronAPI?.oauth) {
         dispatch({ type: 'ERROR', error: 'OAuth not available' })
         return
       }
 
-      dispatch({ type: 'START_LOADING', provider })
+      dispatch({ type: 'START_LOADING' })
 
       try {
-        const result = await window.electronAPI.oauth.start(provider)
+        const result = await window.electronAPI.oauth.start('google')
         if (!result.success) {
           dispatch({
             type: 'ERROR',
             error: result.error || 'Failed to start authentication',
           })
         }
-        // If successful, browser will open and user will complete OAuth there
-        // The success/error callbacks will handle the result
+        // On success the system browser opens; the onSuccess/onError events (and
+        // the in-place Clerk re-render) take over from here.
       } catch {
         dispatch({ type: 'ERROR', error: 'Failed to start authentication' })
       }
-    },
-    [],
-  )
-
-  const handleGoogleClick = useCallback(() => {
-    void handleOAuthClick('google')
-  }, [handleOAuthClick])
-
-  const handleGithubClick = useCallback(() => {
-    void handleOAuthClick('github')
-  }, [handleOAuthClick])
+    })()
+  }, [])
 
   return (
-    <div className="flex flex-col gap-3">
-      <p className="text-center text-sm text-gray-500">
-        Sign in with your preferred provider
-      </p>
-
+    <div className="flex w-full flex-col gap-2">
       <Button
-        variant="outline"
-        className="flex w-full items-center justify-center gap-2"
+        className="w-full gap-2"
         onClick={handleGoogleClick}
-        disabled={isLoading !== null}
+        disabled={isLoading}
+        aria-busy={isLoading}
       >
-        {isLoading === 'google' ? (
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
+        {isLoading ? (
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
         ) : (
-          <svg className="h-5 w-5" viewBox="0 0 24 24">
-            <path
-              fill="currentColor"
-              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-            />
-            <path
-              fill="currentColor"
-              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-            />
-            <path
-              fill="currentColor"
-              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-            />
-            <path
-              fill="currentColor"
-              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-            />
-          </svg>
+          <GoogleMark />
         )}
-        <span>
-          {isLoading === 'google'
-            ? 'Opening browser...'
-            : 'Continue with Google'}
-        </span>
+        <span>{isLoading ? 'Opening browser…' : 'Sign in with Google'}</span>
       </Button>
 
-      <Button
-        variant="outline"
-        className="flex w-full items-center justify-center gap-2"
-        onClick={handleGithubClick}
-        disabled={isLoading !== null}
-      >
-        {isLoading === 'github' ? (
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
-        ) : (
-          <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-          </svg>
-        )}
-        <span>
-          {isLoading === 'github'
-            ? 'Opening browser...'
-            : 'Continue with GitHub'}
-        </span>
-      </Button>
-
-      {error && (
-        <div className="rounded-md bg-red-50 p-3 text-center text-sm text-red-600">
+      {error ? (
+        <p role="alert" className="text-center text-xs text-destructive">
           {error}
-        </div>
+        </p>
+      ) : (
+        <p className="text-center text-xs text-muted-foreground">
+          Opens securely in your browser.
+        </p>
       )}
-
-      <p className="mt-2 text-center text-xs text-gray-400">
-        Authentication will open in your browser for security.
-      </p>
     </div>
+  )
+})
+
+/**
+ * Google "G" glyph as a single-color mark (inherits `currentColor`, so it reads
+ * as paper-white on the amber button instead of clashing Google brand colors
+ * against Warm Cathedral).
+ * @returns A 16px monochrome Google logo SVG, hidden from the a11y tree.
+ * @example
+ * <GoogleMark />
+ */
+const GoogleMark = memo(function GoogleMark() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="currentColor"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
   )
 })
 

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useUser } from '@clerk/nextjs'
 import { arrayMove } from '@dnd-kit/helpers'
 import {
   keepPreviousData,
@@ -29,6 +30,7 @@ import type {
 } from '@/server/schemas/category'
 
 import { FloatingNavigator, type FloatingTodo } from './FloatingNavigator'
+import { SignedOutFloatingCard } from './SignedOutFloatingCard'
 
 const TODO_QUERY_LIMIT = 100
 const TODO_QUERY_OFFSET = 0
@@ -54,6 +56,8 @@ export const FloatingNavigatorContainer = React.memo(
   function FloatingNavigatorContainer() {
     const queryClient = useQueryClient()
     const isClerkQueryReady = useClerkQueryReady()
+    // Clerk auth gate: drives the signed-out front door vs the live navigator.
+    const { isLoaded: isAuthLoaded, isSignedIn } = useUser()
 
     // Category filter state (shared with main app via localStorage)
     const [selectedCategoryId, setSelectedCategoryId] = useSelectedCategory()
@@ -353,6 +357,21 @@ export const FloatingNavigatorContainer = React.memo(
           </p>
         </div>
       )
+    }
+
+    // Auth gate: hold a calm loading state until Clerk resolves, then show the
+    // signed-out front door (this window is the sign-in surface now that the
+    // main window is gone) or fall through to the live navigator. A native OAuth
+    // sign-in re-renders this in place — no reload.
+    if (!isAuthLoaded) {
+      return (
+        <div className="flex h-full w-full items-center justify-center bg-background">
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        </div>
+      )
+    }
+    if (!isSignedIn) {
+      return <SignedOutFloatingCard />
     }
 
     // Show loading state

--- a/src/components/floating-navigator/SignedOutFloatingCard.test.tsx
+++ b/src/components/floating-navigator/SignedOutFloatingCard.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview SignedOutFloatingCard preload-skew degradation tests.
+ *
+ * The sentinel: the Floating window is now the signed-out "front door", and its
+ * sign-in affordance is decided by CAPABILITY (`useShowElectronOAuth`), not a
+ * call-time `?.`. The danger is preload skew — the web renderer ships via Vercel
+ * independently of the packaged app, so an OLDER installed app whose frozen
+ * Floating preload predates `window.electronAPI` will load this new card. If the
+ * card rendered OAuth buttons unconditionally, that user would get dead buttons
+ * (the deep-link bridge isn't there). The skew case below fails if the card ever
+ * stops degrading to the web-app fallback when the oauth bridge is absent.
+ *
+ * Triggered when: `pnpm test` (Vitest, happy-dom).
+ *
+ * @example
+ *   pnpm test -- SignedOutFloatingCard
+ */
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SignedOutFloatingCard } from './SignedOutFloatingCard'
+
+// Stub ONLY the Clerk-dependent OAuth buttons (they need a ClerkProvider); keep
+// the REAL `useShowElectronOAuth` capability hook — that skew-guard is the thing
+// under test, so it must run against the actual `window.electronAPI` we plant.
+vi.mock('@/components/auth/ElectronOAuthButtons', async (importOriginal) => {
+  // Structural shape of the one real export we keep (the capability hook). The
+  // module type isn't imported inline (`typeof import()` is lint-forbidden) and
+  // a value import would be type-only here — restating the stable `() => boolean`
+  // contract keeps the spread typed without either.
+  const actual = await importOriginal<{ useShowElectronOAuth: () => boolean }>()
+  return {
+    ...actual,
+    ElectronOAuthButtons: () => <div data-testid="oauth-buttons" />,
+  }
+})
+
+/**
+ * Plants a fake `window.electronAPI` whose `oauth` bridge is present, mimicking
+ * the current Floating preload after the T2 exposure.
+ */
+function exposeOAuthBridge(): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    // Partial test double for a wide preload global — only `oauth` truthiness is
+    // read by the capability hook, so the cast through `unknown` is intentional.
+    value: { oauth: {} } as unknown as Window['electronAPI'],
+  })
+}
+
+describe('SignedOutFloatingCard', () => {
+  afterEach(() => {
+    // Each case decides the capability from scratch — drop any planted bridge so
+    // the skew case genuinely sees NO electronAPI.
+    Reflect.deleteProperty(window, 'electronAPI')
+  })
+
+  it('offers native sign-in when the Floating preload exposes the oauth bridge', () => {
+    // Arrange: the current Floating preload has exposed window.electronAPI.oauth.
+    exposeOAuthBridge()
+
+    // Act
+    render(<SignedOutFloatingCard />)
+
+    // Assert: the OAuth buttons are reachable — a signed-out user can start the
+    // native browser sign-in right here in the Floating window.
+    expect(screen.getByTestId('oauth-buttons')).toBeInTheDocument()
+  })
+
+  it('points to the web app instead of dead buttons when no oauth bridge exists', () => {
+    // Arrange: preload skew — an installed app's frozen Floating preload predates
+    // window.electronAPI entirely (this feature added it). electronAPI is absent.
+
+    // Act
+    render(<SignedOutFloatingCard />)
+
+    // Assert: NO OAuth buttons (they'd be dead without the bridge), and the
+    // skew-safe fallback guides the user to the web app instead.
+    expect(screen.queryByTestId('oauth-buttons')).not.toBeInTheDocument()
+    expect(screen.getByText(/web app/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/floating-navigator/SignedOutFloatingCard.test.tsx
+++ b/src/components/floating-navigator/SignedOutFloatingCard.test.tsx
@@ -80,4 +80,19 @@ describe('SignedOutFloatingCard', () => {
     expect(screen.queryByTestId('oauth-buttons')).not.toBeInTheDocument()
     expect(screen.getByText(/web app/i)).toBeInTheDocument()
   })
+
+  it('greets the signed-out user with the north-star invitation, not a sign-in demand', () => {
+    // Arrange: the signed-out front door with the oauth bridge present.
+    exposeOAuthBridge()
+
+    // Act
+    render(<SignedOutFloatingCard />)
+
+    // Assert: the warm editorial headline is the panel's voice — an invitation
+    // ("your year is waiting"), rendered as a real heading for a11y, never a
+    // KPI/streak gate. This is the north-star contract for the front door.
+    expect(
+      screen.getByRole('heading', { name: /your year is waiting/i }),
+    ).toBeInTheDocument()
+  })
 })

--- a/src/components/floating-navigator/SignedOutFloatingCard.tsx
+++ b/src/components/floating-navigator/SignedOutFloatingCard.tsx
@@ -1,24 +1,52 @@
 'use client'
 
+import { Heart } from 'lucide-react'
 import { memo } from 'react'
 
 import {
   ElectronOAuthButtons,
   useShowElectronOAuth,
 } from '@/components/auth/ElectronOAuthButtons'
+import { HEATMAP_LEVEL_TOKENS } from '@/lib/heatmap-intensity'
+
+/**
+ * Decorative heatmap "ribbon" — a warming ramp (rest → cathedral-lit) of the
+ * north-star temperature gradient, the year the returning user is picking back
+ * up. Each `level` indexes HEATMAP_LEVEL_TOKENS (the heatmap source-of-truth),
+ * so it resolves per active theme + light/dark mode via the `--hm-*` tokens with
+ * zero extra wiring. Stable ids keep it from ever reordering; it is purely
+ * decorative, so the row is `aria-hidden`.
+ */
+const HEATMAP_RIBBON_CELLS = [
+  { id: 'dawn-a', level: 0 },
+  { id: 'dawn-b', level: 1 },
+  { id: 'morning-a', level: 1 },
+  { id: 'morning-b', level: 2 },
+  { id: 'midday-a', level: 2 },
+  { id: 'midday-b', level: 3 },
+  { id: 'afternoon-a', level: 3 },
+  { id: 'afternoon-b', level: 4 },
+  { id: 'dusk-a', level: 4 },
+  { id: 'dusk-b', level: 3 },
+] as const
 
 /**
  * Signed-out "front door" for the Electron Floating window — rendered by
  * FloatingNavigatorContainer when Clerk reports no active session.
  *
- * Why it exists: the Electron main window was retired, so the Floating panel is
- * now the visible surface a signed-out user signs in from. It must stay visible
- * + interactive while signed out, else a signed-out launch = zero interactive
- * windows. After a native OAuth sign-in, Clerk re-renders the container in place
- * and this card is swapped for the live navigator — no reload, no navigation.
+ * Why it exists: the Electron main window is being retired, so the Floating
+ * panel is now the visible surface a signed-out user signs in from. It must stay
+ * visible + interactive while signed out, else a signed-out launch = zero
+ * interactive windows. After a native OAuth sign-in, Clerk re-renders the
+ * container in place and this card is swapped for the live navigator — no
+ * reload, no navigation (Clerk's `setActive` is called with a no-op `navigate`).
  *
- * @returns Native-OAuth buttons when the preload exposes the oauth bridge, else
- * a skew-safe fallback (an older frozen preload may lack it entirely).
+ * The design is the approved "Warm Cathedral" front door (Variant A): a serif
+ * editorial headline over the accumulated-warmth heatmap motif, carrying the
+ * north star — "your year is waiting", never a KPI gate.
+ *
+ * @returns The amber native-OAuth front door when the preload exposes the oauth
+ * bridge, else a skew-safe fallback (an older frozen preload may lack it).
  * @example
  * if (isLoaded && !isSignedIn) return <SignedOutFloatingCard />
  */
@@ -29,23 +57,51 @@ export const SignedOutFloatingCard = memo(function SignedOutFloatingCard() {
   const canStartOAuth = useShowElectronOAuth()
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-4 bg-background p-5 text-center">
-      <div className="space-y-1">
-        <h1 className="text-base font-semibold text-foreground">CoreLive</h1>
+    <div className="flex h-full w-full flex-col bg-background p-6">
+      {/* Quiet brand wordmark — the headline below is the hero, not this. */}
+      <p className="text-xs font-semibold tracking-wide text-muted-foreground">
+        CoreLive
+      </p>
+
+      {/* Editorial hero: the north-star invitation, serif display per DESIGN.md. */}
+      <div className="mt-5 space-y-2">
+        <h1 className="font-serif text-3xl font-semibold leading-tight text-foreground">
+          Your year is waiting
+        </h1>
         <p className="text-sm text-muted-foreground">
-          Sign in to pick up today.
+          Pick up where you left off.
         </p>
       </div>
 
-      {canStartOAuth ? (
-        <div className="w-full">
+      {/* Sign-in affordance, capability-gated for preload skew (DT3). */}
+      <div className="mt-6">
+        {canStartOAuth ? (
           <ElectronOAuthButtons />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Sign in from the CoreLive web app, then reopen this window.
+          </p>
+        )}
+      </div>
+
+      {/* Push the motif + footer to the bottom edge of the panel. */}
+      <div className="mt-auto space-y-3 pt-6">
+        {/* Accumulated-warmth heatmap ribbon — decorative north-star motif. */}
+        <div className="flex gap-1" aria-hidden="true">
+          {HEATMAP_RIBBON_CELLS.map((cell) => (
+            <span
+              key={cell.id}
+              className="h-2.5 flex-1 rounded-sm"
+              style={{ backgroundColor: HEATMAP_LEVEL_TOKENS[cell.level] }}
+            />
+          ))}
         </div>
-      ) : (
-        <p className="text-xs text-muted-foreground">
-          Sign in from the CoreLive web app, then reopen this window.
+        {/* Quiet-companion footer — affirmation, never a metric. */}
+        <p className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
+          <Heart className="h-3 w-3" aria-hidden="true" />
+          Small steps, meaningful change.
         </p>
-      )}
+      </div>
     </div>
   )
 })

--- a/src/components/floating-navigator/SignedOutFloatingCard.tsx
+++ b/src/components/floating-navigator/SignedOutFloatingCard.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { memo } from 'react'
+
+import {
+  ElectronOAuthButtons,
+  useShowElectronOAuth,
+} from '@/components/auth/ElectronOAuthButtons'
+
+/**
+ * Signed-out "front door" for the Electron Floating window — rendered by
+ * FloatingNavigatorContainer when Clerk reports no active session.
+ *
+ * Why it exists: the Electron main window was retired, so the Floating panel is
+ * now the visible surface a signed-out user signs in from. It must stay visible
+ * + interactive while signed out, else a signed-out launch = zero interactive
+ * windows. After a native OAuth sign-in, Clerk re-renders the container in place
+ * and this card is swapped for the live navigator — no reload, no navigation.
+ *
+ * @returns Native-OAuth buttons when the preload exposes the oauth bridge, else
+ * a skew-safe fallback (an older frozen preload may lack it entirely).
+ * @example
+ * if (isLoaded && !isSignedIn) return <SignedOutFloatingCard />
+ */
+export const SignedOutFloatingCard = memo(function SignedOutFloatingCard() {
+  // Render-time skew guard (DT3/F4): decide the affordance by CAPABILITY, not a
+  // call-time `?.` — a frozen preload from an older install may not expose the
+  // oauth bridge at all, in which case the buttons would be dead.
+  const canStartOAuth = useShowElectronOAuth()
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 bg-background p-5 text-center">
+      <div className="space-y-1">
+        <h1 className="text-base font-semibold text-foreground">CoreLive</h1>
+        <p className="text-sm text-muted-foreground">
+          Sign in to pick up today.
+        </p>
+      </div>
+
+      {canStartOAuth ? (
+        <div className="w-full">
+          <ElectronOAuthButtons />
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Sign in from the CoreLive web app, then reopen this window.
+        </p>
+      )}
+    </div>
+  )
+})

--- a/src/lib/orpc/electron-auth-provider.tsx
+++ b/src/lib/orpc/electron-auth-provider.tsx
@@ -81,16 +81,19 @@ export const ElectronAuthProvider = memo(function ElectronAuthProvider({
         })
 
         await setActive({
-          navigate: ({ session, decorateUrl }) => {
+          // Electron companion: after a native OAuth sign-in we deliberately do
+          // NOT navigate. Clerk's reactive hooks (useUser/useAuth) re-render the
+          // current route in place — the signed-out Floating card swaps to the
+          // live navigator with no reload — and no Electron window wants the web
+          // `/home` dashboard (it was retired with the main window). The only
+          // exception is a multi-step task (e.g. MFA) that can't be completed
+          // inside a companion panel, surfaced here as an error.
+          navigate: ({ session }) => {
             if (session?.currentTask) {
               dispatchOAuthError(
                 'Additional sign-in steps are required. Please complete sign-in in the browser.',
               )
-              return
             }
-
-            const url = decorateUrl('/home')
-            window.location.href = url
           },
           session: createdSessionId,
         })

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview proxy.ts route-protection pin — the public-route carve-out guard.
+ *
+ * The sentinel: `/floating-navigator` MUST stay OUT of the protected matcher. It
+ * is the Electron signed-out "front door" — the Floating window loads it while
+ * signed out and Clerk re-renders it in place after a native OAuth sign-in. If a
+ * future edit drops `/floating-navigator(.*)` into `createRouteMatcher`, a
+ * signed-out load would bounce to `/login`, the card + navigator would never
+ * render, and every SignedOutFloatingCard + DT7 recovery path would silently go
+ * dark — with the rest of the suite still green. This test fails the instant
+ * that carve-out is lost (and its sibling proves the carve-out is scoped, not a
+ * blanket open door).
+ *
+ * It drives the REAL Clerk `createRouteMatcher` (the matcher list is the thing
+ * under test); only `clerkMiddleware` is unwrapped so the handler can be called
+ * directly with a controlled auth state — no Clerk secret / middleware boot.
+ *
+ * Triggered when: `pnpm test` (Vitest, happy-dom).
+ *
+ * @example
+ *   pnpm test -- proxy
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Shape proxy.ts's `clerkMiddleware` handler is actually invoked with: a Clerk
+ * `auth()` thunk and the request. The mock below unwraps `clerkMiddleware` to
+ * this raw handler, so the default export is callable as `(auth, req)` rather
+ * than the `(request, event)` NextMiddleware shape its static type advertises.
+ */
+type ProxyAuth = () => Promise<{ isAuthenticated: boolean }>
+type ProxyRequest = { nextUrl: { pathname: string }; url: string }
+type ProxyHandler = (
+  auth: ProxyAuth,
+  req: ProxyRequest,
+) => Promise<Response | undefined>
+
+// Keep the REAL createRouteMatcher (its route list is the thing under test) but
+// unwrap clerkMiddleware to expose proxy.ts's handler, so the test drives it
+// with a controlled auth state instead of booting Clerk's full middleware.
+vi.mock('@clerk/nextjs/server', async (importOriginal) => {
+  // Structural shape of the one real export we keep — `typeof import()` as a
+  // type arg is lint-forbidden, so restate the createRouteMatcher contract.
+  const actual = await importOriginal<{
+    createRouteMatcher: (
+      routes: readonly string[],
+    ) => (req: { nextUrl: { pathname: string } }) => boolean
+  }>()
+  return {
+    createRouteMatcher: actual.createRouteMatcher,
+    clerkMiddleware: (handler: ProxyHandler) => handler,
+  }
+})
+
+/**
+ * Builds the minimal request the proxy handler reads: `nextUrl.pathname` (what
+ * the real Clerk matcher tests) and an absolute `url` (what the `/login`
+ * redirect is constructed from).
+ *
+ * @param pathname - The request path, e.g. `/floating-navigator`.
+ * @returns A request double carrying exactly those two fields.
+ * @example
+ *   requestFor('/home') // => { nextUrl: { pathname: '/home' }, url: 'https://corelive.app/home' }
+ */
+function requestFor(pathname: string): ProxyRequest {
+  return {
+    nextUrl: { pathname },
+    url: `https://corelive.app${pathname}`,
+  }
+}
+
+describe('proxy route protection', () => {
+  let handler: ProxyHandler
+
+  beforeEach(async () => {
+    // The clerkMiddleware mock unwraps the default export to its raw handler.
+    const proxyModule = await import('./proxy')
+    handler = proxyModule.default as unknown as ProxyHandler
+  })
+
+  it('lets a signed-out visitor reach /floating-navigator instead of bouncing to /login', async () => {
+    // Arrange: a signed-out visitor — the Electron Floating front door loads
+    // this route before any sign-in exists.
+    const auth = vi.fn(async () => ({ isAuthenticated: false }))
+
+    // Act
+    const result = await handler(auth, requestFor('/floating-navigator'))
+
+    // Assert: no redirect response at all — the signed-out front door renders.
+    // A protected route would have produced a /login redirect for this same
+    // signed-out visitor, so an undefined result here means the route is public.
+    expect(result).toBeUndefined()
+    // And it short-circuited as public: it never even consulted auth.
+    expect(auth).not.toHaveBeenCalled()
+  })
+
+  it('still redirects a signed-out visitor on a protected route (/home) to /login', async () => {
+    // Arrange: the same signed-out visitor, but on a protected route — proves
+    // the carve-out is scoped to /floating-navigator, not a blanket open door.
+    const auth = vi.fn(async () => ({ isAuthenticated: false }))
+
+    // Act
+    const result = await handler(auth, requestFor('/home'))
+
+    // Assert: bounced to /login (Next redirect status = 307), proving the
+    // matcher is live and protecting the rest of the app.
+    expect(result?.status).toBe(307)
+    expect(result?.headers.get('location')).toContain('/login')
+  })
+})

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,10 +8,14 @@ const isProtectedRoute = createRouteMatcher([
   // /settings is web-reachable (D15) but still requires auth like the rest of
   // the app — the preferences it edits belong to a signed-in user's experience.
   '/settings(.*)',
-  // Floating Navigator must redirect to /login like the other panels so the
-  // Electron main-process nav-watch can detect an unauthenticated cold boot
-  // and surface the main window instead of an empty panel.
-  '/floating-navigator(.*)',
+  // NOTE: /floating-navigator is intentionally NOT protected. The Electron
+  // companion renders a signed-out "front door" card on this route so the
+  // Floating window stays visible + interactive while signed out, and Clerk
+  // re-renders it in place after a native OAuth sign-in — there is no main
+  // window to surface and no /login redirect to detect. A signed-out web
+  // visitor reaching /floating-navigator (a browser tab, not the Electron
+  // panel) just sees the existing "desktop app only" notice — the card is
+  // Electron-only.
 ])
 
 const middleware = clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
> ## ⚠️ DO NOT MERGE YET — native-OAuth ship gate (T20) is still OWED
>
> This PR is open for **review only** (design ✅, code ✅, **CodeRabbit ✅ resolved** — see the resolution comment). It must **not** be merged until **T20** passes: a **real Google SSO end-to-end sign-in on the _packaged_ macOS app**. Merging `main` triggers the production Vercel deploy of this renderer, which the Electron app loads live — so merge *is* the deploy. T20 needs a human + a real Google account on the packaged build and **cannot be run while unattended**. See **QA status** below.

## What this is

**Phase 1, Lane A** of retiring the Electron main window (strangler-fig — `createMainWindow` stays alive this phase). It turns the **Floating window into a working signed-out front door**: a signed-out launch now shows an inviting "Warm Cathedral" card that starts Google sign-in via the system browser, instead of a dead/zero-interactive window.

After a native OAuth sign-in, Clerk re-renders the container **in place** (no navigation, no reload) and the card is swapped for the live navigator.

## Commits

- `fd3cfe7` feat — Floating window as signed-out OAuth front door (Lane A core)
- `c339aec` feat — DT7 Floating load-failure recovery + signed-out defer
- `86f88bc` test — pin `/floating-navigator` public route + `getWebAppOrigin` fallbacks
- `f45f4f0` feat — **Chunk 3**: Variant A warm signed-out Floating front door (the card + CTA)
- `4845377` docs/test — document OAuth abandonment limitation + harden CTA tests (this session's `/review` follow-ups)
- `6c48c93` fix — resolve CodeRabbit review: initiator-scoped OAuth ticket/errors + DT7 recovery & floating-preload hardening (8 findings, each RED→green; N4 deferred)

## Key decisions

- **DD1 = Option A**: `/floating-navigator` is un-protected in `proxy.ts` (documented inline) so the signed-out card and the live navigator render on the **same route**, gated by `useUser()`. No post-`setActive` navigation.
- **Initiator-targeted OAuth push**: `oauth-start` captures `event.sender`; the sign-in token is pushed back to the **initiating window**, so the right window completes the flow (main ↔ Floating). `6c48c93` extends this targeting to the **error path** and the **pull-fallback** (see CodeRabbit B/C).
- **Atomic shared preload bridge**: `createOAuthBridge` / `createAuthBridge` (`electron/preload-shared/auth-oauth-bridge.ts`) are consumed by **both** `preload.ts` and `preload-floating.ts`, so the bridge shape can never skew between windows.
- **Preload-skew capability gate**: the card decides the sign-in affordance by **capability** (`useShowElectronOAuth`, `useSyncExternalStore`, SSR-safe), not a call-time `?.` — an older frozen preload that lacks the oauth bridge shows a calm fallback instead of a dead button.
- **Design**: approved Warm Cathedral Variant A — Newsreader serif hero ("Your year is waiting"), amber CTA, accumulated-warmth heatmap ribbon (warm `--hm-*` tokens, never GitHub-green), quiet-companion voice. North star: 「些細でも経験値」.

## QA status — read before merging

| Gate | Status |
| ---- | ------ |
| Unit (web) | ✅ 633 passed (`pnpm test`, Node 24.13.0 / CI parity) |
| Unit (electron) | ✅ 322 passed (`pnpm test:electron`) — validated this branch incl. the `6c48c93` fixes |
| Lint / typecheck | ✅ 0 warnings / clean |
| Web E2E | ⏳ **CI is the gate** — Playwright `webServer` can't boot locally on this Mac (loopback mismatch). Wait for the green CI run. |
| **T20 — real Google SSO on packaged app** | ❌ **NOT RUN — OWED.** Now **broader** after `6c48c93` (live-OAuth-path changes are unit-verified only) — see "What T20 must now exercise" below. |

### What T20 must now exercise (expanded after the CodeRabbit fixes)

`6c48c93` changed the **live OAuth callback path** (error routing + token scoping); those changes are **unit-verified only**. The packaged-app run (`pnpm electron:build:dir` → `open dist/mac/CoreLive.app`) must confirm, on the real `corelive://` deep-link round-trip:

1. **Happy path** — the **Floating** window completes sign-in and swaps the card for the live navigator in place. The token reaches it via the **initiator-targeted push** (primary); the **pull-fallback is now _also_ initiator-scoped**.
2. **C identity seam** — the pull-fallback releases the one-time ticket only to a window whose `webContents.id` matches the stored `initiatorId`. Unit tests use a single fixed id, so they **cannot** catch a real-flow case where the initiating window's identity differs between `oauth-start` and the pull (window recreated, not just shown). The in-place `setActive` design keeps the id stable, so this *should* hold — but it's a unit-green / native-unverified seam: **confirm the Floating pull-fallback actually lands.**
3. **Error / denial (B)** — denying access, or a missing / expired token, surfaces the error **on the Floating window**, not the main window.
4. **Recovery (D/E)** — a Floating load failure retries on the **same** window, and on exhaustion dismisses the startup pill **before** showing the Retry/Close dialog.

### Known Phase-1 limitation (documented in code)
If the user **abandons** the browser OAuth flow (closes the tab / picks no account), no event fires and the CTA stays disabled at "Opening browser…" until the window is reopened. **Non-regressive** — the Electron main window is still a working sign-in path during the strangler-fig, so no user is dead-ended. The recovery mechanism (RESET on focus-regain vs. timeout) is deliberately **deferred to T20**, where the real deep-link timing can be observed rather than guessed at. `RESET` is kept in the reducer as the scaffold for that fix.

## Review trail

- `/design-review` → **STRONG PASS** against `DESIGN.md` (fonts, color tokens, voice, north star all confirmed; 3 screenshots at 300×400 light/dark/loading).
- `/review` → No blockers. The one Major (OAuth abandonment dead-end) was re-scoped as the non-regressive Phase-1 limitation above and documented; the cheap nits (distinct error-string assertion, real double-fire assertion) are folded into `4845377`.
- `/coderabbit-resolver` → **✅ resolved in `6c48c93`** — all 5 Majors (A floating-preload prototype-pollution hardening, B error-path targeting, C pull-fallback ticket scoping, D retry-target binding, E startup-pill dismissal) + 3 nits fixed, **each with a RED→green unit test**; N4 (named bridge return types) deferred with reason. Per-finding mapping is in the resolution comment. ⚠️ **B and C change the live OAuth path and are unit-verified only → folded into "What T20 must now exercise" above.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floating window now shows a signed-out “front door” sign-in interface, including an auth-loading state.
  * Added automatic recovery for floating window load failures, with a user-facing Retry/Close dialog.
* **Bug Fixes**
  * OAuth one-time sign-in tokens and related errors now reliably deliver to the specific window that initiated the flow.
  * Floating startup-panel failures no longer incorrectly suppress/route the startup UI.
* **Improvements**
  * Electron OAuth UI is now Google-only, with clearer “Opening browser…” behavior and error display.
  * Hardened the floating window’s auth/OAuth communication and sanitizer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
