### PR TITLE
refactor(electron): Phase 1 — re-home native chrome off the main window (strangler-fig)

### DIFF
--- a/electron/AutoUpdater.ts
+++ b/electron/AutoUpdater.ts
@@ -7,6 +7,7 @@
  */
 
 import { BrowserWindow, dialog, screen } from 'electron'
+import type { MessageBoxOptions, MessageBoxReturnValue } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import type { ProgressInfo, UpdateInfo } from 'electron-updater'
 
@@ -261,14 +262,35 @@ export class AutoUpdater {
   }
 
   /**
+   * Anchors an updater dialog to the main window when one is up, else shows it
+   * parentless — companion-mode update prompts (available / downloaded) must
+   * surface even with no main window (post-T18 the main window is gone).
+   * Mirrors `MenuManager.showMenuMessageBox`'s parent-or-parentless dispatch but
+   * returns the result so the caller can act on the clicked button.
+   * @param options - Electron message-box options (type/title/message/detail/buttons).
+   * @returns The dismissed-button result (`response` is the clicked button index).
+   * @example
+   * const { response } = await this.showUpdaterMessageBox({ type: 'info', message: 'Update Ready', buttons: ['Restart Now', 'Later'] })
+   */
+  private async showUpdaterMessageBox(
+    options: MessageBoxOptions,
+  ): Promise<MessageBoxReturnValue> {
+    const mainWindow = this.mainWindow
+    // Anchor to the main window only while it is genuinely alive; otherwise the
+    // app-modal (parentless) overload keeps update prompts reachable.
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      return dialog.showMessageBox(mainWindow, options)
+    }
+    return dialog.showMessageBox(options)
+  }
+
+  /**
    * Shows dialog when update is available.
    *
    * @param info - Update information including version
    */
   async showUpdateAvailableDialog(info: UpdateInfo): Promise<void> {
-    if (!this.mainWindow) return
-
-    const result = await dialog.showMessageBox(this.mainWindow, {
+    const result = await this.showUpdaterMessageBox({
       type: 'info',
       title: 'Update Available',
       message: `A new version (${info.version}) is available!`,
@@ -299,9 +321,7 @@ export class AutoUpdater {
    * Shows dialog when update has been downloaded.
    */
   async showUpdateDownloadedDialog(): Promise<void> {
-    if (!this.mainWindow) return
-
-    const result = await dialog.showMessageBox(this.mainWindow, {
+    const result = await this.showUpdaterMessageBox({
       type: 'info',
       title: 'Update Ready',
       message: 'Update downloaded successfully!',
@@ -317,9 +337,24 @@ export class AutoUpdater {
   }
 
   /**
-   * Sends status message to window.
+   * Logs the updater status and pushes it as transient TEXT to the main
+   * window's renderer (`AppUpdateSettings` in-card status line).
    *
-   * @param text - Status message
+   * BREADCRUMB (T18, Electron main-retirement): this send is main-window-bound
+   * and already no-ops when no main window is up (`log.info` still records it);
+   * after T18 deletes the main window it becomes a permanent no-op, so the
+   * transient "Update not available" / "Error" TEXT loses its only renderer.
+   * That is an ACCEPTED A3 tradeoff, not a regression — the ACTIONABLE states
+   * surface without a main window: `update-available` / `update-downloaded` show
+   * as the parentless dialogs (`showUpdaterMessageBox`) and download progress
+   * shows in the native progress window. The Settings popover is deliberately
+   * NOT retargeted (blur-to-hide, rejected as a status host), and these sends
+   * target the main renderer's webContents — a different webContents from the
+   * popover — so they never reached it anyway. T18/T19 can drop the
+   * `updater-message` channel (+ its preload allowlist entry and the
+   * `AppUpdateSettings` listener) once the main window is gone.
+   *
+   * @param text - Status message (always logged; rendered only while a main window lives).
    */
   sendStatusToWindow(text: string): void {
     log.info(text)
@@ -337,6 +372,10 @@ export class AutoUpdater {
    */
   private sendDownloadProgress(progress: UpdaterDownloadProgress): void {
     this.downloadProgress = progress
+    // Native progress window is the primary, main-optional UI (above). The
+    // renderer mirror below is secondary; like `sendStatusToWindow` it is
+    // main-window-bound and becomes a permanent no-op after T18 — kept until
+    // then so the in-app Settings view still mirrors progress while main lives.
     this.showUpdateProgressWindow(progress)
 
     if (this.mainWindow && this.mainWindow.webContents) {

--- a/electron/DeepLinkManager.ts
+++ b/electron/DeepLinkManager.ts
@@ -19,6 +19,7 @@ import { log } from './logger'
 import type { NotificationManager } from './NotificationManager'
 import type { OAuthManager } from './OAuthManager'
 import type { IPCEventChannel, IPCEventChannels } from './types/ipc'
+import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 import type { WindowManager } from './WindowManager'
 
 // ============================================================================
@@ -40,14 +41,6 @@ interface ParsedDeepLink {
   originalUrl: string
 }
 
-/** Task data for creation */
-interface TaskData {
-  title: string
-  description?: string
-  priority?: string
-  dueDate?: Date
-}
-
 /** Example URLs structure */
 interface ExampleUrls {
   openTask: string
@@ -67,7 +60,16 @@ export class DeepLinkManager {
   /** Window manager reference */
   private windowManager: WindowManager
 
-  /** API bridge for task operations */
+  /**
+   * API bridge for task operations.
+   *
+   * VESTIGIAL after T15: main.ts already constructs this manager with `null`
+   * (WebView architecture has no in-process task store), and T15 dropped the
+   * last `getTodoById`/`createTodo` reads, so this field is now written-only.
+   * Kept (with the `APIBridge` interface + constructor param) so T18 can delete
+   * the whole apiBridge plumbing in one Phase-2 sweep without touching the
+   * constructor call here first.
+   */
   private apiBridge: APIBridge | null
 
   /** Notification manager reference */
@@ -398,43 +400,11 @@ export class DeepLinkManager {
       return
     }
 
-    try {
-      const task = await this.apiBridge?.getTodoById(taskId)
-
-      if (!task) {
-        log.warn(`Task not found: ${taskId}`)
-        if (this.notificationManager) {
-          this.notificationManager.showNotification(
-            'Task Not Found',
-            `Could not find task with ID: ${taskId}`,
-            { type: 'warning' },
-          )
-        }
-        return
-      }
-
-      this.sendToRenderer('deep-link-focus-task', {
-        task: task as { id: string; title: string; [extra: string]: unknown },
-        params,
-      })
-
-      if (this.notificationManager) {
-        this.notificationManager.showNotification(
-          'Task Opened',
-          `Opened task: ${(task as { title: string }).title}`,
-          { type: 'info' },
-        )
-      }
-    } catch (error) {
-      log.error('Failed to handle task action:', error)
-      if (this.notificationManager) {
-        this.notificationManager.showNotification(
-          'Error',
-          'Failed to open task. Please try again.',
-          { type: 'error' },
-        )
-      }
-    }
+    // Open the task in the browser — mirrors the renderer's default
+    // `deep-link-focus-task` route (`/home?focus=<id>`). `taskId` is
+    // percent-encoded because it arrives from the (untrusted) deep-link path,
+    // unlike the renderer's trusted DB id.
+    this.openInBrowser(`/home?focus=${encodeURIComponent(taskId)}`)
   }
 
   /**
@@ -443,57 +413,21 @@ export class DeepLinkManager {
    * @param params - URL parameters
    */
   async handleCreateAction(params: Record<string, string>): Promise<void> {
+    // Open the create form in the browser, pre-filled from the deep link —
+    // mirrors the renderer's default `deep-link-create-task` route
+    // (`/home?create=true&<prefill>`). NO task is created here (the user
+    // confirms in the browser), so this stays a navigation, not a mutation;
+    // `apiBridge.createTodo` was already a null no-op before T15. `params` are
+    // pre-decoded by `parseDeepLinkUrl`, and `URLSearchParams` re-encodes them.
     const { title, description, priority, dueDate } = params
 
-    if (!title) {
-      log.warn('Create action requires title parameter')
-      this.sendToRenderer('deep-link-create-task', {})
-      return
-    }
+    const search = new URLSearchParams({ create: 'true' })
+    if (title) search.set('title', title)
+    if (description) search.set('description', description)
+    if (priority) search.set('priority', priority)
+    if (dueDate) search.set('dueDate', dueDate)
 
-    try {
-      const taskData: TaskData = {
-        title: decodeURIComponent(title),
-        ...(description && { description: decodeURIComponent(description) }),
-        ...(priority && { priority }),
-        ...(dueDate && { dueDate: new Date(dueDate) }),
-      }
-
-      const newTask = await this.apiBridge?.createTodo(taskData)
-
-      this.sendToRenderer('deep-link-task-created', {
-        task: newTask as {
-          id: string
-          title: string
-          [extra: string]: unknown
-        },
-      })
-
-      if (this.notificationManager && newTask) {
-        this.notificationManager.showNotification(
-          'Task Created',
-          `Created task: ${(newTask as { title: string }).title}`,
-          { type: 'success' },
-        )
-      }
-    } catch (error) {
-      log.error('Failed to create task from deep link:', error)
-
-      this.sendToRenderer('deep-link-create-task', {
-        title: title ? decodeURIComponent(title) : '',
-        description: description ? decodeURIComponent(description) : '',
-        priority,
-        dueDate,
-      })
-
-      if (this.notificationManager) {
-        this.notificationManager.showNotification(
-          'Create Task',
-          'Opening task creation dialog...',
-          { type: 'info' },
-        )
-      }
-    }
+    this.openInBrowser(`/home?${search.toString()}`)
   }
 
   /**
@@ -506,17 +440,13 @@ export class DeepLinkManager {
     path: string,
     params: Record<string, string>,
   ): Promise<void> {
+    // Open the view in the browser — mirrors the renderer's default
+    // `deep-link-navigate` route (`/<view>?<params>`). The leading slash keeps
+    // the URL on-origin even for an attacker-crafted `view` segment.
     const view = path.replace('/', '') || params.view || 'home'
+    const query = new URLSearchParams(params).toString()
 
-    this.sendToRenderer('deep-link-navigate', { view, params })
-
-    if (this.notificationManager) {
-      this.notificationManager.showNotification(
-        'View Opened',
-        `Navigated to: ${view}`,
-        { type: 'info' },
-      )
-    }
+    this.openInBrowser(`/${view}${query ? `?${query}` : ''}`)
   }
 
   /**
@@ -525,20 +455,32 @@ export class DeepLinkManager {
    * @param params - URL parameters
    */
   async handleSearchAction(params: Record<string, string>): Promise<void> {
+    // Open search results in the browser — mirrors the renderer's default
+    // `deep-link-search` route (`/home?search=<q>&filter=<f>`). `params` are
+    // pre-decoded by `parseDeepLinkUrl`; `URLSearchParams` re-encodes them.
     const { query, filter } = params
 
-    this.sendToRenderer('deep-link-search', {
-      query: query ? decodeURIComponent(query) : '',
-      filter,
-    })
+    const search = new URLSearchParams()
+    if (query) search.set('search', query)
+    if (filter) search.set('filter', filter)
 
-    if (this.notificationManager && query) {
-      this.notificationManager.showNotification(
-        'Search',
-        `Searching for: ${decodeURIComponent(query)}`,
-        { type: 'info' },
-      )
-    }
+    this.openInBrowser(`/home?${search.toString()}`)
+  }
+
+  /**
+   * Open a task-app path in the user's browser (T15). Deep links now route to
+   * the web app — the full task UI is web-only after main retirement, so a
+   * `corelive://` link surfaces the task / create / view / search there instead
+   * of pushing IPC at a main renderer that no longer exists.
+   * @param appPath - Leading-slash task-app path; the leading slash plus the
+   *   fixed origin in `openWebAppInBrowser` keep the URL on-origin, so an
+   *   attacker-crafted deep link cannot redirect off corelive.app.
+   * @returns Nothing; `openWebAppInBrowser` logs and swallows browser failures.
+   * @example
+   * this.openInBrowser('/home?focus=42') // opens https://corelive.app/home?focus=42
+   */
+  private openInBrowser(appPath: string): void {
+    openWebAppInBrowser(this.windowManager.getWebAppOrigin(), appPath)
   }
 
   /**
@@ -567,16 +509,14 @@ export class DeepLinkManager {
   }
 
   /**
-   * Send event to renderer process.
-   *
-   * @param event - Event name
-   * @param data - Event data
-   */
-  /**
    * Dispatch a typed event to the main renderer window.
    *
-   * Triggered when: deep-link handlers resolve (e.g., `corelive://open/task/1`).
-   * Called by: the `handleDeepLink*` methods above.
+   * ORPHANED after T15: every deep-link handler now opens the browser
+   * (`openInBrowser`) instead of sending to a renderer, so this method has no
+   * callers. It is kept — together with its `deep-link-*` channel definitions
+   * in `types/ipc` and the (already-unmounted) `useElectronDeepLink` renderer
+   * hook — so T18/T19 can delete the whole main-renderer deep-link bridge in
+   * one Phase-2 sweep rather than half-removing it here.
    *
    * @example
    *   this.sendToRenderer('deep-link-focus-task', { task, params })

--- a/electron/MenuManager.ts
+++ b/electron/MenuManager.ts
@@ -7,13 +7,14 @@
  * @module electron/MenuManager
  */
 
-import { app, dialog, Menu, shell } from 'electron'
-import type { BrowserWindow, MenuItemConstructorOptions } from 'electron'
+import { app, BrowserWindow, dialog, Menu, shell } from 'electron'
+import type { MenuItemConstructorOptions, MessageBoxOptions } from 'electron'
 import { autoUpdater } from 'electron-updater'
 
 import type { ConfigManager } from './ConfigManager'
 import { typedSend } from './ipc/typedSend'
 import { log } from './logger'
+import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 import type { WindowManager } from './WindowManager'
 
 // ============================================================================
@@ -62,12 +63,15 @@ export class MenuManager {
   /**
    * Initializes the menu manager with required dependencies.
    *
-   * @param mainWindow - The main application window
+   * @param mainWindow - The main application window, or `null` when none exists
+   *   (post-main-retirement / signed-out launch). The menu still builds: View &
+   *   Window items are Electron roles that target the focused window, and New Task
+   *   opens the browser, so a `null` main window leaves no dead menu items.
    * @param windowManager - For window-related menu actions
    * @param configManager - For preference-related actions
    */
   initialize(
-    mainWindow: BrowserWindow,
+    mainWindow: BrowserWindow | null,
     windowManager: WindowManager,
     configManager: ConfigManager,
   ): void {
@@ -231,70 +235,26 @@ export class MenuManager {
    * Create View menu.
    */
   createViewMenu(): MenuItemConstructorOptions {
+    // Standard view chrome uses Electron roles so each item targets whatever
+    // window is focused (main, Floating, BrainDump or Settings) — no main-window
+    // reference needed, so these stay correct after main retirement. Explicit
+    // accelerators are kept so the bindings don't shift from the previous build.
     const submenu: MenuItemConstructorOptions[] = [
-      {
-        label: 'Reload',
-        accelerator: 'CmdOrCtrl+R',
-        click: () => {
-          if (this.mainWindow) {
-            this.mainWindow.reload()
-          }
-        },
-      },
+      { label: 'Reload', accelerator: 'CmdOrCtrl+R', role: 'reload' },
       {
         label: 'Force Reload',
         accelerator: 'CmdOrCtrl+Shift+R',
-        click: () => {
-          if (this.mainWindow) {
-            this.mainWindow.webContents.reloadIgnoringCache()
-          }
-        },
+        role: 'forceReload',
       },
       {
         label: 'Toggle Developer Tools',
         accelerator: this.isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-        click: () => {
-          if (this.mainWindow) {
-            this.mainWindow.webContents.toggleDevTools()
-          }
-        },
+        role: 'toggleDevTools',
       },
       { type: 'separator' },
-      {
-        label: 'Actual Size',
-        accelerator: 'CmdOrCtrl+0',
-        click: () => {
-          if (this.mainWindow) {
-            this.mainWindow.webContents.zoomLevel = 0
-          }
-        },
-      },
-      {
-        label: 'Zoom In',
-        accelerator: 'CmdOrCtrl+Plus',
-        click: () => {
-          if (this.mainWindow) {
-            const currentZoom = this.mainWindow.webContents.zoomLevel
-            this.mainWindow.webContents.zoomLevel = Math.min(
-              currentZoom + 0.5,
-              3,
-            )
-          }
-        },
-      },
-      {
-        label: 'Zoom Out',
-        accelerator: 'CmdOrCtrl+-',
-        click: () => {
-          if (this.mainWindow) {
-            const currentZoom = this.mainWindow.webContents.zoomLevel
-            this.mainWindow.webContents.zoomLevel = Math.max(
-              currentZoom - 0.5,
-              -3,
-            )
-          }
-        },
-      },
+      { label: 'Actual Size', accelerator: 'CmdOrCtrl+0', role: 'resetZoom' },
+      { label: 'Zoom In', accelerator: 'CmdOrCtrl+Plus', role: 'zoomIn' },
+      { label: 'Zoom Out', accelerator: 'CmdOrCtrl+-', role: 'zoomOut' },
       { type: 'separator' },
       {
         label: 'Floating Navigator',
@@ -313,11 +273,7 @@ export class MenuManager {
       {
         label: 'Toggle Fullscreen',
         accelerator: this.isMac ? 'Ctrl+Command+F' : 'F11',
-        click: () => {
-          if (this.mainWindow) {
-            this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen())
-          }
-        },
+        role: 'togglefullscreen',
       },
     ]
 
@@ -334,25 +290,11 @@ export class MenuManager {
    * WindowManager; the global accelerator is owned by ShortcutManager.
    */
   createWindowMenu(): MenuItemConstructorOptions {
+    // Minimize/Close are Electron roles so they act on the focused window — they
+    // work for Floating/BrainDump/Settings, not just a main window that may not exist.
     const submenu: MenuItemConstructorOptions[] = [
-      {
-        label: 'Minimize',
-        accelerator: 'CmdOrCtrl+M',
-        click: () => {
-          if (this.mainWindow) {
-            this.mainWindow.minimize()
-          }
-        },
-      },
-      {
-        label: 'Close',
-        accelerator: 'CmdOrCtrl+W',
-        click: () => {
-          if (this.mainWindow) {
-            this.mainWindow.close()
-          }
-        },
-      },
+      { label: 'Minimize', accelerator: 'CmdOrCtrl+M', role: 'minimize' },
+      { label: 'Close', accelerator: 'CmdOrCtrl+W', role: 'close' },
       { type: 'separator' },
       {
         label: 'BrainDump Note',
@@ -415,14 +357,36 @@ export class MenuManager {
 
   // Menu action handlers
 
+  /**
+   * Opens the full web app's new-task flow in the browser — the File ▸ New Task
+   * item, post-main-retirement. No `restoreFromTray` (unlike the global new-task
+   * shortcut in ShortcutManager): a menu click already comes from a focused
+   * window, so there's no tray-resident state to surface.
+   *
+   * The `menu-action` channel stays live — focus-search / import / export still
+   * send it — so only its `'new-task'` variant is now unused (left in place, not
+   * pruned, so the handler/types stay symmetric for the T18/T19 cleanup).
+   * @returns Nothing; logs and no-ops if the WindowManager (origin source) is absent.
+   * @example
+   * this.createNewTask() // opens https://corelive.app/home?create=true
+   */
   createNewTask(): void {
-    if (this.mainWindow && this.mainWindow.webContents) {
-      typedSend(this.mainWindow.webContents, 'menu-action', {
-        action: 'new-task',
-      })
+    if (!this.windowManager) {
+      log.warn('[MenuManager] windowManager unavailable; cannot open New Task')
+      return
     }
+    openWebAppInBrowser(
+      this.windowManager.getWebAppOrigin(),
+      '/home?create=true',
+    )
   }
 
+  // FOLLOW-UP (T14/T18): Find / Import Tasks / Export Tasks still drive the main
+  // renderer over `menu-action`, so they no-op when no main window exists. Their
+  // delete-vs-reroute is unresolved — there's no companion URL for "focus the
+  // search box" and the design names no browser target for menu-driven task
+  // import/export (unlike T14's Floating Import → dashboard). Kept main-optional
+  // for Phase 1 (main still exists for QA); revisit when main is retired.
   focusSearch(): void {
     if (this.mainWindow && this.mainWindow.webContents) {
       typedSend(this.mainWindow.webContents, 'menu-action', {
@@ -517,17 +481,15 @@ export class MenuManager {
     } catch (error) {
       log.error('Failed to check for updates:', error)
 
-      if (this.mainWindow) {
-        const errorMessage =
-          error instanceof Error ? error.message : 'Please try again later.'
-        dialog.showMessageBox(this.mainWindow, {
-          type: 'error',
-          title: 'Update Check Failed',
-          message: 'Failed to check for updates.',
-          detail: errorMessage,
-          buttons: ['OK'],
-        })
-      }
+      const errorMessage =
+        error instanceof Error ? error.message : 'Please try again later.'
+      this.showMenuMessageBox({
+        type: 'error',
+        title: 'Update Check Failed',
+        message: 'Failed to check for updates.',
+        detail: errorMessage,
+        buttons: ['OK'],
+      })
     }
   }
 
@@ -579,14 +541,30 @@ export class MenuManager {
     }
   }
 
-  showAboutDialog(): void {
-    if (!this.mainWindow) return
+  /**
+   * Shows a menu-triggered message box anchored to the focused window, or
+   * parentless when none is up — companion-mode menu dialogs (About, Keyboard
+   * Shortcuts, update-check failure) must surface even with no main window.
+   * @param options - Electron message-box options (type/title/message/detail/buttons).
+   * @returns Nothing; fire-and-forget — the dismissed-button result is unused.
+   * @example
+   * this.showMenuMessageBox({ type: 'info', message: 'About', buttons: ['OK'] })
+   */
+  private showMenuMessageBox(options: MessageBoxOptions): void {
+    const focusedWindow = BrowserWindow.getFocusedWindow()
+    if (focusedWindow) {
+      dialog.showMessageBox(focusedWindow, options)
+    } else {
+      dialog.showMessageBox(options)
+    }
+  }
 
+  showAboutDialog(): void {
     const version = app.getVersion()
     const electronVersion = process.versions.electron
     const nodeVersion = process.versions.node
 
-    dialog.showMessageBox(this.mainWindow, {
+    this.showMenuMessageBox({
       type: 'info',
       title: `About ${app.getName()}`,
       message: `${app.getName()} ${version}`,
@@ -604,13 +582,10 @@ Copyright © 2025 CoreLive`,
   }
 
   showKeyboardShortcuts(): void {
-    if (!this.mainWindow) return
-
     const shortcuts = [
       'Ctrl/Cmd + N: New Task',
       'Ctrl/Cmd + M: Minimize Window',
       'Ctrl/Cmd + Shift + A: Toggle Always on Top',
-      'Ctrl/Cmd + Shift + T: Show Main Window',
       'Ctrl/Cmd + Shift + N: Focus Floating Navigator',
       'Ctrl/Cmd + 3: Toggle Floating Navigator',
       'Alt/Option + Space: Toggle BrainDump',
@@ -627,7 +602,7 @@ Copyright © 2025 CoreLive`,
       '* Shortcut defaults can be changed from Preferences > Keyboard Shortcuts',
     ]
 
-    dialog.showMessageBox(this.mainWindow, {
+    this.showMenuMessageBox({
       type: 'info',
       title: 'Keyboard Shortcuts',
       message: 'Available Keyboard Shortcuts',

--- a/electron/MenuManager.ts
+++ b/electron/MenuManager.ts
@@ -183,9 +183,26 @@ export class MenuManager {
   }
 
   /**
+   * Whether a live main window currently hosts the main-renderer-only menu
+   * actions (File ▸ Import/Export, Edit ▸ Find). They `typedSend` to the main
+   * renderer, so they silently no-op without one — gate their `enabled` on this
+   * so a null/destroyed main (signed-out launch, and post-T18 when main is gone)
+   * shows them disabled rather than as dead-clickable items.
+   * @returns true when `mainWindow` exists and is not destroyed.
+   * @example
+   * { label: 'Find', enabled: this.hasUsableMainWindow(), click: () => this.focusSearch() }
+   */
+  private hasUsableMainWindow(): boolean {
+    return Boolean(this.mainWindow && !this.mainWindow.isDestroyed())
+  }
+
+  /**
    * Create File menu.
    */
   createFileMenu(): MenuItemConstructorOptions {
+    // Import/Export drive the main renderer over `menu-action`, so disable them
+    // when no main window can receive it (see hasUsableMainWindow).
+    const canUseMainRenderer = this.hasUsableMainWindow()
     const submenu: MenuItemConstructorOptions[] = [
       {
         label: 'New Task',
@@ -194,10 +211,12 @@ export class MenuManager {
       { type: 'separator' },
       {
         label: 'Import Tasks...',
+        enabled: canUseMainRenderer,
         click: async () => this.importTasks(),
       },
       {
         label: 'Export Tasks...',
+        enabled: canUseMainRenderer,
         click: async () => this.exportTasks(),
       },
     ]
@@ -224,7 +243,10 @@ export class MenuManager {
         { label: 'Select All', accelerator: 'CmdOrCtrl+A', role: 'selectAll' },
         { type: 'separator' },
         {
+          // Find drives the main renderer's search box over `menu-action`;
+          // disable it when no main window can receive that (see createFileMenu).
           label: 'Find',
+          enabled: this.hasUsableMainWindow(),
           click: () => this.focusSearch(),
         },
       ],

--- a/electron/NotificationManager.ts
+++ b/electron/NotificationManager.ts
@@ -13,10 +13,11 @@ import { Notification, nativeImage, type NativeImage } from 'electron'
 import type { ConfigManager } from './ConfigManager'
 import { typedSend } from './ipc/typedSend'
 import { log } from './logger'
+import type { NotificationOptions, NotificationPreferences } from './types/ipc'
+import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 // NotificationPreferences and NotificationOptions are the canonical contract
 // types from ./types/ipc.ts — imported here so the manager stays aligned with
 // the IPC boundary contract (single source of truth).
-import type { NotificationOptions, NotificationPreferences } from './types/ipc'
 
 // ============================================================================
 // Type Definitions
@@ -25,8 +26,12 @@ import type { NotificationOptions, NotificationPreferences } from './types/ipc'
 /** Window manager interface (minimal) */
 interface WindowManager {
   restoreFromTray(): void
-  hasMainWindow(): boolean
-  getMainWindow(): Electron.BrowserWindow
+  // Nullable to match the real WindowManager (returns null with no main window),
+  // so every deref below is null-guarded ahead of the Phase-2 main-window cut.
+  getMainWindow(): Electron.BrowserWindow | null
+  // Origin of the full web app (dev localhost / prod corelive.app) for routing
+  // notification click-through to the browser task view.
+  getWebAppOrigin(): string
 }
 
 /** System tray manager interface (minimal) */
@@ -322,8 +327,10 @@ export class NotificationManager {
       )
     }
 
-    if (this.windowManager.hasMainWindow()) {
-      const mainWindow = this.windowManager.getMainWindow()
+    // With no main window the tray tooltip above is the only surface for this
+    // guidance — don't escalate a permissions nag to the browser.
+    const mainWindow = this.windowManager.getMainWindow()
+    if (mainWindow) {
       typedSend(mainWindow.webContents, 'notification-permission-denied', {
         reason: _reason,
         guidance: this.getPermissionGuidanceForPlatform(),
@@ -367,11 +374,11 @@ export class NotificationManager {
         this.systemTrayManager.setTrayTooltip(`${title}: ${body}`)
       }
 
-      if (
-        this.fallbackMethods.windowTitle &&
-        this.windowManager.hasMainWindow()
-      ) {
-        const mainWindow = this.windowManager.getMainWindow()
+      // The window-title flash and in-app banner both need a live main window;
+      // with it gone the tray tooltip above is the surviving fallback surface.
+      const mainWindow = this.windowManager.getMainWindow()
+
+      if (this.fallbackMethods.windowTitle && mainWindow) {
         const originalTitle = mainWindow.getTitle()
         mainWindow.setTitle(`${title} - ${originalTitle}`)
 
@@ -382,11 +389,7 @@ export class NotificationManager {
         }, 3000)
       }
 
-      if (
-        this.fallbackMethods.inAppBanner &&
-        this.windowManager.hasMainWindow()
-      ) {
-        const mainWindow = this.windowManager.getMainWindow()
+      if (this.fallbackMethods.inAppBanner && mainWindow) {
         typedSend(mainWindow.webContents, 'show-fallback-notification', {
           title,
           body,
@@ -552,14 +555,15 @@ export class NotificationManager {
   /**
    * Handle task notification click.
    */
-  private async handleTaskNotificationClick(taskId: string): Promise<void> {
+  private async handleTaskNotificationClick(_taskId: string): Promise<void> {
     try {
+      // Surface the Floating quick-navigator, then route to the full task view in
+      // the browser — the task UI lives at corelive.app now, not an Electron
+      // window. The old `focus-task` IPC had no renderer listener even before the
+      // cut; its type def (types/ipc.ts) + preload allowlist are orphaned, slated
+      // for T18/T19 removal. No per-task web route exists, so we open `/home`.
       this.windowManager.restoreFromTray()
-
-      if (this.windowManager.hasMainWindow()) {
-        const mainWindow = this.windowManager.getMainWindow()
-        typedSend(mainWindow.webContents, 'focus-task', { taskId })
-      }
+      openWebAppInBrowser(this.windowManager.getWebAppOrigin(), '/home')
     } catch (error) {
       log.error('Failed to handle task notification click:', error)
     }
@@ -618,8 +622,13 @@ export class NotificationManager {
    */
   private async markTaskComplete(taskId: string): Promise<void> {
     try {
-      if (this.windowManager.hasMainWindow()) {
-        const mainWindow = this.windowManager.getMainWindow()
+      // NOTE: this `mark-task-complete` channel had no renderer listener even
+      // before main retirement, so the action was already inert — the main-window
+      // cut doesn't regress it. Kept main-optional (guarded) rather than routed to
+      // the browser: completing a task via URL has no web contract and a mutation
+      // shouldn't be re-implemented here. Removal tracked with T18/T19.
+      const mainWindow = this.windowManager.getMainWindow()
+      if (mainWindow) {
         typedSend(mainWindow.webContents, 'mark-task-complete', { taskId })
       }
     } catch (error) {

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -10,9 +10,9 @@
 import { BrowserWindow, globalShortcut } from 'electron'
 
 import type { ConfigManager } from './ConfigManager'
-import { typedSend } from './ipc/typedSend'
 import { log } from './logger'
 import type { NotificationManager } from './NotificationManager'
+import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 import type { WindowManager } from './WindowManager'
 
 // ============================================================================
@@ -759,14 +759,18 @@ export class ShortcutManager {
    */
   handleNewTaskShortcut(): void {
     try {
+      // Surface the Floating quick-navigator, then open the new-task flow in the
+      // browser — the full task app is web-only now, and restoreFromTray surfaces
+      // Floating (not the hidden main) so a `shortcut-new-task` IPC to main would
+      // land in an unsurfaced window. Mirrors the deep-link create-task route
+      // (/home?create=true). The renderer listener still lives in
+      // useElectronShortcuts but loses its only sender here — orphaned channel
+      // tracked for T18/T19 cleanup.
       this.windowManager.restoreFromTray()
-
-      if (this.windowManager.hasMainWindow()) {
-        const mainWindow = this.windowManager.getMainWindow()
-        if (mainWindow) {
-          typedSend(mainWindow.webContents, 'shortcut-new-task')
-        }
-      }
+      openWebAppInBrowser(
+        this.windowManager.getWebAppOrigin(),
+        '/home?create=true',
+      )
 
       if (this.notificationManager) {
         this.notificationManager.showNotification(

--- a/electron/SystemIntegrationErrorHandler.ts
+++ b/electron/SystemIntegrationErrorHandler.ts
@@ -7,7 +7,6 @@
  */
 
 import type { ConfigManager } from './ConfigManager'
-import { typedSend } from './ipc/typedSend'
 import { log } from './logger'
 import type { NotificationManager } from './NotificationManager'
 import type { ShortcutManager } from './ShortcutManager'
@@ -465,32 +464,13 @@ export class SystemIntegrationErrorHandler {
       this.systemTrayManager.setTrayTooltip(`${title}: ${message}`)
     }
 
-    if (this.windowManager && this.windowManager.hasMainWindow()) {
-      const mainWindow = this.windowManager.getMainWindow()
-      if (mainWindow) {
-        const originalTitle = mainWindow.getTitle()
-        mainWindow.setTitle(`${title} - ${originalTitle}`)
-
-        setTimeout(() => {
-          if (!mainWindow.isDestroyed()) {
-            mainWindow.setTitle(originalTitle)
-          }
-        }, 5000)
-      }
-    }
-
-    if (this.windowManager && this.windowManager.hasMainWindow()) {
-      const mainWindow = this.windowManager.getMainWindow()
-      if (mainWindow) {
-        typedSend(mainWindow.webContents, 'system-integration-status', {
-          status: this.overallStatus,
-          title,
-          message,
-          issues: this.issues,
-          integrationStatus: this.integrationStatus,
-        })
-      }
-    }
+    // The retired main window was the last fallback surface here (a title flash
+    // + a `system-integration-status` IPC). The title flash is gone with the
+    // window, and that status channel had no renderer listener anywhere — dead
+    // even pre-cut — so it's dropped rather than re-pointed at Floating (a
+    // minimal navigator, not a diagnostics host). The tray tooltip above is the
+    // surviving non-notification surface. Orphaned type def + preload allowlist
+    // entry tracked for T18/T19 cleanup.
   }
 
   /**

--- a/electron/SystemTrayManager.ts
+++ b/electron/SystemTrayManager.ts
@@ -9,10 +9,11 @@
 import fs from 'fs'
 import path from 'path'
 
-import { app, Menu, nativeImage, Notification, shell, Tray } from 'electron'
+import { app, Menu, nativeImage, Notification, Tray } from 'electron'
 import type { MenuItemConstructorOptions, NativeImage } from 'electron'
 
 import { log } from './logger'
+import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 import type { WindowManager } from './WindowManager'
 
 // ============================================================================
@@ -528,11 +529,7 @@ export class SystemTrayManager {
             // The full task app is web-only now that the main window is retired:
             // open corelive.app in the user's browser (↗ = leaves the app),
             // never a native main window. (T9 / user: no item restores main.)
-            shell
-              .openExternal(`${this.windowManager.getWebAppOrigin()}/home`)
-              .catch((error) => {
-                log.error('Failed to open the full app in the browser:', error)
-              })
+            openWebAppInBrowser(this.windowManager.getWebAppOrigin(), '/home')
           },
         },
         { type: 'separator' },
@@ -617,11 +614,7 @@ export class SystemTrayManager {
           label: 'Open full app in browser ↗',
           click: () => {
             // Degraded menu still never restores a native main window.
-            shell
-              .openExternal(`${this.windowManager.getWebAppOrigin()}/home`)
-              .catch((error) => {
-                log.error('Failed to open the full app in the browser:', error)
-              })
+            openWebAppInBrowser(this.windowManager.getWebAppOrigin(), '/home')
           },
         },
         {

--- a/electron/SystemTrayManager.ts
+++ b/electron/SystemTrayManager.ts
@@ -9,7 +9,7 @@
 import fs from 'fs'
 import path from 'path'
 
-import { app, Menu, nativeImage, Notification, Tray } from 'electron'
+import { app, Menu, nativeImage, Notification, shell, Tray } from 'electron'
 import type { MenuItemConstructorOptions, NativeImage } from 'electron'
 
 import { log } from './logger'
@@ -523,13 +523,16 @@ export class SystemTrayManager {
 
       const template: MenuItemConstructorOptions[] = [
         {
-          label: 'Show TODO App',
+          label: 'Open full app in browser ↗',
           click: () => {
-            try {
-              this.windowManager.restoreFromTray()
-            } catch (error) {
-              log.error('Failed to restore window from tray:', error)
-            }
+            // The full task app is web-only now that the main window is retired:
+            // open corelive.app in the user's browser (↗ = leaves the app),
+            // never a native main window. (T9 / user: no item restores main.)
+            shell
+              .openExternal(`${this.windowManager.getWebAppOrigin()}/home`)
+              .catch((error) => {
+                log.error('Failed to open the full app in the browser:', error)
+              })
           },
         },
         { type: 'separator' },
@@ -611,13 +614,14 @@ export class SystemTrayManager {
     try {
       const fallbackMenu = Menu.buildFromTemplate([
         {
-          label: 'Show App',
+          label: 'Open full app in browser ↗',
           click: () => {
-            try {
-              this.windowManager.restoreFromTray()
-            } catch (error) {
-              log.error('Failed to restore window:', error)
-            }
+            // Degraded menu still never restores a native main window.
+            shell
+              .openExternal(`${this.windowManager.getWebAppOrigin()}/home`)
+              .catch((error) => {
+                log.error('Failed to open the full app in the browser:', error)
+              })
           },
         },
         {

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -795,7 +795,7 @@ export class WindowManager {
     this.floatingLoadRecoveryPending = true
     target.show()
     // Cancel the armed startup-pill timeout before the dialog: once recovery
-    // commits, the pill's fallback (restoreFromTray → surface main) must not
+    // commits, the pill's fallback (surfaceMainBackstop → surface main) must not
     // fire and pop the main window over the Floating recovery.
     this.dismissStartupPill()
     void this.promptFloatingLoadFailure(target)
@@ -1108,11 +1108,43 @@ export class WindowManager {
   }
 
   /**
-   * Restore main window from tray.
+   * Surface the Floating Navigator from the tray / dock / notification click /
+   * shortcut / deep-link — the primary companion window now that the main
+   * window is being retired (T6). Shared chokepoint for every native-chrome
+   * caller that used to "restore the app"; creates Floating if absent so these
+   * paths always land on a real window, never a no-op on a tray-resident boot.
+   *
+   * @example
+   * // tray "Focus Floating" / dock activate / notification click all call:
+   * windowManager.restoreFromTray()
    */
   restoreFromTray(): void {
-    // Any path that surfaces the main window retires the cold-boot pill: the
-    // user can now see a real window, so the "Opening…" reassurance is done.
+    // Any path that surfaces a real window retires the cold-boot pill: the user
+    // can now see a window, so the "Opening…" reassurance is done.
+    this.dismissStartupPill()
+    if (!this.floatingNavigator) {
+      this.createFloatingNavigator()
+    }
+    if (this.floatingNavigator) {
+      if (this.floatingNavigator.isMinimized()) {
+        this.floatingNavigator.restore()
+      }
+      this.floatingNavigator.show()
+      this.floatingNavigator.focus()
+    }
+    this.saveWindowState()
+  }
+
+  /**
+   * Surface the main window as the signed-out login surface / wedged-boot
+   * backstop during a panel-only cold boot. Phase-1 holdover: the startup
+   * orchestration still defers to main when a startup panel can't show
+   * (braindump signed-out) or the boot wedges at the hard timeout; Phase 2
+   * (T18) deletes this together with the main window. Not for native-chrome
+   * callers — they use `restoreFromTray` (→ Floating).
+   */
+  private surfaceMainBackstop(): void {
+    // The teardown + surface the old `restoreFromTray` did for main, verbatim.
     this.dismissStartupPill()
     if (this.mainWindow) {
       if (this.mainWindow.isMinimized()) {
@@ -1319,9 +1351,9 @@ export class WindowManager {
       // Signed out or load failed: keep the panel hidden, surface the main
       // window so the user can sign in / see the error, record the fallback,
       // and arm a one-shot re-show for when sign-in completes.
-      // `restoreFromTray` also dismisses the cold-boot pill.
+      // `surfaceMainBackstop` also dismisses the cold-boot pill.
       this.startupAuthFallbacks.add(kind)
-      this.restoreFromTray()
+      this.surfaceMainBackstop()
       this.armPostLoginReshow(panel, kind)
     }
 
@@ -1473,7 +1505,7 @@ export class WindowManager {
 
     // Hard timeout: a boot still showing the pill this late is wedged (offline /
     // timeout / 5xx). Surface the main window as a backstop so the user is never
-    // stranded on an empty desktop; `restoreFromTray` also dismisses the pill.
+    // stranded on an empty desktop; `surfaceMainBackstop` also dismisses the pill.
     //
     // Race note: if a panel's auth load resolves AFTER this fires (sign-in
     // completes 9s into a slow boot), `finish(true)` still shows that panel, so
@@ -1482,7 +1514,7 @@ export class WindowManager {
     // suppress the panel after the timeout.
     this.startupPillTimeoutTimer = setTimeout(() => {
       this.startupPillTimeoutTimer = null
-      this.restoreFromTray()
+      this.surfaceMainBackstop()
     }, STARTUP_PILL_TIMEOUT_MS)
   }
 

--- a/electron/__tests__/AutoUpdater.test.ts
+++ b/electron/__tests__/AutoUpdater.test.ts
@@ -275,3 +275,75 @@ describe('AutoUpdater download progress', () => {
     ).toHaveBeenCalledWith('download-progress')
   })
 })
+
+describe('AutoUpdater update dialogs', () => {
+  beforeEach(() => {
+    electronMocks.createdWindows.length = 0
+    electronMocks.mockShowMessageBox.mockClear()
+    electronMocks.mockShowMessageBox.mockResolvedValue({ response: 1 })
+    electronMocks.mockAutoUpdater.removeAllListeners()
+    electronMocks.mockAutoUpdater.removeAllListeners.mockClear()
+    electronMocks.mockAutoUpdater.downloadUpdate.mockClear()
+    electronMocks.mockAutoUpdater.quitAndInstall.mockClear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('anchors the update-available prompt to the main window while one is open', () => {
+    // Arrange
+    const updater = new AutoUpdater()
+    const mainWindow = createMainWindowStub()
+    updater.setMainWindow(mainWindow)
+
+    // Act
+    electronMocks.mockAutoUpdater.emit('update-available', { version: '1.2.4' })
+
+    // Assert: anchored overload — the window is the dialog's first argument.
+    expect(electronMocks.mockShowMessageBox).toHaveBeenCalledTimes(1)
+    expect(electronMocks.mockShowMessageBox).toHaveBeenCalledWith(
+      mainWindow,
+      expect.objectContaining({ title: 'Update Available' }),
+    )
+
+    updater.cleanup()
+  })
+
+  it('surfaces the update-available prompt even when no main window is open', () => {
+    // Arrange: companion mode — the updater is never handed a main window.
+    const updater = new AutoUpdater()
+
+    // Act
+    electronMocks.mockAutoUpdater.emit('update-available', { version: '1.2.4' })
+
+    // Assert: parentless overload (options-only call) keeps the prompt reachable
+    // after the main window is retired (T18).
+    expect(electronMocks.mockShowMessageBox).toHaveBeenCalledTimes(1)
+    expect(electronMocks.mockShowMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Update Available' }),
+    )
+
+    updater.cleanup()
+  })
+
+  it('surfaces the restart prompt even when no main window is open', () => {
+    // Arrange: companion mode — no main window hosts the downloaded-update dialog.
+    const updater = new AutoUpdater()
+
+    // Act
+    electronMocks.mockAutoUpdater.emit('update-downloaded', {
+      version: '1.2.4',
+    })
+
+    // Assert: parentless overload keeps the "Restart Now" prompt reachable.
+    expect(electronMocks.mockShowMessageBox).toHaveBeenCalledTimes(1)
+    expect(electronMocks.mockShowMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Update Ready' }),
+    )
+
+    updater.cleanup()
+  })
+})

--- a/electron/__tests__/MenuManager.no-main.test.ts
+++ b/electron/__tests__/MenuManager.no-main.test.ts
@@ -1,0 +1,113 @@
+import { Menu } from 'electron'
+import type { MenuItemConstructorOptions } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ConfigManager } from '../ConfigManager'
+import { MenuManager } from '../MenuManager'
+import type { WindowManager } from '../WindowManager'
+
+// vitest hoists every vi.mock above the imports, so the electron + electron-updater
+// + logger stubs are installed before MenuManager resolves at module load.
+// Menu.buildFromTemplate captures the template each build produces, and
+// setApplicationMenu records that a menu was actually installed — both let the
+// test assert on the built menu rather than the native menu bar it can't see.
+vi.mock('electron', () => ({
+  app: { getName: vi.fn(() => 'CoreLive'), quit: vi.fn() },
+  BrowserWindow: { getFocusedWindow: vi.fn(() => null) },
+  dialog: {
+    showMessageBox: vi.fn(),
+    showOpenDialog: vi.fn(),
+    showSaveDialog: vi.fn(),
+  },
+  Menu: {
+    buildFromTemplate: vi.fn((template) => ({ template })),
+    setApplicationMenu: vi.fn(),
+  },
+  shell: { openExternal: vi.fn(async () => {}) },
+}))
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: { on: vi.fn() },
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+/** Read the template array from the most recent Menu.buildFromTemplate call. */
+function lastBuiltTemplate(): MenuItemConstructorOptions[] {
+  const calls = vi.mocked(Menu.buildFromTemplate).mock.calls
+  return calls[calls.length - 1]![0] as MenuItemConstructorOptions[]
+}
+
+/**
+ * Collects every menu item label across the whole submenu tree so a test can
+ * assert which items exist — and which retired ones do not — regardless of depth.
+ *
+ * @param items - A menu template (or a nested submenu) array.
+ * @returns Every defined `label` found, depth-first.
+ * @example
+ * collectLabels([{ label: 'File', submenu: [{ label: 'New Task' }] }])
+ * // => ['File', 'New Task']
+ */
+function collectLabels(items: MenuItemConstructorOptions[]): string[] {
+  const labels: string[] = []
+  for (const item of items) {
+    if (typeof item.label === 'string') {
+      labels.push(item.label)
+    }
+    if (Array.isArray(item.submenu)) {
+      labels.push(...collectLabels(item.submenu))
+    }
+  }
+  return labels
+}
+
+/**
+ * Builds a WindowManager stub exposing only what the menu's click handlers read
+ * (none of which run during a build) — the menu builds purely from static items,
+ * so the stub just satisfies the `initialize` parameter type.
+ * @returns A WindowManager-shaped stub.
+ */
+function createStubWindowManager(): WindowManager {
+  return {
+    getWebAppOrigin: vi.fn(() => 'https://corelive.app'),
+    toggleFloatingNavigator: vi.fn(),
+    toggleBrainDump: vi.fn(),
+  } as unknown as WindowManager
+}
+
+describe('MenuManager builds the application menu without a main window', () => {
+  beforeEach(() => {
+    vi.mocked(Menu.buildFromTemplate).mockClear()
+    vi.mocked(Menu.setApplicationMenu).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('installs the full menu with no dead main-window items when initialized with a null main window', () => {
+    // Arrange: companion mode — there is no main window to host the menu.
+    const menuManager = new MenuManager()
+    const stubConfigManager = {} as unknown as ConfigManager
+
+    // Act: the menu must still build (post-main-retirement / signed-out launch).
+    const buildMenuWithoutMain = () =>
+      menuManager.initialize(null, createStubWindowManager(), stubConfigManager)
+
+    // Assert: it builds and installs a real menu — never throws on the null main.
+    expect(buildMenuWithoutMain).not.toThrow()
+    expect(Menu.setApplicationMenu).toHaveBeenCalledTimes(1)
+
+    // ...with the standard top-level menus present (not collapsed to a shell)...
+    const template = lastBuiltTemplate()
+    const topLevelLabels = template.map((item) => item.label)
+    expect(topLevelLabels).toEqual(
+      expect.arrayContaining(['File', 'View', 'Window', 'Help']),
+    )
+
+    // ...and no resurrected "Show Main Window" item the retired main left behind.
+    expect(collectLabels(template)).not.toContain('Show Main Window')
+  })
+})

--- a/electron/__tests__/MenuManager.no-main.test.ts
+++ b/electron/__tests__/MenuManager.no-main.test.ts
@@ -64,6 +64,33 @@ function collectLabels(items: MenuItemConstructorOptions[]): string[] {
 }
 
 /**
+ * Finds the first menu item with the given label anywhere in the submenu tree,
+ * so a test can assert a nested item's `enabled` state.
+ * @param items - A menu template (or a nested submenu) array.
+ * @param label - The visible label to search for.
+ * @returns The matching item, or undefined if none is found.
+ * @example
+ * findItemByLabel(template, 'Find')?.enabled // => false when no main window
+ */
+function findItemByLabel(
+  items: MenuItemConstructorOptions[],
+  label: string,
+): MenuItemConstructorOptions | undefined {
+  for (const item of items) {
+    if (item.label === label) {
+      return item
+    }
+    if (Array.isArray(item.submenu)) {
+      const found = findItemByLabel(item.submenu, label)
+      if (found) {
+        return found
+      }
+    }
+  }
+  return undefined
+}
+
+/**
  * Builds a WindowManager stub exposing only what the menu's click handlers read
  * (none of which run during a build) — the menu builds purely from static items,
  * so the stub just satisfies the `initialize` parameter type.
@@ -109,5 +136,12 @@ describe('MenuManager builds the application menu without a main window', () => 
 
     // ...and no resurrected "Show Main Window" item the retired main left behind.
     expect(collectLabels(template)).not.toContain('Show Main Window')
+
+    // ...and the main-renderer-only actions (Import/Export/Find drive the main
+    // renderer over `menu-action`) are DISABLED, not dead-clickable, since no
+    // main window can receive that IPC.
+    expect(findItemByLabel(template, 'Import Tasks...')?.enabled).toBe(false)
+    expect(findItemByLabel(template, 'Export Tasks...')?.enabled).toBe(false)
+    expect(findItemByLabel(template, 'Find')?.enabled).toBe(false)
   })
 })

--- a/electron/__tests__/SystemTrayManager.tray-menu.test.ts
+++ b/electron/__tests__/SystemTrayManager.tray-menu.test.ts
@@ -43,13 +43,15 @@ const fakeTray = {
  */
 function createManager(): {
   manager: SystemTrayManager
+  restoreFromTray: ReturnType<typeof vi.fn>
   toggleBrainDump: ReturnType<typeof vi.fn>
   toggleFloatingNavigator: ReturnType<typeof vi.fn>
 } {
+  const restoreFromTray = vi.fn()
   const toggleBrainDump = vi.fn()
   const toggleFloatingNavigator = vi.fn()
   const stubWindowManager = {
-    restoreFromTray: vi.fn(),
+    restoreFromTray,
     openSettings: vi.fn(),
     toggleBrainDump,
     toggleFloatingNavigator,
@@ -59,7 +61,7 @@ function createManager(): {
   // Mirror createTray's side effect so updateTrayMenu's `if (this.tray)` guard
   // passes without standing up the native Tray stack.
   ;(manager as unknown as { tray: Tray | null }).tray = fakeTray
-  return { manager, toggleBrainDump, toggleFloatingNavigator }
+  return { manager, restoreFromTray, toggleBrainDump, toggleFloatingNavigator }
 }
 
 /** Read the template array from the most recent Menu.buildFromTemplate call. */
@@ -104,7 +106,7 @@ describe('SystemTrayManager tray menu — BrainDump toggle + live hotkeys', () =
 
   it('opens the full app in the browser — never a native window — from its tray item', () => {
     // Arrange
-    const { manager } = createManager()
+    const { manager, restoreFromTray } = createManager()
 
     // Act
     manager.updateTrayMenu([])
@@ -121,6 +123,9 @@ describe('SystemTrayManager tray menu — BrainDump toggle + live hotkeys', () =
     expect(vi.mocked(shell.openExternal)).toHaveBeenCalledWith(
       'https://corelive.app/home',
     )
+    // ...and it ONLY opens the browser — it must not also surface a native
+    // window (Floating) via restoreFromTray.
+    expect(restoreFromTray).not.toHaveBeenCalled()
   })
 
   it('shows each toggle item’s live hotkey supplied by the accelerator provider', () => {

--- a/electron/__tests__/SystemTrayManager.tray-menu.test.ts
+++ b/electron/__tests__/SystemTrayManager.tray-menu.test.ts
@@ -1,4 +1,4 @@
-import { Menu } from 'electron'
+import { Menu, shell } from 'electron'
 import type { MenuItemConstructorOptions, Tray } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -20,6 +20,7 @@ vi.mock('electron', () => ({
     createFromBuffer: vi.fn(),
   },
   Notification: vi.fn(),
+  shell: { openExternal: vi.fn(async () => {}) },
   Tray: vi.fn(),
 }))
 
@@ -52,6 +53,7 @@ function createManager(): {
     openSettings: vi.fn(),
     toggleBrainDump,
     toggleFloatingNavigator,
+    getWebAppOrigin: vi.fn(() => 'https://corelive.app'),
   } as unknown as WindowManager
   const manager = new SystemTrayManager(stubWindowManager)
   // Mirror createTray's side effect so updateTrayMenu's `if (this.tray)` guard
@@ -98,6 +100,27 @@ describe('SystemTrayManager tray menu — BrainDump toggle + live hotkeys', () =
     expect(brainDumpItem).toBeDefined()
     expect(findItem(lastBuiltTemplate(), 'Open BrainDump')).toBeUndefined()
     expect(toggleBrainDump).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the full app in the browser — never a native window — from its tray item', () => {
+    // Arrange
+    const { manager } = createManager()
+
+    // Act
+    manager.updateTrayMenu([])
+    const browserItem = findItem(
+      lastBuiltTemplate(),
+      'Open full app in browser ↗',
+    )
+    ;(browserItem?.click as () => void)?.()
+
+    // Assert: the retired main window has no tray entry; the full app is the
+    // web app, opened externally at corelive.app/home.
+    expect(browserItem).toBeDefined()
+    expect(findItem(lastBuiltTemplate(), 'Show TODO App')).toBeUndefined()
+    expect(vi.mocked(shell.openExternal)).toHaveBeenCalledWith(
+      'https://corelive.app/home',
+    )
   })
 
   it('shows each toggle item’s live hotkey supplied by the accelerator provider', () => {

--- a/electron/__tests__/WindowManager.restore-from-tray.test.ts
+++ b/electron/__tests__/WindowManager.restore-from-tray.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Records, per created BrowserWindow, the spies the tray-restore path drives so
+ * a test can assert the Floating window was surfaced (shown + focused) and which
+ * URL it loaded. `restoreFromTray` creates the Floating panel lazily, so the
+ * window under test is whatever the mocked `BrowserWindow` ctor produced.
+ */
+interface CapturedWindow {
+  loadURL: ReturnType<typeof vi.fn>
+  show: ReturnType<typeof vi.fn>
+  focus: ReturnType<typeof vi.fn>
+}
+
+const createdWindows: CapturedWindow[] = []
+
+/**
+ * Returns the Nth created window, failing the test if none exists. Narrows away
+ * the `| undefined` that `noUncheckedIndexedAccess` adds to array indexing, so
+ * the assertions read cleanly without non-null assertions.
+ *
+ * @param index - Zero-based creation order.
+ * @returns The captured window at that index.
+ */
+function getCreatedWindow(index: number): CapturedWindow {
+  const capturedWindow = createdWindows[index]
+  if (!capturedWindow) {
+    throw new Error(`Expected a created window at index ${index}`)
+  }
+  return capturedWindow
+}
+
+// BrowserWindow mock: returns an instance carrying the full method surface the
+// Floating-create + tray-restore path touches — loadURL/on/webContents.on for
+// creation, isMinimized/restore/show/focus for surfacing, and isDestroyed +
+// setVisibleOnAllWorkspaces for the macOS Spaces guard (which runs when the test
+// host is darwin). Each instance's surfacing spies are recorded so the test can
+// assert the Floating window was actually shown.
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(function () {
+    const loadURL = vi.fn()
+    const show = vi.fn()
+    const focus = vi.fn()
+    const instance = {
+      loadURL,
+      show,
+      focus,
+      hide: vi.fn(),
+      restore: vi.fn(),
+      isMinimized: vi.fn(() => false),
+      isDestroyed: vi.fn(() => false),
+      setVisibleOnAllWorkspaces: vi.fn(),
+      on: vi.fn(),
+      once: vi.fn(),
+      webContents: { on: vi.fn(), send: vi.fn() },
+    }
+    createdWindows.push({ loadURL, show, focus })
+    return instance
+  }),
+  screen: {
+    getPrimaryDisplay: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+    getDisplayNearestPoint: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+  },
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+// Imported after the mocks so WindowManager's `import { BrowserWindow }` is stubbed.
+import { WindowManager } from '../WindowManager'
+
+describe('WindowManager tray restore surfaces the Floating window', () => {
+  beforeEach(() => {
+    createdWindows.length = 0
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens and focuses the Floating navigator — never a main window — when restoring from the tray with nothing open', () => {
+    // Arrange: a tray-resident boot — no window has been created yet.
+    const windowManager = new WindowManager('https://corelive.app')
+
+    // Act: the shared "surface the app" chokepoint behind tray "Focus Floating",
+    // dock activate, notification click, shortcut, and deep links.
+    windowManager.restoreFromTray()
+
+    // Assert: it surfaced the Floating panel — created it, loaded the floating
+    // route, then showed and focused it.
+    const floatingWindow = getCreatedWindow(0)
+    expect(windowManager.getFloatingNavigator()).not.toBeNull()
+    expect(floatingWindow.loadURL).toHaveBeenCalledWith(
+      'https://corelive.app/floating-navigator',
+    )
+    expect(floatingWindow.show).toHaveBeenCalledTimes(1)
+    expect(floatingWindow.focus).toHaveBeenCalledTimes(1)
+
+    // ...and never resurrected the retired main window. This is the Phase-1
+    // guarantee T18 leans on: every native-chrome "restore the app" path lands
+    // on Floating, so exactly one window — the Floating panel — was created.
+    expect(windowManager.getMainWindow()).toBeNull()
+    expect(createdWindows).toHaveLength(1)
+  })
+})

--- a/electron/__tests__/WindowManager.startup-pill.test.ts
+++ b/electron/__tests__/WindowManager.startup-pill.test.ts
@@ -64,6 +64,14 @@ vi.mock('electron', () => ({
       focus: vi.fn(),
       restore: vi.fn(),
       minimize: vi.fn(),
+      // Floating-panel chrome createFloatingNavigator drives (T6 restoreFromTray
+      // now creates Floating if absent, so the pill harness must support it).
+      setVisibleOnAllWorkspaces: vi.fn(),
+      setAlwaysOnTop: vi.fn(),
+      isAlwaysOnTop: vi.fn(() => false),
+      isVisible: vi.fn(() => true),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 320, height: 480 })),
+      setBounds: vi.fn(),
       destroy: vi.fn(() => {
         destroyed = true
       }),
@@ -197,13 +205,14 @@ describe('WindowManager cold-boot startup pill', () => {
     expect(getPill().destroy).toHaveBeenCalledTimes(1)
   })
 
-  it('retires the pill the moment the main window is surfaced from the tray', () => {
+  it('retires the pill the moment a window is surfaced from the tray', () => {
     // Arrange
     const windowManager = new WindowManager('https://corelive.app')
     windowManager.armStartupPill()
     const pill = getPill()
 
-    // Act
+    // Act: restoreFromTray surfaces the Floating navigator (T6) and, like every
+    // real-window surface path, tears down the cold-boot "Opening…" pill.
     windowManager.restoreFromTray()
 
     // Assert

--- a/electron/__tests__/WindowManager.test.mjs
+++ b/electron/__tests__/WindowManager.test.mjs
@@ -264,14 +264,21 @@ const createWindowManagerMock = () => {
       }
     }
 
+    // T6: native-chrome callers surface the Floating navigator (create if
+    // absent), not the retiring main window. Mirrors the real WindowManager;
+    // the mock has no startup pill, so the pill teardown is omitted here.
     restoreFromTray() {
-      if (this.mainWindow) {
-        if (this.mainWindow.isMinimized()) {
-          this.mainWindow.restore()
-        }
-        this.mainWindow.show()
-        this.mainWindow.focus()
+      if (!this.floatingNavigator) {
+        this.createFloatingNavigator()
       }
+      if (this.floatingNavigator) {
+        if (this.floatingNavigator.isMinimized()) {
+          this.floatingNavigator.restore()
+        }
+        this.floatingNavigator.show()
+        this.floatingNavigator.focus()
+      }
+      this.saveWindowState()
     }
 
     minimizeToTray() {
@@ -568,30 +575,51 @@ describe('WindowManager', () => {
   })
 
   describe('restoreFromTray', () => {
-    it('should restore and focus main window', () => {
-      const mainWindow = windowManager.createMainWindow()
-      mainWindow.isMinimized.mockReturnValue(true)
+    // T6: native-chrome callers (tray/dock/notification/shortcut/deep-link) now
+    // surface the Floating navigator — the surviving companion window — instead
+    // of the retiring main window.
+    it('restores and focuses the floating navigator when it was minimized', () => {
+      const floatingWindow = windowManager.createFloatingNavigator()
+      floatingWindow.isMinimized.mockReturnValue(true)
 
       windowManager.restoreFromTray()
 
-      expect(mainWindow.restore).toHaveBeenCalled()
-      expect(mainWindow.show).toHaveBeenCalled()
-      expect(mainWindow.focus).toHaveBeenCalled()
+      expect(floatingWindow.restore).toHaveBeenCalled()
+      expect(floatingWindow.show).toHaveBeenCalled()
+      expect(floatingWindow.focus).toHaveBeenCalled()
     })
 
-    it('should show and focus main window if not minimized', () => {
-      const mainWindow = windowManager.createMainWindow()
-      mainWindow.isMinimized.mockReturnValue(false)
+    it('shows and focuses the floating navigator without restoring when not minimized', () => {
+      const floatingWindow = windowManager.createFloatingNavigator()
+      floatingWindow.isMinimized.mockReturnValue(false)
 
       windowManager.restoreFromTray()
 
-      expect(mainWindow.restore).not.toHaveBeenCalled()
-      expect(mainWindow.show).toHaveBeenCalled()
-      expect(mainWindow.focus).toHaveBeenCalled()
+      expect(floatingWindow.restore).not.toHaveBeenCalled()
+      expect(floatingWindow.show).toHaveBeenCalled()
+      expect(floatingWindow.focus).toHaveBeenCalled()
     })
 
-    it('should not throw error if main window does not exist', () => {
-      expect(() => windowManager.restoreFromTray()).not.toThrow()
+    it('creates the floating navigator if none exists so the tray never no-ops', () => {
+      // Cold tray-resident boot: no window has been created yet.
+      windowManager.restoreFromTray()
+
+      const floatingWindow = windowManager.getFloatingNavigator()
+      expect(floatingWindow).not.toBeNull()
+      expect(floatingWindow.show).toHaveBeenCalled()
+      expect(floatingWindow.focus).toHaveBeenCalled()
+    })
+
+    it('does not surface the retiring main window', () => {
+      const mainWindow = windowManager.createMainWindow()
+      // Ignore any show/focus from window creation; only the tray action counts.
+      mainWindow.show.mockClear()
+      mainWindow.focus.mockClear()
+
+      windowManager.restoreFromTray()
+
+      expect(mainWindow.show).not.toHaveBeenCalled()
+      expect(mainWindow.focus).not.toHaveBeenCalled()
     })
   })
 

--- a/electron/__tests__/deep-link-manager.test.mjs
+++ b/electron/__tests__/deep-link-manager.test.mjs
@@ -25,7 +25,8 @@ const mockApp = {
 }
 
 const mockShell = {
-  openExternal: vi.fn(),
+  // openWebAppInBrowser awaits `.catch` on the result, so the mock must be thenable.
+  openExternal: vi.fn(async () => Promise.resolve()),
 }
 
 // Mock modules using vi.doMock for better CommonJS support
@@ -67,6 +68,8 @@ describe('DeepLinkManager', () => {
       hasMainWindow: vi.fn(() => true),
       getMainWindow: vi.fn(() => mockWindow), // Return the same instance every time
       restoreFromTray: vi.fn(),
+      // Post-retirement deep links open the web app in the browser (T15).
+      getWebAppOrigin: vi.fn(() => 'https://corelive.app'),
     }
 
     mockApiBridge = {
@@ -167,53 +170,38 @@ describe('DeepLinkManager', () => {
       deepLinkManager.initialize()
     })
 
-    it('should handle task focus action', async () => {
-      const mockTask = {
-        id: '123',
-        title: 'Test Task',
-        completed: false,
-      }
+    it('opens the task in the browser at /home?focus=<id>', async () => {
+      // Arrange: a `corelive://task/123` deep link (path `/123`, no params).
 
-      mockApiBridge.getTodoById.mockResolvedValue(mockTask)
-
+      // Act
       await deepLinkManager.handleTaskAction('/123', {})
 
-      expect(mockApiBridge.getTodoById).toHaveBeenCalledWith('123')
-      expect(
-        mockWindowManager.getMainWindow().webContents.send,
-      ).toHaveBeenCalledWith('deep-link-focus-task', {
-        task: mockTask,
-        params: {},
-      })
-      expect(mockNotificationManager.showNotification).toHaveBeenCalledWith(
-        'Task Opened',
-        'Opened task: Test Task',
-        { type: 'info' },
+      // Assert: the task surfaces in the web app, not a (now-gone) main renderer.
+      expect(mockShell.openExternal).toHaveBeenCalledWith(
+        'https://corelive.app/home?focus=123',
       )
     })
 
-    it('should handle task not found', async () => {
-      mockApiBridge.getTodoById.mockResolvedValue(null)
+    it('percent-encodes an untrusted task id before opening the browser', async () => {
+      // Arrange: a deep-link path id carrying URL-significant characters.
 
-      await deepLinkManager.handleTaskAction('/123', {})
+      // Act
+      await deepLinkManager.handleTaskAction('/a b&c', {})
 
-      expect(mockNotificationManager.showNotification).toHaveBeenCalledWith(
-        'Task Not Found',
-        'Could not find task with ID: 123',
-        { type: 'warning' },
+      // Assert: the id is encoded so it cannot break out of the query value.
+      expect(mockShell.openExternal).toHaveBeenCalledWith(
+        'https://corelive.app/home?focus=a%20b%26c',
       )
     })
 
-    it('should handle API errors gracefully', async () => {
-      mockApiBridge.getTodoById.mockRejectedValue(new Error('API Error'))
+    it('does nothing when the deep link carries no task id', async () => {
+      // Arrange: empty path and no `id` param.
 
-      await deepLinkManager.handleTaskAction('/123', {})
+      // Act
+      await deepLinkManager.handleTaskAction('/', {})
 
-      expect(mockNotificationManager.showNotification).toHaveBeenCalledWith(
-        'Error',
-        'Failed to open task. Please try again.',
-        { type: 'error' },
-      )
+      // Assert: no browser is opened for an unaddressable task link.
+      expect(mockShell.openExternal).not.toHaveBeenCalled()
     })
   })
 
@@ -222,59 +210,35 @@ describe('DeepLinkManager', () => {
       deepLinkManager.initialize()
     })
 
-    it('should create task from deep link', async () => {
-      const mockTask = {
-        id: '456',
-        title: 'New Task',
-        description: 'Task description',
-        completed: false,
-      }
+    it('opens the create form in the browser pre-filled from the deep link', async () => {
+      // Arrange: a `corelive://create?title=...&description=...` deep link.
 
-      mockApiBridge.createTodo.mockResolvedValue(mockTask)
-
+      // Act
       await deepLinkManager.handleCreateAction({
         title: 'New Task',
         description: 'Task description',
       })
 
-      expect(mockApiBridge.createTodo).toHaveBeenCalledWith({
-        title: 'New Task',
-        description: 'Task description',
-      })
-      expect(
-        mockWindowManager.getMainWindow().webContents.send,
-      ).toHaveBeenCalledWith('deep-link-task-created', { task: mockTask })
-      expect(mockNotificationManager.showNotification).toHaveBeenCalledWith(
-        'Task Created',
-        'Created task: New Task',
-        { type: 'success' },
+      // Assert: the create form opens in the web app, pre-filled. No task is
+      // created here — the user confirms in the browser — so a deep link never
+      // mutates the database.
+      expect(mockShell.openExternal).toHaveBeenCalledWith(
+        'https://corelive.app/home?create=true&title=New+Task&description=Task+description',
       )
-    })
-
-    it('should handle create without title', async () => {
-      await deepLinkManager.handleCreateAction({})
-
-      expect(
-        mockWindowManager.getMainWindow().webContents.send,
-      ).toHaveBeenCalledWith('deep-link-create-task', {})
       expect(mockApiBridge.createTodo).not.toHaveBeenCalled()
     })
 
-    it('should fallback to create dialog on API error', async () => {
-      mockApiBridge.createTodo.mockRejectedValue(new Error('API Error'))
+    it('opens the empty create form in the browser when no fields are provided', async () => {
+      // Arrange: a bare `corelive://create` deep link (no params).
 
-      await deepLinkManager.handleCreateAction({
-        title: 'New Task',
-      })
+      // Act
+      await deepLinkManager.handleCreateAction({})
 
-      expect(
-        mockWindowManager.getMainWindow().webContents.send,
-      ).toHaveBeenCalledWith('deep-link-create-task', {
-        title: 'New Task',
-        description: '',
-        priority: undefined,
-        dueDate: undefined,
-      })
+      // Assert: still opens the create form, just without pre-fill.
+      expect(mockShell.openExternal).toHaveBeenCalledWith(
+        'https://corelive.app/home?create=true',
+      )
+      expect(mockApiBridge.createTodo).not.toHaveBeenCalled()
     })
   })
 
@@ -283,19 +247,15 @@ describe('DeepLinkManager', () => {
       deepLinkManager.initialize()
     })
 
-    it('should handle view navigation', async () => {
+    it('opens the view in the browser at /<view> with its params', async () => {
+      // Arrange: a `corelive://view/completed?filter=recent` deep link.
+
+      // Act
       await deepLinkManager.handleViewAction('/completed', { filter: 'recent' })
 
-      expect(
-        mockWindowManager.getMainWindow().webContents.send,
-      ).toHaveBeenCalledWith('deep-link-navigate', {
-        view: 'completed',
-        params: { filter: 'recent' },
-      })
-      expect(mockNotificationManager.showNotification).toHaveBeenCalledWith(
-        'View Opened',
-        'Navigated to: completed',
-        { type: 'info' },
+      // Assert: the view opens in the web app at the matching route.
+      expect(mockShell.openExternal).toHaveBeenCalledWith(
+        'https://corelive.app/completed?filter=recent',
       )
     })
   })
@@ -305,22 +265,18 @@ describe('DeepLinkManager', () => {
       deepLinkManager.initialize()
     })
 
-    it('should handle search action', async () => {
+    it('opens search results in the browser at /home?search=<query>', async () => {
+      // Arrange: a `corelive://search?query=important&filter=pending` deep link.
+
+      // Act
       await deepLinkManager.handleSearchAction({
         query: 'important',
         filter: 'pending',
       })
 
-      expect(
-        mockWindowManager.getMainWindow().webContents.send,
-      ).toHaveBeenCalledWith('deep-link-search', {
-        query: 'important',
-        filter: 'pending',
-      })
-      expect(mockNotificationManager.showNotification).toHaveBeenCalledWith(
-        'Search',
-        'Searching for: important',
-        { type: 'info' },
+      // Assert: search runs in the web app, not a (now-gone) main renderer.
+      expect(mockShell.openExternal).toHaveBeenCalledWith(
+        'https://corelive.app/home?search=important&filter=pending',
       )
     })
   })

--- a/electron/__tests__/openWebAppInBrowser.test.ts
+++ b/electron/__tests__/openWebAppInBrowser.test.ts
@@ -1,0 +1,53 @@
+import { shell } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { openWebAppInBrowser } from '../utils/openWebAppInBrowser'
+
+// vitest hoists vi.mock above the imports, so `shell.openExternal` is a spy by
+// the time openWebAppInBrowser resolves it. openExternal must be thenable — the
+// helper `.catch`es the result.
+vi.mock('electron', () => ({
+  shell: { openExternal: vi.fn(async () => true) },
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+describe('openWebAppInBrowser', () => {
+  beforeEach(() => {
+    vi.mocked(shell.openExternal).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('opens an absolute path on an http(s) origin in the external browser', () => {
+    // Arrange + Act: a normal tray/menu/deep-link call.
+    openWebAppInBrowser('https://corelive.app', '/home?focus=42')
+
+    // Assert: the exact origin+path is handed to the system browser, unchanged.
+    expect(shell.openExternal).toHaveBeenCalledTimes(1)
+    expect(shell.openExternal).toHaveBeenCalledWith(
+      'https://corelive.app/home?focus=42',
+    )
+  })
+
+  it('refuses a path that is not leading-slash, so the authority cannot be hijacked', () => {
+    // Arrange + Act: a path missing its leading slash would re-interpret the host
+    // (e.g. corelive.app@evil.com) once concatenated onto the origin.
+    openWebAppInBrowser('https://corelive.app', '@evil.com/phish')
+
+    // Assert: nothing is opened.
+    expect(shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('refuses to open a URL whose protocol is not http(s)', () => {
+    // Arrange + Act: a non-http(s) origin must never reach the OS-handoff sink.
+    openWebAppInBrowser('file://host', '/home')
+
+    // Assert: the file: URL is rejected before shell.openExternal.
+    expect(shell.openExternal).not.toHaveBeenCalled()
+  })
+})

--- a/electron/ipc/ipc-schemas.ts
+++ b/electron/ipc/ipc-schemas.ts
@@ -277,6 +277,9 @@ export const IPC_ARG_SCHEMAS: Record<IPCChannel, z.ZodTypeAny> = {
   'floating-window-set-visible-on-all-workspaces': z.tuple([z.boolean()]),
   'floating-window-close': z.tuple([]),
   'floating-window-minimize': z.tuple([]),
+  // Floating Navigator → open the task app's import surface in the browser (T14).
+  // No args: the path is hard-coded main-side so a renderer can't drive the URL.
+  'floating-open-import': z.tuple([]),
   'floating-window-toggle-always-on-top': z.tuple([]),
   'floating-window-get-bounds': z.tuple([]),
   'floating-window-set-bounds': z.tuple([

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2288,12 +2288,13 @@ if (!gotTheLock) {
           return
         }
         // Windows exist but no *real* one is visible — e.g. a panel-only startup
-        // whose panel was later closed, or the main window minimized to the tray.
+        // whose panel was later closed, or every panel hidden to the tray.
         // The startup pill is excluded: it is shown via `showInactive()` so
         // `isVisible()` reports true, but it carries no surface the user can act
         // on, so counting it would wrongly suppress the dock-click reveal. A dock
-        // click must always surface something, so reveal the always-created main
-        // window (restoreFromTray restores + shows + focuses it).
+        // click must always surface something, so surface the Floating navigator —
+        // the surviving companion window — via restoreFromTray (T6 retargeted it
+        // off the retired main; it creates Floating if absent, then shows + focuses).
         //
         // The `windowManager?.` optional chain is intentional: if the manager is
         // somehow absent, `!undefined` is true so the pill (if any) counts as a
@@ -2329,14 +2330,17 @@ if (!gotTheLock) {
 /**
  * Window close behavior for macOS.
  *
- * macOS convention: Close all windows = app stays in dock
- * Users can fully quit via Cmd+Q or the app menu.
+ * macOS convention: closing all windows keeps the app alive. With the main
+ * window retired, CoreLive is a tray-resident companion (BrainDump / Floating /
+ * Settings) — closing every panel leaves it running in the menu bar; the user
+ * quits explicitly via Cmd+Q, the app menu, or the tray's Quit. (T10 / design
+ * Open Question #6: stay tray-resident, never quit on the last panel close.)
  *
- * This handler is intentionally empty to follow macOS platform guidelines.
+ * This handler is intentionally empty to follow that guideline.
  */
 app.on('window-all-closed', () => {
-  // macOS: App stays running when all windows are closed (platform convention)
-  // No action needed - this is the default Electron behavior on macOS
+  // Stay tray-resident: no app.quit() here. Quitting is always explicit
+  // (Cmd+Q / app menu / tray Quit), never an implicit last-panel-close side effect.
 })
 
 /**

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -987,7 +987,12 @@ async function createWindow(): Promise<BrowserWindow> {
         !!mainWindowRef,
       )
 
-      if (menuManager && mainWindowRef) {
+      // Menu initializes even when no main window exists. Post-main-retirement the
+      // menu bar is companion chrome (View/Window roles target whatever window is
+      // focused; New Task opens the browser), so gating on mainWindowRef would leave
+      // a dead menu at a main-less / signed-out launch. mainWindowRef passes through
+      // nullable — MenuManager.initialize accepts `BrowserWindow | null`.
+      if (menuManager) {
         menuManager.initialize(mainWindowRef, windowManager, configManager)
       }
       log.info('✅ [DEFERRED] MenuManager loaded')

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -51,6 +51,7 @@ import {
   type WindowBounds,
 } from './types/ipc'
 import { resolveRemoteDebuggingPort } from './utils/debugMode'
+import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 import { WindowManager } from './WindowManager'
 import {
   WindowStateManager,
@@ -2153,6 +2154,17 @@ function setupIPCHandlers(): void {
   typedHandle('window-show-main', () => {
     if (windowManager) {
       windowManager.restoreFromTray()
+    }
+  })
+
+  // T14: the Floating Navigator's Import button opens the Completed import
+  // surface in the user's browser (/home) rather than broadcasting an open-intent
+  // to the main window's dialog. The full task app is web-only, so import (a
+  // wide flow the narrow floating window can't host) lives in the browser. The
+  // path is hard-coded here so the renderer cannot drive the opened URL.
+  typedHandle('floating-open-import', () => {
+    if (windowManager) {
+      openWebAppInBrowser(windowManager.getWebAppOrigin(), '/home')
     }
   })
 

--- a/electron/preload-floating.ts
+++ b/electron/preload-floating.ts
@@ -244,6 +244,20 @@ contextBridge.exposeInMainWorld('floatingNavigatorAPI', {
     },
   },
 
+  /**
+   * Open the task app's Completed paste-import surface (`/home`) in the user's
+   * browser (T14). The full task app is web-only, so importing happens in the
+   * browser rather than a main-window dialog. Mirrors the tray/menu/shortcut
+   * browser reroutes; the destination path is fixed in the main handler.
+   */
+  openCompletedImport: async (): Promise<void> => {
+    try {
+      await typedInvoke('floating-open-import')
+    } catch (error) {
+      log.error('Floating Navigator: Failed to open import in browser:', error)
+    }
+  },
+
   // Secure event listener management (restricted set for floating navigator)
   on: (
     channel: string,

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -578,6 +578,13 @@ export interface FloatingNavigatorAPI {
     /** Toggle BrainDump window visibility. */
     toggle: () => Promise<void>
   }
+  /**
+   * Open the task app's Completed paste-import surface (`/home`) in the user's
+   * browser (T14). Added after the original window/brainDump surface, so a
+   * renderer must method-guard before calling it (older installed preloads
+   * predate it — see the preload-skew fallback in FloatingNavigator).
+   */
+  openCompletedImport: () => Promise<void>
   /** Subscribe to IPC events */
   on: (channel: string, callback: (...args: unknown[]) => void) => () => void
   /** @deprecated Use the cleanup function returned by `on()` instead */

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -582,9 +582,11 @@ export interface FloatingNavigatorAPI {
    * Open the task app's Completed paste-import surface (`/home`) in the user's
    * browser (T14). Added after the original window/brainDump surface, so a
    * renderer must method-guard before calling it (older installed preloads
-   * predate it — see the preload-skew fallback in FloatingNavigator).
+   * predate it — see the preload-skew fallback in FloatingNavigator). Optional
+   * because an older installed preload may not expose it: callers MUST
+   * method-guard (`typeof api.openCompletedImport === 'function'`) before calling.
    */
-  openCompletedImport: () => Promise<void>
+  openCompletedImport?: () => Promise<void>
   /** Subscribe to IPC events */
   on: (channel: string, callback: (...args: unknown[]) => void) => () => void
   /** @deprecated Use the cleanup function returned by `on()` instead */

--- a/electron/types/ipc.ts
+++ b/electron/types/ipc.ts
@@ -416,6 +416,16 @@ export interface IPCChannels {
     request: void
     response: boolean
   }
+  /**
+   * Floating Navigator → open the task app's Completed import surface (`/home`)
+   * in the user's browser (T14). The full task app is web-only, so importing
+   * happens in the browser, not a main-window dialog. No request payload: the
+   * path is hard-coded in the main handler so the renderer cannot drive the URL.
+   */
+  'floating-open-import': {
+    request: void
+    response: void
+  }
   'floating-window-toggle-always-on-top': {
     request: void
     response: boolean

--- a/electron/utils/openWebAppInBrowser.ts
+++ b/electron/utils/openWebAppInBrowser.ts
@@ -9,12 +9,39 @@ import { log } from '../logger'
  * full app ↗" items and notification click-through.
  * @param origin - Web app origin from `WindowManager.getWebAppOrigin()` (dev: `http://localhost:4991`, prod: `https://corelive.app`).
  * @param appPath - Leading-slash path to open (e.g. `/home`).
- * @returns Nothing; logs and swallows `shell` failures so a missing/blocked browser never crashes the main process.
+ * @returns Nothing; refuses (logs, no-op) a non-absolute path or a non-http(s) result, otherwise logs and swallows `shell` failures so a missing/blocked browser never crashes the main process.
  * @example
  * openWebAppInBrowser('https://corelive.app', '/home') // opens https://corelive.app/home
+ * openWebAppInBrowser('https://corelive.app', 'home')  // refused (not leading-slash) — no browser opened
  */
 export function openWebAppInBrowser(origin: string, appPath: string): void {
-  shell.openExternal(`${origin}${appPath}`).catch((error) => {
+  // appPath MUST be an on-origin absolute path. A value not starting with "/"
+  // (e.g. "@evil.com/...") would re-interpret the authority once concatenated,
+  // so reject it before it can ever reach the system browser.
+  if (!appPath.startsWith('/')) {
+    log.error(`Refusing to open a non-absolute web app path: ${appPath}`)
+    return
+  }
+  // This is the shared chokepoint for tray/menu/notification/shortcut AND the
+  // deep-link flow, whose appPath is built from an untrusted `corelive://` URL
+  // (already percent-encoded upstream in T15). Defense-in-depth at the OS-handoff
+  // sink: parse the final URL and refuse anything that isn't http(s). The opened
+  // string stays exactly `${origin}${appPath}`, so callers' URLs are unchanged.
+  const targetUrl = `${origin}${appPath}`
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(targetUrl)
+  } catch (error) {
+    log.error('Refusing to open a malformed web app URL:', error)
+    return
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    log.error(
+      `Refusing to open a non-http(s) web app URL: ${parsedUrl.protocol}`,
+    )
+    return
+  }
+  shell.openExternal(targetUrl).catch((error) => {
     log.error('Failed to open the full app in the browser:', error)
   })
 }

--- a/electron/utils/openWebAppInBrowser.ts
+++ b/electron/utils/openWebAppInBrowser.ts
@@ -1,0 +1,20 @@
+import { shell } from 'electron'
+
+import { log } from '../logger'
+
+/**
+ * Opens a path of the full web app in the user's external browser — the
+ * post-main-retirement "go to the full app" action, since the task UI now lives
+ * at corelive.app instead of an Electron window. Triggered by the tray "Open
+ * full app ↗" items and notification click-through.
+ * @param origin - Web app origin from `WindowManager.getWebAppOrigin()` (dev: `http://localhost:4991`, prod: `https://corelive.app`).
+ * @param appPath - Leading-slash path to open (e.g. `/home`).
+ * @returns Nothing; logs and swallows `shell` failures so a missing/blocked browser never crashes the main process.
+ * @example
+ * openWebAppInBrowser('https://corelive.app', '/home') // opens https://corelive.app/home
+ */
+export function openWebAppInBrowser(origin: string, appPath: string): void {
+  shell.openExternal(`${origin}${appPath}`).catch((error) => {
+    log.error('Failed to open the full app in the browser:', error)
+  })
+}

--- a/src/components/floating-navigator/FloatingNavigator.test.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.test.tsx
@@ -46,6 +46,7 @@ function installFloatingNavigatorAPI(
         focusMainWindow: vi.fn(),
       },
       brainDump: { toggle: vi.fn() },
+      openCompletedImport: vi.fn(),
     },
   })
 }

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -555,18 +555,30 @@ export const FloatingNavigator = React.memo(function FloatingNavigator({
     }
   }, [])
 
-  // D7: the floating window is too narrow for the import dialog, so Import
-  // broadcasts an open-intent (the main window's Completed entry subscribes)
-  // and surfaces the main window. Broadcast first so the subscriber fires even
-  // if focusing the window is what brings the main renderer to the foreground.
+  // T14: the full task app is web-only, so Import opens the Completed import
+  // surface (/home) in the user's browser instead of broadcasting an open-intent
+  // to the main window's dialog. Preferred path = the new `openCompletedImport`
+  // bridge. Preload skew: an older installed app freezes a preload that predates
+  // this method while still loading this (newer) web bundle, so method-guard and
+  // fall back to the legacy cross-window intent — broadcast to the main window's
+  // Completed dialog + surface it (that older app still has a main window).
   const handleOpenImport = useCallback(async () => {
-    requestOpenCompletedImport()
-    if (isFloatingNavigatorEnvironment()) {
+    if (!isFloatingNavigatorEnvironment()) return
+    const floatingApi = window.floatingNavigatorAPI
+    if (typeof floatingApi?.openCompletedImport === 'function') {
       try {
-        await window.floatingNavigatorAPI!.window.focusMainWindow()
+        await floatingApi.openCompletedImport()
       } catch (error) {
-        log.error('Failed to focus main window for import:', error)
+        log.error('Failed to open import in browser:', error)
       }
+      return
+    }
+    // Preload skew: degrade to the legacy main-window dialog intent.
+    requestOpenCompletedImport()
+    try {
+      await floatingApi?.window.focusMainWindow()
+    } catch (error) {
+      log.error('Failed to focus main window for import:', error)
     }
   }, [])
 
@@ -693,7 +705,7 @@ export const FloatingNavigator = React.memo(function FloatingNavigator({
               variant="ghost"
               onClick={handleOpenImport}
               className="h-6 w-6 p-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              aria-label="Import to Completed in main window"
+              aria-label="Import to Completed"
               title="Import to Completed"
             >
               <Suspense fallback={<IconFallback />}>


### PR DESCRIPTION
## What

Phase 1 of the **Electron main-window retirement** (Approach A): re-home every
native-chrome consumer onto the **Floating navigator** (or the browser) so they
are **main-OPTIONAL** — *while the main window still exists*. This is the staged
strangler-fig step: nothing is deleted yet, so the main window stays alive and
fully QA-able as a fallback. The irreversible deletion is the **follow-up**
(Phase 2 / T18), gated on this being QA-green.

End state (after Phase 2): the full task app runs **browser-only** at
corelive.app; Electron keeps exactly three windows — **BrainDump, Floating,
Settings** — and a native signed-out OAuth front door (Floating, already shipped
in Lane A / v0.13.0).

## Tasks in this PR

| Task | Change |
| ---- | ------ |
| T6  | `restoreFromTray()` → Floating navigator (shared chokepoint for tray/dock/notification/shortcut/deep-link) |
| T8  | Companion-grade app menu; decouple menu init from the main-window ref; drop the ghost *Show Main Window* item |
| T9  | Tray: *Open full app in browser ↗* + *Focus Floating* replace the main-restoring items |
| T10 | `activate` → Floating; `window-all-closed` stays empty (tray-resident) |
| T11 | new-task shortcut opens the browser; shortcut focus → Floating |
| T12 | NotificationManager main-optional; click-through opens the browser |
| T14 | Floating *Import* opens the browser, not the main window's Completed dialog |
| T15 | Deep links (`corelive://task|create|view|search`) open the browser, not the dying main renderer |
| T16 | SystemIntegrationErrorHandler: drop the main title-flash + dead status IPC |
| T17 | AutoUpdater available/downloaded dialogs survive main retirement (anchor-or-parentless) |
| T19 | Regression net: tray-restore → Floating (real `WindowManager`) + menu builds with no main (real `MenuManager`) |

## Explicitly NOT in this PR

- **T18 (Phase 2, one-way door):** stop calling `createMainWindow`; delete
  `createMainWindow` / `armStartupPill` / `startupPill` / the main-login
  fallback / `showMain` plumbing / the deep-link→renderer bridge. Lands only
  **after this PR is QA-green** so the deletion is verified, not blind.
- **T19 scope note:** the design doc also bucketed "delete startup-pill specs"
  and "update ~9 main-assuming specs" into T19. Both move to **T18** — they're
  bound to the code T18 deletes, and rewriting a main-assuming spec to
  post-retirement expectations isn't actionable while the main window still
  exists. So T19 here is **ADD-only** (the green safety net).

## QA

- ✅ `pnpm validate` green — web unit **633 passed** / packages **22** / theme /
  typecheck / build / lint all exit 0.
- ✅ `pnpm test:electron` **329 passed** (incl. the 2 new T19 regression specs,
  verified to exercise the real classes — not mock reimplementations).
- ⏳ **Web E2E** — proven on CI (can't boot the web server locally on this Mac).
- ⏳ **T20 native macOS QA** (packaged app: tray/dock/menu, all 3 windows, motion
  via video frames, signed-out OAuth round-trip) — pending; the OAuth leg needs
  real Google SSO. This is the gate before merge + before Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added “Import to Completed” from the Floating Navigator (opens in your browser).

* **Improvements**
  * Tray actions and keyboard shortcuts now open the full app in your browser (for the home/create flows).
  * Deep links now navigate via browser routes instead of in-app window actions.
  * Menus and keyboard/menu actions remain usable when the main window isn’t available; relevant items are disabled as needed.
  * Update prompts now show reliably whether a main window is present or not.

* **Bug Fixes**
  * Tray “restore” now surfaces the Floating Navigator instead of the main window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->