### PR TITLE
feat: recover stranded "Opening browser…" CTA via timeout backstop

### DIFF
--- a/electron/OAuthManager.ts
+++ b/electron/OAuthManager.ts
@@ -467,10 +467,10 @@ export class OAuthManager {
    * floating-initiated flow surfaces its own error instead of hanging). With the
    * main window retired (T18) there is no default renderer, so an initiator-less
    * error (callback with no/expired state, or a pre-flow failure) can only be
-   * logged. There is no renderer-side timeout backstop: a stranded
-   * "Opening browser…" state clears only when the window is reopened (remount) or
-   * a later sign-in event arrives — the `RESET` recovery path in
-   * `ElectronOAuthButtons` is intentionally unwired pending the T20 UX decision.
+   * logged. The renderer covers the stranded case itself: `ElectronOAuthButtons`
+   * re-arms its "Opening browser…" CTA via a timeout backstop
+   * (`OAUTH_OPENING_BROWSER_TIMEOUT_MS`) when an abandoned flow fires no event, so
+   * an initiator-less error here is non-fatal — the user is never dead-ended.
    *
    * @param error - Error message
    * @param initiator - The renderer that started the flow; receives the error

--- a/src/components/auth/ElectronOAuthButtons.test.tsx
+++ b/src/components/auth/ElectronOAuthButtons.test.tsx
@@ -14,7 +14,7 @@
  * @example
  *   pnpm test -- ElectronOAuthButtons
  */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ElectronOAuthButtons } from './ElectronOAuthButtons'
@@ -107,5 +107,50 @@ describe('ElectronOAuthButtons', () => {
     expect(
       screen.getByRole('button', { name: /sign in with google/i }),
     ).toBeEnabled()
+  })
+
+  it('re-arms the sign-in button after an abandoned browser flow times out', async () => {
+    // Arrange: fake timers so we can fast-forward the abandonment backstop. The
+    // flow STARTS successfully (the system browser opens), but the user then
+    // ABANDONS it — closes the tab / picks no account — so neither onSuccess nor
+    // onError ever fires (the bridge's listeners are registered but never
+    // invoked). Without the backstop the CTA would sit dead at "Opening browser…"
+    // until the window is reopened, which post-main-window-retirement (T18) is
+    // the only other escape.
+    vi.useFakeTimers()
+    try {
+      const start = plantOAuthBridge({ success: true })
+      render(<ElectronOAuthButtons />)
+
+      // Act: press the only sign-in affordance; it enters the in-flight state.
+      fireEvent.click(
+        screen.getByRole('button', { name: /sign in with google/i }),
+      )
+      // Let the awaited start() promise settle (its success path dispatches
+      // nothing further, leaving the button in its loading state).
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(
+        screen.getByRole('button', { name: /opening browser/i }),
+      ).toBeDisabled()
+
+      // Act: the user walks away and the 25s backstop window elapses with no
+      // event from the main process.
+      act(() => {
+        vi.advanceTimersByTime(25_000)
+      })
+
+      // Assert: the CTA recovers to its idle, re-pressable state on its own —
+      // no window reopen required.
+      expect(
+        screen.getByRole('button', { name: /sign in with google/i }),
+      ).toBeEnabled()
+      // And the recovery is local UI only — it did not silently launch a second
+      // browser flow.
+      expect(start).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/components/auth/ElectronOAuthButtons.tsx
+++ b/src/components/auth/ElectronOAuthButtons.tsx
@@ -10,6 +10,19 @@ import { useReducerState } from '@/hooks/useReducerState'
 
 import { isElectronEnvironment } from '../../../electron/utils/electron-client'
 
+/**
+ * How long the sign-in CTA may sit at "Opening browser…" before it re-arms
+ * itself to the idle, re-pressable state. Covers ABANDONMENT (user closes the
+ * browser tab / picks no account), which fires neither a success nor an error
+ * event. Recovery is visual-only: a real sign-in completed after this window
+ * still lands via the decoupled token path (electron-auth-provider's
+ * `onSignInToken` → Clerk session → `user`), up to the main process's 10-minute
+ * OAuth state TTL. Sized past a deliberate, read-the-consent-screen sign-in
+ * (~10-20s) yet short enough that an abandoned flow recovers promptly; tuned
+ * down from 45s after watching the real "Opening browser…" hold in native QA.
+ */
+const OAUTH_OPENING_BROWSER_TIMEOUT_MS = 25_000
+
 type OAuthState = {
   isLoading: boolean
   error: string | null
@@ -39,9 +52,9 @@ function oauthReducer(state: OAuthState, action: OAuthAction): OAuthState {
       return { isLoading: false, error: null }
     case 'ERROR':
       return { isLoading: false, error: action.error }
-    // Intentionally unwired in Phase 1 (nothing dispatches RESET yet) — kept as
-    // the recovery scaffold; see the success branch in handleGoogleClick for the
-    // abandonment limitation it will eventually resolve (T20 UX decision).
+    // Abandonment recovery: dispatched by the "Opening browser…" timeout backstop
+    // when a launched flow fires no success/error event (user closed the browser
+    // tab / picked no account). Returns the CTA to its idle, re-pressable state.
     case 'RESET':
       return { isLoading: false, error: null }
     default:
@@ -107,6 +120,21 @@ export const ElectronOAuthButtons = memo(function ElectronOAuthButtons() {
     }
   }, [])
 
+  // Abandonment backstop: a launched flow the user walks away from (closes the
+  // browser tab / picks no account) fires no success or error event, so without
+  // this the CTA would sit disabled at "Opening browser…" until the window is
+  // reopened — the retired main window (T18) is no longer a fallback sign-in
+  // path. Keyed on the masked `isLoading`, so a success/error event OR a
+  // signed-in user disarms the timer immediately; only a truly stranded flow
+  // reaches the RESET. Visual-only — see OAUTH_OPENING_BROWSER_TIMEOUT_MS.
+  useCycleEffect(() => {
+    if (!isLoading) return
+    const recoveryTimer = setTimeout(() => {
+      dispatch({ type: 'RESET' })
+    }, OAUTH_OPENING_BROWSER_TIMEOUT_MS)
+    return () => clearTimeout(recoveryTimer)
+  }, [isLoading])
+
   // Sync, stable click handler (the Button needs a stable useCallback ref) that
   // fires the async native-OAuth start as fire-and-forget.
   const handleGoogleClick = useCallback(() => {
@@ -129,14 +157,13 @@ export const ElectronOAuthButtons = memo(function ElectronOAuthButtons() {
         // On success the system browser opens; the onSuccess/onError events (and
         // the in-place Clerk re-render) take over from here.
         //
-        // KNOWN Phase-1 limitation: if the user ABANDONS the browser flow (closes
-        // the tab / picks no account), no event fires and the CTA stays disabled
-        // at "Opening browser…" until the window is reopened. Non-regressive — the
-        // Electron main window is still a working sign-in path during Phase 1's
-        // strangler-fig, so this is not a dead-ended user. The recovery mechanism
-        // (dispatch RESET on focus-regain vs. a timeout) is a UX decision to settle
-        // during the T20 packaged native-OAuth QA, where the real deep-link timing
-        // can be observed — it must not be guessed at here.
+        // ABANDONMENT (user closes the tab / picks no account) fires no event, so
+        // the OAUTH_OPENING_BROWSER_TIMEOUT_MS backstop re-arms the CTA — the
+        // retired main window (T18) is no longer a fallback path, so this would
+        // otherwise dead-end at "Opening browser…" until window reopen. A timeout,
+        // not focus-regain: the Floating card is always-on-top so a closed-tab
+        // return won't reliably refocus it, and the success path itself refocuses
+        // the window (OAuthManager) — focus-regain would misfire on both.
       } catch {
         dispatch({ type: 'ERROR', error: 'Failed to start authentication' })
       }


### PR DESCRIPTION
## What & why

The signed-out **Floating front door**'s "Sign in with Google" CTA had a dead-end: when a user **abandons** the launched native-OAuth flow (closes the browser tab / picks no account), neither a success nor an error event ever fires, so the button sat disabled at **"Opening browser…" until the window was reopened**.

This was a deferred decision (T20). The in-code justification for leaving it ("the Electron main window is still a working sign-in path") **died with main-window retirement in v0.14.0** — post-T18 the Floating card is the *only* signed-out sign-in surface, so a stranded "Opening browser…" is now a real dead-end on the first screen a new user sees.

## The fix

Wire the previously-scaffolded `RESET` reducer path via a **timeout backstop** (`OAUTH_OPENING_BROWSER_TIMEOUT_MS = 25_000`): while the CTA shows "Opening browser…", a timer re-arms it to the idle, re-pressable state if no outcome event lands. Keyed on the masked `isLoading`, so a real success/error/sign-in disarms it immediately — only a genuinely stranded flow reaches the `RESET`.

**Why timeout, not focus-regain:** the Floating card is always-on-top, so a closed-tab return won't reliably refocus it (focus-regain might never fire for the exact abandonment we're fixing), and the success path itself calls `initiatorWindow?.focus()` — focus-regain would misfire on both.

**Why it's safe (cosmetic-only):** the token → Clerk session → `user` path (`electron-auth-provider`'s `onSignInToken`) is **decoupled** from this reducer. A late completion within the main process's 10-minute OAuth state TTL still signs the user in even after a reset — the backstop only restores the visual affordance, it can never break a real sign-in.

## QA

- **Live native QA — PASS.** Drove a real signed-out Electron Floating window (prod build of this branch in `_electron`): click → "Opening browser…" disabled → held through abandonment → re-armed to "Sign in with Google" at the configured window (mechanism proven in real Chromium, Δ0.1s). The **25s** value was chosen after watching the real hold.
- **Unit test** (`ElectronOAuthButtons.test.tsx`): `re-arms the sign-in button after an abandoned browser flow times out` — fake timers, RED-meaningful (without the wired `RESET` the button stays at "Opening browser…").
- `pnpm typecheck` clean · eslint clean (0 warnings) · full unit suite green.

## Notes

- Renderer change ships via Vercel; it reaches installed apps only after merge + prod deploy.
- Web E2E is the CI gate (can't boot locally on this Mac).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in reliability: Enhanced OAuth authentication flow with automatic recovery for stalled browser windows. When a sign-in attempt gets stuck in a loading state due to browser-opening issues, the button now automatically resets after a brief timeout, allowing users to retry the authentication process without restarting the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->