### PR TITLE
fix(redux): deepMerge persisted state so an app update never drops preference fields

### DIFF
--- a/src/lib/redux/persistedPreferencesSurviveAppUpdate.test.ts
+++ b/src/lib/redux/persistedPreferencesSurviveAppUpdate.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Spec: a saved preference must survive an app version-up. It must never
+ * silently revert to its default, and a preference field introduced by a newer
+ * app version must read back at its default — not `undefined`.
+ *
+ * Regresses the hydration bug where the persistence middleware's default
+ * `shallowMerge` replaced each persisted slice wholesale (`{ ...current,
+ * ...persisted }`), so any field ADDED after a user first persisted was dropped:
+ * Sound / BrainDump / electronSettings settings read back as "reset to default"
+ * after an update. The fix opts the store into `deepMerge`
+ * (`createPersistenceMiddleware` in `./store`), which fills every missing field
+ * from the current defaults while preserving all user-set values.
+ *
+ * These tests drive the EXACT production persistence config via the shared
+ * `createPersistenceMiddleware` factory, so they fail if production ever drops
+ * the `deepMerge` reconciler.
+ */
+import { configureStore } from '@reduxjs/toolkit'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { STORAGE_SCHEMA_VERSION } from './migratePersistedState'
+import { selectShowInMenuBar } from './slices/electronSettingsSlice'
+import {
+  createPersistenceMiddleware,
+  type RootState,
+  STORAGE_KEY,
+} from './store'
+
+/**
+ * Seeds localStorage with a persisted blob and rehydrates a fresh store through
+ * the real production persistence middleware (deepMerge + migrate).
+ * @param seed - The `{ version, state }` envelope to write to {@link STORAGE_KEY}.
+ * @returns The store's state after hydration completes.
+ */
+async function rehydrateFromSeed(seed: unknown): Promise<RootState> {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(seed))
+  const { middleware, reducer, api } = createPersistenceMiddleware()
+  const store = configureStore({
+    reducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }).concat(middleware),
+  })
+  await api.rehydrate()
+  return store.getState()
+}
+
+describe('preferences survive an app update (no silent revert to defaults)', () => {
+  beforeEach(() => window.localStorage.clear())
+  afterEach(() => window.localStorage.clear())
+
+  it('keeps saved Sound settings and fills new BrainDump fields with defaults', async () => {
+    // Arrange — a current-version blob from a user who set Sound + 居残りモード
+    // BEFORE the BrainDump editor fields (font / size / color / clear-on-complete)
+    // shipped, so the persisted `preferences` predates those fields entirely.
+    const seed = {
+      version: STORAGE_SCHEMA_VERSION,
+      state: {
+        preferences: {
+          completionSound: false,
+          retainCompletedInList: true,
+          soundMoments: { 'task-create': true, complete: true, clear: false },
+          soundTimbre: 'wood',
+          soundVolume: 0.3,
+        },
+      },
+    }
+
+    // Act
+    const state = await rehydrateFromSeed(seed)
+
+    // Assert — every saved value is preserved (no revert)…
+    expect(state.preferences.soundTimbre).toBe('wood')
+    expect(state.preferences.soundVolume).toBe(0.3)
+    expect(state.preferences.retainCompletedInList).toBe(true)
+    expect(state.preferences.completionSound).toBe(false)
+    expect(state.preferences.soundMoments).toEqual({
+      'task-create': true,
+      complete: true,
+      clear: false,
+    })
+    // …and the newer fields are MATERIALIZED at their defaults in raw state,
+    // not left `undefined` (the shallow-merge drop this regresses).
+    expect(state.preferences.braindumpFontFamily).toBe('mono')
+    expect(state.preferences.braindumpFontSize).toBe(14)
+    expect(state.preferences.braindumpTextColor).toBe('var(--foreground)')
+    expect(state.preferences.braindumpClearOnComplete).toBe(false)
+  })
+
+  it('restores the menu-bar default when an older blob predates that electron setting', async () => {
+    // Arrange — an electronSettings blob missing `showInMenuBar` (stand-in for
+    // ANY field a user persisted before it existed). electronSettings selectors
+    // have no `?? default` guard, so under shallow-merge this read back undefined.
+    const seed = {
+      version: STORAGE_SCHEMA_VERSION,
+      state: {
+        electronSettings: { hideAppIcon: true, startAtLogin: false },
+        preferences: {},
+      },
+    }
+
+    // Act
+    const state = await rehydrateFromSeed(seed)
+
+    // Assert — the absent field is filled from its default (true), not undefined;
+    // the saved field is preserved.
+    expect(selectShowInMenuBar(state)).toBe(true)
+    expect(state.electronSettings.showInMenuBar).toBe(true)
+    expect(state.electronSettings.hideAppIcon).toBe(true)
+    expect(state.electronSettings.startAtLogin).toBe(false)
+  })
+
+  it('keeps the other saved preferences when one persisted field is the wrong type', async () => {
+    // Arrange — one corrupt field (wrong type). A reconciler that re-parsed the
+    // slice through Zod would reject the WHOLE slice and reset every preference;
+    // deepMerge preserves the good values (the corrupt one self-heals via its
+    // selector). Locks the deepMerge-over-Zod choice for the hydration boundary.
+    const seed = {
+      version: STORAGE_SCHEMA_VERSION,
+      state: {
+        preferences: {
+          retainCompletedInList: 'yes', // corrupt: must be a boolean
+          soundTimbre: 'wood',
+          soundVolume: 0.3,
+        },
+      },
+    }
+
+    // Act
+    const state = await rehydrateFromSeed(seed)
+
+    // Assert — the good saved values survive (NOT reset to defaults).
+    expect(state.preferences.soundTimbre).toBe('wood')
+    expect(state.preferences.soundVolume).toBe(0.3)
+  })
+})

--- a/src/lib/redux/store.ts
+++ b/src/lib/redux/store.ts
@@ -13,7 +13,10 @@
  * // Access state directly (prefer using hooks)
  * const state = store.getState()
  */
-import { createStorageMiddleware } from '@laststance/redux-storage-middleware'
+import {
+  createStorageMiddleware,
+  deepMerge,
+} from '@laststance/redux-storage-middleware'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 
 import { createPreferencesSyncMiddleware } from '../preferences-sync-channel'
@@ -36,30 +39,47 @@ const rootReducer = combineReducers({
 
 /**
  * Storage key used for localStorage persistence.
- * Changing this will reset all persisted state.
+ * Changing this will reset all persisted state. Exported so hydration tests
+ * seed the same key the production store reads.
  */
-const STORAGE_KEY = 'corelive-redux-state'
+export const STORAGE_KEY = 'corelive-redux-state'
 
 /**
- * Configure redux-storage-middleware for localStorage persistence.
- * Only persists specified slices to avoid bloating localStorage.
+ * Builds CoreLive's localStorage persistence middleware. Extracted (and
+ * exported) so the hydration regression tests drive the EXACT production
+ * reconciler instead of a hand-copied config that could silently drift.
  *
- * The middleware handles:
- * - Automatic persistence of state changes to localStorage
- * - SSR-safe hydration on client-side mount
- * - Selective slice persistence
+ * Why `merge: deepMerge` and not the library default `shallowMerge`:
+ * shallowMerge replaces each persisted slice wholesale (`{ ...current,
+ * ...persisted }`), so any preference field ADDED in a newer app version is
+ * simply absent for users who persisted before it existed — it reads back
+ * `undefined` and the UI shows it "reverted to default" on version-up.
+ * deepMerge recursively fills every missing field (at any depth) from the
+ * current defaults while preserving all user-set values, so an update never
+ * silently resets a preference and newer fields appear at their defaults. It is
+ * also preferred over re-parsing through the Zod schema, which would reject the
+ * WHOLE slice (resetting everything) on a single wrong-typed field — the wrong
+ * trade-off for the user's own persisted data, where "preserve" beats "reject".
+ *
+ * The middleware also handles automatic persistence of state changes, SSR-safe
+ * hydration on mount, and selective slice persistence. Bumping the version runs
+ * `migrate` once on the next rehydrate; it MUST stay total or the middleware
+ * wipes ALL persisted state.
+ *
+ * @returns The storage middleware, hydration-wrapped reducer, and hydration api.
  */
-const { middleware: storageMiddleware, reducer: hydratedReducer } =
+export const createPersistenceMiddleware = () =>
   createStorageMiddleware({
     rootReducer,
     key: STORAGE_KEY,
     slices: ['electronSettings', 'preferences'], // Slices to persist to localStorage
-    // Seal the legacy completionSound → soundMoments fold at the hydration
-    // boundary. Bumping the version runs `migrate` once on the next rehydrate;
-    // it MUST stay total or the middleware wipes ALL persisted state.
     version: STORAGE_SCHEMA_VERSION,
     migrate: migratePersistedState,
+    merge: deepMerge,
   })
+
+const { middleware: storageMiddleware, reducer: hydratedReducer } =
+  createPersistenceMiddleware()
 
 /**
  * Configured Redux store with middleware and dev tools.


### PR DESCRIPTION
## What

Switch the localStorage persistence reconciler from the middleware's default
`shallowMerge` to `deepMerge`, via a shared `createPersistenceMiddleware` factory
used by **both** the production store and the regression test (so the reconciler
can't silently drift between them).

## Why (root cause)

`shallowMerge` = `{ ...current, ...persisted }` replaces each persisted slice
**wholesale**. Any preference field **added in a newer app version** is absent
from a user's older persisted blob, so it reads back `undefined` and the UI shows
it "reverted to default" after a version-up.

- `preferences` masked this with `?? DEFAULT` selectors (displayed value was fine;
  raw state was `undefined`).
- `electronSettings` has **no selector guard** — its next added field would have
  reverted **visibly**.

`deepMerge` recursively fills every missing field from the current defaults while
preserving all user-set values (≈ redux-persist `autoMergeLevel2`). Chosen over a
Zod re-parse, which would reject a *whole slice* (resetting everything) on a
single wrong-typed field — the wrong trade-off for the user's own persisted data.

## Scope (honest)

⚠️ This **hardens the latent class** (`electronSettings` + every future field). It
does **not** change current **Sound** behavior: the historical "Sound 4 settings
revert on version-up" was the legacy `completionSound` → `soundMoments`
**restructure**, already fixed in `fea3fe7` (v0.15.0). The RED run confirms it —
every Sound assertion passed even *without* this change; only BrainDump /
electronSettings failed.

## Tests

`persistedPreferencesSurviveAppUpdate.test.ts` — 3 tests, **proven RED without the
fix**, driving the exact production reconciler through the shared factory:

1. Saved Sound / 居残りモード survive **and** newer BrainDump fields materialize at
   their defaults (`mono` / `14` / `var(--foreground)` / `false`) instead of
   `undefined`.
2. An older `electronSettings` blob missing `showInMenuBar` restores it to its
   default (`true`), not `undefined`.
3. One wrong-typed field does **not** reset the rest of the slice (locks the
   deepMerge-over-Zod choice).

## QA

- ✅ `pnpm validate` green under CI node `24.13.0` — **637 tests** / typecheck /
  build / lint:fix all pass.
- ⏳ Web E2E can't boot locally on this Mac (known) → **CI E2E is the gate**.
- 🔎 CodeRabbit reviews this PR.
- Renderer/Redux only — no native Electron surface touched; ships via Vercel.

## Follow-ups (NOT in this PR)

- **"Does Sound still revert on the current build?"** — put on hold (ambiguous,
  no clean repro). If it reproduces on v0.15.0, the prime suspect is the
  **cross-window broadcast** path (sender posts the *raw* slice; receiver
  `hydratePreferences` **full-replaces** the slice) — a *cross-version* old-tab
  clobber that `deepMerge` does not touch. Needs a fresh repro (single vs multiple
  windows, web vs desktop app, which of the 4 settings) before fixing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating user preferences persist correctly across app version updates and handle preference schema changes without data loss.

* **Chores**
  * Refactored preference persistence configuration for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->