### PR TITLE
feat(braindump): clear completed line instantly on Cmd+Enter (optimistic)

### DIFF
--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -649,6 +649,87 @@ describe('BrainDumpEditor clear-on-complete', () => {
     expect(noteField).toHaveValue('buy milk')
   })
 
+  it('does not duplicate the line when Undo is tapped after a late failure already restored it', async () => {
+    // Arrange — the create rejects, so the failure handler restores the line.
+    // Sonner's dismiss runs an exit animation, leaving the Undo button clickable
+    // for a few hundred ms, so a tap AFTER the restore must NOT re-insert a
+    // SECOND copy of the line (silent note corruption — the exact failure mode
+    // this feature exists to prevent).
+    completedMutateAsync.mockRejectedValueOnce(new Error('network down'))
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    const value = 'keep me\n- [ ] buy milk'
+    fireEvent.change(noteField, { target: { value } })
+    const caret = value.length // caret at end of the second line
+    noteField.selectionStart = caret
+    noteField.selectionEnd = caret
+
+    // Act 1 — complete the second line; its background create rejects and the
+    // failure handler puts the verbatim line back at index 1. The error toast
+    // is the signal the failure handler has finished.
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled()
+    })
+    expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+
+    // Act 2 — tap Undo AFTER the failure already restored the line.
+    const undoAction = vi.mocked(toast.success).mock.calls.at(-1)?.[1]
+      ?.action as { onClick: () => void } | undefined
+    await act(async () => {
+      undoAction?.onClick()
+    })
+
+    // Assert — the line is present exactly ONCE, never doubled.
+    expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+  })
+
+  it('stays silent when the create fails after the user already undid', async () => {
+    // Arrange — hold the create in flight so the user can Undo FIRST, then make
+    // it reject. The user abandoned the completion, so a late create failure is
+    // irrelevant to them: no error toast, and no second re-insert of the line.
+    let rejectCreate: (reason: Error) => void = () => undefined
+    const pendingCreate = new Promise<{ id: number }>((_resolve, reject) => {
+      rejectCreate = reject
+    })
+    completedMutateAsync.mockReturnValueOnce(pendingCreate)
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — complete (line clears), Undo (line restored, create still pending),
+    // THEN the held create rejects.
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('')
+    })
+    const undoAction = vi.mocked(toast.success).mock.calls.at(-1)?.[1]
+      ?.action as { onClick: () => void } | undefined
+    await act(async () => {
+      undoAction?.onClick()
+    })
+    expect(noteField).toHaveValue('buy milk') // restored by Undo
+    await act(async () => {
+      rejectCreate(new Error('network down'))
+    })
+
+    // Assert — the abandoned completion's failure surfaces NO error toast, and
+    // the line stays put (the failure handler must not re-insert a second copy).
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(noteField).toHaveValue('buy milk')
+  })
+
   it('restores the line with its exact leading whitespace on undo (verbatim, not trimmed)', async () => {
     // Arrange — a plain line the user indented with leading spaces.
     const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactElement } from 'react'
 import { Provider } from 'react-redux'
 import { toast } from 'sonner'
 import type { ToastT } from 'sonner'
@@ -46,8 +47,15 @@ vi.mock('@/hooks/useClerkQueryReady', () => ({
   useClerkQueryReady: () => true,
 }))
 
+// Controllable active floating category so a spec can flip the active category
+// mid-test (it drives activeCategoryId while sync is on). Defaults to 1 so every
+// existing spec keeps the single "General" category active.
+const { selectedCategoryRef } = vi.hoisted(() => ({
+  selectedCategoryRef: { current: 1 as number },
+}))
+
 vi.mock('@/hooks/useSelectedCategory', () => ({
-  useSelectedCategory: () => [1],
+  useSelectedCategory: () => [selectedCategoryRef.current],
 }))
 
 vi.mock('@/lib/orpc/client-query', () => ({
@@ -529,6 +537,8 @@ describe('BrainDumpEditor clear-on-complete', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     completedMutateAsync.mockResolvedValue({ id: 1 })
+    // Reset the active floating category — the cross-category spec mutates it.
+    selectedCategoryRef.current = 1
   })
 
   it('removes a finished line from the note immediately when clear-on-complete is on', async () => {
@@ -638,6 +648,11 @@ describe('BrainDumpEditor clear-on-complete', () => {
     const autoClose = vi
       .mocked(toast.success)
       .mock.calls.at(-1)?.[1]?.onAutoClose
+    // This spec only proves the LATE-failure path (undo window closed → outcome
+    // 'confirmed') if onAutoClose actually exists and runs. Without this guard an
+    // undefined onAutoClose would no-op and the test would silently fall back to
+    // exercising the 'pending' path — passing for the wrong reason.
+    expect(autoClose).toBeDefined()
     act(() => {
       autoClose?.({} as ToastT)
     })
@@ -817,5 +832,85 @@ describe('BrainDumpEditor clear-on-complete', () => {
       .mock.calls.at(-1)?.[1]?.onAutoClose
     expect(autoClose).toBeUndefined()
     expect(noteField).toHaveValue('- [x] buy milk')
+  })
+
+  it("restores the cleared line into its origin category's stored note when Undo fires after switching categories", async () => {
+    // Arrange — clear-on-complete on, with TWO categories. note.get is made
+    // category-aware so the assertion proves the line returns to category 1's
+    // REAL content, not an empty stand-in. This is the cross-category data-loss
+    // guard: completing in category 1, switching to 2, then Undo must put the
+    // line back into category 1's STORED note — never category 2's visible one.
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    // Category 1 holds 'keep me'; every other category is empty.
+    api.note.get = vi.fn(async (id: number) => (id === 1 ? 'keep me' : ''))
+    const noteSet = vi.mocked(api.note.set)
+
+    const store = configureStore({
+      reducer: { preferences: preferencesReducer },
+      preloadedState: {
+        preferences: {
+          ...preferencesInitialState,
+          braindumpClearOnComplete: true,
+        },
+      },
+    })
+    const [generalCategory] = categories
+    if (!generalCategory)
+      throw new Error('expected the seeded General category')
+    const twoCategories: CategoryWithCount[] = [
+      generalCategory,
+      { ...generalCategory, id: 2, name: 'Work', isDefault: false },
+    ]
+    // Fresh element each render — passing the SAME element reference to rerender
+    // makes React bail out (reference-equal subtree) and never re-read the
+    // controllable useSelectedCategory mock, so the category switch wouldn't take.
+    const tree = (): ReactElement => (
+      <Provider store={store}>
+        <BrainDumpEditor categories={twoCategories} />
+      </Provider>
+    )
+    const { rerender } = render(tree())
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    // Seed two lines and park the caret on the checkbox line (index 1).
+    const value = 'keep me\n- [ ] buy milk'
+    fireEvent.change(noteField, { target: { value } })
+    const caret = value.length
+    noteField.selectionStart = caret
+    noteField.selectionEnd = caret
+
+    // Complete the checkbox line in category 1 → the line clears to 'keep me'.
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+    await waitFor(() => {
+      expect(noteField).toHaveValue('keep me')
+    })
+
+    // Act — switch the active floating category to 2 (the live textarea now
+    // shows category 2's empty note), THEN tap Undo. The toast's onClick still
+    // holds the category-1 completion via closure even though the swap cleared
+    // the in-memory map.
+    selectedCategoryRef.current = 2
+    rerender(tree())
+    await waitFor(() => {
+      expect(noteField).toHaveValue('') // category 2's empty note has loaded
+    })
+    noteSet.mockClear() // drop the category-swap flush write; assert only the restore
+    const undoAction = vi.mocked(toast.success).mock.calls.at(-1)?.[1]
+      ?.action as { onClick: () => void } | undefined
+    await act(async () => {
+      undoAction?.onClick()
+    })
+
+    // Assert — the verbatim line is written back into category 1's STORED note
+    // at its original index via IPC, so neither the line nor the win is lost…
+    await waitFor(() => {
+      expect(noteSet).toHaveBeenCalledWith(1, 'keep me\n- [ ] buy milk')
+    })
+    // …and category 2's visible note was never touched.
+    expect(noteField).toHaveValue('')
   })
 })

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -531,7 +531,7 @@ describe('BrainDumpEditor clear-on-complete', () => {
     completedMutateAsync.mockResolvedValue({ id: 1 })
   })
 
-  it('clears a finished line once its undo window closes when clear-on-complete is on', async () => {
+  it('removes a finished line from the note immediately when clear-on-complete is on', async () => {
     // Arrange — the editor with clear-on-complete opted in.
     const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
     const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
@@ -542,28 +542,22 @@ describe('BrainDumpEditor clear-on-complete', () => {
     renderEditor({ braindumpClearOnComplete: true })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
 
-    // Act — complete the line, then simulate the undo window elapsing with no
-    // Undo (Sonner fires the success toast's onAutoClose on the timeout).
+    // Act — complete the only line.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
-    await waitFor(() => {
-      expect(noteField).toHaveValue('- [x] buy milk')
-    })
-    const autoClose = vi
-      .mocked(toast.success)
-      .mock.calls.at(-1)?.[1]?.onAutoClose
-    // onAutoClose ignores its ToastT arg (it re-resolves the line from the ref),
-    // so an empty stub stands in for the unused parameter.
-    act(() => {
-      autoClose?.({} as ToastT)
-    })
 
-    // Assert — the finished line is dropped, leaving the scratchpad clean.
-    expect(noteField).toHaveValue('')
+    // Assert — the line is gone instantly (no server round-trip, no 5 s wait),
+    // and the Completed create still fired in the background.
+    await waitFor(() => {
+      expect(noteField).toHaveValue('')
+    })
+    expect(completedMutateAsync).toHaveBeenCalledWith({
+      categoryId: 1,
+      title: 'buy milk',
+    })
   })
 
-  it('keeps a finished line that was undone before its window closed (clear self-suppresses)', async () => {
-    // Arrange — clear-on-complete on; complete a line, then manually uncheck it
-    // (Cmd+Enter on the `- [x]` line) before the undo window elapses.
+  it('undo re-inserts the cleared line at its original position', async () => {
+    // Arrange — clear-on-complete on, two lines so the re-insert index matters.
     const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
     const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
     installBrainDumpAPI({
@@ -572,18 +566,74 @@ describe('BrainDumpEditor clear-on-complete', () => {
     })
     renderEditor({ braindumpClearOnComplete: true })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
-    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
-    await waitFor(() => {
-      expect(noteField).toHaveValue('- [x] buy milk')
-    })
-
-    // Act — manually uncheck (re-fire Cmd+Enter on the checked line), then fire
-    // the original toast's onAutoClose as the window would.
-    noteField.selectionStart = 1
-    noteField.selectionEnd = 1
+    const value = 'keep me\n- [ ] buy milk'
+    fireEvent.change(noteField, { target: { value } })
+    const caret = value.length // caret at end of the second line
+    noteField.selectionStart = caret
+    noteField.selectionEnd = caret
     fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
     await waitFor(() => {
-      expect(noteField).toHaveValue('- [ ] buy milk')
+      expect(noteField).toHaveValue('keep me')
+    })
+
+    // Act — click Undo on the optimistic toast (onClick ignores its event arg).
+    // sonner types `action` as `Action | ReactNode`; in this editor it's always
+    // the Action object, so narrow to its no-arg onClick (our handler ignores
+    // the event) before invoking.
+    const undoAction = vi.mocked(toast.success).mock.calls.at(-1)?.[1]
+      ?.action as { onClick: () => void } | undefined
+    await act(async () => {
+      undoAction?.onClick()
+    })
+
+    // Assert — the verbatim line returns at index 1, not appended at the end.
+    expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+  })
+
+  it('restores the cleared line when the completion create fails', async () => {
+    // Arrange — the create rejects for this completion.
+    completedMutateAsync.mockRejectedValueOnce(new Error('network down'))
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — complete a line whose background create then rejects.
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+
+    // Assert — the verbatim line comes back when the create fails.
+    await waitFor(() => {
+      expect(noteField).toHaveValue('buy milk')
+    })
+  })
+
+  it('still restores the cleared line when the create rejects AFTER the undo window closed', async () => {
+    // Arrange — hold the create in flight so the undo window can close (its
+    // onAutoClose fires) BEFORE the create rejects. Without the late-failure
+    // restore, the line AND the win vanish silently — the bug this guards.
+    let rejectCreate: (reason: Error) => void = () => undefined
+    const pendingCreate = new Promise<{ id: number }>((_resolve, reject) => {
+      rejectCreate = reject
+    })
+    completedMutateAsync.mockReturnValueOnce(pendingCreate)
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — complete (line clears), let the undo window elapse with no Undo
+    // (Sonner fires onAutoClose on the timeout), THEN the create rejects.
+    fireCompleteCommandOnFirstLine(noteField, 'buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('')
     })
     const autoClose = vi
       .mocked(toast.success)
@@ -591,10 +641,75 @@ describe('BrainDumpEditor clear-on-complete', () => {
     act(() => {
       autoClose?.({} as ToastT)
     })
+    await act(async () => {
+      rejectCreate(new Error('network down'))
+    })
 
-    // Assert — the now-unchecked line is NOT a checked match, so it survives
-    // instead of being cleared out from under the user.
-    expect(noteField).toHaveValue('- [ ] buy milk')
+    // Assert — the line is restored even though its undo window already closed.
+    expect(noteField).toHaveValue('buy milk')
+  })
+
+  it('restores the line with its exact leading whitespace on undo (verbatim, not trimmed)', async () => {
+    // Arrange — a plain line the user indented with leading spaces.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act — complete the indented line, then undo it.
+    fireCompleteCommandOnFirstLine(noteField, '   buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('')
+    })
+    // sonner types `action` as `Action | ReactNode`; in this editor it's always
+    // the Action object, so narrow to its no-arg onClick (our handler ignores
+    // the event) before invoking.
+    const undoAction = vi.mocked(toast.success).mock.calls.at(-1)?.[1]
+      ?.action as { onClick: () => void } | undefined
+    await act(async () => {
+      undoAction?.onClick()
+    })
+
+    // Assert — the three leading spaces survive; the DB got the trimmed title
+    // ('buy milk') but the note restores the line exactly as typed.
+    expect(noteField).toHaveValue('   buy milk')
+    expect(completedMutateAsync).toHaveBeenCalledWith({
+      categoryId: 1,
+      title: 'buy milk',
+    })
+  })
+
+  it('keeps the caret out of the following line after the optimistic clear', async () => {
+    // Arrange — three lines; completing the middle one shifts 'c' up into its slot.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    const value = 'a\n- [ ] buy milk\nc'
+    fireEvent.change(noteField, { target: { value } })
+    // Park the caret at the end of the middle line (offset 16) before completing.
+    const caret = 'a\n- [ ] buy milk'.length
+    noteField.selectionStart = caret
+    noteField.selectionEnd = caret
+
+    // Act — complete the middle line.
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+
+    // Assert — the line is gone and the caret sits at the START of the line that
+    // shifted up (offset 2 = after 'a\n'), not stranded mid-'c' where the next
+    // keystroke would corrupt an unrelated line.
+    await waitFor(() => {
+      expect(noteField).toHaveValue('a\nc')
+    })
+    expect(noteField.selectionStart).toBe(2)
   })
 
   it('keeps every finished line in place by default (no auto-close hook wired)', async () => {
@@ -614,68 +729,12 @@ describe('BrainDumpEditor clear-on-complete', () => {
       expect(noteField).toHaveValue('- [x] buy milk')
     })
 
-    // Assert — the success toast carries NO onAutoClose hook, so the finished
-    // line stays put (the clear is strictly opt-in).
+    // Assert — OFF path unchanged: the success toast carries NO onAutoClose
+    // hook, so the finished `[x]` line stays put (the clear is strictly opt-in).
     const autoClose = vi
       .mocked(toast.success)
       .mock.calls.at(-1)?.[1]?.onAutoClose
     expect(autoClose).toBeUndefined()
     expect(noteField).toHaveValue('- [x] buy milk')
-  })
-
-  it('still deletes the right Completed row after an earlier line was auto-cleared', async () => {
-    // Arrange — clear-on-complete on, with two finished lines whose Completed
-    // rows have distinct ids (titles repeat by design — repetition is a feature).
-    completedMutateAsync.mockReset()
-    completedMutateAsync
-      .mockResolvedValueOnce({ id: 1 }) // create: buy milk
-      .mockResolvedValueOnce({ id: 2 }) // create: wash car
-      .mockResolvedValue({ id: 99 }) // any later delete (return ignored)
-    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
-    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
-    installBrainDumpAPI({
-      getVisibleOnAllWorkspaces,
-      setVisibleOnAllWorkspaces,
-    })
-    renderEditor({ braindumpClearOnComplete: true })
-    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
-
-    // Complete the first line ('buy milk', id 1).
-    fireCompleteCommandOnFirstLine(noteField, 'buy milk\nwash car')
-    await waitFor(() => {
-      expect(noteField).toHaveValue('- [x] buy milk\nwash car')
-    })
-    // Complete the second line ('wash car', id 2) — caret at end of line 2.
-    noteField.selectionStart = noteField.value.length
-    noteField.selectionEnd = noteField.value.length
-    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
-    await waitFor(() => {
-      expect(noteField).toHaveValue('- [x] buy milk\n- [x] wash car')
-    })
-
-    // Act — the FIRST line's undo window elapses, auto-clearing 'buy milk' so
-    // 'wash car' shifts up to line 0 (its ref entry key now drifted). Then
-    // uncheck 'wash car'.
-    const autoCloseBuyMilk = vi
-      .mocked(toast.success)
-      .mock.calls.find(
-        (call) => call[0] === 'Completed: buy milk',
-      )?.[1]?.onAutoClose
-    act(() => {
-      autoCloseBuyMilk?.({} as ToastT)
-    })
-    await waitFor(() => {
-      expect(noteField).toHaveValue('- [x] wash car')
-    })
-    noteField.selectionStart = 1
-    noteField.selectionEnd = 1
-    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
-
-    // Assert — the uncheck deletes 'wash car' (id 2), NOT the auto-cleared
-    // 'buy milk' (id 1) whose stale ref entry would otherwise be mis-targeted.
-    await waitFor(() => {
-      expect(completedMutateAsync).toHaveBeenCalledWith({ id: 2 })
-    })
-    expect(completedMutateAsync).not.toHaveBeenCalledWith({ id: 1 })
   })
 })

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -521,7 +521,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
    * @example
    * await syncCompletedAcrossViews()
    */
-  const syncCompletedAcrossViews = async () => {
+  const syncCompletedAcrossViews = async (): Promise<void> => {
     await queryClient.invalidateQueries({
       queryKey: orpc.completed.heatmap.key(),
     })
@@ -727,6 +727,61 @@ export const BrainDumpEditor = function BrainDumpEditor({
   }
 
   /**
+   * Put a cleared line back into the category it came from. While still in that
+   * category, restore it into the live editor (optionally moving the caret);
+   * after switching away, persist it straight to that category's STORED note via
+   * IPC — so a cross-category Undo / failed create never drops the line. Called
+   * by both undoClearedCompletion and the background-create failure path.
+   *
+   * @param entry - The completion's undo memory (line text, origin category, index).
+   * @param moveCaret - Move the caret to the restored line (true for a user Undo; false for a background failure that must not yank a caret elsewhere).
+   * @returns Promise<void> — settles once the line is back: synchronously in-editor when still active, or after the IPC write when cross-category.
+   * @example
+   * await restoreClearedLineToCategory(entry, true)  // user tapped Undo
+   * void restoreClearedLineToCategory(entry, false)  // background create failed
+   */
+  const restoreClearedLineToCategory = async (
+    entry: ClearedLineMemory,
+    moveCaret: boolean,
+  ): Promise<void> => {
+    // Still in the origin category → restore into the live editor; the textarea
+    // shows this category's note, so an in-place re-insert is correct.
+    if (activeCategoryIdRef.current === entry.categoryId) {
+      const restored = insertLineAtIndex(
+        noteTextRef.current,
+        entry.originalLineIndex,
+        entry.reinsertText,
+      )
+      setNoteText(restored)
+      if (moveCaret) {
+        pendingCaretRef.current = lineStartOffset(
+          restored,
+          entry.originalLineIndex,
+        )
+      }
+      return
+    }
+    // Switched away → the live textarea now shows a DIFFERENT category's note, so
+    // writing there would corrupt it. Persist the line into the origin category's
+    // stored note directly (read-modify-write its on-disk text) so the line and
+    // the win never BOTH vanish. The debounce/flush effects only ever touch the
+    // *active* note, so this out-of-band write to an inactive category can't race
+    // them. (Worst case, if that category is re-opened mid-write, the line lands
+    // on disk and surfaces on its next load — eventual consistency, never loss.)
+    const api = window.brainDumpAPI
+    if (!api) return
+    try {
+      const stored = await api.note.get(entry.categoryId)
+      await api.note.set(
+        entry.categoryId,
+        insertLineAtIndex(stored, entry.originalLineIndex, entry.reinsertText),
+      )
+    } catch (error) {
+      log.error('BrainDump cross-category line restore failed', error)
+    }
+  }
+
+  /**
    * Clear-on-complete ON path: remove the just-completed line from the note the
    * *instant* Cmd/Ctrl+Enter fires, show the optimistic Undo toast immediately,
    * and run the Completed-create in the background. This kills the old "wait for
@@ -748,7 +803,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
     lineIndex: BrainDumpLineIndex,
     originalLine: string,
     title: BrainDumpCompletedTitle,
-  ) => {
+  ): void => {
     if (activeCategoryId === null) {
       toast.error('Pick a category before checking items')
       return
@@ -806,21 +861,14 @@ export const BrainDumpEditor = function BrainDumpEditor({
             return null
           }
           // Create failed and the line is still gone. Restore it (the win never
-          // persisted) — but only while we're still in the originating category,
-          // else we'd write a stale line into a different category's note. This
-          // restore fires even after the 5 s window closed (outcome 'confirmed')
-          // — that is the whole point: without it the line AND the win would
-          // silently vanish. We do NOT move the caret: a background failure must
-          // not yank a user who is typing elsewhere.
-          if (activeCategoryIdRef.current === categoryId) {
-            setNoteText(
-              insertLineAtIndex(
-                noteTextRef.current,
-                entry.originalLineIndex,
-                entry.reinsertText,
-              ),
-            )
-          }
+          // persisted). This fires even after the 5 s window closed (outcome
+          // 'confirmed') — that is the whole point: without it the line AND the
+          // win would silently vanish. restoreClearedLineToCategory puts the line
+          // back in the live editor while we're still here, or into the origin
+          // category's STORED note once the user has switched away (never the
+          // wrong category's visible note). No caret move: a background failure
+          // must not yank a user who is typing elsewhere.
+          void restoreClearedLineToCategory(entry, false)
           // Terminal NOW: the failure handler has put the line back, so a late
           // Undo — the toast stays clickable through sonner's dismiss
           // exit-animation — must not restore a SECOND copy (undo early-returns
@@ -868,9 +916,9 @@ export const BrainDumpEditor = function BrainDumpEditor({
    * clear toast's Undo action.
    *
    * Idempotent via `entry.outcome` so a double Undo (or undo racing a late
-   * failure) never re-inserts twice or double-deletes. Skips the text re-insert
-   * when the active category has changed since completion (re-inserting into a
-   * different category's note would corrupt it) but still deletes the row.
+   * failure) never re-inserts twice or double-deletes. Restores the verbatim
+   * line into its origin category — in the live editor when still there, else
+   * into that category's stored note via IPC — then deletes the row.
    *
    * @param entry - The completion's undo memory (mutated to `undone`).
    * @param createPromise - The background create; awaited for the row id.
@@ -879,7 +927,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
   const undoClearedCompletion = async (
     entry: ClearedLineMemory,
     createPromise: Promise<Completed['id'] | null>,
-  ) => {
+  ): Promise<void> => {
     // Idempotent: once the line is already back — via a prior Undo ('undone') or
     // the failure handler's restore ('restored') — do nothing. Re-inserting
     // would duplicate the line; this is the failure→Undo double-insert guard.
@@ -887,21 +935,11 @@ export const BrainDumpEditor = function BrainDumpEditor({
     entry.outcome = 'undone'
     clearedLinesRef.current.delete(entry.token)
 
-    // Re-insert the verbatim line — but only if we're still in the category it
-    // came from. This IS a user action, so moving the caret to the restored
-    // line is desirable (unlike the background-failure path).
-    if (activeCategoryIdRef.current === entry.categoryId) {
-      const restored = insertLineAtIndex(
-        noteTextRef.current,
-        entry.originalLineIndex,
-        entry.reinsertText,
-      )
-      setNoteText(restored)
-      pendingCaretRef.current = lineStartOffset(
-        restored,
-        entry.originalLineIndex,
-      )
-    }
+    // Re-insert the verbatim line into the category it came from — in the live
+    // editor while still here (the caret moves to it, since this IS a user
+    // action), or into that category's STORED note once the user has switched
+    // away (so the line returns to category A, never category B's visible note).
+    await restoreClearedLineToCategory(entry, true)
 
     // Delete the server row once the create resolves. A failed create resolves
     // to null → nothing to delete.

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import * as React from 'react'
-import { useId, useRef, useState } from 'react'
+import { useId, useLayoutEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
@@ -47,6 +47,8 @@ import {
   type BrainDumpCompletedTitle,
   type BrainDumpLineIndex,
   COMPLETED_TITLE_MAX_LENGTH,
+  insertLineAtIndex,
+  lineStartOffset,
   markPlainLineCompleted,
   normalizeCompletedTitle,
   parseAllCheckboxes,
@@ -81,6 +83,43 @@ type CheckedRowMemory = Readonly<{
   /** Verbatim title used to detect double-toggles on the same line. */
   title: BrainDumpCompletedTitle
 }>
+
+/**
+ * Undo memory for a line removed the *instant* it completes (clear-on-complete
+ * ON path). Distinct from `CheckedRowMemory`: there the `[x]` line persists, so
+ * undo re-resolves it by title; here the line is gone, so we must remember its
+ * verbatim text + position to put it back.
+ *
+ * Mutable on purpose — `outcome`/`completedId`/`toastId` evolve as the
+ * background create resolves and the user does (or doesn't) undo. Keyed by a
+ * monotonic `token` (never a `lineIndex`) so a later removal shifting indices
+ * can't collide with this entry; the category-swap effect clears the whole map,
+ * neutralising stale cross-category undos for free.
+ */
+type ClearedLineMemory = {
+  /** Stable map key — a monotonic counter, never reused. */
+  token: number
+  /** Created row id; null until the background create resolves. */
+  completedId: Completed['id'] | null
+  /** Normalised title persisted for this completion. */
+  title: BrainDumpCompletedTitle
+  /** Category the line belonged to — guards cross-category re-insertion. */
+  categoryId: Category['id']
+  /** Index the line sat at when removed (best-effort re-insert position). */
+  originalLineIndex: BrainDumpLineIndex
+  /** Verbatim removed line, restored as-is on undo/failure (preserves spacing). */
+  reinsertText: string
+  /**
+   * Lifecycle guard for the success/failure/undo/auto-close overlap:
+   * - `pending`   — create in flight, no undo yet
+   * - `undone`    — user clicked Undo (line already restored; suppress failure re-insert)
+   * - `confirmed` — undo window elapsed (a late failure still restores → no silent loss)
+   */
+  outcome: 'pending' | 'undone' | 'confirmed'
+  /** sonner toast id, filled right after the create wires up so the failure
+   *  handler can dismiss the optimistic success toast. */
+  toastId: string | number | undefined
+}
 
 /**
  * In-flight create-Completed promise for a line that's been ticked but not
@@ -184,6 +223,20 @@ export const BrainDumpEditor = function BrainDumpEditor({
   const pendingCreatesRef = useRef<Map<BrainDumpLineIndex, PendingCreate>>(
     new Map(),
   )
+  // Clear-on-complete ON path: token-keyed undo memory for lines removed the
+  // instant they complete. Separate map from checkedRowsRef (which serves the
+  // keep-the-[x] OFF path) so the two flows never share keys. Cleared on
+  // category swap (load effect below) to neutralise stale cross-category undos.
+  const clearedLinesRef = useRef<Map<number, ClearedLineMemory>>(new Map())
+  // Monotonic token source for clearedLinesRef keys (never reused → no collision).
+  const nextTokenRef = useRef<number>(0)
+  // Caret offset to apply AFTER the next noteText commit. The optimistic clear
+  // changes the line count, so the caret must be repositioned post-render (see
+  // the layout effect). null = leave the caret alone (the normal typing case).
+  const pendingCaretRef = useRef<number | null>(null)
+  // Latest active category for async create handlers — guards a late failure
+  // from re-inserting a line into a different category's note after a swap.
+  const activeCategoryIdRef = useRef<Category['id'] | null>(activeCategoryId)
   // Latest noteText for callbacks (toast Undo) so they never see a stale snapshot.
   const noteTextRef = useRef<string>('')
   // Synchronous guard because state-driven disabled UI applies after render.
@@ -197,6 +250,28 @@ export const BrainDumpEditor = function BrainDumpEditor({
 
   useCycleEffect(() => {
     noteTextRef.current = noteText
+  }, [noteText])
+
+  // Keep the category ref in step so async create handlers compare against the
+  // live category, not the one captured when the completion fired.
+  useCycleEffect(() => {
+    activeCategoryIdRef.current = activeCategoryId
+  }, [activeCategoryId])
+
+  // Apply a pending caret position after the textarea value commits. The
+  // optimistic clear/undo changes the line count, so a synchronous
+  // setSelectionRange right after setNoteText would read the stale DOM value —
+  // it has to run post-commit. This is a deliberate raw useLayoutEffect (no
+  // lifecycle-effect wrapper is layout-timed; useRenderEffect is a passive
+  // useEffect, which would let a wrong-position caret paint for a frame). The
+  // null guard makes ordinary typing a no-op.
+  useLayoutEffect(() => {
+    const caretOffset = pendingCaretRef.current
+    if (caretOffset === null) return
+    pendingCaretRef.current = null
+    const textarea = textareaRef.current
+    if (!textarea) return
+    textarea.setSelectionRange(caretOffset, caretOffset)
   }, [noteText])
 
   const createCompletedMutation = useMutation(
@@ -300,6 +375,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         lastPersistedRef.current = { categoryId: activeCategoryId, text }
         checkedRowsRef.current.clear()
         pendingCreatesRef.current.clear()
+        clearedLinesRef.current.clear()
       })
       .catch((error) => {
         if (cancelled) return
@@ -312,6 +388,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         lastPersistedRef.current = { categoryId: null, text: '' }
         checkedRowsRef.current.clear()
         pendingCreatesRef.current.clear()
+        clearedLinesRef.current.clear()
       })
       .finally(() => {
         if (cancelled) return
@@ -431,6 +508,24 @@ export const BrainDumpEditor = function BrainDumpEditor({
   }
 
   /**
+   * Invalidate the heatmap query and ask sibling windows to refetch — the
+   * shared tail of every completion mutation (keep-the-`[x]` create-success,
+   * undo, and the optimistic clear's create-success). Extracted so the three
+   * call sites can't drift apart. Awaits the local invalidate first, then
+   * broadcasts, matching the original inline order.
+   *
+   * @returns Promise that settles once the local heatmap refetch is requested.
+   * @example
+   * await syncCompletedAcrossViews()
+   */
+  const syncCompletedAcrossViews = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: orpc.completed.heatmap.key(),
+    })
+    broadcastTodoSync()
+  }
+
+  /**
    * Promote the caret line to `[x]`, create a Completed row, and arm the
    * 5-second undo toast. Called by the complete command (Cmd/Ctrl+Enter) for
    * both checkbox lines and — via `markPlainLineCompleted` — plain prose lines.
@@ -512,10 +607,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
       completedId,
       title: safeTitle,
     })
-    await queryClient.invalidateQueries({
-      queryKey: orpc.completed.heatmap.key(),
-    })
-    broadcastTodoSync()
+    await syncCompletedAcrossViews()
 
     const undoToastId = toast.success(`Completed: ${safeTitle}`, {
       description: 'Tap Undo within 5 s to revert.',
@@ -611,10 +703,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
 
     try {
       await deleteCompletedMutation.mutateAsync({ id: completedId })
-      await queryClient.invalidateQueries({
-        queryKey: orpc.completed.heatmap.key(),
-      })
-      broadcastTodoSync()
+      await syncCompletedAcrossViews()
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to undo completion'
@@ -631,6 +720,178 @@ export const BrainDumpEditor = function BrainDumpEditor({
       if (memoryBeforeUndo) {
         checkedRowsRef.current.set(rollbackLineIndex, memoryBeforeUndo)
       }
+    }
+  }
+
+  /**
+   * Clear-on-complete ON path: remove the just-completed line from the note the
+   * *instant* Cmd/Ctrl+Enter fires, show the optimistic Undo toast immediately,
+   * and run the Completed-create in the background. This kills the old "wait for
+   * the server round-trip + 5 s, then delete" lag — the line disappears now.
+   *
+   * Undo / failure restore the verbatim line; a create rejection re-inserts even
+   * after the 5 s undo window closed (otherwise the win is lost AND the line is
+   * gone — silent data loss). The `outcome` flag on the entry guards the
+   * success/failure/undo/auto-close overlap so nothing double-applies.
+   *
+   * @param text - The note text as it was when the key fired (pre-removal).
+   * @param lineIndex - Zero-based index of the line being completed.
+   * @param originalLine - The verbatim line, restored as-is on undo/failure.
+   * @param title - Title to persist (uncapped; normalised for the DB here).
+   * @returns void — kicks off the background create; nothing to await.
+   */
+  const completeAndClearLine = (
+    text: string,
+    lineIndex: BrainDumpLineIndex,
+    originalLine: string,
+    title: BrainDumpCompletedTitle,
+  ) => {
+    if (activeCategoryId === null) {
+      toast.error('Pick a category before checking items')
+      return
+    }
+    const safeTitle = normalizeCompletedTitle(title)
+    const categoryId = activeCategoryId
+
+    // 1) Instant removal + remembered caret (applied post-commit by the layout
+    //    effect, since the removed line changes the line count).
+    const clearedText = removeLineAtIndex(text, lineIndex)
+    setNoteText(clearedText)
+    pendingCaretRef.current = lineStartOffset(clearedText, lineIndex)
+
+    // 2) Per-completion record (token-keyed; see ClearedLineMemory).
+    const token = nextTokenRef.current
+    nextTokenRef.current += 1
+    const entry: ClearedLineMemory = {
+      token,
+      completedId: null,
+      title: safeTitle,
+      categoryId,
+      originalLineIndex: lineIndex,
+      reinsertText: originalLine,
+      outcome: 'pending',
+      toastId: undefined,
+    }
+    clearedLinesRef.current.set(token, entry)
+
+    // 3) Background create. Success/failure mutate `entry` and consult
+    //    `outcome` so undo / auto-close / late-failure never double-apply.
+    const createPromise = createCompletedMutation
+      .mutateAsync({ categoryId, title: safeTitle })
+      .then(
+        (created): Completed['id'] | null => {
+          entry.completedId = created.id
+          // Skip the sibling-view sync when the user already undid — the row is
+          // about to be deleted by undoClearedCompletion's awaited delete.
+          if (entry.outcome !== 'undone') void syncCompletedAcrossViews()
+          return created.id
+        },
+        (error): null => {
+          // Create failed → the win never persisted but the line is already
+          // gone. Restore it unless the user already undid, and only when we're
+          // still in the originating category (else we'd write a stale line
+          // into a different category's note). This restore fires even after
+          // the 5 s window closed (outcome 'confirmed') — that is the whole
+          // point: without it the line AND the win would silently vanish. We do
+          // NOT move the caret here: a background failure must not yank a user
+          // who is typing elsewhere.
+          if (
+            entry.outcome !== 'undone' &&
+            activeCategoryIdRef.current === categoryId
+          ) {
+            setNoteText(
+              insertLineAtIndex(
+                noteTextRef.current,
+                entry.originalLineIndex,
+                entry.reinsertText,
+              ),
+            )
+          }
+          clearedLinesRef.current.delete(token)
+          if (entry.toastId !== undefined) toast.dismiss(entry.toastId)
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : 'Failed to record completion',
+          )
+          return null
+        },
+      )
+
+    // 4) Immediate optimistic toast — feedback at keypress, not after the
+    //    round-trip. Undo re-inserts the line; auto-close just closes the
+    //    affordance (the line is already gone).
+    entry.toastId = toast.success(`Completed: ${safeTitle}`, {
+      description: 'Tap Undo within 5 s to revert.',
+      duration: TOAST_UNDO_MS,
+      action: {
+        label: 'Undo',
+        onClick: () => {
+          void undoClearedCompletion(entry, createPromise)
+          if (entry.toastId !== undefined) toast.dismiss(entry.toastId)
+        },
+      },
+      // Sonner fires onAutoClose ONLY on the timeout — an Undo click dismisses
+      // (onDismiss) instead, so this never runs for an undone completion.
+      onAutoClose: () => {
+        // Undo window elapsed with no Undo → confirm and drop the map entry. The
+        // create promise's closure still holds the reinsert info for a late
+        // failure, so this cleanup is safe.
+        if (entry.outcome === 'pending') entry.outcome = 'confirmed'
+        clearedLinesRef.current.delete(token)
+      },
+    })
+  }
+
+  /**
+   * Undo an optimistic clear: put the verbatim line back at its original index
+   * and delete the Completed row once the create resolves. Called from the
+   * clear toast's Undo action.
+   *
+   * Idempotent via `entry.outcome` so a double Undo (or undo racing a late
+   * failure) never re-inserts twice or double-deletes. Skips the text re-insert
+   * when the active category has changed since completion (re-inserting into a
+   * different category's note would corrupt it) but still deletes the row.
+   *
+   * @param entry - The completion's undo memory (mutated to `undone`).
+   * @param createPromise - The background create; awaited for the row id.
+   * @returns Promise<void>.
+   */
+  const undoClearedCompletion = async (
+    entry: ClearedLineMemory,
+    createPromise: Promise<Completed['id'] | null>,
+  ) => {
+    if (entry.outcome === 'undone') return
+    entry.outcome = 'undone'
+    clearedLinesRef.current.delete(entry.token)
+
+    // Re-insert the verbatim line — but only if we're still in the category it
+    // came from. This IS a user action, so moving the caret to the restored
+    // line is desirable (unlike the background-failure path).
+    if (activeCategoryIdRef.current === entry.categoryId) {
+      const restored = insertLineAtIndex(
+        noteTextRef.current,
+        entry.originalLineIndex,
+        entry.reinsertText,
+      )
+      setNoteText(restored)
+      pendingCaretRef.current = lineStartOffset(
+        restored,
+        entry.originalLineIndex,
+      )
+    }
+
+    // Delete the server row once the create resolves. A failed create resolves
+    // to null → nothing to delete.
+    const completedId = await createPromise
+    if (completedId === null) return
+    try {
+      await deleteCompletedMutation.mutateAsync({ id: completedId })
+      await syncCompletedAcrossViews()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to undo completion',
+      )
     }
   }
 
@@ -656,6 +917,28 @@ export const BrainDumpEditor = function BrainDumpEditor({
     const line = lines[lineIndex]
     if (line === undefined) return
     const parsed = parseCheckboxLine(line, lineIndex)
+
+    // Clear-on-complete ON + a COMPLETION (a plain line, or ticking an unchecked
+    // box) → remove the line instantly and show the optimistic Undo toast.
+    // Un-ticking an existing `[x]` line (parsed.checked === true) and the OFF
+    // preference both fall through to the legacy keep-the-`[x]` path below.
+    if (clearOnComplete && parsed?.checked !== true) {
+      let completionTitle: BrainDumpCompletedTitle
+      if (parsed) {
+        completionTitle = parsed.title
+      } else {
+        // Plain prose line: reuse markPlainLineCompleted only for its title +
+        // skip guards (blank / empty skeleton → null → no-op); ignore its
+        // `[x]`-wrapped text since this path removes the line instead.
+        const promoted = markPlainLineCompleted(text, lineIndex)
+        if (!promoted) return
+        completionTitle = promoted.title
+      }
+      // `line` is the verbatim source row → restored as-is on undo/failure.
+      completeAndClearLine(text, lineIndex, line, completionTitle)
+      return
+    }
+
     if (!parsed) {
       // Not a checkbox line: let the complete command finish an ordinary prose
       // line by wrapping it as `- [x] …` and promoting it, so users don't have

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -110,12 +110,15 @@ type ClearedLineMemory = {
   /** Verbatim removed line, restored as-is on undo/failure (preserves spacing). */
   reinsertText: string
   /**
-   * Lifecycle guard for the success/failure/undo/auto-close overlap:
+   * Lifecycle guard for the success/failure/undo/auto-close overlap. `undone`
+   * and `restored` are BOTH terminal "line is already back" states — undo
+   * early-returns on either so it can never re-insert a second copy.
    * - `pending`   — create in flight, no undo yet
-   * - `undone`    — user clicked Undo (line already restored; suppress failure re-insert)
-   * - `confirmed` — undo window elapsed (a late failure still restores → no silent loss)
+   * - `undone`    — user clicked Undo (line restored by undo; suppress failure re-insert)
+   * - `confirmed` — undo window elapsed with no undo (a late failure still restores → no silent loss)
+   * - `restored`  — the create FAILED and the failure handler already put the line back
    */
-  outcome: 'pending' | 'undone' | 'confirmed'
+  outcome: 'pending' | 'undone' | 'confirmed' | 'restored'
   /** sonner toast id, filled right after the create wires up so the failure
    *  handler can dismiss the optimistic success toast. */
   toastId: string | number | undefined
@@ -781,24 +784,35 @@ export const BrainDumpEditor = function BrainDumpEditor({
       .then(
         (created): Completed['id'] | null => {
           entry.completedId = created.id
+          // The row is now persisted, so drop the map entry eagerly instead of
+          // waiting for onAutoClose. Sonner PAUSES the close timer while the
+          // window is hidden, and BrainDump windows are hidden (not destroyed)
+          // between toggles — so onAutoClose can be deferred indefinitely, which
+          // would leak this entry across a long session. Undo still works after
+          // this delete: undoClearedCompletion holds `entry` via closure, not
+          // via the map (the map only serves the category-swap bulk-clear).
+          clearedLinesRef.current.delete(token)
           // Skip the sibling-view sync when the user already undid — the row is
           // about to be deleted by undoClearedCompletion's awaited delete.
           if (entry.outcome !== 'undone') void syncCompletedAcrossViews()
           return created.id
         },
         (error): null => {
-          // Create failed → the win never persisted but the line is already
-          // gone. Restore it unless the user already undid, and only when we're
-          // still in the originating category (else we'd write a stale line
-          // into a different category's note). This restore fires even after
-          // the 5 s window closed (outcome 'confirmed') — that is the whole
-          // point: without it the line AND the win would silently vanish. We do
-          // NOT move the caret here: a background failure must not yank a user
-          // who is typing elsewhere.
-          if (
-            entry.outcome !== 'undone' &&
-            activeCategoryIdRef.current === categoryId
-          ) {
+          // The user already undid → the line is back and they abandoned this
+          // completion, so the create's failure is irrelevant to them: leave the
+          // note alone (undo restored it) and stay silent (no error toast).
+          if (entry.outcome === 'undone') {
+            clearedLinesRef.current.delete(token)
+            return null
+          }
+          // Create failed and the line is still gone. Restore it (the win never
+          // persisted) — but only while we're still in the originating category,
+          // else we'd write a stale line into a different category's note. This
+          // restore fires even after the 5 s window closed (outcome 'confirmed')
+          // — that is the whole point: without it the line AND the win would
+          // silently vanish. We do NOT move the caret: a background failure must
+          // not yank a user who is typing elsewhere.
+          if (activeCategoryIdRef.current === categoryId) {
             setNoteText(
               insertLineAtIndex(
                 noteTextRef.current,
@@ -807,6 +821,11 @@ export const BrainDumpEditor = function BrainDumpEditor({
               ),
             )
           }
+          // Terminal NOW: the failure handler has put the line back, so a late
+          // Undo — the toast stays clickable through sonner's dismiss
+          // exit-animation — must not restore a SECOND copy (undo early-returns
+          // on 'restored'). Set before dismissing the toast for that reason.
+          entry.outcome = 'restored'
           clearedLinesRef.current.delete(token)
           if (entry.toastId !== undefined) toast.dismiss(entry.toastId)
           toast.error(
@@ -861,7 +880,10 @@ export const BrainDumpEditor = function BrainDumpEditor({
     entry: ClearedLineMemory,
     createPromise: Promise<Completed['id'] | null>,
   ) => {
-    if (entry.outcome === 'undone') return
+    // Idempotent: once the line is already back — via a prior Undo ('undone') or
+    // the failure handler's restore ('restored') — do nothing. Re-inserting
+    // would duplicate the line; this is the failure→Undo double-insert guard.
+    if (entry.outcome === 'undone' || entry.outcome === 'restored') return
     entry.outcome = 'undone'
     clearedLinesRef.current.delete(entry.token)
 

--- a/src/components/braindump/braindumpUtils.test.ts
+++ b/src/components/braindump/braindumpUtils.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   COMPLETED_TITLE_MAX_LENGTH,
+  insertLineAtIndex,
+  lineStartOffset,
   markPlainLineCompleted,
   normalizeCompletedTitle,
   parseAllCheckboxes,
@@ -167,6 +169,107 @@ describe('removeLineAtIndex', () => {
     // Act + Assert
     expect(removeLineAtIndex(before, 5)).toBe(before)
     expect(removeLineAtIndex(before, -1)).toBe(before)
+  })
+})
+
+describe('insertLineAtIndex', () => {
+  it('re-inserts an undone line back at its original middle position', () => {
+    // Arrange — the line '- [ ] b' was optimistically cleared from between a and c.
+    const cleared = 'a\nc'
+
+    // Act — Undo puts it back at index 1.
+    const restored = insertLineAtIndex(cleared, 1, '- [ ] b')
+
+    // Assert
+    expect(restored).toBe('a\n- [ ] b\nc')
+  })
+
+  it('restores the only line without leaving a trailing blank line', () => {
+    // Arrange — clearing the single line emptied the note.
+    const cleared = ''
+
+    // Act — Undo restores the original sole line.
+    const restored = insertLineAtIndex(cleared, 0, '- [ ] buy milk')
+
+    // Assert — exactly the line, no '- [ ] buy milk\n' tail.
+    expect(restored).toBe('- [ ] buy milk')
+  })
+
+  it('round-trips a remove then insert back to the original text', () => {
+    // Arrange
+    const original = '- [ ] one\n- [ ] two\n- [ ] three'
+
+    // Act — clear the middle line, then undo by re-inserting it.
+    const cleared = removeLineAtIndex(original, 1)
+    const restored = insertLineAtIndex(cleared, 1, '- [ ] two')
+
+    // Assert
+    expect(restored).toBe(original)
+  })
+
+  it('clamps an out-of-range index to the document end', () => {
+    // Arrange
+    const cleared = 'a'
+
+    // Act — a drifted index past the end still lands in-document.
+    const restored = insertLineAtIndex(cleared, 9, 'b')
+
+    // Assert
+    expect(restored).toBe('a\nb')
+  })
+
+  it('inserts at the document head for a negative index', () => {
+    // Arrange
+    const cleared = 'b\nc'
+
+    // Act
+    const restored = insertLineAtIndex(cleared, -3, 'a')
+
+    // Assert
+    expect(restored).toBe('a\nb\nc')
+  })
+})
+
+describe('lineStartOffset', () => {
+  it('returns the caret offset at the start of a middle line', () => {
+    // Arrange — 'a' (len 1) + '\n' (1) puts line 1 at offset 2.
+    const text = 'a\nbb\nccc'
+
+    // Act
+    const offset = lineStartOffset(text, 1)
+
+    // Assert
+    expect(offset).toBe(2)
+  })
+
+  it('returns the caret offset at the start of the third line', () => {
+    // Arrange — 'a\n'(2) + 'bb\n'(3) puts line 2 at offset 5.
+    const text = 'a\nbb\nccc'
+
+    // Act
+    const offset = lineStartOffset(text, 2)
+
+    // Assert
+    expect(offset).toBe(5)
+  })
+
+  it('drops the caret at the document end when the index is past the last line', () => {
+    // Arrange — completing the final line leaves nothing to shift up into its slot.
+    const text = 'a\nbb\nccc'
+
+    // Act — index 3 is past the 3 lines (0..2).
+    const offset = lineStartOffset(text, 3)
+
+    // Assert — clamp to the document length.
+    expect(offset).toBe(8)
+  })
+
+  it('returns 0 for the first line', () => {
+    // Arrange
+    const text = 'first\nsecond'
+
+    // Act + Assert
+    expect(lineStartOffset(text, 0)).toBe(0)
   })
 })
 

--- a/src/components/braindump/braindumpUtils.test.ts
+++ b/src/components/braindump/braindumpUtils.test.ts
@@ -207,6 +207,24 @@ describe('insertLineAtIndex', () => {
     expect(restored).toBe(original)
   })
 
+  it('drops the trailing blank line when the sole content line is cleared then restored (known asymmetry)', () => {
+    // Arrange — one line PLUS a trailing newline (the user typed a line then hit
+    // Enter). `removeLineAtIndex` already collapses BOTH 'buy milk' and
+    // 'buy milk\n' to '', so the trailing blank can never be recovered — this
+    // pins that as intentional, not a latent bug. We keep the single-line
+    // empty-document round-trip lossless (the `text === ''` early return) at the
+    // cost of this trailing newline; restoring content beats a spurious blank.
+    const original = 'buy milk\n'
+
+    // Act — clear line 0, then restore it.
+    const cleared = removeLineAtIndex(original, 0)
+    const restored = insertLineAtIndex(cleared, 0, 'buy milk')
+
+    // Assert — the line content returns; the trailing blank line is dropped.
+    expect(cleared).toBe('')
+    expect(restored).toBe('buy milk')
+  })
+
   it('clamps an out-of-range index to the document end', () => {
     // Arrange
     const cleared = 'a'

--- a/src/components/braindump/braindumpUtils.ts
+++ b/src/components/braindump/braindumpUtils.ts
@@ -195,6 +195,68 @@ export function removeLineAtIndex(
 }
 
 /**
+ * Insert a line at a (clamped) index — the inverse of `removeLineAtIndex`, used
+ * by the optimistic clear-on-complete flow to restore a line that was removed
+ * the instant it completed (toast Undo / failed-create rollback). The index is
+ * clamped to `[0, lines.length]` so a drifted/stale index never throws and the
+ * line always lands in-document; an empty document returns just the line so a
+ * remove→insert round-trip is lossless (no spurious trailing newline).
+ *
+ * @param text - The full document text.
+ * @param lineIndex - Desired zero-based insertion index (clamped in range).
+ * @param newLine - The line content to insert (no trailing newline).
+ * @returns The text with `newLine` spliced in at the clamped index.
+ * @example
+ * insertLineAtIndex('a\nc', 1, '- [ ] b') // → 'a\n- [ ] b\nc'
+ * insertLineAtIndex('', 0, '- [ ] b')     // → '- [ ] b'
+ * insertLineAtIndex('a', 9, 'b')          // → 'a\nb' (clamped to end)
+ */
+export function insertLineAtIndex(
+  text: string,
+  lineIndex: BrainDumpLineIndex,
+  newLine: string,
+): string {
+  // Empty document: return just the line so remove('x')→insert restores 'x'
+  // exactly, instead of 'x\n' (splicing into [''] would keep the empty tail).
+  if (text === '') return newLine
+  const lines = text.split('\n')
+  const clampedIndex = Math.max(0, Math.min(lineIndex, lines.length))
+  lines.splice(clampedIndex, 0, newLine)
+  return lines.join('\n')
+}
+
+/**
+ * Character offset of the start of a given line — used to reposition the caret
+ * after the optimistic clear changes the line count (a removed line shifts all
+ * following text up, so the caret must move with it). Clamps past-the-end to the
+ * document length so completing the final line drops the caret at doc end.
+ *
+ * @param text - The full document text.
+ * @param lineIndex - Zero-based line whose start offset is wanted.
+ * @returns
+ * - The char index of that line's first character when in range.
+ * - `text.length` when `lineIndex` is past the last line (e.g. the final line
+ *   was just removed and nothing shifted up into its slot).
+ * @example
+ * lineStartOffset('a\nbb\nccc', 1) // → 2  (after 'a' + '\n')
+ * lineStartOffset('a\nbb\nccc', 3) // → 8  (past the end → doc length)
+ */
+export function lineStartOffset(
+  text: string,
+  lineIndex: BrainDumpLineIndex,
+): number {
+  const lines = text.split('\n')
+  if (lineIndex >= lines.length) return text.length
+  const clampedIndex = Math.max(0, lineIndex)
+  let offset = 0
+  for (let i = 0; i < clampedIndex; i++) {
+    // +1 for the '\n' separator that join() puts back between lines.
+    offset += (lines[i]?.length ?? 0) + 1
+  }
+  return offset
+}
+
+/**
  * Matches an empty checkbox skeleton — a checkbox prefix with no title, e.g.
  * `- [ ]`, `- [x]`, `- []` (optional trailing whitespace). These have nothing
  * to record, so the complete command must skip them rather than logging a junk


### PR DESCRIPTION
## What

When the **clear-on-complete** preference (`braindumpClearOnComplete`) is ON, pressing
Cmd/Ctrl+Enter on a BrainDump line now removes it from the note **the instant it fires** —
showing the Undo toast immediately and running the Completed-create in the background —
instead of waiting for the server round-trip plus the 5 s undo window before the line
disappears (the inverse of optimistic). The keep-the-`[x]` **OFF path is 100% unchanged.**

North star: 「些細でも経験値、今日自分頑張ったな」— completion should *feel* instant.

## How

- Instant `removeLineAtIndex` + `setNoteText` on keypress; immediate success+Undo toast;
  background `create`. Undo / create-failure **re-insert the verbatim line** (exact leading
  whitespace preserved — A3).
- Token-keyed `clearedLinesRef` undo memory, separate from the OFF path's `checkedRowsRef`.
  A per-completion `outcome` flag guards the success / failure / undo / auto-close overlap.
- **No silent data loss**: a create that rejects re-inserts the line **even after the 5 s
  undo window closed** — otherwise the line is gone AND the win was never recorded.
- Caret repositioned post-commit via a raw layout effect so the next keystroke can't corrupt
  the line that shifted up. Background-failure re-insert deliberately does NOT move the caret.
- New pure utils `insertLineAtIndex` + `lineStartOffset` (clamped, unit-tested). Shared
  `syncCompletedAcrossViews()` extracted for the invalidate+broadcast tail (3 call sites).

## Code review (max) — fixes folded in (commit `ff955f0`)

An independent max-effort review caught one **blocker-class race** the original `outcome`
flag didn't cover:

- **BLOCKER (fixed):** the create-failure handler restored the line but left `outcome`
  non-terminal, so a late Undo (the toast stays clickable through sonner's dismiss
  exit-animation) re-inserted a **second copy** — silent note corruption. Fixed with a
  terminal `'restored'` outcome; undo early-returns on `'undone' | 'restored'`.
- A create that rejects **after** the user already undid no longer pops a spurious error toast.
- The success handler drops its map entry eagerly (sonner defers `onAutoClose` indefinitely
  while the hidden-between-toggle BrainDump window is hidden → closes a slow per-session leak).

## Tests

- `braindumpUtils.test.ts`: full `insertLineAtIndex` / `lineStartOffset` coverage
  (middle / empty / round-trip / clamp / negative) + the known trailing-newline asymmetry.
- `BrainDumpEditor.test.tsx`: immediate-remove, undo re-insert at original position,
  failure restore, **late-failure-after-window restore** (data-loss regression), verbatim
  whitespace, caret-out-of-next-line, **failure→undo no double-insert**, **silent-after-undo**,
  OFF path unchanged.
- `pnpm validate` green (652 unit pass / typecheck 0 / build 0 / lint 0).

## QA

BrainDump is an Electron-only renderer surface (no web-E2E surface; existing electron E2E is
signed-out + window-state only). Renderer logic is covered by the unit suite above; CI
`e2e:electron` gates no-regression on the braindump window/IPC. Local native QA (drive the real
BrainDump: Cmd+Enter → instant clear → Undo restore → failure restore) is run before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed task lines now clear immediately when marked done (when clear-on-complete is enabled).
  * Undo restores the cleared line, and caret positioning is preserved after the removal.
  * If completion fails after the optimistic update, the cleared line is automatically restored.
* **Bug Fixes**
  * Improved handling of undo timing and late failures to prevent duplicate reinsertion and incorrect restoration across category switches.
* **Tests**
  * Expanded unit and editor test coverage, including new helpers for precise line insertion and caret offset calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->