### PR TITLE
fix(e2e): exempt loopback from ambient HTTP proxy so pnpm e2e:web boots locally

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,40 @@ import { defineConfig, devices } from '@playwright/test'
 import 'dotenv/config'
 
 /**
+ * Exempt loopback from any ambient HTTP proxy BEFORE Playwright reads the env.
+ *
+ * Why this exists (Issue #115): this Mac runs the Bash tool inside a network
+ * sandbox (Socket Firewall / `sfw`) that injects `HTTP_PROXY`/`http_proxy=
+ * http://127.0.0.1:<dynamic-port>` into every child process to police outbound
+ * traffic. Playwright's webServer readiness probe resolves its target through
+ * `proxy-from-env` (`getProxyForUrl`), which honors those vars — so the
+ * `http://127.0.0.1:4991` probe gets routed through the firewall proxy, which
+ * answers **405** (observed BEFORE `next` had even started: only a proxy can
+ * 405 a port with no upstream). 405 is >= 400, so the waiter never sees the dev
+ * server's real 200 and times out at 120s — `pnpm e2e:web` could not boot
+ * locally. (`curl`/bare Node bypassed the proxy → 200, which is why earlier
+ * hostname/happy-eyeballs theories looked plausible but were wrong.)
+ *
+ * Fix: add loopback to NO_PROXY so `getProxyForUrl` returns "" for the probe
+ * URL and the waiter connects straight to `next`. EXTERNAL hosts (Clerk,
+ * corelive.app) stay absent from NO_PROXY, so they remain proxied and the
+ * firewall is still enforced for real outbound traffic. No-op on CI, which sets
+ * no proxy at all — there `getProxyForUrl` already returns "" regardless.
+ */
+// IPv6 loopback is bracketed (`[::1]`, not `::1`): `proxy-from-env` matches
+// NO_PROXY entries against the URL's host verbatim, and a URL host keeps its
+// brackets, so a bare `::1` entry would never match a `[::1]` probe.
+const LOOPBACK_NO_PROXY = 'localhost,127.0.0.1,[::1]'
+for (const proxyExemptionKey of ['NO_PROXY', 'no_proxy']) {
+  process.env[proxyExemptionKey] = [
+    process.env[proxyExemptionKey],
+    LOOPBACK_NO_PROXY,
+  ]
+    .filter(Boolean)
+    .join(',')
+}
+
+/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
@@ -101,7 +135,13 @@ export default defineConfig({
 
   webServer: {
     command: 'pnpm start',
-    url: 'http://localhost:4991',
+    // Probe an IP literal (`127.0.0.1`), not `localhost`: unambiguous IPv4, no
+    // dual-stack resolution in the waiter, and it matches the host CI listens
+    // on. The loopback-proxy exemption at the top of this file (Issue #115) is
+    // what actually lets this probe reach `next` — without it the `sfw` sandbox
+    // proxy intercepts the probe and 405s it. `use.baseURL` stays `localhost`
+    // (drives Chromium; Clerk dev keys are localhost-scoped).
+    url: 'http://127.0.0.1:4991',
     reuseExistingServer: false,
     timeout: 120 * 1000,
   },


### PR DESCRIPTION
## Summary

`pnpm e2e:web` could not boot locally on macOS — Playwright's `webServer` readiness
probe timed out at 120s before `next start` was ever reached, so **no** web E2E spec
could run on this machine. This exempts loopback from any ambient HTTP proxy before
Playwright reads the environment, so the probe connects straight to `next`.

Closes #115.

## Root cause (corrected)

The earlier hypothesis in the issue (IPv4/IPv6 loopback / happy-eyeballs mismatch)
was **falsified**: pinning the probe to the `127.0.0.1` literal still timed out, while
`curl`/bare-Node got `200` on the same URL.

The real cause is the **Bash-tool network sandbox** (Socket Firewall / `sfw`): it
injects `HTTP_PROXY`/`http_proxy=http://127.0.0.1:<dynamic-port>` into every child
process to police outbound traffic. Playwright's webServer waiter resolves its target
through `proxy-from-env` (`getProxyForUrl`), which honors those vars — so the
`http://127.0.0.1:4991` probe was routed through the firewall proxy, which answered
**405** (observed *before* `next` had even started — only a proxy can `405` a port
with no upstream). `405 >= 400`, so the waiter never saw the dev server's real `200`
and timed out. `curl`/bare-Node bypass the proxy, which is why they returned `200` and
made the hostname theories look plausible.

> This is a **sandbox artifact**, not a defect in the Mac or the project — a normal
> terminal (no injected proxy) boots `pnpm e2e:web` fine. The fix makes the probe
> proxy-robust and is a strict no-op when no proxy is set.

## Fix

`playwright.config.ts`, top-level (runs before `defineConfig` reads env):

```ts
const LOOPBACK_NO_PROXY = 'localhost,127.0.0.1,[::1]'
for (const proxyExemptionKey of ['NO_PROXY', 'no_proxy']) {
  process.env[proxyExemptionKey] = [process.env[proxyExemptionKey], LOOPBACK_NO_PROXY]
    .filter(Boolean)
    .join(',')
}
```

- Adds loopback to `NO_PROXY`/`no_proxy` so `getProxyForUrl` returns `""` for the
  probe URL and the waiter connects directly to `next`.
- **External hosts stay absent from `NO_PROXY`** (Clerk, corelive.app) — they remain
  proxied, so the firewall is still enforced for real outbound traffic.
- IPv6 loopback is **bracketed** (`[::1]`, not bare `::1`): `proxy-from-env` matches
  `NO_PROXY` entries against the URL host verbatim and a URL host keeps its brackets,
  so a bare `::1` entry would never match a `[::1]` probe.
- The probe `url` stays pinned to the `127.0.0.1` literal (unambiguous IPv4, matches
  the host CI listens on); `use.baseURL` stays `localhost` (drives Chromium; Clerk dev
  keys are localhost-scoped) — unchanged.

## Verification

- `pnpm e2e:web e2e/web/category.spec.ts` under the live sandbox → **21 passed (3.8m)**;
  `DEBUG=pw:webserver` shows `ECONNREFUSED → start → HTTP 200 → WebServer available`
  (no 405, no timeout).
- `mise exec node@24.13.0 -- pnpm test` → **662 passed / 33 skipped**, exit 0.
- **CI is a no-op**: GitHub runners set no proxy, so `getProxyForUrl` already returns
  `""` for loopback regardless — the appended `NO_PROXY` changes nothing there.

## Acceptance criteria (#115)

- [x] `pnpm e2e:web` boots locally on macOS (21-pass proof above)
- [x] CI behavior unchanged (no-op without an ambient proxy — to be confirmed green by the web-E2E job on this PR)
- [x] Fix committed and documented (accurate root-cause comment in `playwright.config.ts`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local test setup reliability when a proxy is present.
  * Updated the dev-server check to use a loopback IP address, helping ensure the browser test runner connects correctly on machines with proxy settings.
  * Expanded loopback bypass coverage so localhost, IPv4, and IPv6 loopback traffic are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->