### PR TITLE
feat: move finished tasks to Completed individually in 居残りモード (#113)

### DIFF
--- a/e2e/web/todo-retain-archive.spec.ts
+++ b/e2e/web/todo-retain-archive.spec.ts
@@ -234,4 +234,44 @@ test.describe('Move finished tasks to Completed individually (#113)', () => {
       { timeout: 10000 },
     )
   })
+
+  test('tucking one finished task leaves my other finished tasks in the list', async ({
+    page,
+  }) => {
+    // Arrange — two finished, retained rows. AC5: moving one files ONLY that one;
+    // the rest of my checked tasks stay in the list until I move each of them.
+    const tuckedText = 'Retain AC5 tucked'
+    const stayingText = 'Retain AC5 staying'
+    await page.goto('/home')
+    await addPendingTodo(page, tuckedText)
+    await addPendingTodo(page, stayingText)
+    await completeRetainedTodo(page, tuckedText)
+    await completeRetainedTodo(page, stayingText)
+
+    // Act — tuck only the first finished task into Completed.
+    const deletePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes(ORPC_PATHS.deleteTodo) &&
+        resp.request().method() === 'POST',
+      { timeout: 10000 },
+    )
+    await page
+      .getByRole('button', { name: `Tuck "${tuckedText}" into Completed` })
+      .click()
+    expect((await deletePromise).status()).toBe(200)
+
+    // Assert — only that one left; the other finished task is untouched, still a
+    // completed-retained row with its own Tuck button and checkbox in the list.
+    await expect(
+      page.getByRole('button', { name: `Tuck "${tuckedText}" into Completed` }),
+    ).toHaveCount(0, { timeout: 10000 })
+    await expect(
+      page.getByRole('button', {
+        name: `Tuck "${stayingText}" into Completed`,
+      }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('checkbox', { name: stayingText }),
+    ).toBeVisible()
+  })
 })

--- a/e2e/web/todo-retain-archive.spec.ts
+++ b/e2e/web/todo-retain-archive.spec.ts
@@ -174,6 +174,9 @@ test.describe('Move finished tasks to Completed individually (#113)', () => {
     const todoText = 'Retain drag fixture'
     await page.goto('/home')
     await addPendingTodo(page, todoText)
+    // #113 gate: with no finished task yet, the Completed drop zone is absent
+    // (isRetaining && completedInListCount > 0) — it appears only once one is checked.
+    await expect(page.getByTestId('completed-dropzone')).toHaveCount(0)
     await completeRetainedTodo(page, todoText)
     const dropZone = page.getByTestId('completed-dropzone')
     await expect(dropZone).toBeVisible()
@@ -215,7 +218,10 @@ test.describe('Move finished tasks to Completed individually (#113)', () => {
     const dropZone = page.getByTestId('completed-dropzone')
     await expect(dropZone).toBeVisible()
 
-    // Act — drag the PENDING row's handle onto the Completed drop zone.
+    // Act — drag the PENDING row's handle onto the Completed drop zone. The
+    // sibling "dragging a finished row" test proves this same mouseDrag lands on
+    // the zone (it fires a 200 delete), so the survival asserted below is the
+    // guard no-oping a *pending* drop — not the drag silently missing its target.
     await mouseDrag(
       page,
       activeRow(page, pendingText).getByRole('button', {
@@ -273,5 +279,83 @@ test.describe('Move finished tasks to Completed individually (#113)', () => {
     await expect(
       page.getByRole('checkbox', { name: stayingText }),
     ).toBeVisible()
+  })
+
+  test('checking then tucking before the save commits keeps the win (no hard-delete)', async ({
+    page,
+  }) => {
+    // Arrange — a pending row, plus a HELD toggle response so the completion
+    // stays "in flight". This is the slow-network window where the #113 data-loss
+    // race lives: the row is optimistically completed in the UI, but the DB still
+    // sees it pending, so the reused delete→archive path would HARD-DELETE it.
+    const todoText = 'Retain race fixture'
+    await page.goto('/home')
+    await addPendingTodo(page, todoText)
+
+    let releaseToggle = (): void => {}
+    const toggleHeld = new Promise<void>((resolve) => {
+      releaseToggle = resolve
+    })
+    // Hold the toggle POST open until we release it (continue, NOT abort —
+    // aborting rolls the optimistic completion back and the button disappears).
+    await page.route(/\/api\/orpc\/todo\/toggle/, async (route) => {
+      await toggleHeld
+      await route.continue()
+    })
+    // Tripwire: nothing may archive/delete this row while the toggle is unsettled.
+    let deleteFiredWhileInFlight = false
+    page.on('request', (request) => {
+      if (
+        request.url().includes(ORPC_PATHS.deleteTodo) &&
+        request.method() === 'POST'
+      ) {
+        deleteFiredWhileInFlight = true
+      }
+    })
+
+    // Act 1 — check the task. The optimistic update strikes it through and shows
+    // the "Tuck into Completed" button immediately, before the toggle commits.
+    await page.getByRole('checkbox', { name: todoText }).first().click()
+    const tuckButton = page.getByRole('button', {
+      name: `Tuck "${todoText}" into Completed`,
+    })
+
+    // Assert 1 — the button is present but INERT until the win is durable. On the
+    // unfixed code it is enabled here, so a tap hard-deletes the completion.
+    await expect(tuckButton).toBeVisible()
+    await expect(tuckButton).toBeDisabled()
+    expect(deleteFiredWhileInFlight).toBe(false)
+
+    // Act 2 — let the toggle commit; the button re-arms once the win is saved.
+    const togglePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes(ORPC_PATHS.toggleTodo) &&
+        resp.request().method() === 'POST',
+      { timeout: 10000 },
+    )
+    releaseToggle()
+    expect((await togglePromise).status()).toBe(200)
+    await expect(tuckButton).toBeEnabled()
+
+    // Act 3 — now tucking archives it (heatmap-safe) instead of hard-deleting.
+    const deletePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes(ORPC_PATHS.deleteTodo) &&
+        resp.request().method() === 'POST',
+      { timeout: 10000 },
+    )
+    await tuckButton.click()
+    expect((await deletePromise).status()).toBe(200)
+
+    // Assert 2 — it left the active list as an archive (not destroyed): the row
+    // is gone and, after a reload, does not come back as a pending task.
+    await expect(tuckButton).toHaveCount(0, { timeout: 10000 })
+    await page.reload()
+    await expect(page.getByRole('checkbox', { name: todoText })).toHaveCount(
+      0,
+      {
+        timeout: 10000,
+      },
+    )
   })
 })

--- a/e2e/web/todo-retain-archive.spec.ts
+++ b/e2e/web/todo-retain-archive.spec.ts
@@ -1,0 +1,237 @@
+import { setupClerkTestingToken } from '@clerk/testing/playwright'
+import { test, expect, type Locator, type Page } from '@playwright/test'
+
+import { STORAGE_SCHEMA_VERSION } from '@/lib/redux/migratePersistedState'
+
+import { resetDatabase } from './_helpers/db'
+
+/**
+ * #113 — moving a single finished task to Completed in 居残りモード, by the per-row
+ * button AND by dragging the row onto the Completed drop zone. The drag tests
+ * also pin down the load-bearing guard: dragging a PENDING row onto the zone must
+ * be a NO-OP, because the reused delete→archive path hard-deletes a non-completed
+ * row (data loss) — and in retain mode pending + completed rows share one
+ * sortable list.
+ *
+ * Runs under the `web` Playwright project (real Clerk storageState → mutations
+ * persist to Postgres). Web E2E can't boot on the author's Mac; CI is the gate.
+ *
+ * @example
+ *   pnpm e2e:web -- todo-retain-archive
+ */
+
+/** localStorage key the Redux store persists preferences under (store.ts). */
+const STORAGE_KEY = 'corelive-redux-state'
+
+const ORPC_PATHS = {
+  toggleTodo: '/api/orpc/todo/toggle',
+  deleteTodo: '/api/orpc/todo/delete',
+} as const
+
+/**
+ * Persisted Redux blob that boots the app with 居残りモード ON, so a checked task
+ * stays in the list (strikethrough) and the per-row "Tuck into Completed" button
+ * + drop zone appear. Seeded at the CURRENT schema version (deep-merged into the
+ * defaults on hydration) — exactly what a user who flipped the switch has on disk.
+ * @returns The JSON string to write into localStorage before the app boots.
+ * @example
+ * seedRetainModeOn() // => '{"version":1,"state":{"preferences":{"retainCompletedInList":true}}}'
+ */
+function seedRetainModeOn(): string {
+  return JSON.stringify({
+    version: STORAGE_SCHEMA_VERSION,
+    state: { preferences: { retainCompletedInList: true } },
+  })
+}
+
+/**
+ * Locates the active-list row for a given task text by anchoring on its checkbox
+ * (aria-label is the task text) and climbing to the TodoItem root.
+ * @param page - Playwright page.
+ * @param text - The task text.
+ * @returns A locator for the row container.
+ */
+function activeRow(page: Page, text: string): Locator {
+  return page
+    .getByRole('checkbox', { name: text })
+    .locator('xpath=ancestor::div[contains(@class,"transition-shadow")]')
+}
+
+/**
+ * Adds a pending task via the Add form and waits for the server row to settle
+ * (positive id — optimistic placeholders are `todo--<ts>`, double-dash).
+ * @param page - Playwright page.
+ * @param text - The task text to add.
+ */
+async function addPendingTodo(page: Page, text: string): Promise<void> {
+  await page.getByPlaceholder('Type a todo, or paste a list...').fill(text)
+  await page.getByRole('button', { name: 'Add', exact: true }).click()
+  const checkbox = page
+    .getByRole('checkbox', { name: text })
+    .and(page.locator('[id^="todo-"]:not([id^="todo--"])'))
+  await expect(checkbox).toBeVisible()
+  await expect(checkbox).toHaveAttribute('id', /^todo-[^-]/, { timeout: 5000 })
+}
+
+/**
+ * Checks a task off in 居残りモード: the toggle POST persists completed:true and
+ * the row STAYS in the list with a strikethrough (the retain behavior).
+ * @param page - Playwright page.
+ * @param text - The task text to complete.
+ */
+async function completeRetainedTodo(page: Page, text: string): Promise<void> {
+  const togglePromise = page.waitForResponse(
+    (resp) =>
+      resp.url().includes(ORPC_PATHS.toggleTodo) &&
+      resp.request().method() === 'POST',
+    { timeout: 10000 },
+  )
+  await page.getByRole('checkbox', { name: text }).first().click()
+  expect((await togglePromise).status()).toBe(200)
+  // It stays in the active list — now a completed-retained row with the button.
+  await expect(
+    page.getByRole('button', { name: `Tuck "${text}" into Completed` }),
+  ).toBeVisible({ timeout: 10000 })
+}
+
+/**
+ * Real-mouse drag from `source` to `target` with enough interpolation to satisfy
+ * dnd-kit's PointerSensor activation. Mirrors the proven skill-tree helper.
+ * @param page - Playwright page.
+ * @param source - The drag handle to pick up.
+ * @param target - The drop target.
+ */
+async function mouseDrag(
+  page: Page,
+  source: Locator,
+  target: Locator,
+): Promise<void> {
+  await source.hover()
+  await target.scrollIntoViewIfNeeded()
+  const [sourceBox, targetBox] = await Promise.all([
+    source.boundingBox(),
+    target.boundingBox(),
+  ])
+  if (!sourceBox || !targetBox) {
+    throw new Error('mouseDrag: source or target has no bounding box')
+  }
+  const startX = sourceBox.x + sourceBox.width / 2
+  const startY = sourceBox.y + sourceBox.height / 2
+  const endX = targetBox.x + targetBox.width / 2
+  const endY = targetBox.y + targetBox.height / 2
+  await page.mouse.move(startX, startY)
+  await page.mouse.down()
+  await page.mouse.move(startX + 10, startY + 10, { steps: 3 })
+  await page.mouse.move(endX, endY, { steps: 20 })
+  await page.mouse.up()
+}
+
+test.describe('Move finished tasks to Completed individually (#113)', () => {
+  test.describe.configure({ mode: 'serial' })
+  test.beforeAll(resetDatabase)
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page })
+    await page.addInitScript(
+      ({ storageKey, blob }) => {
+        localStorage.setItem(storageKey, blob)
+      },
+      { storageKey: STORAGE_KEY, blob: seedRetainModeOn() },
+    )
+  })
+
+  test('the per-row button files just that finished task into Completed', async ({
+    page,
+  }) => {
+    // Arrange — a finished, retained row.
+    const todoText = 'Retain button fixture'
+    await page.goto('/home')
+    await addPendingTodo(page, todoText)
+    await completeRetainedTodo(page, todoText)
+
+    // Act — tap its "Tuck into Completed" button (reuses delete→archive).
+    const deletePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes(ORPC_PATHS.deleteTodo) &&
+        resp.request().method() === 'POST',
+      { timeout: 10000 },
+    )
+    await page
+      .getByRole('button', { name: `Tuck "${todoText}" into Completed` })
+      .click()
+
+    // Assert — it persisted (archive) and left the active list (just that one).
+    expect((await deletePromise).status()).toBe(200)
+    await expect(
+      page.getByRole('button', { name: `Tuck "${todoText}" into Completed` }),
+    ).toHaveCount(0, { timeout: 10000 })
+  })
+
+  test('dragging a finished row onto the Completed zone files just that task', async ({
+    page,
+  }) => {
+    // Arrange — a finished, retained row + the now-visible drop zone.
+    const todoText = 'Retain drag fixture'
+    await page.goto('/home')
+    await addPendingTodo(page, todoText)
+    await completeRetainedTodo(page, todoText)
+    const dropZone = page.getByTestId('completed-dropzone')
+    await expect(dropZone).toBeVisible()
+
+    // Act — drag the row's handle onto the Completed drop zone.
+    const deletePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes(ORPC_PATHS.deleteTodo) &&
+        resp.request().method() === 'POST',
+      { timeout: 10000 },
+    )
+    await mouseDrag(
+      page,
+      activeRow(page, todoText).getByRole('button', {
+        name: 'Drag to reorder',
+      }),
+      dropZone,
+    )
+
+    // Assert — the drop archived it (sortable source → external droppable
+    // resolves) and removed just that one row.
+    expect((await deletePromise).status()).toBe(200)
+    await expect(
+      page.getByRole('button', { name: `Tuck "${todoText}" into Completed` }),
+    ).toHaveCount(0, { timeout: 10000 })
+  })
+
+  test('dragging a PENDING row onto the Completed zone is a no-op (no data loss)', async ({
+    page,
+  }) => {
+    // Arrange — a completed row (so the drop zone exists) AND a pending row that
+    // must NOT be archived/hard-deleted if dragged there.
+    const completedText = 'Retain guard completed'
+    const pendingText = 'Retain guard pending'
+    await page.goto('/home')
+    await addPendingTodo(page, completedText)
+    await completeRetainedTodo(page, completedText)
+    await addPendingTodo(page, pendingText)
+    const dropZone = page.getByTestId('completed-dropzone')
+    await expect(dropZone).toBeVisible()
+
+    // Act — drag the PENDING row's handle onto the Completed drop zone.
+    await mouseDrag(
+      page,
+      activeRow(page, pendingText).getByRole('button', {
+        name: 'Drag to reorder',
+      }),
+      dropZone,
+    )
+
+    // Assert — the guard no-oped: the pending task is still in the list, both in
+    // the live UI and after a reload (it was never deleted from the database).
+    await expect(
+      page.getByRole('checkbox', { name: pendingText }),
+    ).toBeVisible()
+    await page.reload()
+    await expect(page.getByRole('checkbox', { name: pendingText })).toBeVisible(
+      { timeout: 10000 },
+    )
+  })
+})

--- a/e2e/web/todo-retain-archive.spec.ts
+++ b/e2e/web/todo-retain-archive.spec.ts
@@ -128,7 +128,10 @@ async function mouseDrag(
 
 test.describe('Move finished tasks to Completed individually (#113)', () => {
   test.describe.configure({ mode: 'serial' })
-  test.beforeAll(resetDatabase)
+  // Reset per-test (not once for the serial suite) so a mid-suite failure can't
+  // leak persisted rows into the next case. No-op on CI (E2E_SKIP_PER_SPEC_RESET
+  // + global-setup own the reset there); it earns its keep on local sequential runs.
+  test.beforeEach(resetDatabase)
 
   test.beforeEach(async ({ page }) => {
     await setupClerkTestingToken({ page })
@@ -324,6 +327,13 @@ test.describe('Move finished tasks to Completed individually (#113)', () => {
     // unfixed code it is enabled here, so a tap hard-deletes the completion.
     await expect(tuckButton).toBeVisible()
     await expect(tuckButton).toBeDisabled()
+    // The pointer path mirrors the same guard: the Completed drop zone renders
+    // (a finished row now exists) but is marked inert, so a drag-drop can't
+    // silently no-op during the in-flight window.
+    await expect(page.getByTestId('completed-dropzone')).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    )
     expect(deleteFiredWhileInFlight).toBe(false)
 
     // Act 2 — let the toggle commit; the button re-arms once the win is saved.
@@ -336,6 +346,11 @@ test.describe('Move finished tasks to Completed individually (#113)', () => {
     releaseToggle()
     expect((await togglePromise).status()).toBe(200)
     await expect(tuckButton).toBeEnabled()
+    // ...and the drop zone re-arms (sheds its inert marker) once the win is durable.
+    await expect(page.getByTestId('completed-dropzone')).not.toHaveAttribute(
+      'aria-disabled',
+      'true',
+    )
 
     // Act 3 — now tucking archives it (heatmap-safe) instead of hard-deleting.
     const deletePromise = page.waitForResponse(

--- a/src/app/(main)/home/_components/CompletedDropZone.tsx
+++ b/src/app/(main)/home/_components/CompletedDropZone.tsx
@@ -18,25 +18,42 @@ export const COMPLETED_DROPZONE_ID = 'completed-dropzone'
  * visible payoff; a "Completed: N" tile would read as a forbidden KPI per
  * DESIGN.md). Rendered inside TodoList's DragDropProvider; the drop is handled
  * there. Warms with a primary tint (never success-green) while a row hovers it.
+ * @param isTogglePending - True while ANY completion toggle is still saving. In
+ *   that window TodoList's handleDragEnd no-ops a drop here (the row isn't durably
+ *   completed yet, so archiving would hard-delete the win). The zone dims and
+ *   drops its active tint to mirror that guard — the same disabled feedback the
+ *   per-row Tuck button shows — so the block is visible, never a silent failure.
  * @returns A dashed "Completed" drop zone for one-at-a-time tucking.
  * @example
- * <CompletedDropZone />
+ * <CompletedDropZone isTogglePending={isAnyTogglePending} />
  */
-export const CompletedDropZone = function CompletedDropZone() {
+export const CompletedDropZone = function CompletedDropZone({
+  isTogglePending = false,
+}: {
+  isTogglePending?: boolean
+}) {
   const { ref, isDropTarget } = useDroppable({ id: COMPLETED_DROPZONE_ID })
+
+  // A drop is a no-op while a toggle is in flight, so suppress the "active
+  // target" tint even if dnd-kit reports a hover — promising a landing we'd
+  // refuse would be the silent failure path the per-row guard avoids.
+  const showActiveTint = isDropTarget && !isTogglePending
 
   return (
     <div
       ref={ref}
       data-testid="completed-dropzone"
+      // Communicate the temporarily-inert state to assistive tech (absent, not
+      // ="false", in the normal case so it stays quiet).
+      aria-disabled={isTogglePending || undefined}
       // Quiet companion, not a coach: a calm place to tuck a finished thing. The
       // warm tint is primary (amber), never success-green — filing a win is not
       // an error and not a second celebration (DESIGN.md motion/voice notes).
       className={`mt-3 flex items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-6 text-sm transition-colors ${
-        isDropTarget
+        showActiveTint
           ? 'bg-primary/10 border-primary text-foreground'
           : 'border-muted-foreground/30 text-muted-foreground'
-      }`}
+      } ${isTogglePending ? 'opacity-50' : ''}`}
     >
       <Archive className="h-4 w-4" aria-hidden="true" />
       <span>Completed</span>

--- a/src/app/(main)/home/_components/CompletedDropZone.tsx
+++ b/src/app/(main)/home/_components/CompletedDropZone.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useDroppable } from '@dnd-kit/react'
+import { Archive } from 'lucide-react'
+
+/**
+ * dnd-kit droppable id for the 居残りモード "tuck one finished task away" zone.
+ * Shared between this drop target and TodoList's `handleDragEnd` branch so a
+ * sortable row dropped here is archived (delete→Completed) instead of reordered.
+ */
+export const COMPLETED_DROPZONE_ID = 'completed-dropzone'
+
+/**
+ * Retain-mode-only landing strip (issue #113) that lets a single finished
+ * (strikethrough) row be dragged out of the active list into the Completed
+ * journal — the per-row button is the keyboard path, this is the pointer path.
+ * It exists ONLY as a drop target: no task list, no count (the heatmap stays the
+ * visible payoff; a "Completed: N" tile would read as a forbidden KPI per
+ * DESIGN.md). Rendered inside TodoList's DragDropProvider; the drop is handled
+ * there. Warms with a primary tint (never success-green) while a row hovers it.
+ * @returns A dashed "Completed" drop zone for one-at-a-time tucking.
+ * @example
+ * <CompletedDropZone />
+ */
+export const CompletedDropZone = function CompletedDropZone() {
+  const { ref, isDropTarget } = useDroppable({ id: COMPLETED_DROPZONE_ID })
+
+  return (
+    <div
+      ref={ref}
+      data-testid="completed-dropzone"
+      // Quiet companion, not a coach: a calm place to tuck a finished thing. The
+      // warm tint is primary (amber), never success-green — filing a win is not
+      // an error and not a second celebration (DESIGN.md motion/voice notes).
+      className={`mt-3 flex items-center justify-center gap-2 rounded-xl border border-dashed px-4 py-6 text-sm transition-colors ${
+        isDropTarget
+          ? 'bg-primary/10 border-primary text-foreground'
+          : 'border-muted-foreground/30 text-muted-foreground'
+      }`}
+    >
+      <Archive className="h-4 w-4" aria-hidden="true" />
+      <span>Completed</span>
+    </div>
+  )
+}

--- a/src/app/(main)/home/_components/CompletedDropZone.tsx
+++ b/src/app/(main)/home/_components/CompletedDropZone.tsx
@@ -32,7 +32,7 @@ export const CompletedDropZone = function CompletedDropZone() {
       // Quiet companion, not a coach: a calm place to tuck a finished thing. The
       // warm tint is primary (amber), never success-green — filing a win is not
       // an error and not a second celebration (DESIGN.md motion/voice notes).
-      className={`mt-3 flex items-center justify-center gap-2 rounded-xl border border-dashed px-4 py-6 text-sm transition-colors ${
+      className={`mt-3 flex items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-6 text-sm transition-colors ${
         isDropTarget
           ? 'bg-primary/10 border-primary text-foreground'
           : 'border-muted-foreground/30 text-muted-foreground'

--- a/src/app/(main)/home/_components/SortableTodoItem.tsx
+++ b/src/app/(main)/home/_components/SortableTodoItem.tsx
@@ -15,6 +15,12 @@ interface SortableTodoItemProps {
   onUpdateNotes?: (id: string, notes: string) => void
   /** D8: play the 居残りモード retroactive-populate fade-in on this row. */
   isRetroactivelyPopulated?: boolean
+  /**
+   * #113: true while a completion toggle is in flight — forwarded to TodoItem so
+   * its "Tuck into Completed" button stays disabled until the check commits
+   * (tucking too early would hard-delete the task instead of archiving it).
+   */
+  isTogglePending?: boolean
 }
 
 /**
@@ -28,6 +34,8 @@ interface SortableTodoItemProps {
  * @param isRetroactivelyPopulated - D8: fade this row in (the 居残りモード toggle
  *   just surfaced it). Omitted/false for rows already on screen, so an in-place
  *   check stays quiet (D7).
+ * @param isTogglePending - #113: a completion toggle is in flight; forwarded to
+ *   TodoItem to disable its "Tuck into Completed" button until the check commits.
  * @returns A sortable wrapper around the TodoItem row.
  * @example
  * <SortableTodoItem todo={todo} index={0} onToggleComplete={toggle} onDelete={remove} />
@@ -39,6 +47,7 @@ export const SortableTodoItem = function SortableTodoItem({
   onDelete,
   onUpdateNotes,
   isRetroactivelyPopulated,
+  isTogglePending,
 }: SortableTodoItemProps) {
   const { ref, handleRef, isDragging } = useSortable({ id: todo.id, index })
 
@@ -62,6 +71,7 @@ export const SortableTodoItem = function SortableTodoItem({
         onUpdateNotes={onUpdateNotes}
         dragHandleRef={handleRef}
         isDragging={isDragging}
+        isTogglePending={isTogglePending}
       />
     </div>
   )

--- a/src/app/(main)/home/_components/TodoItem.test.tsx
+++ b/src/app/(main)/home/_components/TodoItem.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @fileoverview TodoItem "Tuck into Completed" per-row button (#113).
+ *
+ * The sentinel: in 居残りモード (keep-finished-tasks ON), a finished row must offer
+ * a NON-destructive button that files just that one task into Completed — taking
+ * the exact slot the per-row trash vacates (D14). These tests fail if the button
+ * leaks onto pending rows / non-retain mode, stops reusing the archive path, or
+ * regresses to an accessible name that collides with the ImportUndoBanner
+ * "Move to Completed" button or the skill-tree "completed task:" rows.
+ *
+ * Triggered when: `pnpm test` (Vitest, happy-dom).
+ *
+ * @example
+ *   pnpm test -- TodoItem
+ */
+import { configureStore } from '@reduxjs/toolkit'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { describe, expect, it, vi } from 'vitest'
+
+import preferencesReducer, {
+  initialState,
+} from '@/lib/redux/slices/preferencesSlice'
+
+import type { Todo } from './TodoItem'
+import { TodoItem } from './TodoItem'
+
+const FINISHED_TODO: Todo = {
+  id: '7',
+  text: 'Buy milk',
+  completed: true,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+}
+
+const PENDING_TODO: Todo = {
+  id: '8',
+  text: 'Call mom',
+  completed: false,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+}
+
+/**
+ * Renders a TodoItem under a real preferences store so the retain-mode branch is
+ * exercised exactly as in the app.
+ * @param todo - The row to render.
+ * @param retainCompletedInList - 居残りモード on/off.
+ * @param onDelete - Spy for the archive/delete callback (defaults to a noop spy).
+ */
+function renderTodoItem(
+  todo: Todo,
+  retainCompletedInList: boolean,
+  onDelete = vi.fn(),
+) {
+  const store = configureStore({
+    reducer: { preferences: preferencesReducer },
+    preloadedState: {
+      preferences: { ...initialState, retainCompletedInList },
+    },
+  })
+  render(
+    <Provider store={store}>
+      <TodoItem todo={todo} onToggleComplete={vi.fn()} onDelete={onDelete} />
+    </Provider>,
+  )
+  return { onDelete }
+}
+
+describe('TodoItem — Tuck into Completed (#113)', () => {
+  it('offers the Tuck-into-Completed button on a finished row when keep-in-list is on', () => {
+    // Arrange / Act — a finished task in 居残りモード.
+    renderTodoItem(FINISHED_TODO, true)
+
+    // Assert — the move affordance is present and the destructive trash is not.
+    expect(
+      screen.getByRole('button', { name: 'Tuck "Buy milk" into Completed' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Delete' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not show the Tuck button on a pending row (the trash stays instead)', () => {
+    // Arrange / Act — an unfinished task in 居残りモード.
+    renderTodoItem(PENDING_TODO, true)
+
+    // Assert — only completed rows can be tucked; the pending row keeps its trash.
+    expect(
+      screen.queryByRole('button', { name: /into Completed$/ }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  })
+
+  it('shows the normal Delete (not Tuck) on a finished row when keep-in-list is off', () => {
+    // Arrange / Act — finished task, but 居残りモード is off (default behavior).
+    renderTodoItem(FINISHED_TODO, false)
+
+    // Assert — the per-task move affordance only exists in retain mode.
+    expect(
+      screen.queryByRole('button', { name: /into Completed$/ }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  })
+
+  it('files just that one finished task when the Tuck button is tapped', () => {
+    // Arrange
+    const { onDelete } = renderTodoItem(FINISHED_TODO, true)
+
+    // Act — tap the move affordance.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Tuck "Buy milk" into Completed' }),
+    )
+
+    // Assert — it reuses the delete→archive path for exactly this row.
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    expect(onDelete).toHaveBeenCalledWith('7')
+  })
+
+  it('uses an accessible name that avoids the ImportUndoBanner and skill-tree collisions', () => {
+    // Arrange / Act
+    renderTodoItem(FINISHED_TODO, true)
+
+    // Assert — distinct from "Move to Completed" (ImportUndoBanner, substring-
+    // matched in e2e) and never starting with "completed task" (skill-tree e2e).
+    const moveButton = screen.getByRole('button', {
+      name: 'Tuck "Buy milk" into Completed',
+    })
+    expect(moveButton.getAttribute('aria-label')).toBe(
+      'Tuck "Buy milk" into Completed',
+    )
+    expect(moveButton.getAttribute('aria-label')).not.toContain(
+      'Move to Completed',
+    )
+    expect(moveButton.getAttribute('aria-label')).not.toMatch(
+      /^completed task/i,
+    )
+  })
+
+  it('disables the Tuck button after a tap so a finished row cannot be filed twice', () => {
+    // Arrange
+    renderTodoItem(FINISHED_TODO, true)
+    const moveButton = screen.getByRole('button', {
+      name: 'Tuck "Buy milk" into Completed',
+    })
+    expect(moveButton).not.toBeDisabled()
+
+    // Act — tap once.
+    fireEvent.click(moveButton)
+
+    // Assert — the same-row guard disables it (covers the archive helper's
+    // documented non-idempotent race between the click and the optimistic unmount).
+    expect(moveButton).toBeDisabled()
+  })
+})

--- a/src/app/(main)/home/_components/TodoItem.test.tsx
+++ b/src/app/(main)/home/_components/TodoItem.test.tsx
@@ -45,11 +45,14 @@ const PENDING_TODO: Todo = {
  * @param todo - The row to render.
  * @param retainCompletedInList - 居残りモード on/off.
  * @param onDelete - Spy for the archive/delete callback (defaults to a noop spy).
+ * @param isTogglePending - True while this row's completion toggle is still
+ *   saving; gates the Tuck button so a not-yet-durable win can't be hard-deleted.
  */
 function renderTodoItem(
   todo: Todo,
   retainCompletedInList: boolean,
   onDelete = vi.fn(),
+  isTogglePending = false,
 ) {
   const store = configureStore({
     reducer: { preferences: preferencesReducer },
@@ -59,7 +62,12 @@ function renderTodoItem(
   })
   render(
     <Provider store={store}>
-      <TodoItem todo={todo} onToggleComplete={vi.fn()} onDelete={onDelete} />
+      <TodoItem
+        todo={todo}
+        onToggleComplete={vi.fn()}
+        onDelete={onDelete}
+        isTogglePending={isTogglePending}
+      />
     </Provider>,
   )
   return { onDelete }
@@ -149,5 +157,21 @@ describe('TodoItem — Tuck into Completed (#113)', () => {
     // Assert — the same-row guard disables it (covers the archive helper's
     // documented non-idempotent race between the click and the optimistic unmount).
     expect(moveButton).toBeDisabled()
+  })
+
+  it('keeps the Tuck button inert while the completion is still saving (no hard-delete of an uncommitted win)', () => {
+    // Arrange / Act — a finished row whose completion toggle has NOT yet committed
+    // (isTogglePending). The server still sees it pending, so the reused
+    // delete→archive path would HARD-DELETE the win rather than archive it.
+    const { onDelete } = renderTodoItem(FINISHED_TODO, true, vi.fn(), true)
+    const moveButton = screen.getByRole('button', {
+      name: 'Tuck "Buy milk" into Completed',
+    })
+
+    // Assert — the button is visible but disabled, and a tap fires nothing: the
+    // data-loss gate holds until the toggle is durable.
+    expect(moveButton).toBeDisabled()
+    fireEvent.click(moveButton)
+    expect(onDelete).not.toHaveBeenCalled()
   })
 })

--- a/src/app/(main)/home/_components/TodoItem.tsx
+++ b/src/app/(main)/home/_components/TodoItem.tsx
@@ -46,6 +46,14 @@ interface TodoItemProps {
   dragHandleRef?: DragHandleRef
   /** Whether item is currently being dragged */
   isDragging?: boolean
+  /**
+   * #113 data-loss gate: true while ANY completion toggle for this list is still
+   * in flight. "Tuck into Completed" reuses the delete→archive path, but the
+   * server only archives a row that is ALREADY completed in the DB; tuck a row
+   * whose check hasn't committed yet and it is HARD-DELETED instead (the win is
+   * lost, no heatmap credit). So the button stays disabled until the toggle lands.
+   */
+  isTogglePending?: boolean
 }
 
 export const TodoItem = function TodoItem({
@@ -55,6 +63,7 @@ export const TodoItem = function TodoItem({
   onUpdateNotes,
   dragHandleRef,
   isDragging,
+  isTogglePending = false,
 }: TodoItemProps) {
   const [isNotesOpen, setIsNotesOpen] = useState(false)
   const [notes, setNotes] = useState(todo.notes ?? '')
@@ -193,7 +202,10 @@ export const TodoItem = function TodoItem({
               variant="ghost"
               size="sm"
               onClick={handleMoveToCompleted}
-              disabled={isMovingToCompleted}
+              // Disabled while moving (the double-fire guard) OR while the
+              // completion toggle is still in flight — tucking before the check
+              // commits would hard-delete the win instead of archiving it (#113).
+              disabled={isMovingToCompleted || isTogglePending}
               className="text-muted-foreground hover:text-foreground"
               // Distinct accessible name: must NOT contain "Move to Completed"
               // (ImportUndoBanner owns that, substring-matched in e2e) nor start

--- a/src/app/(main)/home/_components/TodoItem.tsx
+++ b/src/app/(main)/home/_components/TodoItem.tsx
@@ -1,4 +1,5 @@
 import {
+  Archive,
   Trash2,
   StickyNote,
   ChevronDown,
@@ -69,6 +70,14 @@ export const TodoItem = function TodoItem({
   // Undo-toast delete). So hide only when this row is completed AND retain is on.
   const isRetaining = useAppSelector(selectRetainCompletedInList)
   const showDeleteButton = !todo.completed || !isRetaining
+  // #113: the new "Tuck into Completed" button takes the D14 slot the trash
+  // vacates — the exact inverse condition, so the two are mutually exclusive.
+  const showMoveToCompletedButton = todo.completed && isRetaining
+
+  // Same-row double-fire guard: the optimistic delete unmounts this row almost
+  // immediately, but this local flag also disables the button between the click
+  // and that unmount (the archive helper's documented non-idempotent race).
+  const [isMovingToCompleted, setIsMovingToCompleted] = useState(false)
 
   const handleToggleComplete = () => {
     // Fire the opt-in sound only on a real completion (false→true); the CSS
@@ -80,6 +89,14 @@ export const TodoItem = function TodoItem({
   }
 
   const handleDelete = () => {
+    onDelete(todo.id)
+  }
+
+  // #113: tuck this one finished row into Completed. Reuses onDelete — deleting a
+  // completed todo archives it into the Completed journal (heatmap-safe) rather
+  // than hard-deleting, so "move to Completed" IS the completed-row delete path.
+  const handleMoveToCompleted = () => {
+    setIsMovingToCompleted(true)
     onDelete(todo.id)
   }
 
@@ -170,6 +187,22 @@ export const TodoItem = function TodoItem({
                 </Button>
               </CollapsibleTrigger>
             </Collapsible>
+          )}
+          {showMoveToCompletedButton && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleMoveToCompleted}
+              disabled={isMovingToCompleted}
+              className="text-muted-foreground hover:text-foreground"
+              // Distinct accessible name: must NOT contain "Move to Completed"
+              // (ImportUndoBanner owns that, substring-matched in e2e) nor start
+              // with "completed task" (skill-tree e2e). Quiet-companion voice.
+              aria-label={`Tuck "${todo.text}" into Completed`}
+              title="Tuck into Completed"
+            >
+              <Archive className="h-4 w-4" aria-hidden="true" />
+            </Button>
           )}
           {showDeleteButton && (
             <Button

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -642,7 +642,9 @@ export const TodoList = function TodoList() {
                 drop target so a single strikethrough row can be dragged out of
                 the list into Completed (the per-row Archive button is the
                 keyboard path). Lives inside the provider to share its context. */}
-            {isRetaining && completedInListCount > 0 && <CompletedDropZone />}
+            {isRetaining && completedInListCount > 0 && (
+              <CompletedDropZone isTogglePending={isAnyTogglePending} />
+            )}
           </DragDropProvider>
         )}
       </div>

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -49,6 +49,7 @@ import { subscribeToTodoSync } from '@/lib/todo-sync-channel'
 import type { CategoryWithCount } from '@/server/schemas/category'
 
 import { AddTodoForm } from './AddTodoForm'
+import { COMPLETED_DROPZONE_ID, CompletedDropZone } from './CompletedDropZone'
 import { CompletedTodos } from './CompletedTodos'
 import { ContributionGraph } from './ContributionGraph'
 import {
@@ -427,7 +428,22 @@ export const TodoList = function TodoList() {
       return
     }
 
-    const { source } = event.operation
+    const { source, target } = event.operation
+
+    // #113: a row dropped on the Completed drop zone is tucked into the journal
+    // (reuse the delete→archive path) instead of reordered. GUARD is load-
+    // bearing: only a *completed* row may go here — deleteTodo hard-deletes a
+    // pending row (data loss), and in retain mode pending + completed rows share
+    // this one sortable list, so dropping a pending row here must be a no-op.
+    if (target?.id === COMPLETED_DROPZONE_ID) {
+      const droppedTodo = pendingTodos.find(
+        (todo) => todo.id === String(source?.id),
+      )
+      if (droppedTodo?.completed) {
+        deleteTodo(droppedTodo.id)
+      }
+      return
+    }
 
     if (!isSortable(source) || source.initialIndex === source.index) {
       return
@@ -610,6 +626,11 @@ export const TodoList = function TodoList() {
                 />
               ))}
             </div>
+            {/* #113: in 居残りモード, once there's a finished row to file, show a
+                drop target so a single strikethrough row can be dragged out of
+                the list into Completed (the per-row Archive button is the
+                keyboard path). Lives inside the provider to share its context. */}
+            {isRetaining && completedInListCount > 0 && <CompletedDropZone />}
           </DragDropProvider>
         )}
       </div>

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -129,6 +129,7 @@ export const TodoList = function TodoList() {
   const {
     createMutation,
     toggleMutation,
+    isAnyTogglePending,
     deleteMutation,
     updateMutation,
     clearCompletedMutation,
@@ -415,11 +416,17 @@ export const TodoList = function TodoList() {
   }, [retroactivePopulateFadeIds])
 
   /**
-   * Handles drag end event to reorder todos.
-   * Updates local state optimistically and syncs with server.
+   * Resolves a dnd-kit drag-end into one of two outcomes — tuck a finished task
+   * into Completed (drop on the #113 CompletedDropZone) or reorder the active
+   * list — committing optimistically then syncing the server. Fired by
+   * DragDropProvider's onDragEnd.
    * @param event - Latest dnd-kit drag-end event from DragDropProvider.
    * @returns
-   * - No return value; invalid drops exit early and valid drops reorder tasks.
+   * - No return value.
+   * - Drop on the Completed zone: archives the row when it is completed AND its
+   *   completion has committed; a pending row — or one whose toggle is still in
+   *   flight — is a no-op (deleteTodo would hard-delete it — data loss).
+   * - Otherwise: reorders the active list, or exits early on a canceled/invalid drop.
    * @example
    * handleDragEnd(event)
    */
@@ -435,11 +442,15 @@ export const TodoList = function TodoList() {
     // bearing: only a *completed* row may go here — deleteTodo hard-deletes a
     // pending row (data loss), and in retain mode pending + completed rows share
     // this one sortable list, so dropping a pending row here must be a no-op.
+    // The `!isAnyTogglePending` half is the same data-loss gate: a row checked
+    // moments ago is optimistically `completed` here, but until the toggle
+    // commits the server still sees it pending and would hard-delete it. This
+    // reads the MutationCache (any toggle in flight), not one observer's latest.
     if (target?.id === COMPLETED_DROPZONE_ID) {
       const droppedTodo = pendingTodos.find(
         (todo) => todo.id === String(source?.id),
       )
-      if (droppedTodo?.completed) {
+      if (droppedTodo?.completed && !isAnyTogglePending) {
         deleteTodo(droppedTodo.id)
       }
       return
@@ -620,6 +631,7 @@ export const TodoList = function TodoList() {
                   onToggleComplete={toggleComplete}
                   onDelete={deleteTodo}
                   onUpdateNotes={updateNotes}
+                  isTogglePending={isAnyTogglePending}
                   isRetroactivelyPopulated={retroactivePopulateFadeIds.has(
                     todo.id,
                   )}

--- a/src/components/floating-navigator/FloatingNavigator.test.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.test.tsx
@@ -17,10 +17,30 @@
  * @example
  *   pnpm test -- FloatingNavigator
  */
+import { configureStore } from '@reduxjs/toolkit'
 import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import preferencesReducer, {
+  initialState,
+} from '@/lib/redux/slices/preferencesSlice'
+
 import { FloatingNavigator } from './FloatingNavigator'
+
+/**
+ * Wraps the FloatingNavigator in a real preferences store — required once a
+ * completed row renders, because its checkbox pulls in useCompletionFeedback →
+ * useAppSelector (the empty-todos tests above never mount a row, so they don't).
+ */
+function renderFloatingWithStore(ui: ReactElement) {
+  const store = configureStore({
+    reducer: { preferences: preferencesReducer },
+    preloadedState: { preferences: { ...initialState } },
+  })
+  return render(<Provider store={store}>{ui}</Provider>)
+}
 
 // Force the floating-navigator environment so the window-controls toolbar (and
 // its pin button) renders and the mount-init effect runs.
@@ -230,5 +250,57 @@ describe('FloatingNavigator bulk paste (Issue #110 AC#2)', () => {
 
     // Assert: native paste wins; the bulk dialog is NOT opened over a partial edit.
     expect(onBulkPaste).not.toHaveBeenCalled()
+  })
+})
+
+describe('FloatingNavigator — Tuck into Completed parity (#113)', () => {
+  const FINISHED_FLOATING_TODO = {
+    id: '7',
+    text: 'Buy milk',
+    completed: true,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+  }
+
+  it('labels the finished-row action as tucking into Completed, not a destructive delete', async () => {
+    // Arrange: a finished task is shown in the Floating Completed section.
+    installFloatingNavigatorAPI(vi.fn().mockResolvedValue(true))
+    renderFloatingWithStore(
+      <FloatingNavigator {...noopTaskProps} todos={[FINISHED_FLOATING_TODO]} />,
+    )
+
+    // Act: locate the per-row action by its quiet-companion accessible name.
+    const moveButton = await screen.findByRole('button', {
+      name: 'Tuck "Buy milk" into Completed',
+    })
+
+    // Assert: the win-filing button reads as filing, not deleting — the old
+    // "Delete completed task" label (and the trash skin) is gone.
+    expect(moveButton).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /delete completed task/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('files just that finished task into Completed when its button is tapped', async () => {
+    // Arrange
+    installFloatingNavigatorAPI(vi.fn().mockResolvedValue(true))
+    const onTaskDelete = vi.fn()
+    renderFloatingWithStore(
+      <FloatingNavigator
+        {...noopTaskProps}
+        todos={[FINISHED_FLOATING_TODO]}
+        onTaskDelete={onTaskDelete}
+      />,
+    )
+    const moveButton = await screen.findByRole('button', {
+      name: 'Tuck "Buy milk" into Completed',
+    })
+
+    // Act
+    fireEvent.click(moveButton)
+
+    // Assert: only that one task is filed (delete-of-completed archives it).
+    expect(onTaskDelete).toHaveBeenCalledTimes(1)
+    expect(onTaskDelete).toHaveBeenCalledWith('7')
   })
 })

--- a/src/components/floating-navigator/FloatingNavigator.test.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.test.tsx
@@ -303,4 +303,34 @@ describe('FloatingNavigator — Tuck into Completed parity (#113)', () => {
     expect(onTaskDelete).toHaveBeenCalledTimes(1)
     expect(onTaskDelete).toHaveBeenCalledWith('7')
   })
+
+  it('keeps the finished-row tuck button inert while its completion is still saving (no hard-delete)', async () => {
+    // Arrange: a finished row is shown, but its completion toggle has NOT yet
+    // committed to the server (slow network). Tucking reuses delete→archive,
+    // and the server only archives a row that is ALREADY completed in the DB —
+    // fire it before the toggle lands and that row is HARD-DELETED instead (the
+    // win is destroyed, no heatmap credit). So the button must stay disabled
+    // until the completion is durable.
+    installFloatingNavigatorAPI(vi.fn().mockResolvedValue(true))
+    const onTaskDelete = vi.fn()
+    renderFloatingWithStore(
+      <FloatingNavigator
+        {...noopTaskProps}
+        todos={[FINISHED_FLOATING_TODO]}
+        onTaskDelete={onTaskDelete}
+        isTogglePending
+      />,
+    )
+    const moveButton = await screen.findByRole('button', {
+      name: 'Tuck "Buy milk" into Completed',
+    })
+
+    // Act: try to file the win while the completion is still in flight.
+    fireEvent.click(moveButton)
+
+    // Assert: the button is inert and no archive/delete is attempted — the gate
+    // holds the win until the toggle commits.
+    expect(moveButton).toBeDisabled()
+    expect(onTaskDelete).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -119,6 +119,14 @@ interface FloatingNavigatorProps {
   isCategoryCreatePending?: boolean
   isCategoryUpdatePending?: boolean
   isCategoryDeletePending?: boolean
+  /**
+   * #113 data-loss gate: true while a completion toggle is in flight. The
+   * Completed-row "Tuck into Completed" button reuses the delete→archive path,
+   * which only archives a row already completed in the DB; tuck a freshly-checked
+   * row before its toggle commits and it is HARD-DELETED instead (the win is lost,
+   * no heatmap credit). Disables that button until the completion is durable.
+   */
+  isTogglePending?: boolean
 }
 
 interface PendingFloatingTodoRowProps {
@@ -141,6 +149,12 @@ interface CompletedFloatingTodoRowProps {
   todo: FloatingTodo
   onToggle: (id: string) => void
   onDelete: (id: string) => void
+  /**
+   * #113: a completion toggle is in flight; disables the "Tuck into Completed"
+   * button so a freshly-checked win can't be hard-deleted before its toggle
+   * commits (see FloatingNavigatorProps.isTogglePending).
+   */
+  isTogglePending?: boolean
 }
 
 /**
@@ -308,6 +322,7 @@ const CompletedFloatingTodoRow = function CompletedFloatingTodoRow({
   todo,
   onToggle,
   onDelete,
+  isTogglePending = false,
 }: CompletedFloatingTodoRowProps): React.ReactNode {
   const { checkboxMotionClassName } = useCompletionFeedback()
   const handleToggle = () => {
@@ -345,6 +360,10 @@ const CompletedFloatingTodoRow = function CompletedFloatingTodoRow({
         size="sm"
         variant="ghost"
         onClick={handleDelete}
+        // Disabled while the completion toggle is still in flight — tucking
+        // before the check commits would hard-delete the win instead of
+        // archiving it (#113 data-loss race, mirrors the web TodoItem gate).
+        disabled={isTogglePending}
         className="h-6 w-6 p-0 text-muted-foreground opacity-0 hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 group-hover:opacity-100"
         aria-label={`Tuck "${todo.text}" into Completed`}
         title="Tuck into Completed"
@@ -375,6 +394,7 @@ export const FloatingNavigator = function FloatingNavigator({
   isCategoryCreatePending = false,
   isCategoryUpdatePending = false,
   isCategoryDeletePending = false,
+  isTogglePending = false,
 }: FloatingNavigatorProps) {
   const [newTaskText, setNewTaskText] = useState('')
   const [showManagePanel, setShowManagePanel] = useState(false)
@@ -944,6 +964,7 @@ export const FloatingNavigator = function FloatingNavigator({
                       todo={todo}
                       onToggle={handleTaskToggle}
                       onDelete={handleTaskDelete}
+                      isTogglePending={isTogglePending}
                     />
                   ))}
                   {completedTodos.length > 3 && (

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -41,6 +41,9 @@ const Edit2 = lazy(async () =>
 const Trash2 = lazy(async () =>
   import('lucide-react').then((mod) => ({ default: mod.Trash2 })),
 )
+const Archive = lazy(async () =>
+  import('lucide-react').then((mod) => ({ default: mod.Archive })),
+)
 const Minimize2 = lazy(async () =>
   import('lucide-react').then((mod) => ({ default: mod.Minimize2 })),
 )
@@ -334,16 +337,20 @@ const CompletedFloatingTodoRow = function CompletedFloatingTodoRow({
       >
         {todo.text}
       </span>
+      {/* #113: filing a finished task is a win, not a deletion — so this is the
+          neutral Archive affordance, never the destructive (clay-red Trash2)
+          skin. Behaviour is unchanged (onDelete archives the completed row); the
+          accessible name avoids "Move to Completed"/"completed task:" e2e clashes. */}
       <Button
         size="sm"
         variant="ghost"
         onClick={handleDelete}
-        className="h-6 w-6 p-0 text-destructive opacity-0 hover:text-destructive focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 group-hover:opacity-100"
-        aria-label={`Delete completed task: ${todo.text}`}
-        title="Delete task"
+        className="h-6 w-6 p-0 text-muted-foreground opacity-0 hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 group-hover:opacity-100"
+        aria-label={`Tuck "${todo.text}" into Completed`}
+        title="Tuck into Completed"
       >
         <Suspense fallback={<IconFallback />}>
-          <Trash2 className="h-3 w-3" aria-hidden="true" />
+          <Archive className="h-3 w-3" aria-hidden="true" />
         </Suspense>
       </Button>
     </div>

--- a/src/components/floating-navigator/FloatingNavigatorContainer.tsx
+++ b/src/components/floating-navigator/FloatingNavigatorContainer.tsx
@@ -72,6 +72,7 @@ export const FloatingNavigatorContainer =
     const {
       createMutation,
       toggleMutation,
+      isAnyTogglePending,
       deleteMutation,
       updateMutation,
       reorderMutation,
@@ -406,6 +407,11 @@ export const FloatingNavigatorContainer =
           isCategoryCreatePending={categoryCreateMutation.isPending}
           isCategoryUpdatePending={categoryUpdateMutation.isPending}
           isCategoryDeletePending={categoryDeleteMutation.isPending}
+          // #113 data-loss gate: disables a Completed row's "Tuck" button while
+          // ANY completion toggle is in flight, so a freshly-checked win can't be
+          // hard-deleted before the toggle commits (same race as the web list).
+          // Reads the MutationCache (true superset), not one observer's latest.
+          isTogglePending={isAnyTogglePending}
         />
         {/* Controlled bulk paste-import dialog (Issue #110): the task input's
             multi-line paste opens it; it's a portal Dialog so its position in

--- a/src/hooks/useTodoMutations.ts
+++ b/src/hooks/useTodoMutations.ts
@@ -1,7 +1,11 @@
 'use client'
 
 import type { InfiniteData, QueryClient } from '@tanstack/react-query'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  useMutation,
+  useMutationState,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { broadcastCategorySync } from '@/lib/category-sync-channel'
@@ -742,9 +746,26 @@ export function useTodoMutations(
     },
   })
 
+  // #113 data-loss gate, read at the MutationCache level (NOT the observer level).
+  // "Tuck into Completed" reuses the delete→archive path, which only archives a row
+  // the SERVER already sees as completed; tuck a row whose toggle hasn't committed
+  // and it is HARD-DELETED instead — the win is lost, no heatmap credit. A single
+  // mutation's `isPending` tracks only the LATEST mutate() call, so a rapid
+  // double-check whose commits land out of order could read false while an earlier
+  // toggle is still in flight. The cache holds every in-flight toggle independently,
+  // so this stays true while ANY toggle is pending — a true superset of isPending.
+  const pendingToggleMutations = useMutationState({
+    filters: {
+      mutationKey: orpc.todo.toggle.key({ type: 'mutation' }),
+      status: 'pending',
+    },
+  })
+  const isAnyTogglePending = pendingToggleMutations.length > 0
+
   return {
     createMutation,
     toggleMutation,
+    isAnyTogglePending,
     deleteMutation,
     updateMutation,
     clearCompletedMutation,


### PR DESCRIPTION
## Summary

Implements #113 — in 居残りモード ("Keep finished tasks in the list" ON), you can move a single finished task into Completed without clearing the whole list, via **either** a per-row button **or** drag-and-drop.

Commits:
- **`dca5667` feat** — the feature. A `CompletedDropZone` (dashed strip, Archive + "Completed") shows in the main app once retain mode has ≥1 finished task. Each finished row gets a ghost "Tuck into Completed" button. Dragging a checked row onto the drop zone files just that one. Both paths reuse the existing delete→archive route, so the win keeps its heatmap/XP credit.
- **`9829890` test** — proves AC5: tucking one finished task leaves the other finished tasks in place.
- **`e36d121` fix** — closes a completion-toggle data-loss race surfaced by the pre-landing + adversarial review (details below), plus folds in the review polish notes.

All affordances are gated on `todo.completed && isRetaining`, so with the setting **OFF** nothing changes (AC7).

## Test Coverage

- **Unit: 718 pass / 33 skip** (run on CI Node via `mise exec node@24.13.0`); typecheck, lint, build all clean.
- **Web E2E: 6/6 green** in `e2e/web/todo-retain-archive.spec.ts` — per-row button archives one; drag-onto-dropzone archives one; **dragging a *pending* row is a no-op and survives reload** (the data-loss guard); only-that-one stays for siblings; and the new **check-then-tuck race** test (hold the toggle response, assert the Tuck button is disabled and no delete fires until the toggle commits).
- **Floating Navigator coverage is by transitivity, and that is intentional:** both consumers (main `TodoList` + `FloatingNavigatorContainer`) share one hook (`useTodoMutations`), so the Web E2E proves the shared toggle-pending derivation and the mutation key; the Floating jsdom test (`FloatingNavigator.test.tsx`) proves the button goes inert on the prop; the container wiring is typechecked. The Floating **branch renderer** is not locally E2E-automatable (the packaged app loads prod `corelive.app`), so this is the correct coverage shape rather than a silent gap.

## Pre-Landing Review

The review + adversarial pass found one real, high-stakes issue and it is fixed in `e36d121`:

**Completion-toggle data-loss race.** "Tuck into Completed" reuses `todo.delete`, which only **archives** a row the **server** already sees as completed — otherwise it **hard-deletes** (irreversible, no heatmap credit). The original gate read `toggleMutation.isPending` from a single mutation observer, which (confirmed against the TanStack Query v5 docs via Context7) reflects only the **latest** `mutate()` call. A rapid double-check whose toggles commit out of order could read `false` while an earlier toggle was still in flight, letting the button fire a hard-delete on a not-yet-committed win.

Fix: derive `isAnyTogglePending` once in `useTodoMutations` from the **MutationCache** — `useMutationState({ filters: { mutationKey: orpc.todo.toggle.key({ type: 'mutation' }), status: 'pending' } }).length > 0`. This is a **true superset** of the observer's `isPending`: it stays true while *any* toggle is in flight, so it over-blocks (disables the tuck affordances) rather than ever under-blocking. Proven RED→GREEN: breaking only the cache filter key flipped the E2E to RED ("Tuck button enabled" before the toggle committed); restoring it returned GREEN.

> Note for review: disabling the tuck affordance app-wide while *any* toggle is pending is **intentional** — it over-blocks, never under-blocks. Per-id gating was explicitly rejected because it reintroduces the out-of-order-commit hole.

**Red Team triage (non-blocking):**
- *MED* — there is no custom dnd-kit `collisionDetection`, so releasing a *reorder* drag over the drop zone could archive when a reorder was intended. Accepted as non-blocking: it is recoverable (the row lands in the permanent Completed journal, not destroyed), the real data-loss vector is closed by the `completed` guard + the toggle gate, and it's pre-existing drag ergonomics. Tracked as a polish follow-up.
- *LOW* — Floating relabel cosmetic: no action needed (non-retain mode filters completed rows out of the Floating query, so the label can't show inappropriately).

## Design Review

Design review **CLEAN** (cross-model: Codex + web-designer) — 0 fixes required, 3 polish notes confirmed correct-as-is. Folded the review's polish into `e36d121`: `CompletedDropZone` radius → `rounded-lg` (DESIGN.md card radius), and absent-case assertions tightened in the E2E. Completion uses amber/primary, not success-green; no KPI tiles; no streak-shame copy — consistent with DESIGN.md.

## Plan Completion

| AC | Status |
|----|--------|
| AC1 check = strikethrough + stays in list (retain ON) | ✅ unchanged |
| AC2 a Completed area exists | ✅ `CompletedDropZone` |
| AC3 drag a checked task → Completed (Web) | ✅ |
| AC4 per-row button → Completed | ✅ both Web **and** Floating |
| AC5 moves only that one | ✅ unit + E2E |
| AC6 drag **and** button on Web **and** Floating | ⚠️ button parity ✅ both surfaces; Web drag ✅; **Floating drag deferred → #122** |
| AC7 setting OFF = no change | ✅ affordances inert when not retaining |

## Linked Spec

**Addresses #113** (partial delivery — **not** auto-closing). The only gap is AC6 Floating-drag, deferred to **#122** (the Floating completed area is a capped read-only summary rendered outside the DragDropProvider; promoting it to a real droppable is a larger change than the Web path, and button parity already covers Floating users). Close #113 after #122 lands.

## TODOS

No TODOS.md items completed in this PR.

## Test plan

- [x] Unit suite green (718 pass / 33 skip, Node 24.13.0 = CI)
- [x] typecheck / lint / build clean
- [x] Web E2E `todo-retain-archive` 6/6 green, including the data-loss guard + check-then-tuck race
- [x] Data-loss fix proven RED→GREEN on the real container + cache key

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Completed” drop zone in retain mode to tuck finished tasks into Completed via drag-and-drop.
  * Updated the Completed-task action UI to use “Tuck into Completed” wording and matching iconography.

* **Bug Fixes**
  * Prevented archiving/removal while completion toggles are still saving.
  * Kept pending tasks unchanged when dropped onto Completed.
  * Ensured tucking one finished task doesn’t disrupt other finished tasks.

* **Tests**
  * Added/expanded component and end-to-end coverage for retain-mode tuck and race-condition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->