### PR TITLE
fix(electron): freeze-safety for native lone-modifier key-tap (#125)

### DIFF
--- a/docs/design/125-native-keytap-freeze-safety.md
+++ b/docs/design/125-native-keytap-freeze-safety.md
@@ -114,7 +114,7 @@ machine (Karabiner's virtual-HID layer transforms synthetic CGEvents), so it can
 delivery _works_ — but it reproduces the same **1-then-silent ceiling**, which is the
 point. The verdict that delivery FAILS holds for **real physical keys** too.
 
-**Re-confirmed (2026-06-26, fresh signed re-run).** Relaunched the same signed
+**Re-confirmed (2026-06-26 JST, fresh signed re-run).** Relaunched the same signed
 `com.corelive.app` build (`codesign`: `Developer ID Application: Ryota Murakami
 (895TNMSCMH)`, hardened runtime; `app.asar` built 00:55, no builder running). The probe
 forked the `utilityProcess` child, which loaded the native `.node` and posted

--- a/docs/design/125-native-keytap-freeze-safety.md
+++ b/docs/design/125-native-keytap-freeze-safety.md
@@ -1,0 +1,154 @@
+# Design Doc — #125 Freeze-safety for the native key-tap (GA gate)
+
+> Design doc for issue **#125**. Follow-up to #111 / PR #126 (merged `eab43fd`).
+
+## Context
+
+PR #126 shipped lone-modifier global shortcuts (Right ⌥ alone, L/R distinct) behind
+a userland libuiohook key-tap (`uiohook-napi`). Prove-out passed on a packaged arm64
+build with Karabiner: Left ⌥ fired 25× over ~39s, no freeze. But the safety story
+has a hole that GA-gates the feature: **the tap degrades to chord ONLY on two
+catchable conditions — native module load-fail (`isAvailable()===false`) or
+`register()` returning false.** A tap that loads, `start()`s, then _freezes or goes
+silent_ is neither. libuiohook issue #23 ("1 event then frozen") is exactly this
+mode on some setups. Because a lone-modifier bind re-arms the tap on every launch, a
+user who freezes once re-freezes every relaunch — bricked, no in-app recovery.
+Blast radius is bounded today only by opt-in (default config binds no lone-modifier).
+
+## Current State (verified)
+
+| Element        | Location                                                                  | Behavior                                                                                                                                                                                                                                                        |
+| -------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Engine factory | `electron/uiohookEngine.ts`                                               | Lazy `start()` on first bind, `stop()` on last unbind; "pressed alone" press/release state machine; `ensureTapRunning()` returns false if `start()` throws → `register()` rolls back → degrade. **No detection of a tap that started then went silent/wedged.** |
+| Loader         | `electron/utils/loadUiohook.ts`                                           | `require('uiohook-napi').uIOhook` (CJS runtime require).                                                                                                                                                                                                        |
+| Seam           | `electron/main.ts:838` `loadSystemIntegrationStack`                       | `const nativeShortcutEngine = createUiohookShortcutEngine(loadUiohook)` → `new ShortcutManagerCls(win, notif, config, nativeShortcutEngine)`. **This is the one injection point to wrap.**                                                                      |
+| Routing        | `ShortcutManager.registerShortcut` (477) → `registerNativeShortcut` (566) | `isNativeBinding()` routes `lone-modifier:*` to `nativeEngine.register()`; degrades when `isAvailable()` false or `register()` false. `updateShortcuts` (984) re-registers on settings change; `initialize` (207) at startup; `cleanup` (1177) tears down.      |
+| Native module  | `uiohook-napi@1.5.5`                                                      | `start()` → `lib.start(handler)`. libuiohook CGEventTap runs on a **native background thread**; events fire back onto the **main JS thread** via `EventEmitter.emit('keydown'/'keyup')`. Singleton `uIOhook`.                                                   |
+| Packaging      | `electron-builder.json`                                                   | `asarUnpack` includes `uiohook-napi/**` + `node-gyp-build/**`; `node-gyp-build` is a **direct** dep (asar leaf-drop guarded).                                                                                                                                   |
+| Signing        | `build/entitlements.mac.plist`                                            | `hardenedRuntime:true`, `disable-library-validation:true`, `entitlementsInherit` → **a utilityProcess child can load the `.node` prebuild.** TCC (Input-Monitoring) is a runtime grant, NOT an entitlement → see Open Risk.                                     |
+
+## Root cause — why a heartbeat-in-main is insufficient
+
+Two distinct freeze modes, both verified against the threading model:
+
+1. **Tap thread goes silent** (libuiohook #23 / OS disables the tap under load):
+   main is NOT blocked; keydown/keyup just stop arriving. A passive event-heartbeat
+   **cannot distinguish "frozen tap" from "idle user"** — both produce zero events.
+2. **Main JS loop wedges** (dispatch path or a callback blocks the loop): hangs ALL
+   windows. A watchdog timer living **on the same main loop cannot detect its own
+   freeze** — it's frozen too.
+
+Only an **external observer** (a separate process) closes both holes. This confirms
+the issue's stated preference: utilityProcess isolation is the structural fix, not a
+nice-to-have.
+
+## Proposed Change — three composed layers (not either/or)
+
+### Layer 1 — utilityProcess isolation (structural; AC#3)
+
+Move the tap into a `utilityProcess.fork`'d child (`electron/uiohookHost.ts`
+entrypoint, built by electron-vite). The child owns libuiohook + the "pressed alone"
+state machine and posts `{type:'fire', id}` to main over `parentPort`. The main-side
+engine becomes a **thin proxy** implementing the SAME `NativeShortcutEngine`
+interface (so `ShortcutManager` is untouched): `register/unregister` forward to the
+child via `postMessage`; on `'fire'` it invokes the stored callback on the main loop.
+A freeze in the child's tap thread OR its whole loop **cannot block main's windows**.
+
+### Layer 2 — watchdog (detection + auto-degrade; AC#1)
+
+Main pings the child every ~1s; child ponds. Miss N consecutive pongs (~3s budget)
+OR `child-process-gone` fires → declare the tap dead: auto-degrade affected
+lone-modifier binds to chord (or disable), notify renderer. Bounded respawn (e.g. 1
+restart); if it re-freezes, stay degraded. The ping/pong is the **active liveness
+probe** that mode-1 (silent tap) needs.
+
+### Layer 3 — brick-proof launch latch (AC#2)
+
+Before arming the tap on launch, write a small `native-tap-arming` marker to
+userData (a SEPARATE file, NOT `config.json`, so a wedge can't corrupt config).
+Clear it once the child proves liveness (first pong / first delivered event). On
+launch, if the marker is still set from the previous run (= last launch armed and
+never confirmed → it froze), **do NOT re-arm**: start the lone-modifier bind
+disabled/probationary and surface an in-app notice with one-click re-enable.
+Recovery never requires hand-editing `config.json`.
+
+### AC#4 — signed re-prove
+
+Rebuild signed+notarized; grant TCC once; verify (a) the tap fires from the utility
+process under the **existing CoreLive.app** grant (no separate-helper re-grant),
+(b) freeze injection (kill child / simulate hang) auto-degrades within ~3s with no
+window hang, (c) the launch latch blocks re-arm after an unconfirmed prior run.
+
+## Open Risk (for /plan-eng-review + codex to adjudicate)
+
+**TCC attribution of a CGEventTap created inside a utilityProcess.** Entitlements
+solve `.node` _loading_ (disable-library-validation + inherit), but Input-Monitoring
+is a runtime TCC grant keyed by code-signing identity. If macOS attributes the
+helper's tap to a separate helper identity needing its OWN grant, that's a UX
+regression (user must re-grant) and breaks AC#4's "no re-grant" goal.
+
+- **Mitigation to test first:** `disclaim:false` (default) keeps the child under the
+  main app's responsibility; the helper inherits entitlements. Prove empirically on
+  a signed build BEFORE committing to the structural path.
+- **Fallback if infeasible:** keep the tap in main, but add (2) active-probe watchdog
+  - (3) launch latch — closes AC#1/#2 but NOT structural AC#3 (a main-loop wedge
+    stays uncatchable). Would need an explicit documented exception, since Node can't
+    hard-kill a wedged thread cleanly.
+
+## Scope / staging question (for codex)
+
+- **(A) Monolith** — utilityProcess + watchdog + latch in one PR + signed re-prove.
+  Recommended: #125 is the GA gate and AC#3 is structural.
+- **(B) Stage** — PR1 watchdog+latch in-main (AC#1/#2), PR2 utilityProcess (AC#3).
+  Lower risk/PR, but AC#3 can't be deferred past the release tag.
+
+## Acceptance Criteria (from #125, made testable)
+
+1. A tap that stops delivering events / becomes unresponsive is detected ≤~3s and the
+   affected shortcut auto-degrades to chord (or disabled) — no window hang.
+2. A frozen tap never bricks on relaunch; recovery needs no `config.json` hand-edit.
+3. uiohook runs in a utilityProcess/worker so a tap freeze cannot block main at all.
+4. Re-proven on a SIGNED build (TCC grant held by CoreLive.app, freeze auto-degrades,
+   latch blocks re-arm).
+5. Unit + Electron tests for: proxy register/unregister/fire, watchdog miss→degrade,
+   child-gone→degrade, launch-latch arm/confirm/block. No regression to chord path.
+
+## Testing Plan
+
+| Layer             | What                                                                                                                                 | Count |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| Unit              | proxy engine forwards register/unregister; 'fire' invokes callback; watchdog miss-count→degrade; latch arm/confirm/block-on-relaunch | +~8   |
+| Electron (vitest) | fork host smoke (mocked uiohook), child-process-gone→degrade, updateShortcuts re-arm path, cleanup kills child                       | +~5   |
+| Manual signed QA  | AC#4 a/b/c on packaged arm64 (drive packaged app, computer-use)                                                                      | n/a   |
+
+## Rollback
+
+Revert the PR. The engine proxy is additive behind the same `NativeShortcutEngine`
+interface; chord path is untouched. Worst case the lone-modifier feature reverts to
+PR #126 behavior (opt-in, no freeze-safety) — no data risk.
+
+## Effort (rough)
+
+~3h utilityProcess host + proxy engine • ~2h watchdog • ~1.5h launch latch • ~3h
+tests • ~1.5h signed re-prove QA = **~11h**.
+
+## Files Reference
+
+| File                               | Change                                                                                                           |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `electron/uiohookHost.ts`          | NEW — utilityProcess entrypoint: owns uiohook + state machine, parentPort IPC                                    |
+| `electron/uiohookEngine.ts`        | becomes/forks into the main-side PROXY engine (or new `uiohookProxyEngine.ts`); add watchdog ping/pong + degrade |
+| `electron/utils/nativeTapLatch.ts` | NEW — launch latch read/arm/confirm in userData                                                                  |
+| `electron/main.ts:838`             | wire proxy engine + pass a degrade→renderer notifier                                                             |
+| `electron-builder.json`            | ensure `uiohookHost` entry packaged + asarUnpack still covers the native dep                                     |
+| `electron/__tests__/*`             | new specs per Testing Plan                                                                                       |
+
+## Out of Scope
+
+- #124 side-distinct chords (lands after this).
+- Windows/Linux (macOS-only app).
+- Reworking the chord/globalShortcut path.
+
+## Related
+
+- #111 / PR #126 (feature, merged) • #124 (side-distinct chords, after) • libuiohook #23.

--- a/docs/design/125-native-keytap-freeze-safety.md
+++ b/docs/design/125-native-keytap-freeze-safety.md
@@ -9,6 +9,12 @@
 > freeze-safety with a **brick-proof launch latch + powerMonitor/manual re-arm**, with
 > structural isolation (AC#3) recorded as a **documented exception**. The Phase 0
 > evidence and the v1/codex history are preserved below.
+>
+> **codex v2 review (gpt-5.x, high effort): `ready-with-changes`.** Its 9 findings —
+> `setImmediate` (not microtask) + AC#3 "reduced not removed", **fsync** latch (file+dir,
+> fail-safe), `reArm()` **attach-listeners-once**, **inactive** (not "chord") safe mode,
+> `suspend`/`lock-screen` state-clear, **typed** re-arm IPC, scaffold-already-gone — are
+> folded throughout and tagged `(codex #N)`.
 
 ## Context
 
@@ -141,10 +147,11 @@ mechanism is understood, not a mystery to chase.
 > surface `CGEventTapIsEnabled` + maintaining arm64/x64 prebuilds — heavy maintenance
 > for a personal app, guarding the **least severe** mode (feature degrades; app fine).
 >
-> **Covered instead** by the most common real silent-death cause being handled
-> blind (powerMonitor `resume` re-arm), a manual "re-enable" affordance, and the
-> brick-proof latch. **To restore auto-detection, say the word** and I'll scope the
-> `uiohook-napi` fork as its own task. Veto point: the PR.
+> **Covered instead** by the most common real silent-death cause being handled blind
+> (`powerMonitor` `resume`/`unlock-screen` re-arm) plus a manual "re-enable" affordance.
+> The brick-proof latch does **NOT** cover silent-tap (codex #3 — it guards the
+> arming-time brick loop only). **To restore auto-detection, say the word** and I'll scope
+> the `uiohook-napi` fork as its own task. Veto point: the PR.
 
 ---
 
@@ -160,113 +167,150 @@ Structural isolation is **out** (Phase 0). The residual catastrophic-wedge surfa
 tap activity. Harden it:
 
 - The main `keydown`/`keyup` handler does **no heavy synchronous work** — it updates the
-  pressed-set and **schedules** the window toggle (e.g. `setImmediate`/microtask), then
-  returns. Main cannot wedge _through_ the tap.
-- This is cheap and is the entire cost of dropping isolation. **Residual risk is LOW
-  and is documented (AC#3 exception):** the tap runs on its **own native thread** and
-  dispatches via a **non-blocking** threadsafe function (`addon.c:20`), so a tap-thread
-  stall degrades the **feature**, not the app; and the CGEventTap is an **active**
-  listen-and-dispatch tap (`kCGEventTapOptionDefault`), so a slow tap is **disabled by
-  the OS on its own timeout**, it does not freeze the system. With the fire handler
-  non-blocking and the feature opt-in (default binds nothing), the catastrophic mode is
-  bounded without a child process.
+  pressed-set and **schedules** the window toggle via **`setImmediate`** (NOT a microtask —
+  a microtask still drains on the same tick), then returns. This **shrinks**, but does
+  **not eliminate**, the main-thread wedge surface.
+- **Honest scope (codex #1) — AC#3 is RISK-REDUCED, NOT REMOVED.** `setImmediate` only
+  moves the toggle to the next main-loop tick; if `toggleBrainDump()` / window work itself
+  hangs, the app still freezes. We do **not** claim "main cannot wedge through the tap."
+  What IS true and bounds the risk: the tap runs on its **own native thread** dispatching
+  via a **non-blocking** threadsafe function (`addon.c:20`), so a tap-thread stall degrades
+  the **feature**, not the app; the CGEventTap is **active** (`kCGEventTapOptionDefault`),
+  so a slow tap is **disabled by the OS on its own timeout**; the toggle work is light and
+  the feature is opt-in (default binds nothing). The latch (Layer 3) catches an
+  **arming-time** crash/wedge, **not** a later runtime freeze after the marker cleared.
+  Net: the catastrophic mode is **reduced** to a small, opt-in surface without a child
+  process — the documented exception, not a structural fix.
 
 ### Layer 2 — re-arm on the recoverable causes (no silence-detection)
 
 No runtime silence-detector (descoped). Instead, **re-arm the tap on the events that
 actually correlate with a tap going dead**, none of which need detection:
 
-- **`powerMonitor` `resume` → re-arm.** CGEventTaps commonly die across sleep/wake. On
-  `resume`, if a lone-modifier binding is active, **stop + start** the tap (full
-  re-arm). This handles the single most common real-world silent-death cause **blind**,
-  with no false-positive risk (re-arming a healthy tap is a no-op cost).
-- **Manual re-arm affordance.** A user-facing "shortcut not responding? re-enable"
-  control (renderer → IPC → engine) does the same stop+start and re-enables the binding.
-  This is the recovery path for the residual silent-tap case the latch doesn't cover.
+- **`reArm()` must attach listeners ONCE (codex #4 — critical).** Today
+  `ensureTapRunning()` re-attaches `keydown`/`keyup` on **every** `start()`; a naive
+  stop→start re-arm would **duplicate listeners → duplicate fires**. So the engine gains a
+  `listenersAttached` guard (attach exactly once, ever) and a `reArm()` that **resets
+  `pressedKeycodes` + `armedKeycode` before AND after** the `stop()`+`start()` cycle. A
+  unit test asserts **10 reArms still fire exactly once**.
+- **`powerMonitor` events (codex #5).** CGEventTaps commonly die across sleep/wake, and a
+  modifier **held across sleep/lock** can leave a stale pressed-set. So: on **`suspend`**
+  and **`lock-screen`** → clear the pressed-set state; on **`resume`** and
+  **`unlock-screen`** → `reArm()` if a lone-modifier binding is active. (Skip
+  display-change unless QA shows it matters.) Re-arming a healthy tap is a cheap no-op, so
+  no false-positive risk.
+- **Manual re-arm affordance (typed IPC — codex #7).** A user-facing "shortcut not
+  responding? re-enable" control **reuses the existing typed shortcut IPC stack**
+  (`ipc-schemas.ts` + `types/ipc.ts` + `typedHandle` + `preload.ts`), adding
+  `shortcuts-reenable-native-tap` + `shortcuts-get-native-tap-status` — **not** ad-hoc
+  `ipcMain.handle`. It calls the same `reArm()` and re-enables the binding — the recovery
+  path for the residual silent-tap case (NOT covered by the latch; see Layer 3).
 - **libuiohook's built-in re-enable (free, documented).** `input_hook.c:995` already
   calls `CGEventTapEnable(true)` on `kCGEventTapDisabledByTimeout`, so the **timeout**
   sub-case self-heals inside the native layer. **Gap (documented):**
   `kCGEventTapDisabledByUserInput` is **not** handled — but it fires only transiently
-  (secure-input fields) and is covered by the manual re-arm. No code change here; we
-  rely on and document existing behavior.
+  (secure-input fields) and is covered by the manual re-arm. No code change here.
 
 ### Layer 3 — brick-proof launch latch (THE core fix; AC#2)
 
 The real GA blocker is the **relaunch brick loop**. Fix it with a process-stability
 latch in userData (a **SEPARATE file, NOT `config.json`**):
 
-- **Arm:** before starting the tap, write a `native-tap-arming` marker to userData.
-- **Clear:** a short **stability window** after a successful `start()`, if the process
-  is still alive and responsive, clear the marker. (Honest semantics — codex finding #2:
-  this is a **process-stability latch**, not a tap-liveness latch; it exists to break a
-  **wedge/crash brick loop** and is named accordingly. A wedge or crash during/just
-  after arming means the clear-timer never runs → marker persists.)
-- **Block:** on launch, if the marker is **still set** from last run (armed, never
-  confirmed → last launch crashed/wedged during arming), **do NOT re-arm the tap** —
-  start with the lone-modifier binding **inactive (chord-only safe mode)** and notify
-  the renderer ("native shortcut disabled after a failed start — re-enable?"). The user
-  recovers with one click (Layer 2 manual re-arm), which re-arms + clears the latch.
-  **Recovery never needs a `config.json` hand-edit.**
+This is a **process-stability latch** (codex #2), **not** a tap-liveness latch: it breaks
+a **wedge/crash brick loop**, and protects **only** against an arming-time crash/wedge — it
+does **NOT** cover a `start()`-succeeds-but-tap-silent case (codex #3; that is accepted
+degradation, recovered via Layer 2 re-arm). It is its **own** util (`nativeTapLatch.ts`),
+**not** `ConfigManager.saveConfig()` — that uses temp+rename **without fsync**, too weak
+for a launch-safety gate. Durable ordering (codex #2):
 
-"Degrade-to-chord" therefore lives **at the boot/latch layer** (latch trips → start
-chord-only), not in a runtime silence-detector. That is the entire degrade mechanism.
+- **Read** the marker **before any tap start**. A **present or corrupt** marker ⇒ **block**
+  (fail-safe).
+- **Arm:** before `start()`, write temp JSON → **`fsync` the file** → `rename` → **`fsync`
+  the userData dir**. If the arming write fails, **refuse to start** (never arm a tap whose
+  brick-guard didn't persist).
+- **Clear:** a **stability window** after a healthy `start()`, `unlink` the marker (`fsync`
+  the dir so a stale marker can't false-block next launch). A wedge/crash before then ⇒ the
+  clear-timer never runs ⇒ marker persists ⇒ next launch blocks.
+- **Block path:** marker still set ⇒ **do NOT re-arm**; start the lone-modifier in
+  **native-shortcut-inactive safe mode** (codex #6 — a lone modifier has **no chord
+  equivalent**, so this is _inactive_, NOT "degrade to chord"; `registerNativeShortcut()`
+  returning false already leaves it unregistered) + notify the renderer ("native shortcut
+  disabled after a failed start — re-enable?"). One click (Layer 2 manual re-arm) re-arms +
+  clears the latch. **Recovery never needs a `config.json` hand-edit.**
+
+The degrade therefore lives **at the boot/latch layer** (latch trips → start the
+lone-modifier **inactive**), not in a runtime silence-detector.
 
 ### AC#4 — signed re-prove
 
 Rebuild signed+notarized; grant TCC once; verify on the packaged arm64 build: (a) the
 in-main tap fires under the existing CoreLive.app grant (#126 baseline re-confirmed);
-(b) a simulated unconfirmed prior run (pre-set latch marker) starts chord-only +
-notifies, and manual re-enable recovers; (c) `powerMonitor resume` re-arms without a
+(b) a simulated unconfirmed prior run (pre-set latch marker) starts the lone-modifier in
+**inactive safe mode** + notifies, and manual re-enable recovers; (c) `powerMonitor`
+`resume`/`unlock-screen` re-arms (and `suspend`/`lock-screen` clears state) without a
 window hang.
 
 ## Acceptance Criteria (v2, testable)
 
 1. **(descoped — see notice)** Silent-tap auto-detection is **not** in scope. The
-   silent-tap case is covered by powerMonitor re-arm + manual re-enable + the latch.
-2. **A frozen/crashed tap never bricks on relaunch** — an unconfirmed prior arming
-   starts chord-only safe mode; recovery is one click, no `config.json` hand-edit.
-3. **(documented exception)** The tap runs **in main**, not isolated. Mode #2
-   (catastrophic main wedge) is **bounded** by a non-blocking fire handler + the OS
-   active-tap timeout + opt-in default, and the residual risk is documented as LOW —
-   **not** structurally removed. _Phase 0 proved isolation non-viable on macOS._
-4. **`powerMonitor resume` re-arms** the tap when a lone-modifier binding is active,
-   with no window hang and no false-degrade.
+   silent-tap case (`start()` succeeds, tap goes dead) is **accepted degradation**,
+   recovered via `powerMonitor` re-arm + manual re-enable **only** — the latch does NOT
+   cover it (codex #3).
+2. **A frozen/crashed tap never bricks on relaunch** — an unconfirmed prior arming starts
+   the lone-modifier in **native-shortcut-inactive safe mode** (NOT a chord — codex #6);
+   recovery is one click, no `config.json` hand-edit. Latch writes are fsync-durable and
+   fail-safe (corrupt/missing-on-arm ⇒ block).
+3. **(documented exception — RISK-REDUCED, not removed; codex #1)** The tap runs **in
+   main**, not isolated. Mode #2 (catastrophic main wedge) is **reduced** by a
+   `setImmediate` fire handler + the OS active-tap timeout + opt-in default, but is **not**
+   structurally removed — a hang inside the toggle work itself still freezes main, and the
+   latch only catches an arming-time wedge. _Phase 0 proved isolation non-viable on macOS._
+4. **`reArm()` is listener-safe** (attach-once guard; 10 reArms fire once — codex #4) and
+   fires on `resume`/`unlock-screen`; `suspend`/`lock-screen` clears the pressed-set — no
+   window hang, no false-degrade (codex #5).
 5. Re-proven on a **SIGNED** build (existing grant honored; latch blocks re-arm after an
-   unconfirmed prior run; manual + resume re-arm work).
-6. Unit + Electron tests: latch arm/clear/block-on-relaunch; powerMonitor-resume →
-   re-arm; manual re-arm IPC → re-arm + re-enable; fire handler is non-blocking
-   (schedules, doesn't block). **No regression to the chord path.**
+   unconfirmed prior run; manual + power-event re-arm work).
+6. Unit + Electron tests: latch arm/clear/block-on-relaunch + **corrupt-marker-blocks**;
+   **reArm-attaches-listeners-once (10× → 1 fire)**; power-event re-arm/clear; manual
+   re-arm IPC → re-arm + re-enable; fire handler schedules via `setImmediate` (no
+   synchronous heavy work). **No regression to the chord path.**
 
 ## Testing Plan
 
-| Layer             | What                                                                                                                                                            | Count |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| Unit              | latch arm writes marker; stability-window clears it; marker-present-on-boot → engine NOT armed + binding inactive + notify; manual re-arm path re-arms + clears | +~7   |
-| Electron (vitest) | powerMonitor `resume` → engine `stop()`+`start()`; fire handler schedules (no synchronous heavy work); packaged `.node` real-load smoke; cleanup tears down     | +~5   |
-| Manual signed QA  | AC#4 a/b/c on packaged arm64 (drive packaged app, computer-use): #126 baseline re-fires; pre-set latch → chord-only + notify; resume re-arm                     | n/a   |
+| Layer                       | What                                                                                                                                                                                                                                                             | Count |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| Unit                        | latch arm(fsync)/clear/block-on-relaunch + **corrupt/missing marker ⇒ block**; **reArm attaches listeners ONCE → 10 reArms fire exactly once**; pressed-set reset on reArm; manual re-arm re-arms + clears                                                       | +~9   |
+| Electron (vitest)           | `resume`/`unlock-screen` → `reArm()`; `suspend`/`lock-screen` → clear state; fire handler schedules via `setImmediate`; packaged `.node` real-load smoke; cleanup tears down                                                                                     | +~6   |
+| Manual signed QA (codex #8) | packaged arm64 (drive app + computer-use, **real physical keys**): #126 baseline re-fires; **20 manual reArms → still fires once, no dup**; **sleep/wake + lock/unlock** re-arm; **latch-preseed boot → inactive safe mode + notify**, manual re-enable recovers | n/a   |
 
-> **TEST IMPLICATION:** every latch/re-arm test drives a **fake engine** (inject the
-> state — "marker present", "resume fired") — **never synthetic real keys.** Synthetic
-> key injection cannot exercise the live tap on a Karabiner machine (Phase 0 proved 0
-> fires), so it is invalid as a test vehicle. Real keys are for the signed manual QA only.
+> **TEST IMPLICATION:** every unit/electron latch/re-arm test drives a **fake engine**
+> (inject the state — "marker present", "resume fired", "10× reArm") — **never synthetic
+> keys.** Synthetic injection cannot exercise the live tap on a Karabiner machine (Phase 0:
+> at most 1-then-silent), so it is invalid as a unit vehicle. **Real physical keys are for
+> the signed manual QA only** — and fake tests alone are insufficient (codex #8): they
+> can't prove real `uiohook-napi` start→stop→start, listener duplication, TSFN cleanup, or
+> wake/unlock, hence the signed-QA row.
 
 ## Build / Packaging
 
-- **No new entry points.** v1's `utilityProcess` child host
-  (`electron/uiohookHost.ts`), the `electron.vite.config.ts` `uiohookHost` input, and
-  the Phase 0 probe (`electron/utils/tccProbe.ts` + the `main.ts` probe hook) are
-  **removed** in implementation — they were Phase 0 scaffolding and their finding
-  (TCC PASS) is now durable in this doc.
+- **No new entry points.** v1's Phase 0 scaffolding (`electron/uiohookHost.ts`,
+  `electron/utils/tccProbe.ts`, the `electron.vite.config.ts` `uiohookHost` input, the
+  `main.ts` probe hook) was **already reverted** before this doc's commit (codex #9) — so
+  the implementation step is just **verify no scaffold remains** (`git grep -i 'tccProbe\|uiohookHost'`
+  ⇒ empty). Its finding (TCC PASS) is durable in this doc.
 - The native `.node` stays `asarUnpack`'d and is loaded by the existing in-main loader
   (`loadUiohook.ts`); the packaged real-load smoke test guards the asar-leaf-drop class.
 
 ## Sequencing
 
-In-main is **smaller** than v1 (no child, no IPC, no ready-handshake, no gen tokens, no
-proxy). Single staged PR: (1) remove Phase 0 scaffolding; (2) fire-and-forget handler +
-latch; (3) powerMonitor + manual re-arm; (4) tests. A PR that ships before the signed
-AC#4 proof is **risk-reduction, NOT the closed GA gate** — the GA gate closes only on
-the signed re-prove. **Do not push a `v*` release tag until #125 lands + signed re-prove.**
+In-main is **smaller** than v1 (no child, no IPC ready-handshake, no gen tokens, no
+proxy). Single staged PR: (1) verify Phase 0 scaffold gone (already reverted); (2)
+`setImmediate` fire handler + `listenersAttached` guard + `reArm()` + fsync latch; (3)
+`powerMonitor` suspend/lock/resume/unlock + typed manual-re-arm IPC; (4) tests. A PR that
+ships before the signed AC#4 proof is **risk-reduction, NOT the closed GA gate** — the GA
+gate closes only on the signed re-prove. \*_Do not push a `v_` release tag until #125 lands
+
+- signed re-prove.\*\*
 
 ## Rollback
 
@@ -282,16 +326,15 @@ powerMonitor + manual re-arm ~1.5h • tests ~2.5h • signed re-prove ~1.5h = *
 
 ## Files Reference
 
-| File                               | Change                                                                                                         |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `electron/uiohookEngine.ts`        | fire-and-forget keydown/keyup handler; expose a `reArm()` (stop+start); latch arm/clear around `start()`       |
-| `electron/utils/nativeTapLatch.ts` | **NEW** — process-stability launch latch read/arm/clear in userData (separate file, NOT `config.json`)         |
-| `electron/ShortcutManager.ts`      | boot: if latch blocks, start lone-modifier inactive + notify; manual-re-arm intake re-enables + clears latch   |
-| `electron/main.ts`                 | `powerMonitor.on('resume')` → re-arm; remove the Phase 0 probe hook; wire manual re-arm IPC + degrade→renderer |
-| `electron/uiohookHost.ts`          | **DELETE** — v1 utilityProcess child host (Phase 0 scaffolding)                                                |
-| `electron/utils/tccProbe.ts`       | **DELETE** — Phase 0 gated probe launcher                                                                      |
-| `electron.vite.config.ts`          | **REVERT** — remove the `uiohookHost` main input                                                               |
-| `electron/__tests__/*`             | new specs per Testing Plan (fake engine; no synthetic keys)                                                    |
+| File                                                           | Change                                                                                                                                                                                |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `electron/uiohookEngine.ts`                                    | `setImmediate` fire-and-forget keydown/keyup; **`listenersAttached` attach-once guard**; `reArm()` (stop+start, **reset pressed-set before+after**); latch arm/clear around `start()` |
+| `electron/utils/nativeTapLatch.ts`                             | **NEW** — process-stability latch (separate userData file, NOT `config.json`); **fsync file + dir**, fail-safe (corrupt/missing ⇒ block)                                              |
+| `electron/ShortcutManager.ts`                                  | boot: if latch blocks, start lone-modifier **inactive** + notify; manual-re-arm intake re-enables + clears latch                                                                      |
+| `electron/main.ts`                                             | `powerMonitor`: `suspend`/`lock-screen` → clear state, `resume`/`unlock-screen` → `reArm()`; wire manual re-arm IPC + degrade→renderer                                                |
+| `ipc-schemas.ts` · `types/ipc.ts` · `preload.ts`               | **typed IPC** (codex #7): `shortcuts-reenable-native-tap` + `shortcuts-get-native-tap-status` (reuse `typedHandle`, not ad-hoc `ipcMain`)                                             |
+| Phase 0 scaffold (`uiohookHost.ts`, `tccProbe.ts`, vite input) | **already reverted** (codex #9) — implementation just verifies none remains                                                                                                           |
+| `electron/__tests__/*`                                         | new specs per Testing Plan (fake engine; no synthetic keys)                                                                                                                           |
 
 ## Out of Scope
 

--- a/docs/design/125-native-keytap-freeze-safety.md
+++ b/docs/design/125-native-keytap-freeze-safety.md
@@ -103,10 +103,22 @@ is a **known macOS limitation**: a `CGEventTap` in a **faceless helper / utility
 with no `NSApplication`/Cocoa main run loop** stops delivering events beyond the
 initial setup (confirmed via deepwiki against the libuiohook/CGEventTap model).
 libuiohook runs its own `CFRunLoopRun()` on a worker pthread, but that is **insufficient
-in a non-GUI helper**. Synthetic key injection was a dead test vehicle on this machine
-(Karabiner's virtual-HID layer transforms synthetic CGEvents — System Events `key code`
-and computer-use `key` both gave 0 fires); the verdict rests on **real physical keys**
-against the running signed probe.
+in a non-GUI helper**. Synthetic key injection is an unreliable delivery vehicle on this
+machine (Karabiner's virtual-HID layer transforms synthetic CGEvents), so it cannot prove
+delivery _works_ — but it reproduces the same **1-then-silent ceiling**, which is the
+point. The verdict that delivery FAILS holds for **real physical keys** too.
+
+**Re-confirmed (2026-06-26, fresh signed re-run).** Relaunched the same signed
+`com.corelive.app` build (`codesign`: `Developer ID Application: Ryota Murakami
+(895TNMSCMH)`, hardened runtime; `app.asar` built 00:55, no builder running). The probe
+forked the `utilityProcess` child, which loaded the native `.node` and posted
+`{type:'started'}`. **15 key events (10×Right, 5×Escape) → exactly ONE `fire`
+(keycode 57421), then silence for the remaining 14** — the 1-then-silent signature
+reproduced. System Settings → Input Monitoring again listed **only `CoreLive.app`**
+(enabled), **no new helper entry** (full list: CoreLive, Cursor, Discord, three Karabiner
+items, KeyCue). So **TCC attribution = PASS** (independently re-verified) and **delivery =
+NOT VIABLE** both hold across two independent runs (original real-key run + this signed
+re-run). The pivot's foundation is solid.
 
 **Decision (FAIL branch, pre-authorized in v1):** abandon `utilityProcess` isolation;
 **keep the tap in main** (the proven #126 baseline) and deliver freeze-safety via the

--- a/docs/design/125-native-keytap-freeze-safety.md
+++ b/docs/design/125-native-keytap-freeze-safety.md
@@ -1,6 +1,14 @@
 # Design Doc — #125 Freeze-safety for the native key-tap (GA gate)
 
 > Design doc for issue **#125**. Follow-up to #111 / PR #126 (merged `eab43fd`).
+> **v2 — rewritten after the Phase 0 probe.** v1 proposed isolating the tap in a
+> `utilityProcess` child; **Phase 0 proved that path non-viable on macOS** (TCC gate
+> PASSED, but a CGEventTap in a faceless helper delivers exactly one event then goes
+> silent — a known macOS run-loop limitation). The plan now takes the **pre-authorized
+> in-main FAIL branch**: keep the tap in main (the proven #126 baseline), and buy
+> freeze-safety with a **brick-proof launch latch + powerMonitor/manual re-arm**, with
+> structural isolation (AC#3) recorded as a **documented exception**. The Phase 0
+> evidence and the v1/codex history are preserved below.
 
 ## Context
 
@@ -12,143 +20,277 @@ catchable conditions — native module load-fail (`isAvailable()===false`) or
 `register()` returning false.** A tap that loads, `start()`s, then _freezes or goes
 silent_ is neither. libuiohook issue #23 ("1 event then frozen") is exactly this
 mode on some setups. Because a lone-modifier bind re-arms the tap on every launch, a
-user who freezes once re-freezes every relaunch — bricked, no in-app recovery.
-Blast radius is bounded today only by opt-in (default config binds no lone-modifier).
+user who freezes once re-freezes every relaunch — **bricked, no in-app recovery.**
+That brick loop is the real GA blocker. Blast radius is bounded today only by opt-in
+(default config binds no lone-modifier).
+
+## What the codex review changed (v1 — preserved)
+
+codex (gpt-5.5, high) pressure-tested the v1 draft and returned **needs-rethink**.
+The load-bearing corrections, each **verified against source** before adoption, still
+hold and shaped v2:
+
+1. **Ping/pong does NOT detect a silent tap (P1).** A main→child ping/pong proves the
+   **child process** is alive, not the **tap**. Verified in
+   `node_modules/uiohook-napi/dist/index.js`: the `EventType` enum forwarded to JS is
+   **only** key/mouse (4–11). libuiohook's `EVENT_HOOK_ENABLED`(1)/`DISABLED`(2) are
+   **not** surfaced to JS, and `kCGEventTapDisabledByTimeout` is re-enabled+logged
+   inside libuiohook, never delivered up. **There is no clean typed signal for "tap
+   went silent."** This is _why_ silent-tap auto-detection is descoped (below), and it
+   applies identically whether the tap runs in a child or in main.
+2. **TCC attribution is a GATE, not a footnote (P1).** Whether the tap process rides
+   CoreLive.app's existing Input-Monitoring grant decided whether the utilityProcess
+   path was viable → it became **Phase 0**, blocking. **Result below.**
+3. **`register()` is synchronous (P1).** In-main this is a non-issue — the engine is
+   already synchronous (no child handshake to reconcile). The async-bridge complexity
+   v1 carried is **deleted** in v2.
+4. **There is no runtime degrade-to-chord path today (P1).** Still true; v2 defines an
+   explicit degrade — but at the **boot/latch layer**, not a runtime silence-detector.
+5. **Smaller (P2/P3):** main can still wedge via the `fire` callback (kept as a real
+   hardening — fire-and-forget handler); watchdog false-positives; build wiring;
+   prove-out must be redone on a signed build. Folded below.
 
 ## Current State (verified)
 
-| Element        | Location                                                                  | Behavior                                                                                                                                                                                                                                                        |
-| -------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Engine factory | `electron/uiohookEngine.ts`                                               | Lazy `start()` on first bind, `stop()` on last unbind; "pressed alone" press/release state machine; `ensureTapRunning()` returns false if `start()` throws → `register()` rolls back → degrade. **No detection of a tap that started then went silent/wedged.** |
-| Loader         | `electron/utils/loadUiohook.ts`                                           | `require('uiohook-napi').uIOhook` (CJS runtime require).                                                                                                                                                                                                        |
-| Seam           | `electron/main.ts:838` `loadSystemIntegrationStack`                       | `const nativeShortcutEngine = createUiohookShortcutEngine(loadUiohook)` → `new ShortcutManagerCls(win, notif, config, nativeShortcutEngine)`. **This is the one injection point to wrap.**                                                                      |
-| Routing        | `ShortcutManager.registerShortcut` (477) → `registerNativeShortcut` (566) | `isNativeBinding()` routes `lone-modifier:*` to `nativeEngine.register()`; degrades when `isAvailable()` false or `register()` false. `updateShortcuts` (984) re-registers on settings change; `initialize` (207) at startup; `cleanup` (1177) tears down.      |
-| Native module  | `uiohook-napi@1.5.5`                                                      | `start()` → `lib.start(handler)`. libuiohook CGEventTap runs on a **native background thread**; events fire back onto the **main JS thread** via `EventEmitter.emit('keydown'/'keyup')`. Singleton `uIOhook`.                                                   |
-| Packaging      | `electron-builder.json`                                                   | `asarUnpack` includes `uiohook-napi/**` + `node-gyp-build/**`; `node-gyp-build` is a **direct** dep (asar leaf-drop guarded).                                                                                                                                   |
-| Signing        | `build/entitlements.mac.plist`                                            | `hardenedRuntime:true`, `disable-library-validation:true`, `entitlementsInherit` → **a utilityProcess child can load the `.node` prebuild.** TCC (Input-Monitoring) is a runtime grant, NOT an entitlement → see Open Risk.                                     |
+| Element        | Location                                                                  | Behavior                                                                                                                                                                                                                                                                           |
+| -------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Engine factory | `electron/uiohookEngine.ts`                                               | Lazy `start()` on first bind, `stop()` on last unbind; "pressed alone" press/release state machine; `ensureTapRunning()` returns false if `start()` throws → `register()` rolls back → degrade. **No detection of a tap that started then went silent/wedged.**                    |
+| Loader         | `electron/utils/loadUiohook.ts`                                           | `require('uiohook-napi').uIOhook` (CJS runtime require).                                                                                                                                                                                                                           |
+| Seam           | `electron/main.ts:838` `loadSystemIntegrationStack`                       | `const nativeShortcutEngine = createUiohookShortcutEngine(loadUiohook)` → `new ShortcutManagerCls(win, notif, config, nativeShortcutEngine)`. **This is the one injection point to wrap.**                                                                                         |
+| Routing        | `ShortcutManager.registerShortcut` (477) → `registerNativeShortcut` (566) | `isNativeBinding()` routes `lone-modifier:*` to `nativeEngine.register()` (sync `boolean`); degrades only when `isAvailable()` false or `register()` false. `updateShortcuts` (984) re-registers; `initialize` (207) at startup; `cleanup` (1177) tears down.                      |
+| Native module  | `uiohook-napi@1.5.5`                                                      | `start()` → `lib.start(handler)`. CGEventTap on a **native bg thread**; events cross to the **main JS thread** via a **non-blocking** napi_threadsafe_function (`src/lib/addon.c:20`, `napi_tsfn_nonblocking`). Singleton `uIOhook`. **No hook-disabled signal to JS** (verified). |
+| Packaging      | `electron-builder.json`                                                   | `asarUnpack` includes `uiohook-napi/**` + `node-gyp-build/**`; `node-gyp-build` is a **direct** dep (asar leaf-drop guarded).                                                                                                                                                      |
+| Signing        | `build/entitlements.mac.plist`                                            | `hardenedRuntime:true`, `disable-library-validation:true`. TCC (Input-Monitoring) is a runtime grant, NOT an entitlement → was **Phase 0**.                                                                                                                                        |
 
-## Root cause — why a heartbeat-in-main is insufficient
+## Root cause — why a heartbeat-in-main is insufficient (verified)
 
 Two distinct freeze modes, both verified against the threading model:
 
 1. **Tap thread goes silent** (libuiohook #23 / OS disables the tap under load):
    main is NOT blocked; keydown/keyup just stop arriving. A passive event-heartbeat
-   **cannot distinguish "frozen tap" from "idle user"** — both produce zero events.
-2. **Main JS loop wedges** (dispatch path or a callback blocks the loop): hangs ALL
-   windows. A watchdog timer living **on the same main loop cannot detect its own
-   freeze** — it's frozen too.
+   **cannot distinguish "frozen tap" from "idle user"** — both produce zero events,
+   and (verified) uiohook-napi exposes no hook-disabled signal. This is the
+   **degraded-feature** mode (shortcut stops; the app is otherwise fine).
+2. **Main JS loop wedges** (a `fire` callback blocks the loop): hangs ALL windows. A
+   watchdog timer living **on the same main loop cannot detect its own freeze**. This
+   is the **catastrophic** mode.
 
-Only an **external observer** (a separate process) closes both holes. This confirms
-the issue's stated preference: utilityProcess isolation is the structural fix, not a
-nice-to-have.
+v1 proposed `utilityProcess` isolation to structurally remove mode #2. **Phase 0
+proved that path non-viable** (below), so v2 _bounds_ mode #2 instead of removing it —
+honestly scoped as **low residual risk** (see AC#3 exception), and _bounds_ mode #1
+with brick-proofing + recovery rather than claiming to auto-detect it.
 
-## Proposed Change — three composed layers (not either/or)
+---
 
-### Layer 1 — utilityProcess isolation (structural; AC#3)
+## ✅ Phase 0 RESULT — TCC: PASS · utilityProcess isolation: NOT VIABLE (decided)
 
-Move the tap into a `utilityProcess.fork`'d child (`electron/uiohookHost.ts`
-entrypoint, built by electron-vite). The child owns libuiohook + the "pressed alone"
-state machine and posts `{type:'fire', id}` to main over `parentPort`. The main-side
-engine becomes a **thin proxy** implementing the SAME `NativeShortcutEngine`
-interface (so `ShortcutManager` is untouched): `register/unregister` forward to the
-child via `postMessage`; on `'fire'` it invokes the stored callback on the main loop.
-A freeze in the child's tap thread OR its whole loop **cannot block main's windows**.
+A gated (`CORELIVE_TCC_PROBE=1`) probe forked a `uiohook-napi` tap into a
+`utilityProcess` child on a **signed, packaged arm64 build** and answered the two
+open questions:
 
-### Layer 2 — watchdog (detection + auto-degrade; AC#1)
+**(a) TCC attribution — ✅ PASS.** The child's CGEventTap rode **CoreLive.app's
+existing Input-Monitoring grant**. System Settings → Privacy & Security → Input
+Monitoring listed **only `CoreLive.app`** (toggle ON); **no** `CoreLive Helper` /
+`corelive-uiohook` / `Electron` entry appeared, and no new TCC prompt fired. The child
+runs as a standard NodeService helper under the app bundle and inherits its TCC
+responsibility. The native `.node` prebuild loaded in the child (no `load-error`).
+**The make-or-break gate passed** — TCC was never the blocker.
 
-Main pings the child every ~1s; child ponds. Miss N consecutive pongs (~3s budget)
-OR `child-process-gone` fires → declare the tap dead: auto-degrade affected
-lone-modifier binds to chord (or disable), notify renderer. Bounded respawn (e.g. 1
-restart); if it re-freezes, stay degraded. The ping/pong is the **active liveness
-probe** that mode-1 (silent tap) needs.
+**(b) Delivery reliability — ❌ NOT VIABLE.** The child's tap delivered **exactly ONE
+key event, then went permanently silent** (child stayed alive at ~0% CPU; real
+physical keypresses produced zero further fires). This is **not** a fixable bug — it
+is a **known macOS limitation**: a `CGEventTap` in a **faceless helper / utilityProcess
+with no `NSApplication`/Cocoa main run loop** stops delivering events beyond the
+initial setup (confirmed via deepwiki against the libuiohook/CGEventTap model).
+libuiohook runs its own `CFRunLoopRun()` on a worker pthread, but that is **insufficient
+in a non-GUI helper**. Synthetic key injection was a dead test vehicle on this machine
+(Karabiner's virtual-HID layer transforms synthetic CGEvents — System Events `key code`
+and computer-use `key` both gave 0 fires); the verdict rests on **real physical keys**
+against the running signed probe.
 
-### Layer 3 — brick-proof launch latch (AC#2)
+**Decision (FAIL branch, pre-authorized in v1):** abandon `utilityProcess` isolation;
+**keep the tap in main** (the proven #126 baseline) and deliver freeze-safety via the
+launch latch + powerMonitor/manual re-arm. **AC#3 (structural isolation) becomes a
+documented exception** — see below. This pivot is well-supported: empirical
+(one-then-silent on a signed build) + deepwiki (known limitation) + the FFI/run-loop
+mechanism is understood, not a mystery to chase.
 
-Before arming the tap on launch, write a small `native-tap-arming` marker to
-userData (a SEPARATE file, NOT `config.json`, so a wedge can't corrupt config).
-Clear it once the child proves liveness (first pong / first delivered event). On
-launch, if the marker is still set from the previous run (= last launch armed and
-never confirmed → it froze), **do NOT re-arm**: start the lone-modifier bind
-disabled/probationary and surface an in-app notice with one-click re-enable.
-Recovery never requires hand-editing `config.json`.
+---
+
+> ## 🔻 DESCOPE NOTICE — AC#1 silent-tap auto-detection (decided, reversible)
+>
+> **Original AC#1** ("a tap that stops delivering events is auto-detected ≤3s and
+> degrades to chord") is **descoped**. There is no clean signal for "tap went silent"
+> (codex finding #1, verified), and the two ways to synthesize one are both dead:
+> a **synthetic self-probe** injects fake keystrokes into the user's focused app
+> (dangerous UX) **and** is unreliable on a Karabiner machine (Phase 0 proved synthetic
+> injection gives 0 fires); a **silence timer** cannot tell "frozen tap" from "idle
+> user." Cleanly detecting a silent tap would require **forking `uiohook-napi`** to
+> surface `CGEventTapIsEnabled` + maintaining arm64/x64 prebuilds — heavy maintenance
+> for a personal app, guarding the **least severe** mode (feature degrades; app fine).
+>
+> **Covered instead** by the most common real silent-death cause being handled
+> blind (powerMonitor `resume` re-arm), a manual "re-enable" affordance, and the
+> brick-proof latch. **To restore auto-detection, say the word** and I'll scope the
+> `uiohook-napi` fork as its own task. Veto point: the PR.
+
+---
+
+## Proposed Change — in-main freeze-safety (3 layers, no child)
+
+The engine **stays in main** behind the existing `NativeShortcutEngine` interface, so
+`ShortcutManager` is untouched at the call site. Three additive layers:
+
+### Layer 1 — fire-and-forget dispatch (bound the catastrophic mode; AC#3 exception)
+
+Structural isolation is **out** (Phase 0). The residual catastrophic-wedge surface
+(mode #2) is **the `fire` callback on the main loop** — the one place main can block on
+tap activity. Harden it:
+
+- The main `keydown`/`keyup` handler does **no heavy synchronous work** — it updates the
+  pressed-set and **schedules** the window toggle (e.g. `setImmediate`/microtask), then
+  returns. Main cannot wedge _through_ the tap.
+- This is cheap and is the entire cost of dropping isolation. **Residual risk is LOW
+  and is documented (AC#3 exception):** the tap runs on its **own native thread** and
+  dispatches via a **non-blocking** threadsafe function (`addon.c:20`), so a tap-thread
+  stall degrades the **feature**, not the app; and the CGEventTap is an **active**
+  listen-and-dispatch tap (`kCGEventTapOptionDefault`), so a slow tap is **disabled by
+  the OS on its own timeout**, it does not freeze the system. With the fire handler
+  non-blocking and the feature opt-in (default binds nothing), the catastrophic mode is
+  bounded without a child process.
+
+### Layer 2 — re-arm on the recoverable causes (no silence-detection)
+
+No runtime silence-detector (descoped). Instead, **re-arm the tap on the events that
+actually correlate with a tap going dead**, none of which need detection:
+
+- **`powerMonitor` `resume` → re-arm.** CGEventTaps commonly die across sleep/wake. On
+  `resume`, if a lone-modifier binding is active, **stop + start** the tap (full
+  re-arm). This handles the single most common real-world silent-death cause **blind**,
+  with no false-positive risk (re-arming a healthy tap is a no-op cost).
+- **Manual re-arm affordance.** A user-facing "shortcut not responding? re-enable"
+  control (renderer → IPC → engine) does the same stop+start and re-enables the binding.
+  This is the recovery path for the residual silent-tap case the latch doesn't cover.
+- **libuiohook's built-in re-enable (free, documented).** `input_hook.c:995` already
+  calls `CGEventTapEnable(true)` on `kCGEventTapDisabledByTimeout`, so the **timeout**
+  sub-case self-heals inside the native layer. **Gap (documented):**
+  `kCGEventTapDisabledByUserInput` is **not** handled — but it fires only transiently
+  (secure-input fields) and is covered by the manual re-arm. No code change here; we
+  rely on and document existing behavior.
+
+### Layer 3 — brick-proof launch latch (THE core fix; AC#2)
+
+The real GA blocker is the **relaunch brick loop**. Fix it with a process-stability
+latch in userData (a **SEPARATE file, NOT `config.json`**):
+
+- **Arm:** before starting the tap, write a `native-tap-arming` marker to userData.
+- **Clear:** a short **stability window** after a successful `start()`, if the process
+  is still alive and responsive, clear the marker. (Honest semantics — codex finding #2:
+  this is a **process-stability latch**, not a tap-liveness latch; it exists to break a
+  **wedge/crash brick loop** and is named accordingly. A wedge or crash during/just
+  after arming means the clear-timer never runs → marker persists.)
+- **Block:** on launch, if the marker is **still set** from last run (armed, never
+  confirmed → last launch crashed/wedged during arming), **do NOT re-arm the tap** —
+  start with the lone-modifier binding **inactive (chord-only safe mode)** and notify
+  the renderer ("native shortcut disabled after a failed start — re-enable?"). The user
+  recovers with one click (Layer 2 manual re-arm), which re-arms + clears the latch.
+  **Recovery never needs a `config.json` hand-edit.**
+
+"Degrade-to-chord" therefore lives **at the boot/latch layer** (latch trips → start
+chord-only), not in a runtime silence-detector. That is the entire degrade mechanism.
 
 ### AC#4 — signed re-prove
 
-Rebuild signed+notarized; grant TCC once; verify (a) the tap fires from the utility
-process under the **existing CoreLive.app** grant (no separate-helper re-grant),
-(b) freeze injection (kill child / simulate hang) auto-degrades within ~3s with no
-window hang, (c) the launch latch blocks re-arm after an unconfirmed prior run.
+Rebuild signed+notarized; grant TCC once; verify on the packaged arm64 build: (a) the
+in-main tap fires under the existing CoreLive.app grant (#126 baseline re-confirmed);
+(b) a simulated unconfirmed prior run (pre-set latch marker) starts chord-only +
+notifies, and manual re-enable recovers; (c) `powerMonitor resume` re-arms without a
+window hang.
 
-## Open Risk (for /plan-eng-review + codex to adjudicate)
+## Acceptance Criteria (v2, testable)
 
-**TCC attribution of a CGEventTap created inside a utilityProcess.** Entitlements
-solve `.node` _loading_ (disable-library-validation + inherit), but Input-Monitoring
-is a runtime TCC grant keyed by code-signing identity. If macOS attributes the
-helper's tap to a separate helper identity needing its OWN grant, that's a UX
-regression (user must re-grant) and breaks AC#4's "no re-grant" goal.
-
-- **Mitigation to test first:** `disclaim:false` (default) keeps the child under the
-  main app's responsibility; the helper inherits entitlements. Prove empirically on
-  a signed build BEFORE committing to the structural path.
-- **Fallback if infeasible:** keep the tap in main, but add (2) active-probe watchdog
-  - (3) launch latch — closes AC#1/#2 but NOT structural AC#3 (a main-loop wedge
-    stays uncatchable). Would need an explicit documented exception, since Node can't
-    hard-kill a wedged thread cleanly.
-
-## Scope / staging question (for codex)
-
-- **(A) Monolith** — utilityProcess + watchdog + latch in one PR + signed re-prove.
-  Recommended: #125 is the GA gate and AC#3 is structural.
-- **(B) Stage** — PR1 watchdog+latch in-main (AC#1/#2), PR2 utilityProcess (AC#3).
-  Lower risk/PR, but AC#3 can't be deferred past the release tag.
-
-## Acceptance Criteria (from #125, made testable)
-
-1. A tap that stops delivering events / becomes unresponsive is detected ≤~3s and the
-   affected shortcut auto-degrades to chord (or disabled) — no window hang.
-2. A frozen tap never bricks on relaunch; recovery needs no `config.json` hand-edit.
-3. uiohook runs in a utilityProcess/worker so a tap freeze cannot block main at all.
-4. Re-proven on a SIGNED build (TCC grant held by CoreLive.app, freeze auto-degrades,
-   latch blocks re-arm).
-5. Unit + Electron tests for: proxy register/unregister/fire, watchdog miss→degrade,
-   child-gone→degrade, launch-latch arm/confirm/block. No regression to chord path.
+1. **(descoped — see notice)** Silent-tap auto-detection is **not** in scope. The
+   silent-tap case is covered by powerMonitor re-arm + manual re-enable + the latch.
+2. **A frozen/crashed tap never bricks on relaunch** — an unconfirmed prior arming
+   starts chord-only safe mode; recovery is one click, no `config.json` hand-edit.
+3. **(documented exception)** The tap runs **in main**, not isolated. Mode #2
+   (catastrophic main wedge) is **bounded** by a non-blocking fire handler + the OS
+   active-tap timeout + opt-in default, and the residual risk is documented as LOW —
+   **not** structurally removed. _Phase 0 proved isolation non-viable on macOS._
+4. **`powerMonitor resume` re-arms** the tap when a lone-modifier binding is active,
+   with no window hang and no false-degrade.
+5. Re-proven on a **SIGNED** build (existing grant honored; latch blocks re-arm after an
+   unconfirmed prior run; manual + resume re-arm work).
+6. Unit + Electron tests: latch arm/clear/block-on-relaunch; powerMonitor-resume →
+   re-arm; manual re-arm IPC → re-arm + re-enable; fire handler is non-blocking
+   (schedules, doesn't block). **No regression to the chord path.**
 
 ## Testing Plan
 
-| Layer             | What                                                                                                                                 | Count |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----- |
-| Unit              | proxy engine forwards register/unregister; 'fire' invokes callback; watchdog miss-count→degrade; latch arm/confirm/block-on-relaunch | +~8   |
-| Electron (vitest) | fork host smoke (mocked uiohook), child-process-gone→degrade, updateShortcuts re-arm path, cleanup kills child                       | +~5   |
-| Manual signed QA  | AC#4 a/b/c on packaged arm64 (drive packaged app, computer-use)                                                                      | n/a   |
+| Layer             | What                                                                                                                                                            | Count |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| Unit              | latch arm writes marker; stability-window clears it; marker-present-on-boot → engine NOT armed + binding inactive + notify; manual re-arm path re-arms + clears | +~7   |
+| Electron (vitest) | powerMonitor `resume` → engine `stop()`+`start()`; fire handler schedules (no synchronous heavy work); packaged `.node` real-load smoke; cleanup tears down     | +~5   |
+| Manual signed QA  | AC#4 a/b/c on packaged arm64 (drive packaged app, computer-use): #126 baseline re-fires; pre-set latch → chord-only + notify; resume re-arm                     | n/a   |
+
+> **TEST IMPLICATION:** every latch/re-arm test drives a **fake engine** (inject the
+> state — "marker present", "resume fired") — **never synthetic real keys.** Synthetic
+> key injection cannot exercise the live tap on a Karabiner machine (Phase 0 proved 0
+> fires), so it is invalid as a test vehicle. Real keys are for the signed manual QA only.
+
+## Build / Packaging
+
+- **No new entry points.** v1's `utilityProcess` child host
+  (`electron/uiohookHost.ts`), the `electron.vite.config.ts` `uiohookHost` input, and
+  the Phase 0 probe (`electron/utils/tccProbe.ts` + the `main.ts` probe hook) are
+  **removed** in implementation — they were Phase 0 scaffolding and their finding
+  (TCC PASS) is now durable in this doc.
+- The native `.node` stays `asarUnpack`'d and is loaded by the existing in-main loader
+  (`loadUiohook.ts`); the packaged real-load smoke test guards the asar-leaf-drop class.
+
+## Sequencing
+
+In-main is **smaller** than v1 (no child, no IPC, no ready-handshake, no gen tokens, no
+proxy). Single staged PR: (1) remove Phase 0 scaffolding; (2) fire-and-forget handler +
+latch; (3) powerMonitor + manual re-arm; (4) tests. A PR that ships before the signed
+AC#4 proof is **risk-reduction, NOT the closed GA gate** — the GA gate closes only on
+the signed re-prove. **Do not push a `v*` release tag until #125 lands + signed re-prove.**
 
 ## Rollback
 
-Revert the PR. The engine proxy is additive behind the same `NativeShortcutEngine`
-interface; chord path is untouched. Worst case the lone-modifier feature reverts to
+Revert the PR. All three layers are additive behind the same `NativeShortcutEngine`
+interface; the chord path is untouched. Worst case the lone-modifier feature reverts to
 PR #126 behavior (opt-in, no freeze-safety) — no data risk.
 
-## Effort (rough)
+## Effort (rough, v2)
 
-~3h utilityProcess host + proxy engine • ~2h watchdog • ~1.5h launch latch • ~3h
-tests • ~1.5h signed re-prove QA = **~11h**.
+Phase 0 ✅ done • remove scaffolding ~0.5h • fire-and-forget handler + latch ~2.5h •
+powerMonitor + manual re-arm ~1.5h • tests ~2.5h • signed re-prove ~1.5h = **~8.5h**
+(down from v1's ~12h — isolation, IPC, and gen-token machinery are gone).
 
 ## Files Reference
 
-| File                               | Change                                                                                                           |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `electron/uiohookHost.ts`          | NEW — utilityProcess entrypoint: owns uiohook + state machine, parentPort IPC                                    |
-| `electron/uiohookEngine.ts`        | becomes/forks into the main-side PROXY engine (or new `uiohookProxyEngine.ts`); add watchdog ping/pong + degrade |
-| `electron/utils/nativeTapLatch.ts` | NEW — launch latch read/arm/confirm in userData                                                                  |
-| `electron/main.ts:838`             | wire proxy engine + pass a degrade→renderer notifier                                                             |
-| `electron-builder.json`            | ensure `uiohookHost` entry packaged + asarUnpack still covers the native dep                                     |
-| `electron/__tests__/*`             | new specs per Testing Plan                                                                                       |
+| File                               | Change                                                                                                         |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `electron/uiohookEngine.ts`        | fire-and-forget keydown/keyup handler; expose a `reArm()` (stop+start); latch arm/clear around `start()`       |
+| `electron/utils/nativeTapLatch.ts` | **NEW** — process-stability launch latch read/arm/clear in userData (separate file, NOT `config.json`)         |
+| `electron/ShortcutManager.ts`      | boot: if latch blocks, start lone-modifier inactive + notify; manual-re-arm intake re-enables + clears latch   |
+| `electron/main.ts`                 | `powerMonitor.on('resume')` → re-arm; remove the Phase 0 probe hook; wire manual re-arm IPC + degrade→renderer |
+| `electron/uiohookHost.ts`          | **DELETE** — v1 utilityProcess child host (Phase 0 scaffolding)                                                |
+| `electron/utils/tccProbe.ts`       | **DELETE** — Phase 0 gated probe launcher                                                                      |
+| `electron.vite.config.ts`          | **REVERT** — remove the `uiohookHost` main input                                                               |
+| `electron/__tests__/*`             | new specs per Testing Plan (fake engine; no synthetic keys)                                                    |
 
 ## Out of Scope
 
+- **Structural utilityProcess isolation** (Phase 0 proved non-viable on macOS).
+- **Silent-tap auto-detection via a `uiohook-napi` fork** (descoped; restorable on request).
 - #124 side-distinct chords (lands after this).
 - Windows/Linux (macOS-only app).
 - Reworking the chord/globalShortcut path.
 
 ## Related
 
-- #111 / PR #126 (feature, merged) • #124 (side-distinct chords, after) • libuiohook #23.
+- #111 / PR #126 (feature, merged `eab43fd`) • #124 (side-distinct chords, after) •
+  libuiohook #23 (1-event-then-frozen) • deepwiki: CGEventTap needs an active run loop
+  (the Phase 0 (b) limitation).

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -15,6 +15,7 @@ import { isNativeBinding, parseNativeBinding } from './nativeBinding'
 import {
   createUnavailableNativeShortcutEngine,
   type NativeShortcutEngine,
+  type NativeTapStatus,
 } from './nativeShortcutEngine'
 import type { NotificationManager } from './NotificationManager'
 import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
@@ -584,6 +585,26 @@ export class ShortcutManager {
       return false
     }
 
+    // #125 brick-proof launch latch: a prior launch armed the tap but never
+    // confirmed stability (it may have wedged the app during arming). Re-arming
+    // would risk re-freezing on every launch — so do NOT register. A lone
+    // modifier has no chord equivalent, so the binding is simply left INACTIVE
+    // (not "degraded to chord"); the user re-enables it from Settings, which
+    // calls reenableNativeTap() to clear the block and re-arm.
+    if (this.nativeEngine.isLatchBlocked()) {
+      log.warn(
+        `[registerNativeShortcut] Latch-blocked; leaving ${id} inactive (prior arming unconfirmed). Manual re-enable required.`,
+      )
+      if (this.notificationManager) {
+        this.notificationManager.showNotification(
+          'Native Shortcut Disabled',
+          `${this.getShortcutDisplayName(id)} was disabled after a failed start. Re-enable it in Settings.`,
+          { silent: true },
+        )
+      }
+      return false
+    }
+
     // Replace any prior binding under this id (native or accelerator) first.
     if (this.registeredShortcuts.has(id)) {
       this.unregisterShortcut(id)
@@ -615,6 +636,62 @@ export class ShortcutManager {
       `[registerNativeShortcut] Native engine rejected ${id} = ${nativeBinding}`,
     )
     return false
+  }
+
+  /**
+   * Reports the native tap's health for the renderer's re-enable affordance
+   * (#125) — exposed over the `shortcuts-get-native-tap-status` IPC so the UI
+   * can show a "disabled after a failed start — re-enable" control when a prior
+   * arming was left unconfirmed.
+   * @returns `{ available, latchBlocked }` straight from the engine.
+   * @example
+   * getNativeTapStatus() // => { available: true, latchBlocked: true }
+   */
+  getNativeTapStatus(): NativeTapStatus {
+    return {
+      available: this.nativeEngine.isAvailable(),
+      latchBlocked: this.nativeEngine.isLatchBlocked(),
+    }
+  }
+
+  /**
+   * Manual "re-enable" path after a latch-blocked launch (#125): clears the
+   * engine's stale-latch block, then re-runs registration so the lone-modifier
+   * binding re-arms the tap (a fresh arm overwrites the stale marker, which then
+   * clears after the stability window). Triggered by the
+   * `shortcuts-reenable-native-tap` IPC from the renderer's re-enable control.
+   * @returns the post-re-enable status so the caller can confirm the block cleared.
+   * @example
+   * reenableNativeTap() // => { available: true, latchBlocked: false }
+   */
+  reenableNativeTap(): NativeTapStatus {
+    this.nativeEngine.clearLatchBlock()
+    // Re-run the global registration chokepoint; with the block cleared, the
+    // lone-modifier binding now arms the tap instead of being left inactive.
+    this.registerGlobalShortcuts()
+    return this.getNativeTapStatus()
+  }
+
+  /**
+   * Revives a tap that may have gone silent across sleep/lock by stopping and
+   * restarting it (#125). Wired to `powerMonitor` `resume`/`unlock-screen` in
+   * `main.ts`; no-op when the engine is unavailable or has no active binding.
+   * @example
+   * reArmNativeTap() // after `powerMonitor` 'resume'
+   */
+  reArmNativeTap(): void {
+    this.nativeEngine.reArm()
+  }
+
+  /**
+   * Drops any in-flight pressed-alone state WITHOUT restarting the tap (#125),
+   * so a modifier "held across sleep" can't leave a stale pressed key that
+   * mis-fires on wake. Wired to `powerMonitor` `suspend`/`lock-screen`.
+   * @example
+   * resetNativeTapState() // before `powerMonitor` 'suspend' sleeps the machine
+   */
+  resetNativeTapState(): void {
+    this.nativeEngine.resetPressedState()
   }
 
   /**

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -656,7 +656,10 @@ export class ShortcutManager {
    * can show a "disabled after a failed start — re-enable" control when a prior
    * arming was left unconfirmed.
    * @returns `{ available, latchBlocked, active }` — engine health plus whether a
-   *   lone-modifier binding is actually live right now (codex #5).
+   *   lone-modifier binding is actually LIVE right now. `active` reads the engine's
+   *   RUNTIME state (codex review), not registration: after a failed re-enable/
+   *   re-arm the binding stays registered while the tap is down, and the renderer
+   *   must keep the recovery affordance, so registration intent is not the truth.
    * @example
    * getNativeTapStatus() // => { available: true, latchBlocked: true, active: false }
    */
@@ -664,24 +667,8 @@ export class ShortcutManager {
     return {
       available: this.nativeEngine.isAvailable(),
       latchBlocked: this.nativeEngine.isLatchBlocked(),
-      active: this.hasActiveNativeBinding(),
+      active: this.nativeEngine.isActive(),
     }
-  }
-
-  /**
-   * Whether any lone-modifier binding is currently registered as native — i.e.
-   * the tap actually armed and the binding is live (codex #5). Lets
-   * {@link getNativeTapStatus} report `active: false` when a re-enable cleared the
-   * latch block but the re-arm still failed, so the UI keeps the recovery control.
-   * @returns `true` when a registered shortcut is flagged `isNative`.
-   * @example
-   * hasActiveNativeBinding() // => false right after a failed re-enable
-   */
-  private hasActiveNativeBinding(): boolean {
-    for (const registered of this.registeredShortcuts.values()) {
-      if (registered.isNative) return true
-    }
-    return false
   }
 
   /**

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -123,6 +123,14 @@ export class ShortcutManager {
    */
   private nativeEngine: NativeShortcutEngine
 
+  /**
+   * One-shot guard so a latch-blocked launch notifies the user ONCE, not on
+   * every `registerGlobalShortcuts()` retry while still blocked (codex #6). Reset
+   * by {@link reenableNativeTap} so a fresh block after a manual re-enable can
+   * notify again.
+   */
+  private hasNotifiedLatchBlock = false
+
   constructor(
     windowManager: WindowManager,
     notificationManager: NotificationManager | null,
@@ -595,7 +603,11 @@ export class ShortcutManager {
       log.warn(
         `[registerNativeShortcut] Latch-blocked; leaving ${id} inactive (prior arming unconfirmed). Manual re-enable required.`,
       )
-      if (this.notificationManager) {
+      // Notify ONCE per block (codex #6): registerGlobalShortcuts() can run many
+      // times while still latch-blocked (startup, rebinds), and an OS toast on
+      // each would spam the user.
+      if (this.notificationManager && !this.hasNotifiedLatchBlock) {
+        this.hasNotifiedLatchBlock = true
         this.notificationManager.showNotification(
           'Native Shortcut Disabled',
           `${this.getShortcutDisplayName(id)} was disabled after a failed start. Re-enable it in Settings.`,
@@ -643,15 +655,33 @@ export class ShortcutManager {
    * (#125) — exposed over the `shortcuts-get-native-tap-status` IPC so the UI
    * can show a "disabled after a failed start — re-enable" control when a prior
    * arming was left unconfirmed.
-   * @returns `{ available, latchBlocked }` straight from the engine.
+   * @returns `{ available, latchBlocked, active }` — engine health plus whether a
+   *   lone-modifier binding is actually live right now (codex #5).
    * @example
-   * getNativeTapStatus() // => { available: true, latchBlocked: true }
+   * getNativeTapStatus() // => { available: true, latchBlocked: true, active: false }
    */
   getNativeTapStatus(): NativeTapStatus {
     return {
       available: this.nativeEngine.isAvailable(),
       latchBlocked: this.nativeEngine.isLatchBlocked(),
+      active: this.hasActiveNativeBinding(),
     }
+  }
+
+  /**
+   * Whether any lone-modifier binding is currently registered as native — i.e.
+   * the tap actually armed and the binding is live (codex #5). Lets
+   * {@link getNativeTapStatus} report `active: false` when a re-enable cleared the
+   * latch block but the re-arm still failed, so the UI keeps the recovery control.
+   * @returns `true` when a registered shortcut is flagged `isNative`.
+   * @example
+   * hasActiveNativeBinding() // => false right after a failed re-enable
+   */
+  private hasActiveNativeBinding(): boolean {
+    for (const registered of this.registeredShortcuts.values()) {
+      if (registered.isNative) return true
+    }
+    return false
   }
 
   /**
@@ -665,6 +695,9 @@ export class ShortcutManager {
    * reenableNativeTap() // => { available: true, latchBlocked: false }
    */
   reenableNativeTap(): NativeTapStatus {
+    // Re-arm the one-shot toast guard so a fresh block (re-arm fails again) can
+    // re-notify the user (codex #6).
+    this.hasNotifiedLatchBlock = false
     this.nativeEngine.clearLatchBlock()
     // Re-run the global registration chokepoint; with the block cleared, the
     // lone-modifier binding now arms the tap instead of being left inactive.

--- a/electron/__tests__/ShortcutManager.nativeRouting.test.ts
+++ b/electron/__tests__/ShortcutManager.nativeRouting.test.ts
@@ -40,19 +40,38 @@ const NEW_TASK_ACCELERATOR = 'CommandOrControl+N'
 /**
  * Builds an available native tap whose register/unregister are spies, so a test
  * can assert the lone-modifier binding reached the engine with the right id.
- * @returns the engine plus its register/unregister/unregisterAll spies.
+ * `isLatchBlocked` is a spy defaulting to `false` (healthy) so routing tests are
+ * unchanged; a latch-block test overrides it to drive the inactive path (#125).
+ * @returns the engine plus its register/unregister/unregisterAll/isLatchBlocked spies.
  */
 function createAvailableNativeEngineHarness() {
   const register = vi.fn(() => true)
   const unregister = vi.fn(() => true)
   const unregisterAll = vi.fn()
+  const isLatchBlocked = vi.fn(() => false)
+  const clearLatchBlock = vi.fn()
+  const reArm = vi.fn()
+  const resetPressedState = vi.fn()
   const engine: NativeShortcutEngine = {
     isAvailable: () => true,
     register,
     unregister,
     unregisterAll,
+    isLatchBlocked,
+    clearLatchBlock,
+    reArm,
+    resetPressedState,
   }
-  return { engine, register, unregister, unregisterAll }
+  return {
+    engine,
+    register,
+    unregister,
+    unregisterAll,
+    isLatchBlocked,
+    clearLatchBlock,
+    reArm,
+    resetPressedState,
+  }
 }
 
 /** Minimal WindowManager stand-in — only the constructor chokepoint hook is read. */
@@ -93,6 +112,36 @@ describe('ShortcutManager routing of native lone-modifier bindings', () => {
       callback,
     )
     expect(globalRegisterMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves a lone-modifier binding INACTIVE when the freeze-safety latch is blocked', () => {
+    // Arrange: a prior launch armed the tap but never confirmed stability (#125),
+    // so the engine reports latch-blocked — re-arming could re-freeze every launch.
+    const { engine, register, isLatchBlocked } =
+      createAvailableNativeEngineHarness()
+    isLatchBlocked.mockReturnValue(true)
+    const shortcutManager = new ShortcutManager(
+      createWindowManagerStub(),
+      null,
+      null,
+      engine,
+    )
+
+    // Act
+    const didRegister = shortcutManager.registerShortcut(
+      RIGHT_OPTION_BINDING,
+      'toggleBrainDump',
+      vi.fn(),
+    )
+
+    // Assert: never re-arms (engine.register untouched), reports inactive, and a
+    // lone modifier has NO chord equivalent so globalShortcut stays untouched too.
+    expect(didRegister).toBe(false)
+    expect(register).not.toHaveBeenCalled()
+    expect(globalRegisterMock).not.toHaveBeenCalled()
+    expect(
+      shortcutManager.getRegisteredShortcuts()['toggleBrainDump'],
+    ).toBeUndefined()
   })
 
   it('exposes the native binding in the read-back map so a rebind is confirmed', () => {
@@ -152,6 +201,10 @@ describe('ShortcutManager routing of native lone-modifier bindings', () => {
       register: vi.fn(() => true),
       unregister: vi.fn(() => true),
       unregisterAll: vi.fn(),
+      isLatchBlocked: () => false,
+      clearLatchBlock: vi.fn(),
+      reArm: vi.fn(),
+      resetPressedState: vi.fn(),
     }
     const shortcutManager = new ShortcutManager(
       createWindowManagerStub(),
@@ -195,5 +248,80 @@ describe('ShortcutManager routing of native lone-modifier bindings', () => {
       callback,
     )
     expect(register).not.toHaveBeenCalled()
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Freeze-safety recovery surface (#125): status + power-event + manual re-arm
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('reports the native tap status straight from the engine for the renderer affordance', () => {
+    // Arrange: a latch-blocked engine (a prior arming never confirmed).
+    const { engine, isLatchBlocked } = createAvailableNativeEngineHarness()
+    isLatchBlocked.mockReturnValue(true)
+    const shortcutManager = new ShortcutManager(
+      createWindowManagerStub(),
+      null,
+      null,
+      engine,
+    )
+
+    // Act + Assert
+    expect(shortcutManager.getNativeTapStatus()).toEqual({
+      available: true,
+      latchBlocked: true,
+    })
+  })
+
+  it('revives the tap on reArmNativeTap (wired to powerMonitor resume/unlock)', () => {
+    // Arrange
+    const { engine, reArm } = createAvailableNativeEngineHarness()
+    const shortcutManager = new ShortcutManager(
+      createWindowManagerStub(),
+      null,
+      null,
+      engine,
+    )
+
+    // Act
+    shortcutManager.reArmNativeTap()
+
+    // Assert
+    expect(reArm).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops pressed-alone state on resetNativeTapState (wired to powerMonitor suspend/lock)', () => {
+    // Arrange
+    const { engine, resetPressedState } = createAvailableNativeEngineHarness()
+    const shortcutManager = new ShortcutManager(
+      createWindowManagerStub(),
+      null,
+      null,
+      engine,
+    )
+
+    // Act
+    shortcutManager.resetNativeTapState()
+
+    // Assert
+    expect(resetPressedState).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the latch block and returns status on manual reenableNativeTap', () => {
+    // Arrange
+    const { engine, clearLatchBlock } = createAvailableNativeEngineHarness()
+    const shortcutManager = new ShortcutManager(
+      createWindowManagerStub(),
+      null,
+      null,
+      engine,
+    )
+
+    // Act
+    const status = shortcutManager.reenableNativeTap()
+
+    // Assert: the block is cleared (so the next register re-arms) and the
+    // post-action status is surfaced back to the caller.
+    expect(clearLatchBlock).toHaveBeenCalledTimes(1)
+    expect(status).toEqual({ available: true, latchBlocked: false })
   })
 })

--- a/electron/__tests__/ShortcutManager.nativeRouting.test.ts
+++ b/electron/__tests__/ShortcutManager.nativeRouting.test.ts
@@ -44,7 +44,9 @@ const NEW_TASK_ACCELERATOR = 'CommandOrControl+N'
  * can assert the lone-modifier binding reached the engine with the right id.
  * `isLatchBlocked` is a spy defaulting to `false` (healthy) so routing tests are
  * unchanged; a latch-block test overrides it to drive the inactive path (#125).
- * @returns the engine plus its register/unregister/unregisterAll/isLatchBlocked spies.
+ * `isActive` is a spy defaulting to `false` (no live tap); the "tap is live" test
+ * drives it `true` to prove `getNativeTapStatus` surfaces engine RUNTIME state.
+ * @returns the engine plus its register/unregister/unregisterAll/isLatchBlocked/isActive spies.
  */
 function createAvailableNativeEngineHarness() {
   const register = vi.fn(() => true)
@@ -54,6 +56,7 @@ function createAvailableNativeEngineHarness() {
   const clearLatchBlock = vi.fn()
   const reArm = vi.fn()
   const resetPressedState = vi.fn()
+  const isActive = vi.fn(() => false)
   const engine: NativeShortcutEngine = {
     isAvailable: () => true,
     register,
@@ -63,6 +66,7 @@ function createAvailableNativeEngineHarness() {
     clearLatchBlock,
     reArm,
     resetPressedState,
+    isActive,
   }
   return {
     engine,
@@ -73,6 +77,7 @@ function createAvailableNativeEngineHarness() {
     clearLatchBlock,
     reArm,
     resetPressedState,
+    isActive,
   }
 }
 
@@ -207,6 +212,7 @@ describe('ShortcutManager routing of native lone-modifier bindings', () => {
       clearLatchBlock: vi.fn(),
       reArm: vi.fn(),
       resetPressedState: vi.fn(),
+      isActive: () => false,
     }
     const shortcutManager = new ShortcutManager(
       createWindowManagerStub(),
@@ -371,8 +377,11 @@ describe('ShortcutManager routing of native lone-modifier bindings', () => {
   })
 
   it('marks the native tap active once a lone-modifier binding is live', () => {
-    // Arrange: an available tap whose register succeeds (#125, codex #5).
-    const { engine } = createAvailableNativeEngineHarness()
+    // Arrange: an available tap that registers the bind AND reports itself live
+    // at runtime (#125 codex review). `active` must come from the engine's
+    // RUNTIME state, so the harness drives isActive() true here.
+    const { engine, isActive } = createAvailableNativeEngineHarness()
+    isActive.mockReturnValue(true)
     const shortcutManager = new ShortcutManager(
       createWindowManagerStub(),
       null,
@@ -380,14 +389,14 @@ describe('ShortcutManager routing of native lone-modifier bindings', () => {
       engine,
     )
 
-    // Act: a successful native registration makes the tap active.
+    // Act: a successful native registration with a live tap.
     shortcutManager.registerShortcut(
       RIGHT_OPTION_BINDING,
       'toggleBrainDump',
       vi.fn(),
     )
 
-    // Assert
+    // Assert: getNativeTapStatus surfaces the engine's live runtime state.
     expect(shortcutManager.getNativeTapStatus().active).toBe(true)
   })
 

--- a/electron/__tests__/ShortcutManager.nativeRouting.test.ts
+++ b/electron/__tests__/ShortcutManager.nativeRouting.test.ts
@@ -1,8 +1,10 @@
 import { globalShortcut } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ConfigManager } from '../ConfigManager'
 import { createNativeBinding } from '../nativeBinding'
 import type { NativeShortcutEngine } from '../nativeShortcutEngine'
+import type { NotificationManager } from '../NotificationManager'
 import ShortcutManager from '../ShortcutManager'
 import type { WindowManager } from '../WindowManager'
 
@@ -265,10 +267,12 @@ describe('ShortcutManager routing of native lone-modifier bindings', () => {
       engine,
     )
 
-    // Act + Assert
+    // Act + Assert: latch-blocked, and no lone-modifier binding registered, so
+    // the tap is not active — the renderer keeps the recovery affordance (#125).
     expect(shortcutManager.getNativeTapStatus()).toEqual({
       available: true,
       latchBlocked: true,
+      active: false,
     })
   })
 
@@ -320,8 +324,108 @@ describe('ShortcutManager routing of native lone-modifier bindings', () => {
     const status = shortcutManager.reenableNativeTap()
 
     // Assert: the block is cleared (so the next register re-arms) and the
-    // post-action status is surfaced back to the caller.
+    // post-action status is surfaced back to the caller. With only default chord
+    // shortcuts (no lone-modifier binding) nothing arms the tap, so active stays
+    // false — the status honestly reflects no live native binding (#125, codex #5).
     expect(clearLatchBlock).toHaveBeenCalledTimes(1)
-    expect(status).toEqual({ available: true, latchBlocked: false })
+    expect(status).toEqual({
+      available: true,
+      latchBlocked: false,
+      active: false,
+    })
+  })
+
+  it('notifies the user only once while the tap stays latch-blocked', () => {
+    // Arrange: a latch-blocked engine + a configured lone-modifier binding, so
+    // every registerGlobalShortcuts() hits the inactive branch. The OS toast must
+    // fire once, not once per attempt (startup + rebinds would spam) — codex #6.
+    const { engine, isLatchBlocked } = createAvailableNativeEngineHarness()
+    isLatchBlocked.mockReturnValue(true)
+    const showNotification = vi.fn()
+    const notificationManager = {
+      showNotification,
+    } as unknown as NotificationManager
+    const configManager = {
+      getSection: vi.fn((section: string) =>
+        section === 'shortcuts'
+          ? { toggleBrainDump: 'lone-modifier:rightOption' }
+          : {},
+      ),
+      get: vi.fn(),
+      set: vi.fn(),
+    } as unknown as ConfigManager
+    const shortcutManager = new ShortcutManager(
+      createWindowManagerStub(),
+      notificationManager,
+      configManager,
+      engine,
+    )
+
+    // Act: the chokepoint runs several times while still blocked.
+    shortcutManager.registerGlobalShortcuts()
+    shortcutManager.registerGlobalShortcuts()
+    shortcutManager.registerGlobalShortcuts()
+
+    // Assert: exactly one toast across all attempts.
+    expect(showNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks the native tap active once a lone-modifier binding is live', () => {
+    // Arrange: an available tap whose register succeeds (#125, codex #5).
+    const { engine } = createAvailableNativeEngineHarness()
+    const shortcutManager = new ShortcutManager(
+      createWindowManagerStub(),
+      null,
+      null,
+      engine,
+    )
+
+    // Act: a successful native registration makes the tap active.
+    shortcutManager.registerShortcut(
+      RIGHT_OPTION_BINDING,
+      'toggleBrainDump',
+      vi.fn(),
+    )
+
+    // Assert
+    expect(shortcutManager.getNativeTapStatus().active).toBe(true)
+  })
+
+  it('keeps the tap INACTIVE after a re-enable whose re-arm still fails', () => {
+    // Arrange: a lone-modifier binding is configured, but the engine refuses to
+    // register it even once the block is cleared (the tap won't start). The
+    // status must NOT claim a healthy tap — the renderer keeps the recovery
+    // control because active is false despite latchBlocked clearing (codex #5).
+    const { engine, register, clearLatchBlock } =
+      createAvailableNativeEngineHarness()
+    register.mockReturnValue(false)
+    const configManager = {
+      getSection: vi.fn((section: string) =>
+        section === 'shortcuts'
+          ? { toggleBrainDump: 'lone-modifier:rightOption' }
+          : {},
+      ),
+      get: vi.fn(),
+      set: vi.fn(),
+    } as unknown as ConfigManager
+    const shortcutManager = new ShortcutManager(
+      createWindowManagerStub(),
+      null,
+      configManager,
+      engine,
+    )
+
+    // Act
+    const status = shortcutManager.reenableNativeTap()
+
+    // Assert: block cleared and a re-register was attempted, but it failed so the
+    // tap is honestly reported inactive.
+    expect(clearLatchBlock).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalled()
+    expect(status).toEqual({
+      available: true,
+      latchBlocked: false,
+      active: false,
+    })
   })
 })

--- a/electron/__tests__/nativeTapLatch.test.ts
+++ b/electron/__tests__/nativeTapLatch.test.ts
@@ -112,14 +112,61 @@ describe('nativeTapLatch', () => {
     expect(isNativeTapLatchSet()).toBe(true)
   })
 
-  it('treats an unreadable marker as SET (fail-safe over re-bricking)', () => {
-    // Arrange: stat itself fails (e.g. permission/IO error) — ambiguity must block.
-    vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-      throw new Error('EACCES: stat failed')
+  it('treats a permission/IO stat error as SET, not absent (fail-safe over re-bricking)', () => {
+    // Arrange: statSync fails with a NON-ENOENT error (e.g. permission/IO). The
+    // old existsSync collapsed this to "false" (not armed) and would re-brick;
+    // statSync lets us treat the ambiguity as armed instead (codex #2).
+    vi.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw Object.assign(new Error('EACCES: permission denied'), {
+        code: 'EACCES',
+      })
     })
 
     // Act + Assert
     expect(isNativeTapLatchSet()).toBe(true)
+  })
+
+  it('rolls back and returns false when a real IO error breaks the directory fsync', () => {
+    // Arrange: the temp write + atomic rename succeed, but flushing the directory
+    // metadata hits a real IO error, so the rename may not be crash-durable. arm()
+    // must refuse (return false) AND leave no unconfirmed marker behind (codex #1).
+    let fsyncCallCount = 0
+    vi.spyOn(fs, 'fsyncSync').mockImplementation(() => {
+      fsyncCallCount += 1
+      // 1st fsync = the temp FILE (let it pass); 2nd fsync = the DIRECTORY (fail).
+      if (fsyncCallCount >= 2) {
+        throw Object.assign(new Error('EIO: i/o error'), { code: 'EIO' })
+      }
+    })
+
+    // Act
+    const didArm = armNativeTapLatch()
+
+    // Assert: refused to start unguarded, and the half-durable marker is gone.
+    expect(didArm).toBe(false)
+    expect(fs.existsSync(markerPath())).toBe(false)
+  })
+
+  it('still arms when the filesystem cannot fsync a directory (EINVAL is benign)', () => {
+    // Arrange: some filesystems reject directory fsync outright — that is NOT a
+    // durability failure of our write, so the lone-modifier feature must keep
+    // working there: arm() still succeeds and the marker persists (codex #1).
+    let fsyncCallCount = 0
+    vi.spyOn(fs, 'fsyncSync').mockImplementation(() => {
+      fsyncCallCount += 1
+      if (fsyncCallCount >= 2) {
+        throw Object.assign(new Error('EINVAL: invalid argument'), {
+          code: 'EINVAL',
+        })
+      }
+    })
+
+    // Act
+    const didArm = armNativeTapLatch()
+
+    // Assert
+    expect(didArm).toBe(true)
+    expect(fs.existsSync(markerPath())).toBe(true)
   })
 
   it('returns false from arm when the marker write fails (refuse to start unguarded)', () => {

--- a/electron/__tests__/nativeTapLatch.test.ts
+++ b/electron/__tests__/nativeTapLatch.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview Brick-proof launch-latch tests (#125).
+ *
+ * Locks the contract that the native key-tap's on-disk arming marker survives a
+ * crash/wedge during arming (so a frozen tap can't re-arm and re-brick on every
+ * relaunch) and that any read ambiguity is treated as "armed" (fail-safe). Guards
+ * the durable arm → clear-after-stability → block-on-relaunch lifecycle the latch
+ * exists to deliver, plus the corrupt/unreadable-marker fail-safe.
+ *
+ * Triggered when: `pnpm test:electron` (Vitest).
+ *
+ * @example
+ *   pnpm test:electron -- nativeTapLatch
+ */
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// A mutable holder so the hoisted electron mock resolves a fresh temp userData
+// directory per test (vi.mock factories cannot close over later-declared vars).
+const userDataDir = vi.hoisted(() => ({ current: '' }))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => userDataDir.current),
+  },
+}))
+
+// Silence the real pino logger so fail-safe warnings never spew into output.
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+// Imported after the mocks so the latch's `import { app }` is stubbed.
+import {
+  armNativeTapLatch,
+  clearNativeTapLatch,
+  defaultNativeTapLatch,
+  isNativeTapLatchSet,
+  LATCH_FILENAME,
+} from '../utils/nativeTapLatch'
+
+/** Absolute path to the marker the latch writes under the temp userData dir. */
+function markerPath(): string {
+  return path.join(userDataDir.current, LATCH_FILENAME)
+}
+
+describe('nativeTapLatch', () => {
+  beforeEach(() => {
+    // Arrange: isolate every test in its own temp userData directory.
+    userDataDir.current = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'corelive-latch-'),
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(userDataDir.current, { recursive: true, force: true })
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('reports not-set when no prior arming left a marker', () => {
+    // Act + Assert: a clean userData dir means the tap is safe to arm.
+    expect(isNativeTapLatchSet()).toBe(false)
+  })
+
+  it('arms a durable marker that then reads as set', () => {
+    // Act
+    const didArm = armNativeTapLatch()
+
+    // Assert: the marker persisted, so a relaunch before clear would block.
+    expect(didArm).toBe(true)
+    expect(fs.existsSync(markerPath())).toBe(true)
+    expect(isNativeTapLatchSet()).toBe(true)
+  })
+
+  it('writes a valid JSON marker carrying the arm timestamp', () => {
+    // Act
+    armNativeTapLatch()
+
+    // Assert: the marker is well-formed JSON (so a future read could inspect it).
+    const parsed = JSON.parse(fs.readFileSync(markerPath(), 'utf8'))
+    expect(typeof parsed.armedAt).toBe('number')
+  })
+
+  it('clears the marker after a confirmed-healthy session so the next launch is unblocked', () => {
+    // Arrange
+    armNativeTapLatch()
+    expect(isNativeTapLatchSet()).toBe(true)
+
+    // Act
+    clearNativeTapLatch()
+
+    // Assert
+    expect(fs.existsSync(markerPath())).toBe(false)
+    expect(isNativeTapLatchSet()).toBe(false)
+  })
+
+  it('treats clearing a missing marker as success (idempotent)', () => {
+    // Act + Assert: clearing when nothing is armed must not throw.
+    expect(() => clearNativeTapLatch()).not.toThrow()
+    expect(isNativeTapLatchSet()).toBe(false)
+  })
+
+  it('blocks on a corrupt marker — presence alone means "armed, unconfirmed"', () => {
+    // Arrange: a prior arming wrote garbage / was interrupted mid-write.
+    fs.writeFileSync(markerPath(), 'not-json{{{')
+
+    // Act + Assert: the latch is presence-based, so a corrupt marker still blocks.
+    expect(isNativeTapLatchSet()).toBe(true)
+  })
+
+  it('treats an unreadable marker as SET (fail-safe over re-bricking)', () => {
+    // Arrange: stat itself fails (e.g. permission/IO error) — ambiguity must block.
+    vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+      throw new Error('EACCES: stat failed')
+    })
+
+    // Act + Assert
+    expect(isNativeTapLatchSet()).toBe(true)
+  })
+
+  it('returns false from arm when the marker write fails (refuse to start unguarded)', () => {
+    // Arrange: the atomic rename into place fails, so the guard never lands.
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw new Error('ENOSPC: no space')
+    })
+
+    // Act
+    const didArm = armNativeTapLatch()
+
+    // Assert: a failed arm reports false so the caller refuses to start the tap.
+    expect(didArm).toBe(false)
+  })
+
+  it('exposes the fs-backed lifecycle through the default injectable latch', () => {
+    // Act: drive the same arm → set → clear cycle via the injected default.
+    expect(defaultNativeTapLatch.isSet()).toBe(false)
+    expect(defaultNativeTapLatch.arm()).toBe(true)
+    expect(defaultNativeTapLatch.isSet()).toBe(true)
+    defaultNativeTapLatch.clear()
+
+    // Assert
+    expect(defaultNativeTapLatch.isSet()).toBe(false)
+  })
+})

--- a/electron/__tests__/uiohookEngine.test.ts
+++ b/electron/__tests__/uiohookEngine.test.ts
@@ -490,4 +490,72 @@ describe('createUiohookShortcutEngine', () => {
     // Assert: no second start (the restart was skipped to avoid a double-start).
     expect(start).toHaveBeenCalledTimes(1)
   })
+
+  it('keeps the brick-guard set and the tap un-restartable when stop throws on the last unbind', () => {
+    // Arrange: stop() throws when the final binding is removed, so the old tap's
+    // state is unknown. Treating that as a clean shutdown (clearing the guard and
+    // flipping isTapRunning) would let a later register() start() a SECOND
+    // CGEventTap — the same double-start reArm() guards against (codex review).
+    const start = vi.fn()
+    const stopThrowingModule: UiohookModule = {
+      on: () => {},
+      start,
+      stop: () => {
+        throw new Error('stop failed on idle')
+      },
+    }
+    const { latch, clear } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => stopThrowingModule, latch)
+    engine.register('rightOption', 'toggleBrainDump', vi.fn())
+    expect(start).toHaveBeenCalledTimes(1) // initial lazy start
+
+    // Act: remove the last binding (stop() throws), then bind again — a mistaken
+    // "clean shutdown" would start() a second tap here.
+    engine.unregister('toggleBrainDump')
+    engine.register('rightOption', 'toggleBrainDump', vi.fn())
+
+    // Assert: the failed stop did NOT clear the guard, and no second start ran.
+    expect(clear).not.toHaveBeenCalled()
+    expect(start).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports isActive true while a binding is registered and the tap is running', () => {
+    // Arrange
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+
+    // Act
+    engine.register('rightOption', 'toggleBrainDump', vi.fn())
+
+    // Assert: a live tap with a binding is active (renderer hides recovery).
+    expect(engine.isActive()).toBe(true)
+  })
+
+  it('reports isActive false after a re-arm whose restart fails, though the binding stays registered', () => {
+    // Arrange: the initial start succeeds but the start during reArm throws, so
+    // the tap is down while the binding remains registered. isActive must read
+    // RUNTIME state (tap down), not registration intent, or the renderer would
+    // hide the recovery affordance over a dead tap (codex review).
+    let startCount = 0
+    const start = vi.fn(() => {
+      startCount += 1
+      if (startCount >= 2) throw new Error('start failed on re-arm')
+    })
+    const reArmFailingModule: UiohookModule = {
+      on: () => {},
+      start,
+      stop: vi.fn(),
+    }
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => reArmFailingModule, latch)
+    engine.register('rightOption', 'toggleBrainDump', vi.fn())
+    expect(engine.isActive()).toBe(true) // live before the failed re-arm
+
+    // Act: reArm stops cleanly then fails to restart.
+    engine.reArm()
+
+    // Assert: tap is down → inactive, even though the binding is still registered.
+    expect(engine.isActive()).toBe(false)
+  })
 })

--- a/electron/__tests__/uiohookEngine.test.ts
+++ b/electron/__tests__/uiohookEngine.test.ts
@@ -445,4 +445,49 @@ describe('createUiohookShortcutEngine', () => {
     expect(fake.stop).toHaveBeenCalledTimes(1)
     expect(clear).toHaveBeenCalled()
   })
+
+  it('cancels a deferred shortcut whose binding is unregistered before the immediate runs', async () => {
+    // Arrange: the toggle is dispatched via setImmediate (codex #1), so a window
+    // exists where the binding can be torn down between keyup and the next tick.
+    // A stale callback firing after unregister/stop would be a use-after-free
+    // (codex #3) — e.g. Settings disabling the shortcut, or app cleanup.
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+    const callback = vi.fn()
+    engine.register('rightOption', 'toggleBrainDump', callback)
+
+    // Act: press+release SCHEDULES the deferred toggle, then unregister BEFORE
+    // the macrotask queue drains.
+    fake.pressKey(RIGHT_OPTION_KEYCODE)
+    fake.releaseKey(RIGHT_OPTION_KEYCODE)
+    engine.unregister('toggleBrainDump')
+    await flushImmediate()
+
+    // Assert: the now-stale callback was cancelled.
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('skips the reArm restart when stop throws, so a wedged tap is not double-started', () => {
+    // Arrange: stop() throws on re-arm, so the old CGEventTap's state is unknown.
+    // Starting again could double-start the OS tap (codex #4) — reArm must bail.
+    const start = vi.fn()
+    const stopThrowingModule: UiohookModule = {
+      on: () => {},
+      start,
+      stop: () => {
+        throw new Error('stop failed during re-arm')
+      },
+    }
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => stopThrowingModule, latch)
+    engine.register('rightOption', 'toggleBrainDump', vi.fn())
+    expect(start).toHaveBeenCalledTimes(1) // initial lazy start
+
+    // Act: reArm — stop() throws.
+    engine.reArm()
+
+    // Assert: no second start (the restart was skipped to avoid a double-start).
+    expect(start).toHaveBeenCalledTimes(1)
+  })
 })

--- a/electron/__tests__/uiohookEngine.test.ts
+++ b/electron/__tests__/uiohookEngine.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Silence the real pino logger so tap start/re-arm info lines never spew here.
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
 import {
   createUiohookShortcutEngine,
   type UiohookKeyboardEvent,
   type UiohookModule,
 } from '../uiohookEngine'
+import type { NativeTapLatch } from '../utils/nativeTapLatch'
 
 /** libuiohook keycodes used by the specs (UiohookKey constants). */
 const RIGHT_OPTION_KEYCODE = 0x0e38 // UiohookKey.AltRight
@@ -35,12 +41,44 @@ function createFakeUiohook() {
     module,
     start,
     stop,
+    /** How many keydown listeners are attached — proves attach-once on reArm. */
+    keydownListenerCount: () => keydownListeners.length,
     pressKey: (keycode: number) =>
       keydownListeners.forEach((listener) => listener({ keycode })),
     releaseKey: (keycode: number) =>
       keyupListeners.forEach((listener) => listener({ keycode })),
   }
 }
+
+/**
+ * An in-memory {@link NativeTapLatch} so the engine's freeze-safety wrapper is
+ * unit-tested without `electron.app` / fs (the injectable seam mirrors the
+ * native-module loader). `arm()` flips the marker on and returns success;
+ * `clear()` flips it off; `isSet()` reports the current marker.
+ * @param initiallySet - Simulates a prior launch that armed but never confirmed.
+ * @returns the latch to inject plus its isSet/arm/clear spies.
+ */
+function createFakeLatch(initiallySet = false) {
+  let isSetValue = initiallySet
+  const isSet = vi.fn(() => isSetValue)
+  const arm = vi.fn(() => {
+    isSetValue = true
+    return true
+  })
+  const clear = vi.fn(() => {
+    isSetValue = false
+  })
+  const latch: NativeTapLatch = { isSet, arm, clear }
+  return { latch, isSet, arm, clear }
+}
+
+/**
+ * Drains the macrotask queue so a `setImmediate`-deferred shortcut callback has
+ * run. The engine schedules the toggle off the tap's dispatch path (codex #1),
+ * so fire assertions must await this rather than reading synchronously.
+ */
+const flushImmediate = async (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve))
 
 describe('createUiohookShortcutEngine', () => {
   beforeEach(() => {
@@ -50,9 +88,10 @@ describe('createUiohookShortcutEngine', () => {
   it('reports available when the native module loads', () => {
     // Arrange
     const fake = createFakeUiohook()
+    const { latch } = createFakeLatch()
 
     // Act
-    const engine = createUiohookShortcutEngine(() => fake.module)
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
 
     // Assert
     expect(engine.isAvailable()).toBe(true)
@@ -60,7 +99,8 @@ describe('createUiohookShortcutEngine', () => {
 
   it('reports unavailable and refuses to bind when the native module is absent', () => {
     // Arrange: the prebuilt is missing / wrong arch, so the loader returns null.
-    const engine = createUiohookShortcutEngine(() => null)
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => null, latch)
 
     // Act
     const didRegister = engine.register(
@@ -76,9 +116,10 @@ describe('createUiohookShortcutEngine', () => {
 
   it('reports unavailable when loading the native module throws', () => {
     // Arrange: a corrupt binary makes require() throw — must not crash construction.
+    const { latch } = createFakeLatch()
     const engine = createUiohookShortcutEngine(() => {
       throw new Error('dlopen failed')
-    })
+    }, latch)
 
     // Assert
     expect(engine.isAvailable()).toBe(false)
@@ -94,7 +135,8 @@ describe('createUiohookShortcutEngine', () => {
       },
       stop: () => {},
     }
-    const engine = createUiohookShortcutEngine(() => startThrowingModule)
+    const { latch, clear } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => startThrowingModule, latch)
 
     // Act
     const didRegister = engine.register(
@@ -103,29 +145,54 @@ describe('createUiohookShortcutEngine', () => {
       vi.fn(),
     )
 
-    // Assert: register reports failure so ShortcutManager falls back to a chord.
+    // Assert: register reports failure so ShortcutManager falls back to a chord,
+    // and the latch is cleared (a sync start() failure is not a freeze).
     expect(didRegister).toBe(false)
+    expect(clear).toHaveBeenCalled()
   })
 
-  it('fires the shortcut when its lone modifier is pressed and released by itself', () => {
+  it('fires the shortcut when its lone modifier is pressed and released by itself', async () => {
     // Arrange
     const fake = createFakeUiohook()
-    const engine = createUiohookShortcutEngine(() => fake.module)
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
     const callback = vi.fn()
     engine.register('rightOption', 'toggleBrainDump', callback)
 
-    // Act: press and release the right Option key alone.
+    // Act: press and release the right Option key alone, then drain the deferral.
     fake.pressKey(RIGHT_OPTION_KEYCODE)
     fake.releaseKey(RIGHT_OPTION_KEYCODE)
+    await flushImmediate()
 
     // Assert
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  it('does not fire when another key is pressed between the modifier press and release', () => {
+  it('dispatches the shortcut via setImmediate, not synchronously on the tap thread', async () => {
+    // Arrange: heavy window work must never run on the native tap's emit path
+    // (codex #1) — the callback is deferred to the next main-loop tick.
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+    const callback = vi.fn()
+    engine.register('rightOption', 'toggleBrainDump', callback)
+
+    // Act
+    fake.pressKey(RIGHT_OPTION_KEYCODE)
+    fake.releaseKey(RIGHT_OPTION_KEYCODE)
+
+    // Assert: not yet on the same tick…
+    expect(callback).not.toHaveBeenCalled()
+    // …only after the macrotask queue drains.
+    await flushImmediate()
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire when another key is pressed between the modifier press and release', async () => {
     // Arrange
     const fake = createFakeUiohook()
-    const engine = createUiohookShortcutEngine(() => fake.module)
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
     const callback = vi.fn()
     engine.register('rightOption', 'toggleBrainDump', callback)
 
@@ -133,15 +200,17 @@ describe('createUiohookShortcutEngine', () => {
     fake.pressKey(RIGHT_OPTION_KEYCODE)
     fake.pressKey(LETTER_B_KEYCODE)
     fake.releaseKey(RIGHT_OPTION_KEYCODE)
+    await flushImmediate()
 
     // Assert: the intervening key disarmed the lone-modifier candidate.
     expect(callback).not.toHaveBeenCalled()
   })
 
-  it('does not fire after the binding is unregistered', () => {
+  it('does not fire after the binding is unregistered', async () => {
     // Arrange
     const fake = createFakeUiohook()
-    const engine = createUiohookShortcutEngine(() => fake.module)
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
     const callback = vi.fn()
     engine.register('rightOption', 'toggleBrainDump', callback)
 
@@ -149,15 +218,17 @@ describe('createUiohookShortcutEngine', () => {
     engine.unregister('toggleBrainDump')
     fake.pressKey(RIGHT_OPTION_KEYCODE)
     fake.releaseKey(RIGHT_OPTION_KEYCODE)
+    await flushImmediate()
 
     // Assert
     expect(callback).not.toHaveBeenCalled()
   })
 
-  it('rebinds an id to a new modifier without the old key still firing it', () => {
+  it('rebinds an id to a new modifier without the old key still firing it', async () => {
     // Arrange
     const fake = createFakeUiohook()
-    const engine = createUiohookShortcutEngine(() => fake.module)
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
     const callback = vi.fn()
     engine.register('rightOption', 'toggleBrainDump', callback)
 
@@ -167,6 +238,7 @@ describe('createUiohookShortcutEngine', () => {
     fake.releaseKey(RIGHT_OPTION_KEYCODE)
     fake.pressKey(LEFT_OPTION_KEYCODE)
     fake.releaseKey(LEFT_OPTION_KEYCODE)
+    await flushImmediate()
 
     // Assert: only the new (left) modifier fires; the old (right) one is dead.
     expect(callback).toHaveBeenCalledTimes(1)
@@ -175,7 +247,8 @@ describe('createUiohookShortcutEngine', () => {
   it('starts the global tap on the first bind and stops it after the last unbind', () => {
     // Arrange
     const fake = createFakeUiohook()
-    const engine = createUiohookShortcutEngine(() => fake.module)
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
 
     // Act + Assert: first bind starts the tap.
     engine.register('rightOption', 'toggleBrainDump', vi.fn())
@@ -185,5 +258,191 @@ describe('createUiohookShortcutEngine', () => {
     // Removing the last binding stops it (the app releases the global hook).
     engine.unregister('toggleBrainDump')
     expect(fake.stop).toHaveBeenCalledTimes(1)
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Freeze-safety (#125): brick-proof latch, attach-once reArm, pressed reset
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('arms the brick-proof latch before starting the tap', () => {
+    // Arrange
+    const fake = createFakeUiohook()
+    const { latch, arm } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+
+    // Act
+    engine.register('rightOption', 'toggleBrainDump', vi.fn())
+
+    // Assert: the on-disk guard is persisted before the tap runs.
+    expect(arm).toHaveBeenCalledTimes(1)
+    expect(fake.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses to start the tap when the latch cannot be armed', () => {
+    // Arrange: arming the brick-guard fails (e.g. fsync write didn't land), so the
+    // tap must NOT start unguarded — a freeze with no marker would brick relaunch.
+    const fake = createFakeUiohook()
+    const { latch, arm } = createFakeLatch()
+    arm.mockReturnValue(false)
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+
+    // Act
+    const didRegister = engine.register(
+      'rightOption',
+      'toggleBrainDump',
+      vi.fn(),
+    )
+
+    // Assert
+    expect(didRegister).toBe(false)
+    expect(fake.start).not.toHaveBeenCalled()
+  })
+
+  it('starts the lone modifier INACTIVE when a prior arming was left unconfirmed', () => {
+    // Arrange: the latch marker is still set from a prior launch that armed but
+    // never confirmed stability (it may have wedged the app) — do NOT re-arm.
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch(true)
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+
+    // Act
+    const didRegister = engine.register(
+      'rightOption',
+      'toggleBrainDump',
+      vi.fn(),
+    )
+
+    // Assert: the binding is inactive and the tap never started (no brick loop).
+    expect(engine.isLatchBlocked()).toBe(true)
+    expect(didRegister).toBe(false)
+    expect(fake.start).not.toHaveBeenCalled()
+  })
+
+  it('re-enables a latch-blocked tap once the block is manually cleared', () => {
+    // Arrange: a latch-blocked launch left the binding inactive.
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch(true)
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+    expect(engine.register('rightOption', 'toggleBrainDump', vi.fn())).toBe(
+      false,
+    )
+
+    // Act: the manual "re-enable" path clears the block, then re-registers.
+    engine.clearLatchBlock()
+    const didRegister = engine.register(
+      'rightOption',
+      'toggleBrainDump',
+      vi.fn(),
+    )
+
+    // Assert: the tap now arms and starts.
+    expect(engine.isLatchBlocked()).toBe(false)
+    expect(didRegister).toBe(true)
+    expect(fake.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms without duplicating listeners — 10 reArms still fire the shortcut once', async () => {
+    // Arrange: reArm() used to attach listeners on each start, so a stop+start
+    // stacked duplicate keydown/keyup handlers and fired each binding N times.
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+    const callback = vi.fn()
+    engine.register('rightOption', 'toggleBrainDump', callback)
+
+    // Act: revive the tap ten times (as repeated resume/unlock events would).
+    for (let i = 0; i < 10; i++) engine.reArm()
+    fake.pressKey(RIGHT_OPTION_KEYCODE)
+    fake.releaseKey(RIGHT_OPTION_KEYCODE)
+    await flushImmediate()
+
+    // Assert: exactly one keydown listener, and the shortcut fires exactly once.
+    expect(fake.keydownListenerCount()).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops and restarts the tap on reArm (reviving a possibly-silent tap)', () => {
+    // Arrange
+    const fake = createFakeUiohook()
+    const { latch, arm } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+    engine.register('rightOption', 'toggleBrainDump', vi.fn())
+    expect(fake.start).toHaveBeenCalledTimes(1)
+    expect(arm).toHaveBeenCalledTimes(1)
+
+    // Act
+    engine.reArm()
+
+    // Assert: a clean stop then a fresh guarded start (arm again).
+    expect(fake.stop).toHaveBeenCalledTimes(1)
+    expect(fake.start).toHaveBeenCalledTimes(2)
+    expect(arm).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing on reArm when no binding is active', () => {
+    // Arrange: an unbound engine has no tap to revive.
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+
+    // Act
+    engine.reArm()
+
+    // Assert
+    expect(fake.start).not.toHaveBeenCalled()
+    expect(fake.stop).not.toHaveBeenCalled()
+  })
+
+  it('clears a modifier held across sleep so its dangling release does not fire (reArm)', async () => {
+    // Arrange: the modifier goes down, then the machine sleeps; reArm() on wake
+    // must reset the pressed-alone state so the post-wake release can't mis-fire.
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+    const callback = vi.fn()
+    engine.register('rightOption', 'toggleBrainDump', callback)
+
+    // Act: press (arms it), reArm (wake), then the dangling release arrives.
+    fake.pressKey(RIGHT_OPTION_KEYCODE)
+    engine.reArm()
+    fake.releaseKey(RIGHT_OPTION_KEYCODE)
+    await flushImmediate()
+
+    // Assert: the stale armed key was cleared — no phantom toggle.
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('drops in-flight pressed state on resetPressedState without restarting the tap', async () => {
+    // Arrange: suspend/lock-screen resets pressed-state but leaves the tap running.
+    const fake = createFakeUiohook()
+    const { latch } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+    const callback = vi.fn()
+    engine.register('rightOption', 'toggleBrainDump', callback)
+
+    // Act: arm the modifier, reset state (suspend), then the dangling release.
+    fake.pressKey(RIGHT_OPTION_KEYCODE)
+    engine.resetPressedState()
+    fake.releaseKey(RIGHT_OPTION_KEYCODE)
+    await flushImmediate()
+
+    // Assert: no fire, and the tap was never stopped (reset ≠ restart).
+    expect(callback).not.toHaveBeenCalled()
+    expect(fake.stop).not.toHaveBeenCalled()
+  })
+
+  it('clears the brick-proof latch on a clean stop (a confirmed-healthy session)', () => {
+    // Arrange
+    const fake = createFakeUiohook()
+    const { latch, clear } = createFakeLatch()
+    const engine = createUiohookShortcutEngine(() => fake.module, latch)
+    engine.register('rightOption', 'toggleBrainDump', vi.fn())
+
+    // Act: removing the last binding stops the tap cleanly.
+    engine.unregister('toggleBrainDump')
+
+    // Assert: a clean stop drops the guard so the next launch isn't false-blocked.
+    expect(fake.stop).toHaveBeenCalledTimes(1)
+    expect(clear).toHaveBeenCalled()
   })
 })

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -118,3 +118,18 @@ export const SETTINGS_POPOVER_MAX_HEIGHT_PX = 900
 
 /** Debounce delay (ms) before persisting Settings popover size after a resize drag. */
 export const SETTINGS_POPOVER_RESIZE_DEBOUNCE_MS = 200
+
+// ============================================================================
+// Native key-tap freeze-safety (#125)
+// ============================================================================
+
+/**
+ * How long after a healthy `uIOhook.start()` the brick-proof launch latch waits
+ * before clearing its on-disk marker (electron/utils/nativeTapLatch.ts). The
+ * marker is armed just before `start()`; if the tap start crashes or wedges the
+ * process within this window the clear-timer never runs, so the marker survives
+ * to the next launch and blocks a re-arm (the brick loop). 5s comfortably covers
+ * a near-immediate arming crash while keeping the false-block window (app killed
+ * right after launch) small and one-click recoverable.
+ */
+export const NATIVE_TAP_STABILITY_WINDOW_MS = 5000

--- a/electron/ipc/ipc-schemas.ts
+++ b/electron/ipc/ipc-schemas.ts
@@ -147,6 +147,10 @@ export const IPC_ARG_SCHEMAS: Record<IPCChannel, z.ZodTypeAny> = {
   'shortcuts-enable': z.tuple([]),
   'shortcuts-disable': z.tuple([]),
   'shortcuts-get-stats': z.tuple([]),
+  // #125 native key-tap freeze-safety: query the tap's health and the manual
+  // re-enable after a latch-blocked launch. Both take no args.
+  'shortcuts-get-native-tap-status': z.tuple([]),
+  'shortcuts-reenable-native-tap': z.tuple([]),
 
   // ──────────────────────────────────────────────────────────────────────────
   // Configuration

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -22,6 +22,7 @@ import {
   dialog,
   session,
   Notification,
+  powerMonitor,
   screen,
 } from 'electron'
 import type { WebContents, Event as ElectronEvent } from 'electron'
@@ -268,6 +269,13 @@ let notificationManager: NotificationManagerType | null = null
 /** Promise to track in-flight NotificationManager initialization (prevents race conditions) */
 let notificationManagerPromise: Promise<NotificationManagerType> | null = null
 let shortcutManager: ShortcutManagerType | null = null
+/**
+ * Guards the one-time attachment of the #125 native key-tap `powerMonitor`
+ * listeners (sleep/lock → reset pressed-state, wake/unlock → re-arm). They are
+ * app-lifetime, so re-running the deferred ShortcutManager load must not stack
+ * duplicate listeners.
+ */
+let nativeTapPowerListenersAttached = false
 let systemIntegrationErrorHandler: SystemIntegrationErrorHandlerType | null =
   null
 let menuManager: MenuManagerType | null = null
@@ -844,6 +852,23 @@ async function loadSystemIntegrationStack(): Promise<void> {
     nativeShortcutEngine,
   )
   log.info('✅ [DEFERRED] ShortcutManager loaded')
+
+  // #125 native key-tap freeze-safety — power-event recovery. A CGEventTap can
+  // silently die across display sleep / screen lock; revive it on wake/unlock.
+  // And a lone modifier "held across sleep" must not leave a stale pressed-alone
+  // key, so drop the pressed-set before sleeping. Attached once (app-lifetime).
+  if (!nativeTapPowerListenersAttached) {
+    nativeTapPowerListenersAttached = true
+    // Sleep / lock: clear in-flight pressed-alone state WITHOUT restarting.
+    const dropNativeTapPressedState = () =>
+      shortcutManager?.resetNativeTapState()
+    powerMonitor.on('suspend', dropNativeTapPressedState)
+    powerMonitor.on('lock-screen', dropNativeTapPressedState)
+    // Wake / unlock: stop→start the tap so a silently-dead tap revives.
+    const reviveNativeTap = () => shortcutManager?.reArmNativeTap()
+    powerMonitor.on('resume', reviveNativeTap)
+    powerMonitor.on('unlock-screen', reviveNativeTap)
+  }
 
   // Feed the tray live, display-only hotkeys for the two toggle items it shows.
   // ShortcutManager is constructed AFTER SystemTrayManager, so this is a setter
@@ -2144,6 +2169,22 @@ function setupIPCHandlers(): void {
       }
     }
     return shortcutManager.getStats()
+  })
+
+  // #125 native key-tap freeze-safety: surface tap health + manual re-enable to
+  // the renderer's "disabled after a failed start — re-enable" control.
+  typedHandle('shortcuts-get-native-tap-status', () => {
+    if (!shortcutManager) {
+      return { available: false, latchBlocked: false }
+    }
+    return shortcutManager.getNativeTapStatus()
+  })
+
+  typedHandle('shortcuts-reenable-native-tap', () => {
+    if (!shortcutManager) {
+      return { available: false, latchBlocked: false }
+    }
+    return shortcutManager.reenableNativeTap()
   })
 
   // Deep linking IPC handlers

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2175,14 +2175,14 @@ function setupIPCHandlers(): void {
   // the renderer's "disabled after a failed start — re-enable" control.
   typedHandle('shortcuts-get-native-tap-status', () => {
     if (!shortcutManager) {
-      return { available: false, latchBlocked: false }
+      return { available: false, latchBlocked: false, active: false }
     }
     return shortcutManager.getNativeTapStatus()
   })
 
   typedHandle('shortcuts-reenable-native-tap', () => {
     if (!shortcutManager) {
-      return { available: false, latchBlocked: false }
+      return { available: false, latchBlocked: false, active: false }
     }
     return shortcutManager.reenableNativeTap()
   })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,6 +55,7 @@ import { createUiohookShortcutEngine } from './uiohookEngine'
 import { applyShortcutRebind } from './utils/applyShortcutRebind'
 import { resolveRemoteDebuggingPort } from './utils/debugMode'
 import { loadUiohook } from './utils/loadUiohook'
+import { isNativeTapLatchSet } from './utils/nativeTapLatch'
 import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 import { WindowManager } from './WindowManager'
 import {
@@ -2175,14 +2176,28 @@ function setupIPCHandlers(): void {
   // the renderer's "disabled after a failed start — re-enable" control.
   typedHandle('shortcuts-get-native-tap-status', () => {
     if (!shortcutManager) {
-      return { available: false, latchBlocked: false, active: false }
+      // ShortcutManager not constructed yet: read the persisted brick-guard from
+      // disk so an early renderer poll during a latch-blocked launch still sees
+      // the block (and keeps the re-enable affordance) instead of a false
+      // "not blocked" (codex review). `active` is false — nothing is live yet.
+      return {
+        available: false,
+        latchBlocked: isNativeTapLatchSet(),
+        active: false,
+      }
     }
     return shortcutManager.getNativeTapStatus()
   })
 
   typedHandle('shortcuts-reenable-native-tap', () => {
     if (!shortcutManager) {
-      return { available: false, latchBlocked: false, active: false }
+      // Re-enable can't act before ShortcutManager exists, but report the real
+      // persisted latch state so the renderer doesn't conclude the block cleared.
+      return {
+        available: false,
+        latchBlocked: isNativeTapLatchSet(),
+        active: false,
+      }
     }
     return shortcutManager.reenableNativeTap()
   })

--- a/electron/nativeShortcutEngine.ts
+++ b/electron/nativeShortcutEngine.ts
@@ -28,6 +28,13 @@ export interface NativeTapStatus {
   available: boolean
   /** Whether a prior unconfirmed arming is blocking a re-arm (needs manual re-enable). */
   latchBlocked: boolean
+  /**
+   * Whether a lone-modifier binding is actually registered and live in the tap
+   * right now (codex #5). Distinct from `!latchBlocked`: a manual re-enable can
+   * clear the block yet still fail to arm/start, leaving the binding inactive —
+   * the renderer must not hide the recovery affordance in that case.
+   */
+  active: boolean
 }
 
 /**

--- a/electron/nativeShortcutEngine.ts
+++ b/electron/nativeShortcutEngine.ts
@@ -103,6 +103,16 @@ export interface NativeShortcutEngine {
    * stale pressed key that mis-fires or never re-fires after wake.
    */
   resetPressedState(): void
+
+  /**
+   * Whether the tap is LIVE right now — a binding is registered AND the OS-level
+   * tap is actually running (#125 codex review). This is RUNTIME truth, distinct
+   * from registration intent: after a failed {@link reArm} (stop succeeded but
+   * the restart failed) a binding stays registered while the tap is down, so the
+   * caller must read this — not "a binding exists" — to decide `active`, or the
+   * renderer would hide the recovery affordance over a dead tap.
+   */
+  isActive(): boolean
 }
 
 /**
@@ -125,5 +135,6 @@ export function createUnavailableNativeShortcutEngine(): NativeShortcutEngine {
     clearLatchBlock: () => {},
     reArm: () => {},
     resetPressedState: () => {},
+    isActive: () => false,
   }
 }

--- a/electron/nativeShortcutEngine.ts
+++ b/electron/nativeShortcutEngine.ts
@@ -17,6 +17,20 @@
 import type { LoneModifierId } from './nativeBinding'
 
 /**
+ * The observable health of the native tap, surfaced to the renderer so a
+ * latch-blocked launch can show a "re-enable" affordance (#125). `available`
+ * mirrors {@link NativeShortcutEngine.isAvailable}; `latchBlocked` mirrors
+ * {@link NativeShortcutEngine.isLatchBlocked}. Kept here (next to the engine)
+ * so `ShortcutManager`'s status method and the IPC layer share one shape.
+ */
+export interface NativeTapStatus {
+  /** Whether the tap can run right now (module loaded + permission). */
+  available: boolean
+  /** Whether a prior unconfirmed arming is blocking a re-arm (needs manual re-enable). */
+  latchBlocked: boolean
+}
+
+/**
  * A swappable recognizer for lone-modifier key taps. A concrete implementation
  * (uiohook adapter / signed helper) holds the OS-level event tap and invokes the
  * stored callback when its modifier is pressed alone; `ShortcutManager` treats it
@@ -53,6 +67,35 @@ export interface NativeShortcutEngine {
 
   /** Removes every binding and releases the tap (called on cleanup/disable). */
   unregisterAll(): void
+
+  /**
+   * Whether a prior launch armed this tap but never confirmed stability (the
+   * brick-proof launch latch is still set — #125). `true` means {@link register}
+   * will refuse to start the tap; the caller binds the shortcut INACTIVE and
+   * offers a manual re-enable instead of re-arming a possible brick loop.
+   */
+  isLatchBlocked(): boolean
+
+  /**
+   * Clear the latch-block state so the next {@link register} may arm the tap —
+   * the manual "re-enable" path taken after a latch-blocked launch.
+   */
+  clearLatchBlock(): void
+
+  /**
+   * Stop then restart the running tap, resetting the pressed-alone state, to
+   * revive a tap that may have gone silent across sleep/lock (powerMonitor
+   * `resume`/`unlock-screen`) or on a manual re-enable. No-op when unavailable
+   * or when no binding is active.
+   */
+  reArm(): void
+
+  /**
+   * Drop any in-flight pressed-alone state WITHOUT restarting the tap — used on
+   * `suspend`/`lock-screen` so a modifier "held across sleep" can't leave a
+   * stale pressed key that mis-fires or never re-fires after wake.
+   */
+  resetPressedState(): void
 }
 
 /**
@@ -71,5 +114,9 @@ export function createUnavailableNativeShortcutEngine(): NativeShortcutEngine {
     register: () => false,
     unregister: () => false,
     unregisterAll: () => {},
+    isLatchBlocked: () => false,
+    clearLatchBlock: () => {},
+    reArm: () => {},
+    resetPressedState: () => {},
   }
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -39,6 +39,7 @@ import type {
   DeepLinkExamples,
   IPCEventChannel,
   IPCResponse,
+  NativeTapStatus,
   NotificationOptions,
   NotificationPreferences,
   ShortcutDefinition,
@@ -853,6 +854,34 @@ contextBridge.exposeInMainWorld('electronAPI', {
       } catch (error) {
         log.error('Failed to get shortcut stats:', error)
         return null
+      }
+    },
+
+    /**
+     * Read the native key-tap's health (#125) so the renderer can show a
+     * "disabled after a failed start — re-enable" control when a prior arming
+     * was left unconfirmed. Falls back to "unavailable, not blocked" on error.
+     */
+    getNativeTapStatus: async (): Promise<NativeTapStatus> => {
+      try {
+        return await typedInvoke('shortcuts-get-native-tap-status')
+      } catch (error) {
+        log.error('Failed to get native tap status:', error)
+        return { available: false, latchBlocked: false }
+      }
+    },
+
+    /**
+     * Manually re-enable the native key-tap after a latch-blocked launch (#125):
+     * clears the stale-latch block and re-arms the tap. Returns the post-action
+     * status so the UI can confirm the block cleared.
+     */
+    reenableNativeTap: async (): Promise<NativeTapStatus> => {
+      try {
+        return await typedInvoke('shortcuts-reenable-native-tap')
+      } catch (error) {
+        log.error('Failed to re-enable native tap:', error)
+        return { available: false, latchBlocked: false }
       }
     },
   },

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -867,7 +867,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         return await typedInvoke('shortcuts-get-native-tap-status')
       } catch (error) {
         log.error('Failed to get native tap status:', error)
-        return { available: false, latchBlocked: false }
+        return { available: false, latchBlocked: false, active: false }
       }
     },
 
@@ -881,7 +881,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         return await typedInvoke('shortcuts-reenable-native-tap')
       } catch (error) {
         log.error('Failed to re-enable native tap:', error)
-        return { available: false, latchBlocked: false }
+        return { available: false, latchBlocked: false, active: false }
       }
     },
   },

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -28,6 +28,7 @@ import type {
   IPCResponse,
   IPCEventChannel,
   IPCEventData,
+  NativeTapStatus,
 } from './ipc'
 
 /**
@@ -135,6 +136,17 @@ export interface ElectronAPI {
       platform: string
       shortcuts: Record<string, string>
     }>
+    /**
+     * Native key-tap freeze-safety status (#125) — `available` / `latchBlocked`
+     * / `active` so the renderer can show a "disabled after a failed start —
+     * re-enable" control when a prior arming was left unconfirmed.
+     */
+    getNativeTapStatus: () => Promise<NativeTapStatus>
+    /**
+     * Manually re-enable a latch-blocked native key-tap (#125): clears the
+     * stale-latch block and re-arms the tap, returning the post-action status.
+     */
+    reenableNativeTap: () => Promise<NativeTapStatus>
   }
 
   /**

--- a/electron/types/ipc.ts
+++ b/electron/types/ipc.ts
@@ -11,6 +11,10 @@ import type { IpcMainInvokeEvent } from 'electron'
 
 import type { LoadingStatus } from '../LazyLoadManager'
 import type { MemoryStatistics } from '../MemoryProfiler'
+import type { NativeTapStatus } from '../nativeShortcutEngine'
+// Re-export so the preload barrel (`./types/ipc`) stays the single type surface
+// the renderer bridge imports from — it never reaches into main-process modules.
+export type { NativeTapStatus } from '../nativeShortcutEngine'
 import type { PerformanceMetrics } from '../performance-config'
 import type {
   DisplayInfo as WindowManagerDisplayInfo,
@@ -652,6 +656,15 @@ export interface IPCChannels {
       platform: string
       shortcuts: Record<string, string>
     }
+  }
+  // #125 native key-tap freeze-safety: read tap health / manually re-enable.
+  'shortcuts-get-native-tap-status': {
+    request: void
+    response: NativeTapStatus
+  }
+  'shortcuts-reenable-native-tap': {
+    request: void
+    response: NativeTapStatus
   }
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/electron/uiohookEngine.ts
+++ b/electron/uiohookEngine.ts
@@ -244,18 +244,24 @@ export function createUiohookShortcutEngine(
   /** Stop the tap when no bindings remain so the app releases the global hook. */
   const stopTapIfIdle = (): void => {
     if (uiohook === null || !isTapRunning || bindingByKeycode.size > 0) return
-    if (stabilityTimer) {
-      clearTimeout(stabilityTimer)
-      stabilityTimer = null
-    }
+    // Stop FIRST. A thrown stop() leaves the old tap in an UNKNOWN state, so bail
+    // WITHOUT flipping isTapRunning or clearing the brick-guard (codex review):
+    // keeping isTapRunning=true makes a later register() see the tap as still up
+    // and skip a second start() — the same double-start reArm() already avoids.
     try {
       uiohook.stop()
     } catch (error) {
       log.error('[uiohookEngine] Failed to stop global key tap:', error)
+      return
+    }
+    // Clean stop only — now safe to drop the stability timer, mark the tap down,
+    // reset pressed-state, and clear the brick-guard (a confirmed-healthy session).
+    if (stabilityTimer) {
+      clearTimeout(stabilityTimer)
+      stabilityTimer = null
     }
     isTapRunning = false
     resetPressedState()
-    // A clean stop is a confirmed-healthy session — drop the brick-guard.
     latch.clear()
   }
 
@@ -348,6 +354,12 @@ export function createUiohookShortcutEngine(
     },
 
     resetPressedState,
+
+    // RUNTIME truth for the renderer's `active` flag (#125 codex review): a
+    // binding is registered AND the tap is actually running. After a failed
+    // reArm() the binding map is still populated but `isTapRunning` is false, so
+    // this correctly reports inactive while registration intent persists.
+    isActive: () => isTapRunning && bindingByKeycode.size > 0,
   }
 }
 

--- a/electron/uiohookEngine.ts
+++ b/electron/uiohookEngine.ts
@@ -7,6 +7,15 @@
  * first/last binding. The native module is INJECTED (a loader thunk) so the
  * adapter unit-tests with a fake and `main.ts` supplies the real `require`.
  *
+ * Freeze-safety (#125): the tap stays in the main process (a `utilityProcess`
+ * child proved non-viable on macOS — a CGEventTap with no Cocoa run loop delivers
+ * one event then goes silent). Instead the adapter (a) dispatches the toggle via
+ * `setImmediate` so heavy window work never runs on the tap's emit path, (b)
+ * exposes `reArm()` to revive a possibly-silent tap on sleep/wake without
+ * duplicating listeners (attached once, ever), and (c) wraps `start()` in a
+ * brick-proof launch latch so a tap that crashes/wedges during arming starts
+ * INACTIVE next launch instead of re-bricking.
+ *
  * macOS needs Accessibility/Input-Monitoring (TCC) permission for the tap to
  * deliver events; `isAvailable()` only reports that the module LOADED — whether
  * events actually flow is proven at runtime (and on a signed build), which is why
@@ -15,9 +24,14 @@
  * @module electron/uiohookEngine
  */
 
+import { NATIVE_TAP_STABILITY_WINDOW_MS } from './constants'
 import { log } from './logger'
 import type { LoneModifierId } from './nativeBinding'
 import type { NativeShortcutEngine } from './nativeShortcutEngine'
+import {
+  defaultNativeTapLatch,
+  type NativeTapLatch,
+} from './utils/nativeTapLatch'
 
 /**
  * Lone-modifier id → libuiohook keycode (left/right distinct). Values are the
@@ -65,6 +79,8 @@ interface KeycodeBinding {
  * permanently unavailable and every op is a safe no-op, so callers degrade to a
  * chord exactly as with {@link createUnavailableNativeShortcutEngine}.
  * @param loadUiohook - Thunk returning the `uIOhook` singleton, or `null` on failure.
+ * @param latch - Injectable brick-proof latch (#125); defaults to the fsync-backed
+ *   marker file. Tests pass an in-memory fake to drive the latch-blocked path.
  * @returns A {@link NativeShortcutEngine} backed by the global key tap.
  * @example
  * const engine = createUiohookShortcutEngine(() => {
@@ -73,6 +89,7 @@ interface KeycodeBinding {
  */
 export function createUiohookShortcutEngine(
   loadUiohook: () => UiohookModule | null,
+  latch: NativeTapLatch = defaultNativeTapLatch,
 ): NativeShortcutEngine {
   const uiohook = safeLoad(loadUiohook)
 
@@ -88,6 +105,21 @@ export function createUiohookShortcutEngine(
   // The tap is started lazily on the first bind and stopped on the last, so the
   // app holds no global hook (and triggers no permission prompt) until needed.
   let isTapRunning = false
+
+  // Listeners are attached EXACTLY ONCE, ever (codex #4). They used to be added
+  // inside the start path; a reArm() (stop+start) would then stack duplicate
+  // keydown/keyup listeners and fire each binding twice (then thrice, …).
+  let listenersAttached = false
+
+  // Brick-proof launch latch (#125): clear-after-stability timer, and whether a
+  // PRIOR launch armed the tap but never confirmed (→ start INACTIVE this run).
+  let stabilityTimer: ReturnType<typeof setTimeout> | null = null
+  let blockedByStaleLatch = uiohook !== null && latch.isSet()
+  if (blockedByStaleLatch) {
+    log.warn(
+      '[uiohookEngine] freeze-safety latch set from a prior unconfirmed arming — tap starts INACTIVE until re-enabled',
+    )
+  }
 
   /** Fire a lone-modifier callback without letting a throw kill the tap. */
   const invokeBindingSafely = (binding: KeycodeBinding): void => {
@@ -116,10 +148,75 @@ export function createUiohookShortcutEngine(
       const binding = bindingByKeycode.get(keycode)
       armedKeycode = null
       pressedKeycodes.delete(keycode)
-      if (binding) invokeBindingSafely(binding)
+      // Schedule the toggle off the tap's dispatch path (codex #1): heavy window
+      // work must NOT run synchronously where the native thread delivers events.
+      // `setImmediate` defers to the next main-loop tick — NOT a microtask, which
+      // would still drain on this tick. (This shrinks, not removes, the wedge
+      // surface — a hang INSIDE the callback still freezes main; see AC#3.)
+      if (binding) setImmediate(() => invokeBindingSafely(binding))
       return
     }
     pressedKeycodes.delete(keycode)
+  }
+
+  /** Wire keydown/keyup to the singleton exactly once for the engine's lifetime. */
+  const attachListenersOnce = (): void => {
+    if (uiohook === null || listenersAttached) return
+    uiohook.on('keydown', handleKeyDown)
+    uiohook.on('keyup', handleKeyUp)
+    listenersAttached = true
+  }
+
+  /** Drop in-flight pressed-alone state (used around reArm and on suspend/lock). */
+  const resetPressedState = (): void => {
+    pressedKeycodes.clear()
+    armedKeycode = null
+  }
+
+  /**
+   * Clear the latch marker once the tap has run a stability window without
+   * crashing/wedging the process. A crash/wedge before this fires leaves the
+   * marker set → next launch starts INACTIVE (the brick-loop break).
+   */
+  const scheduleLatchClear = (): void => {
+    if (stabilityTimer) clearTimeout(stabilityTimer)
+    stabilityTimer = setTimeout(() => {
+      stabilityTimer = null
+      latch.clear()
+    }, NATIVE_TAP_STABILITY_WINDOW_MS)
+    stabilityTimer.unref()
+  }
+
+  /**
+   * Arm the brick-guard, attach listeners once, start the tap, schedule the
+   * latch clear. Shared by the first lazy start and every reArm so the
+   * freeze-safety wrapper is identical on each (re)start.
+   * @returns `true` when the tap is running; `false` if the latch couldn't be
+   *   armed (refuse to start unguarded) or `start()` threw.
+   */
+  const startTapGuarded = (): boolean => {
+    if (uiohook === null) return false
+    // Persist the brick-guard BEFORE start(); a freeze with no on-disk guard
+    // would brick the next launch, so refuse to start if it didn't land.
+    if (!latch.arm()) {
+      log.error(
+        '[uiohookEngine] could not arm freeze-safety latch; refusing to start tap',
+      )
+      return false
+    }
+    attachListenersOnce()
+    try {
+      uiohook.start()
+      isTapRunning = true
+      scheduleLatchClear()
+      return true
+    } catch (error) {
+      log.error('[uiohookEngine] Failed to start global key tap:', error)
+      // A synchronous start() failure is not a freeze — clear the guard so the
+      // next launch isn't falsely blocked.
+      latch.clear()
+      return false
+    }
   }
 
   /**
@@ -131,34 +228,37 @@ export function createUiohookShortcutEngine(
   const ensureTapRunning = (): boolean => {
     if (uiohook === null) return false
     if (isTapRunning) return true
-    try {
-      uiohook.on('keydown', handleKeyDown)
-      uiohook.on('keyup', handleKeyUp)
-      uiohook.start()
-      isTapRunning = true
-      log.info('[uiohookEngine] Global key tap started')
-      return true
-    } catch (error) {
-      log.error('[uiohookEngine] Failed to start global key tap:', error)
-      return false
-    }
+    const started = startTapGuarded()
+    if (started) log.info('[uiohookEngine] Global key tap started')
+    return started
   }
 
   /** Stop the tap when no bindings remain so the app releases the global hook. */
   const stopTapIfIdle = (): void => {
     if (uiohook === null || !isTapRunning || bindingByKeycode.size > 0) return
+    if (stabilityTimer) {
+      clearTimeout(stabilityTimer)
+      stabilityTimer = null
+    }
     try {
       uiohook.stop()
     } catch (error) {
       log.error('[uiohookEngine] Failed to stop global key tap:', error)
     }
     isTapRunning = false
-    pressedKeycodes.clear()
-    armedKeycode = null
+    resetPressedState()
+    // A clean stop is a confirmed-healthy session — drop the brick-guard.
+    latch.clear()
   }
 
   return {
     isAvailable: () => uiohook !== null,
+
+    isLatchBlocked: () => blockedByStaleLatch,
+
+    clearLatchBlock: () => {
+      blockedByStaleLatch = false
+    },
 
     register: (
       modifier: LoneModifierId,
@@ -166,6 +266,9 @@ export function createUiohookShortcutEngine(
       callback: () => void,
     ): boolean => {
       if (uiohook === null) return false
+      // #125: a prior unconfirmed arming → do NOT re-arm (possible brick loop).
+      // The caller reads isLatchBlocked() to bind INACTIVE + offer re-enable.
+      if (blockedByStaleLatch) return false
 
       // Drop any prior binding for this id before re-binding it.
       const previousKeycode = keycodeById.get(id)
@@ -201,6 +304,29 @@ export function createUiohookShortcutEngine(
       bindingByKeycode.clear()
       stopTapIfIdle()
     },
+
+    reArm: (): void => {
+      // Revive a possibly-silent tap (resume / unlock-screen / manual re-enable).
+      // Only meaningful when a binding exists; attach-once means stop+start never
+      // duplicates listeners (codex #4). Reset pressed-state on BOTH sides so a
+      // modifier "held across sleep" can't leave a stale armed key (codex #5).
+      if (uiohook === null || bindingByKeycode.size === 0) return
+      resetPressedState()
+      if (stabilityTimer) {
+        clearTimeout(stabilityTimer)
+        stabilityTimer = null
+      }
+      try {
+        if (isTapRunning) uiohook.stop()
+      } catch (error) {
+        log.error('[uiohookEngine] stop during re-arm failed:', error)
+      }
+      isTapRunning = false
+      if (startTapGuarded()) log.info('[uiohookEngine] Global key tap re-armed')
+      resetPressedState()
+    },
+
+    resetPressedState,
   }
 }
 

--- a/electron/uiohookEngine.ts
+++ b/electron/uiohookEngine.ts
@@ -153,7 +153,15 @@ export function createUiohookShortcutEngine(
       // `setImmediate` defers to the next main-loop tick — NOT a microtask, which
       // would still drain on this tick. (This shrinks, not removes, the wedge
       // surface — a hang INSIDE the callback still freezes main; see AC#3.)
-      if (binding) setImmediate(() => invokeBindingSafely(binding))
+      if (binding)
+        setImmediate(() => {
+          // Re-resolve at fire time (codex #3): an unregister / unregisterAll /
+          // rebind between this tick and the next must cancel a now-stale
+          // callback. Fire ONLY if this exact binding is still the live one for
+          // the keycode — a replaced or removed binding bails.
+          if (bindingByKeycode.get(keycode) === binding)
+            invokeBindingSafely(binding)
+        })
       return
     }
     pressedKeycodes.delete(keycode)
@@ -312,14 +320,27 @@ export function createUiohookShortcutEngine(
       // modifier "held across sleep" can't leave a stale armed key (codex #5).
       if (uiohook === null || bindingByKeycode.size === 0) return
       resetPressedState()
+      // Stop the old tap FIRST. If stop() throws, the old singleton's state is
+      // unknown — starting again could double-start a CGEventTap (codex #4). Bail
+      // BEFORE touching the stability timer / isTapRunning so state stays exactly
+      // as it was; the still-armed latch self-heals on a later clean stop / next
+      // launch rather than this turning a stop failure into a double-start.
+      if (isTapRunning) {
+        try {
+          uiohook.stop()
+        } catch (error) {
+          log.error(
+            '[uiohookEngine] stop during re-arm failed; skipping restart to avoid double-start:',
+            error,
+          )
+          return
+        }
+      }
+      // Stop succeeded (or the tap wasn't running) — now safe to drop the old
+      // stability timer and re-arm a fresh tap.
       if (stabilityTimer) {
         clearTimeout(stabilityTimer)
         stabilityTimer = null
-      }
-      try {
-        if (isTapRunning) uiohook.stop()
-      } catch (error) {
-        log.error('[uiohookEngine] stop during re-arm failed:', error)
       }
       isTapRunning = false
       if (startTapGuarded()) log.info('[uiohookEngine] Global key tap re-armed')

--- a/electron/utils/nativeTapLatch.ts
+++ b/electron/utils/nativeTapLatch.ts
@@ -1,0 +1,162 @@
+/**
+ * @fileoverview Brick-proof launch latch for the native key-tap (#125). A tap
+ * that loads, `start()`s, then crashes/wedges the process during arming would
+ * re-arm — and re-crash — on every relaunch, bricking the app with no in-app
+ * recovery. This latch breaks that loop: arm a marker file BEFORE `start()`,
+ * clear it a stability window after a healthy start (or on clean stop); if a
+ * launch finds the marker still set from last run, the tap is started INACTIVE
+ * instead of re-arming. It is a **process-stability** guard (crash/wedge during
+ * arming), NOT tap-liveness — a `start()`-succeeds-but-tap-silent case clears the
+ * marker normally and is handled by powerMonitor/manual re-arm, not here.
+ *
+ * Kept in its OWN file (not `ConfigManager`, whose `saveConfig` does temp+rename
+ * WITHOUT fsync) because a launch-safety gate needs durable, fail-safe writes:
+ * fsync the file AND the userData dir, and treat any read ambiguity as "armed"
+ * so a corrupt/locked marker blocks rather than silently re-arming a brick loop.
+ *
+ * @module electron/utils/nativeTapLatch
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+import { app } from 'electron'
+
+import { log } from '../logger'
+
+/** Marker filename under userData; its mere presence means "armed, unconfirmed". */
+export const LATCH_FILENAME = 'native-tap-arming.json'
+
+/** Absolute path to the latch marker in the per-user app data dir. */
+function latchPath(): string {
+  return path.join(app.getPath('userData'), LATCH_FILENAME)
+}
+
+/**
+ * fsync a directory so a create/rename/unlink of one of its entries is durable
+ * across a power loss — without it the rename can be lost even though the file
+ * data was fsync'd. Best-effort: some filesystems reject directory fsync, which
+ * must not fail the caller.
+ * @param dirPath - The directory whose metadata to flush.
+ */
+function fsyncDir(dirPath: string): void {
+  let fd: number | undefined
+  try {
+    fd = fs.openSync(dirPath, 'r')
+    fs.fsyncSync(fd)
+  } catch (error) {
+    log.warn('[nativeTapLatch] directory fsync failed (non-fatal):', error)
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd)
+      } catch {
+        // closing a read fd after fsync — nothing actionable on failure.
+      }
+    }
+  }
+}
+
+/**
+ * Whether a prior launch armed the tap but never cleared the marker — i.e. it
+ * crashed/wedged during arming. Fail-safe: a present OR unreadable marker counts
+ * as set, so ambiguity blocks the re-arm rather than risking the brick loop.
+ * @returns
+ * - `true`: marker present (or its state can't be read) → start the tap INACTIVE
+ * - `false`: no marker → safe to arm
+ * @example
+ * if (isNativeTapLatchSet()) startInactive() // a prior arming never confirmed
+ */
+export function isNativeTapLatchSet(): boolean {
+  try {
+    return fs.existsSync(latchPath())
+  } catch (error) {
+    log.warn(
+      '[nativeTapLatch] latch stat failed; treating as SET (fail-safe):',
+      error,
+    )
+    return true
+  }
+}
+
+/**
+ * Arm the latch DURABLY before starting the tap: temp write → fsync file →
+ * atomic rename → fsync dir. Returns `false` if the marker didn't persist so the
+ * caller can refuse to start a tap whose brick-guard isn't on disk.
+ * @returns
+ * - `true`: marker is durably on disk → safe to `start()` the tap
+ * - `false`: write failed → do NOT start (no brick-guard means a freeze bricks)
+ * @example
+ * if (armNativeTapLatch()) uIOhook.start() // guard persisted first
+ */
+export function armNativeTapLatch(): boolean {
+  const target = latchPath()
+  const temp = `${target}.tmp`
+  let fd: number | undefined
+  try {
+    fd = fs.openSync(temp, 'w')
+    fs.writeSync(fd, JSON.stringify({ armedAt: Date.now() }))
+    fs.fsyncSync(fd)
+    fs.closeSync(fd)
+    fd = undefined
+    fs.renameSync(temp, target)
+    fsyncDir(path.dirname(target))
+    return true
+  } catch (error) {
+    log.error('[nativeTapLatch] failed to arm latch:', error)
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd)
+      } catch {
+        // best-effort cleanup of the temp fd
+      }
+    }
+    try {
+      if (fs.existsSync(temp)) fs.unlinkSync(temp)
+    } catch {
+      // best-effort cleanup of the temp file
+    }
+    return false
+  }
+}
+
+/**
+ * Clear the latch after a healthy start (or on clean tap stop). Idempotent — a
+ * missing marker is success, not an error. Fsyncs the dir so a stale marker can't
+ * survive to falsely block the next launch.
+ * @example
+ * setTimeout(clearNativeTapLatch, STABILITY_WINDOW_MS) // confirmed stable
+ */
+export function clearNativeTapLatch(): void {
+  const target = latchPath()
+  try {
+    fs.unlinkSync(target)
+    fsyncDir(path.dirname(target))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log.warn('[nativeTapLatch] failed to clear latch:', error)
+    }
+  }
+}
+
+/**
+ * The latch operations the tap engine depends on, as an INJECTABLE seam so the
+ * engine unit-tests with an in-memory fake (no `electron.app` / no fs) — mirroring
+ * how the engine already injects its native-module loader. `main.ts` uses the
+ * default fs-backed implementation below.
+ */
+export interface NativeTapLatch {
+  /** True when a prior launch armed but never confirmed (start the tap INACTIVE). */
+  isSet(): boolean
+  /** Persist the marker before `start()`; false if the write didn't land. */
+  arm(): boolean
+  /** Remove the marker after a healthy start / clean stop. Idempotent. */
+  clear(): void
+}
+
+/** The real, fsync-durable latch backed by a marker file under userData. */
+export const defaultNativeTapLatch: NativeTapLatch = {
+  isSet: isNativeTapLatchSet,
+  arm: armNativeTapLatch,
+  clear: clearNativeTapLatch,
+}

--- a/electron/utils/nativeTapLatch.ts
+++ b/electron/utils/nativeTapLatch.ts
@@ -35,17 +35,38 @@ function latchPath(): string {
 /**
  * fsync a directory so a create/rename/unlink of one of its entries is durable
  * across a power loss — without it the rename can be lost even though the file
- * data was fsync'd. Best-effort: some filesystems reject directory fsync, which
- * must not fail the caller.
+ * data was fsync'd. Distinguishes "this FS can't fsync a dir" (EINVAL/ENOTSUP —
+ * not our write's fault, treat as flushed) from a real IO failure (EIO/ENOSPC —
+ * the rename may NOT be durable), so `armNativeTapLatch` can refuse to start
+ * unguarded on a genuine durability failure (codex #1) without breaking the
+ * feature on exotic filesystems that simply don't support directory fsync.
  * @param dirPath - The directory whose metadata to flush.
+ * @returns
+ * - `true`: dir metadata flushed, or the FS doesn't support dir fsync (benign)
+ * - `false`: a real IO error — the just-renamed entry may not be crash-durable
  */
-function fsyncDir(dirPath: string): void {
+function fsyncDir(dirPath: string): boolean {
   let fd: number | undefined
   try {
     fd = fs.openSync(dirPath, 'r')
     fs.fsyncSync(fd)
+    return true
   } catch (error) {
-    log.warn('[nativeTapLatch] directory fsync failed (non-fatal):', error)
+    const code = (error as NodeJS.ErrnoException).code
+    // Some filesystems reject directory fsync outright — that is not a
+    // durability failure of our write, so it must not fail the caller.
+    if (code === 'EINVAL' || code === 'ENOTSUP') {
+      log.warn(
+        '[nativeTapLatch] directory fsync unsupported (non-fatal):',
+        error,
+      )
+      return true
+    }
+    log.error(
+      '[nativeTapLatch] directory fsync failed; marker not durable:',
+      error,
+    )
+    return false
   } finally {
     if (fd !== undefined) {
       try {
@@ -61,18 +82,28 @@ function fsyncDir(dirPath: string): void {
  * Whether a prior launch armed the tap but never cleared the marker — i.e. it
  * crashed/wedged during arming. Fail-safe: a present OR unreadable marker counts
  * as set, so ambiguity blocks the re-arm rather than risking the brick loop.
+ *
+ * Uses `statSync`, NOT `existsSync` (codex #2): `existsSync` collapses EVERY
+ * error — including a permission/IO failure — to `false`, which would report
+ * "not armed" on an ambiguous read and re-arm a possible brick loop. `statSync`
+ * lets us treat ONLY `ENOENT` as "definitely absent" and any other error as SET.
  * @returns
  * - `true`: marker present (or its state can't be read) → start the tap INACTIVE
- * - `false`: no marker → safe to arm
+ * - `false`: marker definitively absent (ENOENT) → safe to arm
  * @example
  * if (isNativeTapLatchSet()) startInactive() // a prior arming never confirmed
  */
 export function isNativeTapLatchSet(): boolean {
   try {
-    return fs.existsSync(latchPath())
+    fs.statSync(latchPath())
+    // The entry exists (file, or even a stray dir) → armed-and-unconfirmed.
+    return true
   } catch (error) {
+    // ENOENT is the ONLY signal that the marker is truly absent; every other
+    // error (EACCES, EIO, …) is ambiguous and must block (fail-safe).
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
     log.warn(
-      '[nativeTapLatch] latch stat failed; treating as SET (fail-safe):',
+      '[nativeTapLatch] latch stat ambiguous; treating as SET (fail-safe):',
       error,
     )
     return true
@@ -100,7 +131,19 @@ export function armNativeTapLatch(): boolean {
     fs.closeSync(fd)
     fd = undefined
     fs.renameSync(temp, target)
-    fsyncDir(path.dirname(target))
+    // A real dir-fsync IO failure means the rename may not survive a crash, so
+    // the brick-guard isn't durable — roll the marker back and refuse to start
+    // (codex #1). On filesystems that simply don't support dir fsync this still
+    // returns true, so the lone-modifier feature keeps working there.
+    if (!fsyncDir(path.dirname(target))) {
+      try {
+        fs.unlinkSync(target)
+      } catch {
+        // best-effort rollback; a leftover marker only blocks (fail-safe), it
+        // never bricks, so an unlink failure here is not actionable.
+      }
+      return false
+    }
     return true
   } catch (error) {
     log.error('[nativeTapLatch] failed to arm latch:', error)

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -7,6 +7,7 @@
 import type {
   AuxWindowVisibility,
   IPCResponse,
+  NativeTapStatus,
   StartupWindowConfig,
 } from '@/electron/types/ipc'
 
@@ -106,6 +107,9 @@ interface ElectronAPI {
     enable: () => Promise<boolean>
     disable: () => Promise<boolean>
     getStats: () => Promise<any>
+    // Native key-tap freeze-safety (#125) — status + manual re-enable.
+    getNativeTapStatus: () => Promise<NativeTapStatus>
+    reenableNativeTap: () => Promise<NativeTapStatus>
   }
 
   // Authentication


### PR DESCRIPTION
Closes #125.

## What

In-main **freeze-safety hardening** for the native lone-modifier global key-tap (the Right ⌥ → BrainDump/Floating binding from #111). A wedged `CGEventTap` can stall input dispatch and — worse — re-arm and re-brick on every relaunch. This is the **GA gate** for shipping lone-modifier shortcuts.

> **Design pivot (honest note):** the issue title proposes a `utilityProcess` isolation + watchdog. The codex-reviewed **v2 design** (`docs/design/125-native-keytap-freeze-safety.md`, commits `d908def`/`7ed51c8`) pivots to an **in-main** 3-layer approach after the Phase 0 prove-out showed the tap itself doesn't freeze under normal load — the real GA risk is a *brick loop*, which a durable launch latch addresses far more simply than process isolation. Watchdog/utilityProcess remains a documented future escalation if a real-world freeze ever surfaces.

## How — 3 layers

- **L1 — non-blocking dispatch.** Shortcut callbacks fire via `setImmediate` (fire-and-forget) so a slow/throwing handler can never stall the tap's event loop. Binding is re-resolved at fire time (identity check) so an unregister/replace between press and release can't fire a stale callback.
- **L2 — re-arm on recoverable causes.** `powerMonitor` suspend/lock resets pressed-state; resume/unlock re-arms the tap. A manual re-enable IPC (`reenableNativeTap`) recovers a latch-blocked tap.
- **L3 — brick-proof launch latch.** An fsync-durable on-disk marker (`native-tap-arming.json`) is armed *before* `start()` and cleared only after a stability window. If a prior launch froze mid-arming, the marker is still present next launch ⇒ the tap starts **INACTIVE** instead of re-bricking. Corrupt/unreadable marker ⇒ treated as set (fail-safe).

## Codex /review — 7 findings fixed (`cea8f18`)

No Critical, no false positives. Highlights: `fsyncDir` distinguishes benign unsupported-FS (EINVAL/ENOTSUP) from real IO failure (rolls back the marker); `isNativeTapLatchSet` uses `statSync` (ENOENT-only → false, any other error → fail-safe SET); `reArm` bails before mutating timer/running state if `stop()` throws (no double-start); `NativeTapStatus` gains an `active` field so status can't mislead. Each fix carries a regression test.

## QA

- **Test A — brick-proof block path (packaged `:dir` binary, autonomous, no TCC):** ✅ PASS. Preseeded a stale marker + `toggleBrainDump = lone-modifier:rightOption`, ran the binary directly. Logs confirm `freeze-safety latch set from a prior unconfirmed arming` (proves **uiohook-napi loads** in packaged AND marker read) and `Latch-blocked; leaving toggleBrainDump inactive`; marker survived; app booted without bricking (`1/2 global shortcuts`, deferred init OK).
- **Test B — healthy arm→clear:** user-gated (needs TCC Input-Monitoring `start()`; a freshly-built unsigned `:dir` binary won't carry the grant). Covered by `nativeTapLatch` unit lifecycle tests + the #111 packaged live prove-out.
- **Tests:** 384 electron tests green (+regressions). `pnpm validate` green.

> ⚠️ **Release note:** do **not** push a `v*` tag from this until a **signed-build re-prove** of the live arm→start→fire→clear path on a notarized binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native shortcut “freeze-safety” status reporting plus a manual re-enable action in the Settings-facing controls.
  * Automatically recovers native tap state on suspend/lock and resume/unlock events.

* **Bug Fixes**
  * Improved resilience for lone-modifier shortcuts to avoid getting stuck or repeatedly failing after power/system interruptions.
  * Disabled-native notifications are now shown only once per blocked period.

* **Tests**
  * Expanded coverage for native tap latch durability, recovery behavior, and one-time listener/dispatch guarantees.

* **Documentation**
  * Added a detailed design document for the freeze-safety latch approach and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->