### PR TITLE
feat(128): disable spellcheck red underlines in braindump writing surface

### DIFF
--- a/docs/design/128-braindump-disable-spellcheck.md
+++ b/docs/design/128-braindump-disable-spellcheck.md
@@ -1,0 +1,77 @@
+# #128 — Braindump hides spellcheck red underlines
+
+## Context
+
+Braindump is the quick, messy-capture surface. The native browser spellchecker draws
+red squiggly underlines under misspelled / unfinished / mixed-language words, which makes
+half-formed thoughts feel "corrected" and noisy — the opposite of the calm, self-affirming
+writing surface the product wants (DESIGN.md north star: capture without judgement).
+
+## Root cause
+
+`src/components/braindump/BrainDumpEditor.tsx` renders its writing area as a raw
+`<textarea>` with a **bare `spellCheck` attribute** (line 1449). In JSX a bare attribute is
+`spellCheck={true}`, so the browser spellchecker is explicitly enabled and red underlines show.
+
+## Design
+
+Single-character-of-intent change: set the textarea's `spellCheck={false}`.
+
+```diff
+- spellCheck
++ spellCheck={false}
+```
+
+`spellCheck` is the standard React DOM attribute; `spellCheck={false}` renders the HTML
+`spellcheck="false"`, which disables the native spellchecker (no red underlines) on that
+element across Chromium/WebKit. Typing, editing, IME composition, and saving are untouched —
+`spellcheck` only governs the correction overlay, not input or `value`.
+
+### Why only `spellCheck` (scope discipline)
+
+The issue is specifically about **red spellcheck underlines**. `autoCorrect` /
+`autoCapitalize` / `autoComplete` govern auto-substitution and suggestions (mostly mobile),
+not the red underline, and changing them would alter typing behavior beyond the ask. They are
+intentionally **out of scope** — minimal change, no behavior creep.
+
+## Surface coverage ("consistent wherever Braindump is available")
+
+The braindump writing area is a **single shared component** rendered in exactly one place:
+
+- `BrainDumpEditor` (the only braindump text input — one raw `<textarea>`, line 1436) is
+  rendered solely by `src/app/braindump/page.tsx` (`<BrainDumpEditor categories={…} />`).
+- Every Electron braindump surface (the Floating / BrainDump windows) loads the **remote web
+  `/braindump` route** (Electron is a full WebView of `corelive.app`), so they render the same
+  component. There is no separate native or duplicate braindump editor.
+- The only other `<textarea>` in the app is the generic shadcn primitive
+  `src/components/ui/textarea.tsx`, which braindump does **not** use and which must stay
+  untouched (it backs unrelated inputs).
+
+⇒ Changing the one `BrainDumpEditor` textarea satisfies the "consistent across all surfaces"
+acceptance criterion by construction.
+
+## Testing
+
+- **Unit (regression):** extend `BrainDumpEditor.test.tsx` to assert the writing textarea
+  renders with spellcheck disabled (`spellcheck="false"` in the DOM), so a future refactor
+  can't silently re-enable the red underlines. Hard-coded expected value, AAA, behavior-named.
+- **Renderer E2E:** existing braindump specs continue to prove typing / completing / saving
+  still work (no behavior change to input). The spellcheck overlay itself is a browser-native
+  rendering with no DOM hook for E2E — the unit DOM-attribute assertion is the right gate.
+
+## Local QA
+
+Web renderer (`/braindump`): type a deliberately misspelled word and confirm no red underline
+appears, and that typing / line-complete (Cmd/Ctrl+Enter) / save still work. Renderer-only
+change → no native-Cocoa QA owed; the Electron windows show the identical remote route.
+
+## Files touched
+
+- `src/components/braindump/BrainDumpEditor.tsx` — `spellCheck` → `spellCheck={false}`.
+- `src/components/braindump/BrainDumpEditor.test.tsx` — spellcheck-disabled regression assertion.
+- `docs/design/128-braindump-disable-spellcheck.md` — this doc.
+
+## Scope
+
+Renderer-only. No Electron main-process / native code, no DB, no API. Already live via Vercel
+on merge; no signed release needed.

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -330,6 +330,31 @@ describe('BrainDumpEditor text styling preferences', () => {
   })
 })
 
+describe('BrainDumpEditor writing surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps the surface calm by disabling the native red spellcheck underlines', async () => {
+    // Arrange
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+
+    // Act — open the braindump writing surface.
+    renderEditor()
+    const noteField = await screen.findByRole('textbox')
+
+    // Assert — the textarea opts out of the browser spellchecker, so misspelled,
+    // unfinished, or mixed-language fragments never get red correction underlines.
+    // Regression guard for #128: a refactor that drops this re-enables the noise.
+    expect(noteField.getAttribute('spellcheck')).toBe('false')
+  })
+})
+
 describe('BrainDumpEditor focus on window show', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -1446,7 +1446,11 @@ export const BrainDumpEditor = function BrainDumpEditor({
         }
         disabled={activeCategoryId === null}
         maxLength={NOTE_MAX_LENGTH}
-        spellCheck
+        // Braindump is messy quick-capture — the native red spellcheck underlines
+        // make unfinished / mixed-language fragments feel "corrected" and noisy, so
+        // we keep the writing surface calm by disabling them. Only the correction
+        // overlay is suppressed; typing / IME / save are unaffected (#128).
+        spellCheck={false}
         className="bg-background/60 flex-1 resize-none rounded-lg border p-3 shadow-sm focus:outline-none disabled:opacity-50"
         // Inline (not a useMemo) — a fresh style object on an intrinsic element is
         // free. Spread NO_DRAG_REGION_STYLE first (load-bearing: keeps the


### PR DESCRIPTION
Closes #128.

## What
Braindump is messy quick-capture; the native browser spellchecker draws red squiggly underlines under misspelled / unfinished / mixed-language words, which makes half-formed thoughts feel "corrected" and noisy. This sets the braindump writing `<textarea>`'s **`spellCheck={false}`** so the surface stays calm.

Only the correction overlay is suppressed — typing, IME composition, and save are untouched (`spellcheck` governs the red-underline overlay only, not input or `value`).

## Why one change covers every surface
`BrainDumpEditor` is the **single shared braindump text input** (one raw `<textarea>`), rendered solely by `src/app/braindump/page.tsx`. Every Electron braindump surface (Floating / BrainDump windows) loads the remote web `/braindump` route, so they render the same component — satisfying acceptance criterion (3) "consistent wherever Braindump is available" by construction. The only other `<textarea>` in the app is the generic shadcn primitive, which braindump does not use and which stays untouched.

## Scope discipline
`autoCorrect` / `autoCapitalize` govern auto-substitution, not the red underline, and are intentionally left untouched (changing them would alter typing behavior beyond the ask).

## Testing / QA
- **Unit regression** (`BrainDumpEditor.test.tsx`): asserts the textarea renders `spellcheck="false"`, so a future refactor can't silently re-enable the underlines.
- **CI E2E**: existing braindump specs continue to prove typing / line-complete / save are unaffected.
- `pnpm validate` green (test, typecheck, build, lint). Renderer-only — no Electron native / DB / API; no signed release needed (ships via Vercel on merge).
- context7 (react.dev) confirms `spellCheck={false}` is the canonical React DOM attribute → `spellcheck="false"`.

## Review trail
- `/plan-eng-review` (codex): plan sound, zero CRITICAL/MAJOR/MINOR.
- `/review` (codex review --base main): narrowly scoped, regression test passes, no findings.

Design doc: `docs/design/128-braindump-disable-spellcheck.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled the browser’s native spellcheck underlines in the Braindump writing area, improving the editor’s visual appearance without changing typing or saving behavior.

- **Tests**
  - Added coverage to verify the Braindump textarea renders with spellcheck turned off.

- **Documentation**
  - Added design notes describing the change scope and validation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->