### PR TITLE
fix(electron): route signed-out BrainDump auth to FloatingNavigator

### DIFF
--- a/e2e/electron/braindump-window.spec.ts
+++ b/e2e/electron/braindump-window.spec.ts
@@ -90,8 +90,9 @@ test('opening braindump creates a new browser window', async () => {
   expect(electronApp.windows().length).toBe(windowCountBefore + 1)
 })
 
-test('aux visibility reports the braindump as visible after opening', async () => {
-  // Arrange: braindump was shown by the previous test
+test('signed-out BrainDump stays hidden while Floating remains the sign-in front door', async () => {
+  // Arrange: the previous test created BrainDump while signed out. It must stay
+  // hidden because the protected route redirects to /login.
   // Act
   const visibility = await settingsWindow.evaluate(async () => {
     const getFn = window.electronAPI?.window?.getAuxVisibility
@@ -99,8 +100,9 @@ test('aux visibility reports the braindump as visible after opening', async () =
     return getFn()
   })
 
-  // Assert
-  expect(visibility.braindump).toBe(true)
+  // Assert: login is not exposed in BrainDump; Floating is the sign-in surface.
+  expect(visibility.braindump).toBe(false)
+  expect(visibility.floating).toBe(true)
 })
 
 test('setting braindump opacity to 0.75 persists the exact value', async () => {

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -109,6 +109,8 @@ export class WindowManager {
   private brainDumpHasLoadedOnce: boolean
   /** True while a manual BrainDump show waits for auth redirect/load settlement. */
   private brainDumpRevealPending: boolean
+  /** Cancels the current delayed BrainDump reveal watcher, if one is active. */
+  private cancelBrainDumpReveal: (() => void) | null
   /** True after BrainDump was suppressed and must reload `/braindump` before reveal. */
   private brainDumpNeedsReloadBeforeReveal: boolean
 
@@ -185,6 +187,7 @@ export class WindowManager {
     this.brainDumpWindow = null
     this.brainDumpHasLoadedOnce = false
     this.brainDumpRevealPending = false
+    this.cancelBrainDumpReveal = null
     this.brainDumpNeedsReloadBeforeReveal = false
     this.settingsWindow = null
     this.isDev = process.env.NODE_ENV === 'development'
@@ -826,6 +829,7 @@ export class WindowManager {
     log.debug('Loading BrainDump URL:', brainDumpUrl)
     this.brainDumpHasLoadedOnce = false
     this.brainDumpRevealPending = false
+    this.cancelBrainDumpReveal = null
     this.brainDumpNeedsReloadBeforeReveal = false
     this.brainDumpWindow.loadURL(brainDumpUrl)
 
@@ -858,6 +862,7 @@ export class WindowManager {
       this.brainDumpWindow = null
       this.brainDumpHasLoadedOnce = false
       this.brainDumpRevealPending = false
+      this.cancelBrainDumpReveal = null
       this.brainDumpNeedsReloadBeforeReveal = false
     })
 
@@ -903,6 +908,11 @@ export class WindowManager {
       return false
     }
 
+    if (this.brainDumpRevealPending) {
+      this.cancelPendingBrainDumpReveal()
+      return false
+    }
+
     this.showBrainDump()
     return true
   }
@@ -943,7 +953,7 @@ export class WindowManager {
       // The old hidden window is parked on /login; reload the protected editor
       // route so a later signed-in open can reach BrainDump instead of stale auth/error.
       this.brainDumpHasLoadedOnce = false
-      this.brainDumpRevealPending = false
+      this.cancelPendingBrainDumpReveal()
       this.brainDumpNeedsReloadBeforeReveal = false
       panel.loadURL(this.getPanelUrl('braindump'))
     }
@@ -976,10 +986,27 @@ export class WindowManager {
 
     this.brainDumpRevealPending = true
 
+    const cancelReveal = (): void => {
+      if (decided) return
+      decided = true
+      this.brainDumpRevealPending = false
+      if (this.cancelBrainDumpReveal === cancelReveal) {
+        this.cancelBrainDumpReveal = null
+      }
+      removeListeners.forEach((remove) => remove())
+
+      // A toggle-off before load settlement must keep BrainDump hidden.
+      if (!panel.isDestroyed()) panel.hide()
+    }
+    this.cancelBrainDumpReveal = cancelReveal
+
     const finish = (authenticated: boolean): void => {
       if (decided) return
       decided = true
       this.brainDumpRevealPending = false
+      if (this.cancelBrainDumpReveal === cancelReveal) {
+        this.cancelBrainDumpReveal = null
+      }
       removeListeners.forEach((remove) => remove())
 
       if (panel.isDestroyed()) return
@@ -1046,9 +1073,26 @@ export class WindowManager {
   private suppressBrainDumpAuthRedirect(panel: BrowserWindow): void {
     this.brainDumpHasLoadedOnce = false
     this.brainDumpRevealPending = false
+    this.cancelBrainDumpReveal = null
     this.brainDumpNeedsReloadBeforeReveal = true
     panel.hide()
     this.restoreFromTray()
+  }
+
+  /**
+   * Cancels a pending manual BrainDump reveal when callers toggle it off before navigation settles.
+   *
+   * @returns void.
+   * @example
+   * this.cancelPendingBrainDumpReveal()
+   */
+  private cancelPendingBrainDumpReveal(): void {
+    if (this.cancelBrainDumpReveal) {
+      this.cancelBrainDumpReveal()
+      return
+    }
+
+    this.brainDumpRevealPending = false
   }
 
   /** Hide the BrainDump window without destroying it (instant re-show). */
@@ -1352,6 +1396,7 @@ export class WindowManager {
       if (kind === 'braindump') {
         this.brainDumpHasLoadedOnce = false
         this.brainDumpRevealPending = false
+        this.cancelBrainDumpReveal = null
         this.brainDumpNeedsReloadBeforeReveal = true
       }
       this.startupAuthFallbacks.add(kind)

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -990,6 +990,8 @@ export class WindowManager {
       if (decided) return
       decided = true
       this.brainDumpRevealPending = false
+      this.brainDumpHasLoadedOnce = false
+      this.brainDumpNeedsReloadBeforeReveal = true
       if (this.cancelBrainDumpReveal === cancelReveal) {
         this.cancelBrainDumpReveal = null
       }

--- a/electron/WindowManager.ts
+++ b/electron/WindowManager.ts
@@ -105,6 +105,12 @@ export class WindowManager {
 
   /** Frameless transparent BrainDump Note panel */
   private brainDumpWindow: BrowserWindow | null
+  /** True after BrainDump has loaded its protected editor route in this window. */
+  private brainDumpHasLoadedOnce: boolean
+  /** True while a manual BrainDump show waits for auth redirect/load settlement. */
+  private brainDumpRevealPending: boolean
+  /** True after BrainDump was suppressed and must reload `/braindump` before reveal. */
+  private brainDumpNeedsReloadBeforeReveal: boolean
 
   /** Settings window */
   private settingsWindow: BrowserWindow | null
@@ -177,6 +183,9 @@ export class WindowManager {
   ) {
     this.floatingNavigator = null
     this.brainDumpWindow = null
+    this.brainDumpHasLoadedOnce = false
+    this.brainDumpRevealPending = false
+    this.brainDumpNeedsReloadBeforeReveal = false
     this.settingsWindow = null
     this.isDev = process.env.NODE_ENV === 'development'
     this.serverUrl = serverUrl
@@ -815,6 +824,9 @@ export class WindowManager {
     const brainDumpUrl = this.getPanelUrl('braindump')
 
     log.debug('Loading BrainDump URL:', brainDumpUrl)
+    this.brainDumpHasLoadedOnce = false
+    this.brainDumpRevealPending = false
+    this.brainDumpNeedsReloadBeforeReveal = false
     this.brainDumpWindow.loadURL(brainDumpUrl)
 
     this.brainDumpWindow.on('resize', () => {
@@ -844,6 +856,9 @@ export class WindowManager {
     this.brainDumpWindow.on('closed', () => {
       log.debug('BrainDump window closed')
       this.brainDumpWindow = null
+      this.brainDumpHasLoadedOnce = false
+      this.brainDumpRevealPending = false
+      this.brainDumpNeedsReloadBeforeReveal = false
     })
 
     this.brainDumpWindow.webContents.on(
@@ -892,13 +907,148 @@ export class WindowManager {
     return true
   }
 
-  /** Show the BrainDump window, creating it if needed, then focus it. */
+  /**
+   * Show BrainDump only after its protected route settles; signed-out redirects surface Floating Navigator instead.
+   *
+   * @returns void.
+   * @example
+   * windowManager.showBrainDump()
+   */
   showBrainDump(): void {
-    if (!this.brainDumpWindow || this.brainDumpWindow.isDestroyed()) {
-      this.createBrainDumpWindow()
+    const brainDumpWindow =
+      !this.brainDumpWindow || this.brainDumpWindow.isDestroyed()
+        ? this.createBrainDumpWindow()
+        : this.brainDumpWindow
+
+    this.revealBrainDumpAfterAuthGate(brainDumpWindow)
+  }
+
+  /**
+   * Reveal a manual BrainDump open only when it is on the editor route; auth pages are always re-homed to Floating.
+   *
+   * @param panel - Hidden BrainDump window whose current navigation decides whether it can appear.
+   * @returns void.
+   * @example
+   * this.revealBrainDumpAfterAuthGate(this.createBrainDumpWindow())
+   */
+  private revealBrainDumpAfterAuthGate(panel: BrowserWindow): void {
+    if (panel.isDestroyed()) return
+
+    const currentUrl = panel.webContents.getURL()
+
+    if (
+      this.brainDumpNeedsReloadBeforeReveal ||
+      (currentUrl && this.isAuthPathname(currentUrl))
+    ) {
+      // The old hidden window is parked on /login; reload the protected editor
+      // route so a later signed-in open can reach BrainDump instead of stale auth/error.
+      this.brainDumpHasLoadedOnce = false
+      this.brainDumpRevealPending = false
+      this.brainDumpNeedsReloadBeforeReveal = false
+      panel.loadURL(this.getPanelUrl('braindump'))
     }
-    this.brainDumpWindow?.show()
-    this.brainDumpWindow?.focus()
+
+    if (this.brainDumpHasLoadedOnce) {
+      panel.show()
+      panel.focus()
+      return
+    }
+
+    // A prior manual show is already waiting for the redirect/load decision.
+    if (this.brainDumpRevealPending) return
+
+    this.watchManualBrainDumpLoad(panel)
+  }
+
+  /**
+   * Watch a manual BrainDump open until it either reaches the editor or redirects to auth.
+   *
+   * @param panel - BrainDump BrowserWindow that has started loading `/braindump`.
+   * @returns void.
+   * @example
+   * this.watchManualBrainDumpLoad(panel)
+   */
+  private watchManualBrainDumpLoad(panel: BrowserWindow): void {
+    const { webContents } = panel
+    const removeListeners: Array<() => void> = []
+    let decided = false
+    let latestMainFrameUrl = webContents.getURL() || null
+
+    this.brainDumpRevealPending = true
+
+    const finish = (authenticated: boolean): void => {
+      if (decided) return
+      decided = true
+      this.brainDumpRevealPending = false
+      removeListeners.forEach((remove) => remove())
+
+      if (panel.isDestroyed()) return
+
+      if (authenticated) {
+        // Authenticated: now the editor route is safe to expose in BrainDump.
+        this.brainDumpHasLoadedOnce = true
+        this.brainDumpNeedsReloadBeforeReveal = false
+        panel.show()
+        panel.focus()
+        return
+      }
+
+      this.suppressBrainDumpAuthRedirect(panel)
+    }
+
+    const onDidNavigate = (_event: Electron.Event, url: string): void => {
+      latestMainFrameUrl = url
+      // Auth redirects are terminal: do not let /login render inside BrainDump.
+      if (this.isAuthPathname(url)) finish(false)
+    }
+
+    const onDidFinishLoad = (): void => {
+      // Trust the route only after load settles; unauthenticated redirects can
+      // report the requested /braindump URL before landing on /login.
+      const currentSettledUrl = webContents.getURL() || latestMainFrameUrl
+      finish(
+        currentSettledUrl === null
+          ? false
+          : !this.isAuthPathname(currentSettledUrl),
+      )
+    }
+
+    const onDidFailLoad = (
+      _event: Electron.Event,
+      errorCode: number,
+      _errorDescription: string,
+      _validatedURL: string,
+      isMainFrame: boolean,
+    ): void => {
+      // Ignore subresource failures and normal redirect cancellations.
+      if (!isMainFrame || errorCode === ERR_ABORTED) return
+      finish(false)
+    }
+
+    webContents.on('did-navigate', onDidNavigate)
+    webContents.on('did-finish-load', onDidFinishLoad)
+    webContents.on('did-fail-load', onDidFailLoad)
+    removeListeners.push(
+      () => webContents.removeListener('did-navigate', onDidNavigate),
+      () => webContents.removeListener('did-finish-load', onDidFinishLoad),
+      () => webContents.removeListener('did-fail-load', onDidFailLoad),
+    )
+  }
+
+  /**
+   * Hide BrainDump when it hits auth and show Floating Navigator as the only sign-in surface.
+   *
+   * @param panel - BrainDump BrowserWindow that attempted to host an auth page.
+   * @returns void.
+   * @example
+   * this.suppressBrainDumpAuthRedirect(panel)
+   */
+  private suppressBrainDumpAuthRedirect(panel: BrowserWindow): void {
+    this.brainDumpHasLoadedOnce = false
+    this.brainDumpRevealPending = false
+    this.brainDumpNeedsReloadBeforeReveal = true
+    panel.hide()
+    this.restoreFromTray()
   }
 
   /** Hide the BrainDump window without destroying it (instant re-show). */
@@ -1185,6 +1335,10 @@ export class WindowManager {
 
       if (authenticated) {
         // Authed: reveal the panel the user asked to start with.
+        if (kind === 'braindump') {
+          this.brainDumpHasLoadedOnce = true
+          this.brainDumpNeedsReloadBeforeReveal = false
+        }
         panel.show()
         return
       }
@@ -1195,6 +1349,11 @@ export class WindowManager {
       // signed-out launch always leaves one visible, interactive window to sign in
       // from. The suppressed panel reopens from the tray after sign-in; main's
       // post-login auto-reshow is retired with the window.
+      if (kind === 'braindump') {
+        this.brainDumpHasLoadedOnce = false
+        this.brainDumpRevealPending = false
+        this.brainDumpNeedsReloadBeforeReveal = true
+      }
       this.startupAuthFallbacks.add(kind)
       this.restoreFromTray()
     }

--- a/electron/__tests__/WindowManager.startup-panel.test.ts
+++ b/electron/__tests__/WindowManager.startup-panel.test.ts
@@ -369,6 +369,31 @@ describe('WindowManager startup panel nav-watch', () => {
     expect(restoreFromTray).toHaveBeenCalledTimes(1)
   })
 
+  it('cancels a pending manual BrainDump reveal when toggled off before load settles', () => {
+    // Arrange: the first toggle starts a hidden BrainDump load guarded by the
+    // manual auth watcher, but the route has not settled yet.
+    const windowManager = new WindowManager(SERVER_URL)
+    const firstToggleResult = windowManager.toggleBrainDump()
+    const brainDumpWindow = getWindow(0)
+
+    // Act: a second toggle before did-finish-load means the caller intended to
+    // close the pending reveal, then the original load completes successfully.
+    const secondToggleResult = windowManager.toggleBrainDump()
+    brainDumpWindow.fireWebContents(
+      'did-navigate',
+      {},
+      `${SERVER_URL}/braindump`,
+    )
+    brainDumpWindow.fireWebContents('did-finish-load')
+
+    // Assert: the stale load callback cannot show/focus BrainDump after cancel.
+    expect(firstToggleResult).toBe(true)
+    expect(secondToggleResult).toBe(false)
+    expect(brainDumpWindow.win.hide).toHaveBeenCalledTimes(1)
+    expect(brainDumpWindow.win.show).not.toHaveBeenCalled()
+    expect(brainDumpWindow.win.focus).not.toHaveBeenCalled()
+  })
+
   it('reloads a suppressed BrainDump back to its route before revealing it after sign-in', () => {
     // Arrange: the first open is signed out, leaving the hidden BrainDump window
     // sitting on /login until the user signs in from Floating Navigator.

--- a/electron/__tests__/WindowManager.startup-panel.test.ts
+++ b/electron/__tests__/WindowManager.startup-panel.test.ts
@@ -346,6 +346,65 @@ describe('WindowManager startup panel nav-watch', () => {
     expect(panelWindow.win.show).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps a signed-out manual BrainDump open hidden and surfaces the Floating front door', () => {
+    // Arrange: a menu/shortcut/manual BrainDump open does not go through the
+    // startup-only gate, so WindowManager must guard this path itself.
+    const windowManager = new WindowManager(SERVER_URL)
+    const restoreFromTray = vi
+      .spyOn(windowManager, 'restoreFromTray')
+      .mockImplementation(() => {})
+
+    // Act: proxy.ts redirected the protected BrainDump route to /login.
+    windowManager.showBrainDump()
+    const brainDumpWindow = getWindow(0)
+    brainDumpWindow.fireWebContents(
+      'did-navigate',
+      {},
+      `${SERVER_URL}/login?redirect_url=/braindump`,
+    )
+
+    // Assert: login never renders in BrainDump; Floating becomes the sign-in front door.
+    expect(brainDumpWindow.win.show).not.toHaveBeenCalled()
+    expect(brainDumpWindow.win.focus).not.toHaveBeenCalled()
+    expect(restoreFromTray).toHaveBeenCalledTimes(1)
+  })
+
+  it('reloads a suppressed BrainDump back to its route before revealing it after sign-in', () => {
+    // Arrange: the first open is signed out, leaving the hidden BrainDump window
+    // sitting on /login until the user signs in from Floating Navigator.
+    const windowManager = new WindowManager(SERVER_URL)
+    vi.spyOn(windowManager, 'restoreFromTray').mockImplementation(() => {})
+    windowManager.showBrainDump()
+    const brainDumpWindow = getWindow(0)
+    brainDumpWindow.fireWebContents(
+      'did-navigate',
+      {},
+      `${SERVER_URL}/login?redirect_url=/braindump`,
+    )
+
+    // Act: after sign-in, opening BrainDump again reloads /braindump and waits
+    // for that protected route to settle before showing the panel.
+    windowManager.showBrainDump()
+    brainDumpWindow.fireWebContents(
+      'did-navigate',
+      {},
+      `${SERVER_URL}/braindump`,
+    )
+    brainDumpWindow.fireWebContents('did-finish-load')
+
+    // Assert: the stale /login host was not shown; the real editor route was.
+    expect(brainDumpWindow.win.loadURL).toHaveBeenNthCalledWith(
+      1,
+      `${SERVER_URL}/braindump`,
+    )
+    expect(brainDumpWindow.win.loadURL).toHaveBeenNthCalledWith(
+      2,
+      `${SERVER_URL}/braindump`,
+    )
+    expect(brainDumpWindow.win.show).toHaveBeenCalledTimes(1)
+    expect(brainDumpWindow.win.focus).toHaveBeenCalledTimes(1)
+  })
+
   it('locks in the first navigation decision and ignores a later load failure', () => {
     // Arrange: a panel-only cold boot.
     const windowManager = new WindowManager(SERVER_URL)

--- a/electron/__tests__/WindowManager.startup-panel.test.ts
+++ b/electron/__tests__/WindowManager.startup-panel.test.ts
@@ -394,6 +394,44 @@ describe('WindowManager startup panel nav-watch', () => {
     expect(brainDumpWindow.win.focus).not.toHaveBeenCalled()
   })
 
+  it('reloads BrainDump on the next open after canceling a pending reveal', () => {
+    // Arrange: a hidden BrainDump load is canceled, then the old navigation
+    // settles after its listeners were removed.
+    const windowManager = new WindowManager(SERVER_URL)
+    windowManager.toggleBrainDump()
+    const brainDumpWindow = getWindow(0)
+    windowManager.toggleBrainDump()
+    brainDumpWindow.fireWebContents(
+      'did-navigate',
+      {},
+      `${SERVER_URL}/braindump`,
+    )
+    brainDumpWindow.fireWebContents('did-finish-load')
+    brainDumpWindow.win.show.mockClear()
+    brainDumpWindow.win.focus.mockClear()
+
+    // Act: the next open must start a fresh protected-route load before reveal.
+    windowManager.showBrainDump()
+    brainDumpWindow.fireWebContents(
+      'did-navigate',
+      {},
+      `${SERVER_URL}/braindump`,
+    )
+    brainDumpWindow.fireWebContents('did-finish-load')
+
+    // Assert: the canceled settled page was reloaded, then safely revealed.
+    expect(brainDumpWindow.win.loadURL).toHaveBeenNthCalledWith(
+      1,
+      `${SERVER_URL}/braindump`,
+    )
+    expect(brainDumpWindow.win.loadURL).toHaveBeenNthCalledWith(
+      2,
+      `${SERVER_URL}/braindump`,
+    )
+    expect(brainDumpWindow.win.show).toHaveBeenCalledTimes(1)
+    expect(brainDumpWindow.win.focus).toHaveBeenCalledTimes(1)
+  })
+
   it('reloads a suppressed BrainDump back to its route before revealing it after sign-in', () => {
     // Arrange: the first open is signed out, leaving the hidden BrainDump window
     // sitting on /login until the user signs in from Floating Navigator.

--- a/vitest.config.storybook.ts
+++ b/vitest.config.storybook.ts
@@ -59,7 +59,6 @@ export default defineConfig({
       'react',
       'react-dom',
       'react/jsx-runtime',
-      '@storybook/addon-vitest/vitest-plugin',
       'clsx',
       'tailwind-merge',
       'class-variance-authority',


### PR DESCRIPTION
## Summary
- Keep BrainDump hidden when a signed-out manual open resolves to the login/auth route.
- Restore FloatingNavigator as the only sign-in surface so users can complete login from the expected window.
- Reload `/braindump` before the next reveal after a suppressed signed-out BrainDump open.
- Add Electron regression coverage and update the BrainDump E2E expectation for the signed-out path.

## Test plan
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm test:electron -- WindowManager.startup-panel` (41 files, 413 tests)
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm typecheck`
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm exec eslint electron/WindowManager.ts electron/__tests__/WindowManager.startup-panel.test.ts e2e/electron/braindump-window.spec.ts --max-warnings 0`
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm exec prettier --check electron/WindowManager.ts electron/__tests__/WindowManager.startup-panel.test.ts e2e/electron/braindump-window.spec.ts`
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm build`
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm e2e:electron -- e2e/electron/braindump-window.spec.ts` (28 passed)
- [x] Packaged macOS QA: launched `dist/mac-arm64/CoreLive.app` against `localhost:4991`, triggered `Window > BrainDump Note` while signed out, confirmed FloatingNavigator remained the only visible sign-in surface and CDP exposed only `/floating-navigator`.

🤖 Generated with [OpenAI Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Signed-out users opening BrainDump are kept on the sign-in door, preventing any accidental exposure of the protected editor.
  - BrainDump now reliably reloads `/braindump` when auth redirects occur, then reveals at the correct time.
  - If BrainDump is toggled off while a reveal is pending, the reveal is cancelled and BrainDump remains hidden.

- **Tests**
  - Updated and expanded Electron e2e coverage for signed-out hidden/reveal behavior.
  - Added Vitest cases for manual open, toggle cancellation, and post-suppression reload/reveal.

- **Chores**
  - Improved Storybook/Vitest stability by adjusting Vitest pre-bundling settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->