### PR TITLE
fix(braindump): show checked state before clearing completed line

### DIFF
--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -1113,6 +1113,80 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
     expect(noteField).toHaveValue('buy milk\nkeep me')
   })
 
+  it('restores the origin category when a failed linger completion still reads the pre-flush row after switching away', async () => {
+    // Arrange — hold the create in flight so category 1 can switch away before the
+    // failure handler runs. Its stored note still reads the original row, matching
+    // the real pre-flush race CodeRabbit caught.
+    let rejectCreate: (reason: Error) => void = () => undefined
+    const pendingCreate = new Promise<{ id: number }>((_resolve, reject) => {
+      rejectCreate = reject
+    })
+    completedMutateAsync.mockReturnValueOnce(pendingCreate)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.note.get = vi.fn(async (id: number) =>
+      id === 1 ? 'buy milk\nkeep me' : '',
+    )
+    const noteSet = vi.mocked(api.note.set)
+
+    const store = configureStore({
+      reducer: { preferences: preferencesReducer },
+      preloadedState: {
+        preferences: {
+          ...preferencesInitialState,
+          braindumpClearOnComplete: true,
+          braindumpClearDelayMs: LINGER_MS,
+        },
+      },
+    })
+    const [generalCategory] = categories
+    if (!generalCategory)
+      throw new Error('expected the seeded General category')
+    const twoCategories: CategoryWithCount[] = [
+      generalCategory,
+      { ...generalCategory, id: 2, name: 'Work', isDefault: false },
+    ]
+    const tree = (): ReactElement => (
+      <Provider store={store}>
+        <BrainDumpEditor categories={twoCategories} />
+      </Provider>
+    )
+    const { rerender } = render(tree())
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    const value = 'buy milk\nkeep me'
+    fireEvent.change(noteField, { target: { value } })
+    noteField.selectionStart = 'buy milk'.length
+    noteField.selectionEnd = 'buy milk'.length
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+    expect(noteField).toHaveValue('- [x] buy milk\nkeep me')
+
+    selectedCategoryRef.current = 2
+    rerender(tree())
+    await waitFor(() => {
+      expect(noteField).toHaveValue('')
+    })
+    noteSet.mockClear()
+
+    // Act — category 1 still reads the original row, so the restore must be
+    // idempotent and explicitly write that original row back instead of skipping.
+    await act(async () => {
+      rejectCreate(new Error('network down'))
+    })
+
+    // Assert — the origin note is restored even though it never observed `[x]`.
+    await waitFor(() => {
+      expect(noteSet).toHaveBeenCalledWith(1, 'buy milk\nkeep me')
+    })
+    expect(noteSet).not.toHaveBeenCalledWith(
+      2,
+      expect.stringContaining('buy milk'),
+    )
+  })
+
   it('does not remove the tracked line if the user edited it during the linger', async () => {
     // Arrange
     installBrainDumpAPI({

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -591,6 +591,28 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
   })
 
+  it('shows the checked state once before an instant clear removes the line', async () => {
+    // Arrange: instant clear should still acknowledge the completion visually
+    // before the line leaves the scratchpad.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Act: complete an unchecked checkbox line.
+    fireCompleteCommandOnFirstLine(noteField, '- [ ] buy milk')
+
+    // Assert: the user sees the box tick before the async clear tucks it away.
+    expect(noteField).toHaveValue('- [x] buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('')
+    })
+  })
+
   it('undo re-inserts the cleared line at its original position', async () => {
     // Arrange — clear-on-complete on, two lines so the re-insert index matters.
     const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
@@ -977,9 +999,9 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
     // Act — complete the first of two lines.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk\nkeep me')
 
-    // Assert — the line LINGERS (still on screen the moment after completing,
-    // while the Completed create has already fired in the background)…
-    expect(noteField).toHaveValue('buy milk\nkeep me')
+    // Assert — the checked line LINGERS (the completion is visible before it
+    // leaves, while the Completed create has already fired in the background)…
+    expect(noteField).toHaveValue('- [x] buy milk\nkeep me')
     expect(completedMutateAsync).toHaveBeenCalledWith({
       categoryId: 1,
       title: 'buy milk',
@@ -1010,14 +1032,14 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
 
     // Act — complete line 0 ('buy milk'), then ~100 ms later complete line 1
-    // ('dishes'); the note is unchanged meanwhile, so all three lines stay present
-    // and both completions are tracked at their original indices (0 and 1).
+    // ('dishes'); the checked lines stay present meanwhile, and both completions
+    // are tracked at their original indices (0 and 1).
     fireCompleteCommandOnFirstLine(noteField, 'buy milk\ndishes\nlaundry')
     // The deferred path advances the caret to the START OF THE NEXT line itself,
     // so the second Cmd/Ctrl+Enter naturally targets 'dishes' — assert that here
     // and DON'T reposition the caret by hand (a manual set masked the
     // caret-never-advances bug this regression now guards).
-    expect(noteField.selectionStart).toBe(9) // start of 'dishes' (line 1)
+    expect(noteField.selectionStart).toBe(15) // start of 'dishes' (line 1)
     // ~100 ms human-paced gap so the second completion lands while line 0's
     // removal timer is still pending — both timers pend together (finding G).
     await new Promise((resolve) => setTimeout(resolve, 100))
@@ -1160,9 +1182,9 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
     noteField.selectionStart = 'buy milk'.length
     noteField.selectionEnd = 'buy milk'.length
 
-    // Complete line 0 in category 1 → the line is now lingering, not yet removed.
+    // Complete line 0 in category 1 → the checked line lingers, not yet removed.
     fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
-    expect(noteField).toHaveValue('buy milk\nkeep me')
+    expect(noteField).toHaveValue('- [x] buy milk\nkeep me')
 
     // Act — switch to category 2 before the linger elapses; its empty note loads.
     selectedCategoryRef.current = 2
@@ -1315,8 +1337,7 @@ describe('BrainDumpEditor completion toast — close button + display duration (
     // action runs); the guard must keep the restored line in place.
     const toastOptions = vi.mocked(toast.success).mock.calls.at(-1)?.[1]
     const undoAction = toastOptions?.action as
-      | { onClick: () => void }
-      | undefined
+      { onClick: () => void } | undefined
     await act(async () => {
       undoAction?.onClick()
     })
@@ -1344,9 +1365,9 @@ describe('BrainDumpEditor completion toast — close button + display duration (
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
 
-    // Act — complete line 0; the deferred path leaves it on screen for now.
+    // Act — complete line 0; the deferred path leaves it checked on screen for now.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk\nkeep me')
-    expect(noteField).toHaveValue('buy milk\nkeep me')
+    expect(noteField).toHaveValue('- [x] buy milk\nkeep me')
 
     // Assert — after 150 ms (past the 100 ms toast, before the 300 ms delay) the
     // line is already gone: the clamp picked the shorter toast duration.

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -86,10 +86,9 @@ type CheckedRowMemory = Readonly<{
 }>
 
 /**
- * Undo memory for a line removed the *instant* it completes (clear-on-complete
- * ON path). Distinct from `CheckedRowMemory`: there the `[x]` line persists, so
- * undo re-resolves it by title; here the line is gone, so we must remember its
- * verbatim text + position to put it back.
+ * Undo memory for a line that clear-on-complete will tuck away. Distinct from
+ * `CheckedRowMemory`: here the line may be briefly visible as `[x]`, then
+ * removed, so we remember both the checked text and the original text to restore.
  *
  * Mutable on purpose — `outcome`/`completedId`/`toastId` evolve as the
  * background create resolves and the user does (or doesn't) undo. Keyed by a
@@ -108,6 +107,8 @@ type ClearedLineMemory = {
   categoryId: Category['id']
   /** Index the line sat at when removed (best-effort re-insert position). */
   originalLineIndex: BrainDumpLineIndex
+  /** Checked row shown before removal; guards delayed clears from edited lines. */
+  completedLineText: string
   /** Verbatim removed line, restored as-is on undo/failure (preserves spacing). */
   reinsertText: string
   /**
@@ -126,10 +127,9 @@ type ClearedLineMemory = {
   /**
    * Whether the line has actually been REMOVED from the note yet. With a
    * non-zero clear delay the removal is deferred, so during the linger the line
-   * is still on screen (`false`) — undo/failure then just cancel the pending
-   * removal and leave it in place (no re-insert). `true` once removed (the
-   * instant path, or after the deferred timer fired). Undo/failure only
-   * re-insert when this is `true`.
+   * is still on screen (`false`) — undo/failure replace the visible `[x]` row
+   * with its original text. `true` once removed (the instant timer, or after the
+   * deferred timer fired). Undo/failure re-insert only when this is `true`.
    */
   lineCleared: boolean
   /**
@@ -139,6 +139,8 @@ type ClearedLineMemory = {
    * removal so it can't fire after the completion was reverted.
    */
   removalTimerId: number | undefined
+  /** Exact caret destination after instant removal; null preserves the live caret. */
+  caretAfterClearOffset: number | null
 }
 
 /**
@@ -295,10 +297,10 @@ export const BrainDumpEditor = function BrainDumpEditor({
   const braindumpToastDurationMs = useAppSelector(
     selectBraindumpToastDurationMs,
   )
-  // How long the finished line lingers before it's removed (clear-on-complete ON
-  // path). 0 = remove instantly (prior behaviour); >0 defers the removal by this
-  // many ms so the eye registers the completion first (#108). Clamped ≤ the Undo
-  // window by the schema, so the line never outlasts its own Undo affordance.
+  // How long the checked finished line lingers before it's removed
+  // (clear-on-complete ON path). 0 = remove on the next timer turn after `[x]`
+  // renders; >0 defers the removal so the eye registers the completion first.
+  // Clamped ≤ the Undo window by the schema, so the line never outlasts Undo.
   const clearDelayMs = useAppSelector(selectBraindumpClearDelayMs)
 
   const activeCategoryId = syncEnabled ? floatingCategoryId : localCategoryId
@@ -893,6 +895,55 @@ export const BrainDumpEditor = function BrainDumpEditor({
   }
 
   /**
+   * Reverts a still-visible checked clear-on-complete line back to its original text.
+   *
+   * @param entry - Completion memory containing the checked row and original row.
+   * @param moveCaret - Move the caret to the restored row for a user Undo.
+   * @returns Promise that settles after the visible/stored note is restored, or no-ops if edited.
+   * @example
+   * await restoreLingeringCompletedLine(entry, true)
+   */
+  const restoreLingeringCompletedLine = async (
+    entry: ClearedLineMemory,
+    moveCaret: boolean,
+  ): Promise<void> => {
+    if (activeCategoryIdRef.current === entry.categoryId) {
+      const lines = noteTextRef.current.split('\n')
+      // If the user edited the lingering row, do not overwrite their new text.
+      if (lines[entry.originalLineIndex] !== entry.completedLineText) return
+      const restored = replaceLineAtIndex(
+        noteTextRef.current,
+        entry.originalLineIndex,
+        entry.reinsertText,
+      )
+      noteTextRef.current = restored
+      setNoteText(restored)
+      if (moveCaret) {
+        pendingCaretRef.current = lineStartOffset(
+          restored,
+          entry.originalLineIndex,
+        )
+      }
+      return
+    }
+
+    const api = window.brainDumpAPI
+    if (!api) return
+    try {
+      const stored = await api.note.get(entry.categoryId)
+      const lines = stored.split('\n')
+      // Category switched before the linger cleared; repair the origin note only.
+      if (lines[entry.originalLineIndex] !== entry.completedLineText) return
+      await api.note.set(
+        entry.categoryId,
+        replaceLineAtIndex(stored, entry.originalLineIndex, entry.reinsertText),
+      )
+    } catch (error) {
+      log.error('BrainDump lingering line restore failed', error)
+    }
+  }
+
+  /**
    * Cancel a single completion's pending deferred-clear timer (if still armed)
    * and stop tracking it. Idempotent. Called by undo and the create-failure
    * handler so a removal can't fire after the completion was reverted.
@@ -915,7 +966,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
    * `clearDelayMs` linger (clear-on-complete ON, delay > 0). The line stays on
    * screen during the linger so it exits gently instead of snapping out the
    * instant it completes; when the timer fires we remove it — but ONLY if the
-   * tracked index STILL holds the verbatim line (finding A: a user edit, or an
+   * tracked index STILL holds the checked line (finding A: a user edit, or an
    * unaccounted shift, self-suppresses to a no-op, leaving the line). The caret
    * is preserved across the removal (finding B). After removing, every
    * still-pending sibling below shifts up by one, so we decrement their tracked
@@ -946,12 +997,12 @@ export const BrainDumpEditor = function BrainDumpEditor({
       if (entry.outcome === 'undone' || entry.outcome === 'restored') return
       const currentText = noteTextRef.current
       const lines = currentText.split('\n')
-      // Finding A: only remove when the tracked index STILL holds this exact
+      // Finding A: only remove when the tracked index STILL holds this checked
       // line; otherwise leave it (the win is already recorded).
-      if (lines[entry.originalLineIndex] !== entry.reinsertText) return
+      if (lines[entry.originalLineIndex] !== entry.completedLineText) return
       const removalStart = lineStartOffset(currentText, entry.originalLineIndex)
       // removeLineAtIndex drops the line plus its joining newline.
-      const removedLength = entry.reinsertText.length + 1
+      const removedLength = entry.completedLineText.length + 1
       const clearedText = removeLineAtIndex(
         currentText,
         entry.originalLineIndex,
@@ -960,13 +1011,16 @@ export const BrainDumpEditor = function BrainDumpEditor({
       // block shift up by its length, inside the block clamp to its start, above
       // it leave untouched. Read the LIVE DOM caret (the user may have typed on).
       const liveCaret = textareaRef.current?.selectionStart ?? removalStart
-      let nextCaret = liveCaret
-      if (liveCaret >= removalStart + removedLength) {
-        nextCaret = liveCaret - removedLength
-      } else if (liveCaret > removalStart) {
-        nextCaret = removalStart
+      let nextCaret = entry.caretAfterClearOffset ?? liveCaret
+      if (entry.caretAfterClearOffset === null) {
+        if (liveCaret >= removalStart + removedLength) {
+          nextCaret = liveCaret - removedLength
+        } else if (liveCaret > removalStart) {
+          nextCaret = removalStart
+        }
       }
       pendingCaretRef.current = nextCaret
+      noteTextRef.current = clearedText
       setNoteText(clearedText)
       entry.lineCleared = true
       // Finding G: our removal shifted every later still-pending line up by one,
@@ -982,27 +1036,25 @@ export const BrainDumpEditor = function BrainDumpEditor({
   }
 
   /**
-   * Clear-on-complete ON path: remove the just-completed line from the note —
-   * instantly when the clear delay is 0, else after the configured `clearDelayMs`
-   * linger (#108) — show the optimistic Undo toast immediately, and run the
-   * Completed-create in the background. This kills the old "wait for the server
-   * round-trip + 5 s, then delete" lag.
+   * Clear-on-complete ON path: show `[x]` first, then remove the just-completed
+   * line on the configured clear timer while the Completed-create runs in the
+   * background. This keeps the completion visually legible without waiting for
+   * the server round-trip.
    *
-   * Undo / failure restore the verbatim line ONLY if it was already removed; during
-   * the linger the line is still on screen, so they just cancel the pending removal
-   * and leave it. A create rejection still re-inserts a removed line even after the
-   * 5 s undo window closed (otherwise the win is lost AND the line is gone — silent
-   * data loss). The `outcome` flag on the entry guards the
-   * success/failure/undo/auto-close overlap so nothing double-applies.
+   * Undo / failure restore the verbatim line: they replace a still-visible `[x]`
+   * row during linger, or re-insert the row after the clear timer has removed it.
+   * A create rejection still re-inserts a removed line even after the 5 s undo
+   * window closed (otherwise the win is lost AND the line is gone — silent data
+   * loss). The `outcome` flag guards success/failure/undo/auto-close overlap.
    *
-   * @param text - The note text as it was when the key fired (pre-removal).
+   * @param completedText - Full note text with the completed row shown as `[x]`.
    * @param lineIndex - Zero-based index of the line being completed.
-   * @param originalLine - The verbatim line, restored as-is on undo/failure.
+   * @param originalLine - The verbatim source line, restored as-is on undo/failure.
    * @param title - Title to persist (uncapped; normalised for the DB here).
    * @returns void — kicks off the background create; nothing to await.
    */
   const completeAndClearLine = (
-    text: string,
+    completedText: string,
     lineIndex: BrainDumpLineIndex,
     originalLine: string,
     title: BrainDumpCompletedTitle,
@@ -1024,36 +1076,32 @@ export const BrainDumpEditor = function BrainDumpEditor({
       title: safeTitle,
       categoryId,
       originalLineIndex: lineIndex,
+      completedLineText: completedText.split('\n')[lineIndex] ?? originalLine,
       reinsertText: originalLine,
       outcome: 'pending',
       toastId: undefined,
       lineCleared: false,
       removalTimerId: undefined,
+      caretAfterClearOffset:
+        clearDelayMs <= 0
+          ? lineStartOffset(
+              removeLineAtIndex(completedText, lineIndex),
+              lineIndex,
+            )
+          : null,
     }
     clearedLinesRef.current.set(token, entry)
 
-    // 2) Remove the line — instantly (delay ≤ 0) or after the chosen linger.
-    if (clearDelayMs <= 0) {
-      // Instant path (verbatim prior behaviour): drop the line now and put the
-      // caret at the start of the line that slid up into its place. The layout
-      // effect applies the caret post-commit since the line count changed.
-      const clearedText = removeLineAtIndex(text, lineIndex)
-      setNoteText(clearedText)
-      pendingCaretRef.current = lineStartOffset(clearedText, lineIndex)
-      entry.lineCleared = true
-    } else {
-      // Deferred path: leave the line on screen for the linger, but move the
-      // caret to the START OF THE NEXT line NOW so a repeated Cmd/Ctrl+Enter
-      // walks down the list instead of re-completing this still-visible line.
-      // Apply it synchronously (NOT via pendingCaretRef): the textarea value is
-      // unchanged in this branch, so the `[noteText]` layout effect never fires
-      // to consume a pending ref — a stashed offset would sit stale and then
-      // yank the caret on the next unrelated noteText change (e.g. typing).
-      // The line itself is removed when the timer fires (finding A/B/G).
-      const nextLineCaret = lineStartOffset(text, lineIndex + 1)
-      textareaRef.current?.setSelectionRange(nextLineCaret, nextLineCaret)
-      scheduleDeferredClear(entry)
+    // 2) Show the checked state first, then remove it on the clear timer. A
+    // 0 ms setting means "next turn", not "skip the visible check mark".
+    noteTextRef.current = completedText
+    setNoteText(completedText)
+    if (clearDelayMs > 0) {
+      // During a linger, move the caret to the START OF THE NEXT line after the
+      // checked text commits, so repeated Cmd/Ctrl+Enter walks down the list.
+      pendingCaretRef.current = lineStartOffset(completedText, lineIndex + 1)
     }
+    scheduleDeferredClear(entry)
 
     // 3) Background create. Success/failure mutate `entry` and consult
     //    `outcome` so undo / auto-close / late-failure never double-apply.
@@ -1099,6 +1147,8 @@ export const BrainDumpEditor = function BrainDumpEditor({
           // cancelled above), there is nothing to restore — leave it.
           if (entry.lineCleared) {
             void restoreClearedLineToCategory(entry, false)
+          } else {
+            void restoreLingeringCompletedLine(entry, false)
           }
           // Terminal NOW: a late Undo — the toast stays clickable through sonner's
           // dismiss exit-animation — must not restore a SECOND copy (undo
@@ -1175,18 +1225,18 @@ export const BrainDumpEditor = function BrainDumpEditor({
     entry.outcome = 'undone'
     clearedLinesRef.current.delete(entry.token)
     // Cancel a still-pending deferred removal: if the line never left the editor
-    // (linger not yet elapsed), undo just abandons the clear and leaves it.
+    // (linger not yet elapsed), undo cancels the clear and restores `[x]` to
+    // the original row; after removal, it re-inserts the original row.
     cancelPendingClearTimer(entry)
 
-    // Re-insert the verbatim line into the category it came from — but ONLY if it
-    // was actually removed (instant path, or the timer already fired). If it is
-    // still on screen (deferred clear cancelled above) there is nothing to put
-    // back. When restored: into the live editor while still here (the caret moves
-    // to it, since this IS a user action), or into that category's STORED note
-    // once the user switched away (so the line returns to category A, never
-    // category B's visible note).
+    // Restore the verbatim line into the category it came from. If the clear timer
+    // already removed it, re-insert; if it is still on screen as `[x]`, replace it.
+    // Cross-category restore writes to the origin category's STORED note, never
+    // category B's visible note.
     if (entry.lineCleared) {
       await restoreClearedLineToCategory(entry, true)
+    } else {
+      await restoreLingeringCompletedLine(entry, true)
     }
 
     // Delete the server row once the create resolves. A failed create resolves
@@ -1227,23 +1277,24 @@ export const BrainDumpEditor = function BrainDumpEditor({
     const parsed = parseCheckboxLine(line, lineIndex)
 
     // Clear-on-complete ON + a COMPLETION (a plain line, or ticking an unchecked
-    // box) → remove the line instantly and show the optimistic Undo toast.
+    // box) → show `[x]`, then tuck the line away and show the optimistic Undo toast.
     // Un-ticking an existing `[x]` line (parsed.checked === true) and the OFF
     // preference both fall through to the legacy keep-the-`[x]` path below.
     if (clearOnComplete && parsed?.checked !== true) {
       let completionTitle: BrainDumpCompletedTitle
+      let completedText: string
       if (parsed) {
         completionTitle = parsed.title
+        completedText = setCheckboxStateAtLine(text, lineIndex, true)
       } else {
-        // Plain prose line: reuse markPlainLineCompleted only for its title +
-        // skip guards (blank / empty skeleton → null → no-op); ignore its
-        // `[x]`-wrapped text since this path removes the line instead.
+        // Plain prose line: wrap as `[x]` first so the eye sees the completion.
         const promoted = markPlainLineCompleted(text, lineIndex)
         if (!promoted) return
         completionTitle = promoted.title
+        completedText = promoted.text
       }
       // `line` is the verbatim source row → restored as-is on undo/failure.
-      completeAndClearLine(text, lineIndex, line, completionTitle)
+      completeAndClearLine(completedText, lineIndex, line, completionTitle)
       return
     }
 

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -932,8 +932,15 @@ export const BrainDumpEditor = function BrainDumpEditor({
     try {
       const stored = await api.note.get(entry.categoryId)
       const lines = stored.split('\n')
-      // Category switched before the linger cleared; repair the origin note only.
-      if (lines[entry.originalLineIndex] !== entry.completedLineText) return
+      const currentLine = lines[entry.originalLineIndex]
+      // Category switched before linger finished; write the original row even if
+      // the stored note still shows the pre-flush original instead of `[x]`.
+      if (
+        currentLine !== entry.completedLineText &&
+        currentLine !== entry.reinsertText
+      ) {
+        return
+      }
       await api.note.set(
         entry.categoryId,
         replaceLineAtIndex(stored, entry.originalLineIndex, entry.reinsertText),


### PR DESCRIPTION
## Summary
- Render the completed `[x]` state before BrainDump clear-on-complete removes the active line.
- Track checked display text separately from the original row so undo and completion failures restore the exact source line.
- Add regression coverage for both instant clear and deferred linger behavior.

## Test Coverage
All changed BrainDump completion paths have regression coverage in `BrainDumpEditor.test.tsx`.

## Pre-Landing Review
No additional issues found during the targeted fix pass.

## Eval Results
No prompt-related files changed; evals skipped.

## Plan Completion
No plan file detected.

## Verification Results
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm test -- BrainDumpEditor.test.tsx --runInBand`
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm typecheck`
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm lint`
- [x] `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm validate`

## Test plan
- [x] Regression test confirms `[x]` renders once before instant clear removes the line.
- [x] Regression test confirms linger mode shows `- [x]` before delayed removal.

🤖 Generated with [OpenAI Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checklist completions now render as checked immediately, with correct behavior for both instant and delayed clear-on-complete.
  * Completion cleanup undo is more consistent, whether the completed line is still visible or already removed.
  * Caret placement after clearing completed checklist lines has been improved for more natural editing.
  * Switching categories during the clear delay no longer disrupts the correct restoration of the checked state and stored notes.
* **Tests**
  * Updated and expanded coverage for clear timing, caret offsets, category switching, and undo flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->