### PR TITLE
fix(braindump): preserve notes during reload

### DIFF
--- a/electron/preload-braindump.ts
+++ b/electron/preload-braindump.ts
@@ -194,8 +194,10 @@ contextBridge.exposeInMainWorld('brainDumpAPI', {
       try {
         return await typedInvoke('braindump-note-get', categoryId)
       } catch (error) {
+        // Re-throw so the renderer can avoid treating a failed disk read as an
+        // intentionally empty note; swallowing this can overwrite real content.
         log.error('BrainDump: Failed to read note:', error)
-        return ''
+        throw error
       }
     },
 

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -384,6 +384,33 @@ describe('BrainDumpEditor note persistence during reload', () => {
     expect(noteSet).not.toHaveBeenCalled()
   })
 
+  it('blocks editing while the existing category note is still loading', async () => {
+    // Arrange
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.note.get = vi.fn(async () => new Promise<string>(() => undefined))
+    const noteSet = vi.mocked(api.note.set)
+    const user = userEvent.setup()
+
+    // Act
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitFor(() => {
+      expect(api.note.get).toHaveBeenCalledWith(1)
+    })
+    await user.type(noteField, 'do not save during load')
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    // Assert
+    expect(noteField).toBeDisabled()
+    expect(noteField).toHaveValue('')
+    expect(noteSet).not.toHaveBeenCalled()
+  })
+
   it('keeps the existing category note on disk when loading that note fails', async () => {
     // Arrange
     installBrainDumpAPI({

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -410,6 +410,35 @@ describe('BrainDumpEditor note persistence during reload', () => {
     expect(noteSet).not.toHaveBeenCalledWith(1, '')
     expect(noteSet).not.toHaveBeenCalled()
   })
+
+  it('persists a new user edit after the existing category note fails to load', async () => {
+    // Arrange
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.note.get = vi
+      .fn()
+      .mockRejectedValue(new Error('temporary disk read error'))
+    const noteSet = vi.mocked(api.note.set)
+
+    // Act
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Failed to load note for this category',
+      )
+    })
+    fireEvent.change(noteField, { target: { value: 'fresh rescue note' } })
+
+    // Assert
+    await waitFor(() => {
+      expect(noteSet).toHaveBeenCalledWith(1, 'fresh rescue note')
+    })
+  })
 })
 
 describe('BrainDumpEditor focus on window show', () => {

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -450,6 +450,7 @@ describe('BrainDumpEditor note persistence during reload', () => {
       .fn()
       .mockRejectedValue(new Error('temporary disk read error'))
     const noteSet = vi.mocked(api.note.set)
+    const user = userEvent.setup()
 
     // Act
     renderEditor()
@@ -459,7 +460,8 @@ describe('BrainDumpEditor note persistence during reload', () => {
         'Failed to load note for this category',
       )
     })
-    fireEvent.change(noteField, { target: { value: 'fresh rescue note' } })
+    expect(noteField).toBeEnabled()
+    await user.type(noteField, 'fresh rescue note')
 
     // Assert
     await waitFor(() => {

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -355,6 +355,63 @@ describe('BrainDumpEditor writing surface', () => {
   })
 })
 
+describe('BrainDumpEditor note persistence during reload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectedCategoryRef.current = 1
+  })
+
+  it('keeps the existing category note on disk when BrainDump reloads before the note finishes loading', async () => {
+    // Arrange
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.note.get = vi.fn(async () => new Promise<string>(() => undefined))
+    const noteSet = vi.mocked(api.note.set)
+
+    // Act
+    const { unmount } = renderEditor()
+    await waitFor(() => {
+      expect(api.note.get).toHaveBeenCalledWith(1)
+    })
+    unmount()
+
+    // Assert
+    expect(noteSet).not.toHaveBeenCalledWith(1, '')
+    expect(noteSet).not.toHaveBeenCalled()
+  })
+
+  it('keeps the existing category note on disk when loading that note fails', async () => {
+    // Arrange
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.note.get = vi
+      .fn()
+      .mockRejectedValue(new Error('temporary disk read error'))
+    const noteSet = vi.mocked(api.note.set)
+
+    // Act
+    renderEditor()
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Failed to load note for this category',
+      )
+    })
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    // Assert
+    expect(noteSet).not.toHaveBeenCalledWith(1, '')
+    expect(noteSet).not.toHaveBeenCalled()
+  })
+})
+
 describe('BrainDumpEditor focus on window show', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -1520,7 +1520,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
             ? 'Pick a category to start writing'
             : '- [ ] braindump anything here…\nUse Cmd/Ctrl+Enter to complete the current line.'
         }
-        disabled={activeCategoryId === null}
+        disabled={activeCategoryId === null || isLoadingNote}
         maxLength={NOTE_MAX_LENGTH}
         // Braindump is messy quick-capture — the native red spellcheck underlines
         // make unfinished / mixed-language fragments feel "corrected" and noisy, so

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -345,6 +345,9 @@ export const BrainDumpEditor = function BrainDumpEditor({
     categoryId: Category['id'] | null
     text: string
   }>({ categoryId: null, text: '' })
+  // Category whose textarea value may be written back to disk. It only flips on
+  // after a successful load or direct user input, so load failures do not save "".
+  const noteWritableCategoryRef = useRef<Category['id'] | null>(null)
 
   useCycleEffect(() => {
     noteTextRef.current = noteText
@@ -476,6 +479,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
     if (!isMounted || !isBrainDumpEnvironment() || activeCategoryId === null) {
       setNoteText('')
       lastPersistedRef.current = { categoryId: null, text: '' }
+      noteWritableCategoryRef.current = null
       return
     }
     const api = window.brainDumpAPI
@@ -484,6 +488,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
     if (!api) return
     let cancelled = false
     setIsLoadingNote(true)
+    noteWritableCategoryRef.current = null
     api.note
       .get(activeCategoryId)
       .then((text) => {
@@ -492,6 +497,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         // Mark as already-persisted so the debounce effect doesn't immediately
         // echo this text back to disk.
         lastPersistedRef.current = { categoryId: activeCategoryId, text }
+        noteWritableCategoryRef.current = activeCategoryId
         checkedRowsRef.current.clear()
         pendingCreatesRef.current.clear()
         clearedLinesRef.current.clear()
@@ -505,6 +511,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         // while we render category B's failure.
         setNoteText('')
         lastPersistedRef.current = { categoryId: null, text: '' }
+        noteWritableCategoryRef.current = null
         checkedRowsRef.current.clear()
         pendingCreatesRef.current.clear()
         clearedLinesRef.current.clear()
@@ -531,7 +538,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
     const persisted = lastPersistedRef.current
     // Never persist the initial empty textarea before this category's note has
     // loaded; a deploy-driven reload can otherwise overwrite real disk content.
-    if (persisted.categoryId !== activeCategoryId) return
+    if (noteWritableCategoryRef.current !== activeCategoryId) return
     if (
       persisted.categoryId === activeCategoryId &&
       persisted.text === noteText
@@ -563,7 +570,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
       const persisted = lastPersistedRef.current
       // If note.get never resolved for this category, `text` is only the local
       // initial value. Skipping the flush preserves the existing stored note.
-      if (persisted.categoryId !== flushCategoryId) return
+      if (noteWritableCategoryRef.current !== flushCategoryId) return
       if (persisted.categoryId === flushCategoryId && persisted.text === text) {
         return
       }
@@ -1501,7 +1508,12 @@ export const BrainDumpEditor = function BrainDumpEditor({
         ref={textareaRef}
         id={noteInputId}
         value={noteText}
-        onChange={(event) => setNoteText(event.target.value)}
+        onChange={(event) => {
+          // A direct edit after a load failure is intentional new content, so it
+          // can be saved even though no prior disk value was loaded.
+          noteWritableCategoryRef.current = activeCategoryId
+          setNoteText(event.target.value)
+        }}
         onKeyDown={handleKeyDown}
         placeholder={
           activeCategoryId === null

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -529,6 +529,9 @@ export const BrainDumpEditor = function BrainDumpEditor({
     const api = window.brainDumpAPI
     if (!api) return
     const persisted = lastPersistedRef.current
+    // Never persist the initial empty textarea before this category's note has
+    // loaded; a deploy-driven reload can otherwise overwrite real disk content.
+    if (persisted.categoryId !== activeCategoryId) return
     if (
       persisted.categoryId === activeCategoryId &&
       persisted.text === noteText
@@ -558,6 +561,9 @@ export const BrainDumpEditor = function BrainDumpEditor({
     return () => {
       const text = noteTextRef.current
       const persisted = lastPersistedRef.current
+      // If note.get never resolved for this category, `text` is only the local
+      // initial value. Skipping the flush preserves the existing stored note.
+      if (persisted.categoryId !== flushCategoryId) return
       if (persisted.categoryId === flushCategoryId && persisted.text === text) {
         return
       }


### PR DESCRIPTION
## Summary
- Prevent BrainDump from writing the initial empty textarea to disk before the active category note finishes loading.
- Add regressions for deploy/reload and load-failure paths that previously wiped the stored category note.

## Root Cause
BrainDump persisted notes by category through `window.brainDumpAPI.note.set(categoryId, text)`. During a deploy-triggered reload/unmount, `noteText` could still be the component initial value (`""`) while `note.get(categoryId)` was pending or failed. The cleanup/debounce persistence effects then flushed that empty value and overwrote the existing local note for the CoreLive category.

## Validation
- ✅ `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm test -- BrainDumpEditor.test.tsx -t "BrainDumpEditor note persistence during reload" --runInBand`
- ✅ `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm test -- BrainDumpEditor.test.tsx --runInBand`
- ✅ `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm validate`
- ✅ Local QA with `window.brainDumpAPI.note.get` intentionally left pending, then page reload: no `note.set(categoryId, "")` call was made.
- ✅ Real local BrainDump config note lengths stayed unchanged after QA.
- ✅ `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm e2e:electron` (28/28 passed)

## Merge Gate
- ⚠️ `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm e2e:web` currently fails in unrelated TODO specs:
  - `e2e/web/todo-app.spec.ts:187` checkbox stayed checked when moving a completed TODO back to pending.
  - `e2e/web/todo-retain-archive.spec.ts:147` timed out waiting for `todo.delete`.
- I reproduced those same TODO failures with the targeted Playwright run, so this PR is draft until the Web E2E gate is green or explicitly accepted as unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented per-category note persistence from overwriting stored notes with empty/placeholder content during editor reloads, category switches, or unmount races while a note is still loading.
  * Improved note load failure handling so failures surface **“Failed to load note for this category”**, the editor avoids persisting incomplete text, and the note textarea stays disabled during loading.
  * Updated note read behavior to re-throw disk-read errors for clearer failure handling.
* **Tests**
  * Added regression coverage for note persistence during reload, including delayed resolution, load failure behavior, and recovery after a failed load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->