### PR TITLE
fix(electron): restore macOS menu bar template icon

### DIFF
--- a/electron/SystemTrayManager.ts
+++ b/electron/SystemTrayManager.ts
@@ -194,17 +194,15 @@ export class SystemTrayManager {
 
       if (iconPath) {
         try {
+          const isTemplateIcon = this.isMacTemplateIconPath(iconPath)
           trayIcon = nativeImage.createFromPath(iconPath)
           if (!trayIcon.isEmpty()) {
-            if (
-              process.platform === 'darwin' &&
-              iconPath.includes('Template')
-            ) {
+            if (isTemplateIcon) {
               trayIcon.setTemplateImage(true)
               log.warn('Set tray icon as Template image for macOS')
             }
 
-            if (process.platform === 'darwin') {
+            if (process.platform === 'darwin' && !isTemplateIcon) {
               trayIcon = trayIcon.resize({ width: 16, height: 16 })
             }
 
@@ -234,6 +232,20 @@ export class SystemTrayManager {
       log.error('Error creating tray icon:', error)
       return null
     }
+  }
+
+  /**
+   * Detects macOS Template icon files so the tray keeps system tinting intact.
+   * @param iconPath - The absolute path returned by getTrayIconPath.
+   * @returns true when the file follows Electron's `*Template.png` convention.
+   * @example
+   * this.isMacTemplateIconPath('/Resources/tray-icons/trayTemplate.png') // => true
+   */
+  private isMacTemplateIconPath(iconPath: string): boolean {
+    return (
+      process.platform === 'darwin' &&
+      /Template(?:@2x)?\.png$/.test(path.basename(iconPath))
+    )
   }
 
   /**
@@ -819,15 +831,14 @@ export class SystemTrayManager {
     }
 
     try {
-      const iconPath = this.getTrayIconPath(state)
-      if (iconPath) {
-        const icon = nativeImage.createFromPath(iconPath)
+      const icon = this.createTrayIcon(state)
+      if (icon && !icon.isEmpty()) {
         this.tray.setImage(icon)
         return true
-      } else {
-        log.warn(`Tray icon for state '${state}' not found`)
-        return false
       }
+
+      log.warn(`Tray icon for state '${state}' not found`)
+      return false
     } catch (error) {
       log.error('Failed to set tray icon state:', error)
       return false

--- a/electron/__tests__/icon-system.test.mjs
+++ b/electron/__tests__/icon-system.test.mjs
@@ -1,7 +1,29 @@
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 
+import sharp from 'sharp'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { generateMacTemplateTrayIcons } from '../../scripts/generate-icons.js'
+
+/**
+ * Temporarily overrides process.platform so macOS-only tray behavior can run on CI.
+ * @param platform - The platform value exposed during the callback.
+ * @param callback - The assertions or setup that need the temporary platform.
+ * @returns The callback's return value.
+ * @example
+ * withPlatform('darwin', () => process.platform) // => 'darwin'
+ */
+function withPlatform(platform, callback) {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { value: platform })
+  try {
+    return callback()
+  } finally {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+}
 
 describe('Icon System', () => {
   const iconDir = path.join(process.cwd(), 'build', 'icons')
@@ -30,6 +52,40 @@ describe('Icon System', () => {
           )
           expect(fs.existsSync(iconPath)).toBe(true)
         }
+      }
+    })
+
+    it('generates macOS Template tray icons in a clean output directory', async () => {
+      // Arrange
+      const outputDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'corelive-tray-icons-'),
+      )
+      const expectedTemplateIcons = [
+        { filename: 'trayTemplate.png', size: 16 },
+        { filename: 'trayTemplate@2x.png', size: 32 },
+        { filename: 'checkTemplate.png', size: 16 },
+        { filename: 'checkTemplate@2x.png', size: 32 },
+      ]
+
+      try {
+        // Act
+        await generateMacTemplateTrayIcons(outputDir)
+
+        // Assert
+        for (const templateIcon of expectedTemplateIcons) {
+          const templateIconPath = path.join(outputDir, templateIcon.filename)
+          const metadata = await sharp(templateIconPath).metadata()
+          const stats = await sharp(templateIconPath).stats()
+
+          expect(metadata.width).toBe(templateIcon.size)
+          expect(metadata.height).toBe(templateIcon.size)
+          expect(stats.channels[0].max).toBe(0)
+          expect(stats.channels[1].max).toBe(0)
+          expect(stats.channels[2].max).toBe(0)
+          expect(stats.channels[3].max).toBeGreaterThan(0)
+        }
+      } finally {
+        fs.rmSync(outputDir, { recursive: true, force: true })
       }
     })
 
@@ -72,8 +128,15 @@ describe('Icon System', () => {
     let SystemTrayManager
     let trayManager
     let mockWindowManager
+    let mockNativeImageInstance
 
     beforeEach(async () => {
+      mockNativeImageInstance = {
+        isEmpty: vi.fn(() => false),
+        setTemplateImage: vi.fn(),
+        resize: vi.fn(() => mockNativeImageInstance),
+      }
+
       // Mock Electron modules
       vi.doMock('electron', () => ({
         app: {
@@ -91,11 +154,7 @@ describe('Icon System', () => {
           buildFromTemplate: vi.fn(() => ({})),
         },
         nativeImage: {
-          createFromPath: vi.fn(() => ({
-            isEmpty: vi.fn(() => false),
-            resize: vi.fn(() => ({})),
-            setTemplateImage: vi.fn(),
-          })),
+          createFromPath: vi.fn(() => mockNativeImageInstance),
         },
         Notification: vi.fn(),
       }))
@@ -136,6 +195,27 @@ describe('Icon System', () => {
       it('should be a function that accepts a state parameter', () => {
         expect(typeof trayManager.getTrayIconPath).toBe('function')
         expect(trayManager.getTrayIconPath.length).toBe(0) // Has default parameter
+      })
+    })
+
+    describe('createTrayIcon', () => {
+      it('marks Template icons without resizing away the macOS template image', () => {
+        withPlatform('darwin', () => {
+          // Arrange
+          trayManager.getTrayIconPath = vi.fn(
+            () => '/mock/path/trayTemplate.png',
+          )
+
+          // Act
+          const icon = trayManager.createTrayIcon()
+
+          // Assert
+          expect(icon).toBe(mockNativeImageInstance)
+          expect(mockNativeImageInstance.setTemplateImage).toHaveBeenCalledWith(
+            true,
+          )
+          expect(mockNativeImageInstance.resize).not.toHaveBeenCalled()
+        })
       })
     })
 

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -32,6 +32,36 @@ const ICON_SIZES = {
   tray: [16, 20, 24, 32],
 }
 
+const MAC_TEMPLATE_TRAY_ICON_COLOR = '#000000'
+
+const MAC_TEMPLATE_TRAY_ICONS = [
+  {
+    filename: 'trayTemplate.png',
+    size: 16,
+    createSvg: createNotepadCheckmarkTemplateSVG,
+  },
+  {
+    filename: 'trayTemplate@2x.png',
+    size: 32,
+    createSvg: createNotepadCheckmarkTemplateSVG,
+  },
+  {
+    filename: 'checkTemplate.png',
+    size: 16,
+    createSvg: createCheckmarkTemplateSVG,
+  },
+  {
+    filename: 'checkTemplate@2x.png',
+    size: 32,
+    createSvg: createCheckmarkTemplateSVG,
+  },
+]
+
+const DEPRECATED_TEMPLATE_TRAY_ICON_FILENAMES = [
+  'filledTemplate.png',
+  'filledTemplate@2x.png',
+]
+
 // Tray icon states
 const TRAY_STATES = {
   default: { suffix: '', description: 'Default tray icon' },
@@ -51,6 +81,100 @@ const TRAY_STATES = {
 const BIG_SUR_CANVAS = 1024
 const BIG_SUR_SAFE_AREA = 824
 const BIG_SUR_PADDING = (BIG_SUR_CANVAS - BIG_SUR_SAFE_AREA) / 2 // 100
+
+/**
+ * Builds the fallback checkmark template SVG used when the primary tray glyph is unavailable.
+ * @param size - The square canvas size in physical pixels.
+ * @returns Black-alpha SVG markup that macOS can tint as a Template image.
+ * @example
+ * createCheckmarkTemplateSVG(16) // => '<svg width="16" ...'
+ */
+function createCheckmarkTemplateSVG(size) {
+  const strokeWidth = Math.max(2, size / 7)
+
+  return `
+<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M${size * 0.15} ${size * 0.5} L${size * 0.4} ${size * 0.75} L${size * 0.85} ${size * 0.25}"
+    stroke="${MAC_TEMPLATE_TRAY_ICON_COLOR}"
+    stroke-width="${strokeWidth}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+</svg>
+`
+}
+
+/**
+ * Builds the primary notepad/check template SVG for CoreLive's macOS menu bar item.
+ * @param size - The square canvas size in physical pixels.
+ * @returns Black-alpha SVG markup that macOS can tint as a Template image.
+ * @example
+ * createNotepadCheckmarkTemplateSVG(16) // => '<svg width="16" ...'
+ */
+function createNotepadCheckmarkTemplateSVG(size) {
+  const padding = Math.max(1, Math.round(size * 0.06))
+  const innerSize = size - padding * 2
+  const strokeWidth = Math.max(1.6, size / 10)
+  const checkmarkStrokeWidth = Math.max(1.9, size / 8)
+
+  return `
+<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
+  <rect
+    x="${padding}"
+    y="${padding + innerSize * 0.12}"
+    width="${innerSize}"
+    height="${innerSize * 0.88}"
+    rx="${Math.max(1.5, size / 8)}"
+    fill="none"
+    stroke="${MAC_TEMPLATE_TRAY_ICON_COLOR}"
+    stroke-width="${strokeWidth}"
+  />
+  <line x1="${padding + innerSize * 0.25}" y1="${padding}" x2="${padding + innerSize * 0.25}" y2="${padding + innerSize * 0.2}" stroke="${MAC_TEMPLATE_TRAY_ICON_COLOR}" stroke-width="${strokeWidth}" stroke-linecap="round"/>
+  <line x1="${padding + innerSize * 0.5}" y1="${padding}" x2="${padding + innerSize * 0.5}" y2="${padding + innerSize * 0.2}" stroke="${MAC_TEMPLATE_TRAY_ICON_COLOR}" stroke-width="${strokeWidth}" stroke-linecap="round"/>
+  <line x1="${padding + innerSize * 0.75}" y1="${padding}" x2="${padding + innerSize * 0.75}" y2="${padding + innerSize * 0.2}" stroke="${MAC_TEMPLATE_TRAY_ICON_COLOR}" stroke-width="${strokeWidth}" stroke-linecap="round"/>
+  <path
+    d="M${padding + innerSize * 0.22} ${padding + innerSize * 0.55} L${padding + innerSize * 0.4} ${padding + innerSize * 0.73} L${padding + innerSize * 0.78} ${padding + innerSize * 0.38}"
+    stroke="${MAC_TEMPLATE_TRAY_ICON_COLOR}"
+    stroke-width="${checkmarkStrokeWidth}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+</svg>
+`
+}
+
+/**
+ * Writes macOS Template tray PNGs so clean builds never fall back to the colored app icon.
+ * @param outputDir - The directory that electron-builder packages as `tray-icons`.
+ * @param logger - Logger with warn/error methods, usually the build-script logger.
+ * @returns A promise that resolves after all Template PNGs are written.
+ * @example
+ * await generateMacTemplateTrayIcons('build/icons/tray')
+ */
+async function generateMacTemplateTrayIcons(outputDir, logger = log) {
+  await fs.mkdir(outputDir, { recursive: true })
+  logger.warn('\n🔔 Generating macOS Template tray icons...')
+
+  for (const templateIcon of MAC_TEMPLATE_TRAY_ICONS) {
+    const svg = templateIcon.createSvg(templateIcon.size)
+    const outputPath = path.join(outputDir, templateIcon.filename)
+
+    await sharp(Buffer.from(svg))
+      .resize(templateIcon.size, templateIcon.size)
+      .png({ compressionLevel: 9 })
+      .toFile(outputPath)
+
+    logger.warn(`  ✅ Generated ${templateIcon.filename}`)
+  }
+
+  // Remove old square alternatives so packaged apps only ship the live glyphs.
+  for (const filename of DEPRECATED_TEMPLATE_TRAY_ICON_FILENAMES) {
+    await fs.rm(path.join(outputDir, filename), { force: true })
+  }
+}
 
 class IconGenerator {
   constructor() {
@@ -226,6 +350,8 @@ class IconGenerator {
         }
       }
     }
+
+    await generateMacTemplateTrayIcons(this.trayDir)
   }
 
   async generateFavicons() {
@@ -420,6 +546,22 @@ class IconGenerator {
             manifest.icons.tray[state][size] = `tray/${file}`
           }
         }
+
+        const templateMatch = file.match(
+          /^(trayTemplate|checkTemplate)(@2x)?\.png$/,
+        )
+        if (templateMatch) {
+          const state =
+            templateMatch[1] === 'trayTemplate' ? 'default' : 'check'
+          const size = templateMatch[2] ? 32 : 16
+          if (!manifest.icons.tray.template) {
+            manifest.icons.tray.template = {}
+          }
+          if (!manifest.icons.tray.template[state]) {
+            manifest.icons.tray.template[state] = {}
+          }
+          manifest.icons.tray.template[state][size] = `tray/${file}`
+        }
       }
 
       // Save manifest
@@ -465,4 +607,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   generator.generateAll()
 }
 
-export { IconGenerator }
+export { IconGenerator, generateMacTemplateTrayIcons }

--- a/scripts/generate-tray-icons.js
+++ b/scripts/generate-tray-icons.js
@@ -1,211 +1,30 @@
 #!/usr/bin/env node
 /**
- * @fileoverview Generate macOS Template tray icons
- *
- * macOS menu bar icons require:
- * - Template naming: ends with "Template.png" or "Template@2x.png"
- * - Monochrome: Black shapes on transparent background
- * - Sizes: 16x16 (1x) and 32x32 (@2x) for Retina
- *
- * macOS automatically inverts template images for dark mode.
- *
- * @see https://electronjs.org/docs/latest/tutorial/tray
+ * @fileoverview Generate the macOS Template tray icons by reusing the main icon pipeline.
  */
 
-import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
-import sharp from 'sharp'
+import { generateMacTemplateTrayIcons } from './generate-icons.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 /**
- * Simple checkmark SVG for tray icon
- * - White (#FFFFFF) on transparent background for dark menu bars
- * - Bold, visible design for small sizes
- *
- * macOS Template images:
- * - Use white for visibility on dark backgrounds
- * - Thick strokes (2.5-3px at 18x18)
- * - Simple, recognizable shapes
+ * Runs the standalone tray-template generator for manual refreshes and old scripts.
+ * @param outputDir - Directory that receives the generated Template PNG files.
+ * @returns A promise that resolves when the tray template files are current.
+ * @example
+ * await generateStandaloneTrayIcons('build/icons/tray')
  */
-const createCheckmarkSVG = (size) => {
-  // Thicker stroke for visibility
-  const strokeWidth = Math.max(2.5, size / 6)
-
-  return `
-<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
-  <path 
-    d="M${size * 0.15} ${size * 0.5} L${size * 0.4} ${size * 0.75} L${size * 0.85} ${size * 0.25}"
-    stroke="#FFFFFF"
-    stroke-width="${strokeWidth}"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    fill="none"
-  />
-</svg>
-`
+async function generateStandaloneTrayIcons(
+  outputDir = path.join(__dirname, '../build/icons/tray'),
+) {
+  await generateMacTemplateTrayIcons(outputDir)
 }
 
-/**
- * Filled square with checkmark - more visible in menu bar
- * Uses a WHITE filled background for better visibility on dark menu bars
- */
-const createFilledCheckmarkSVG = (size) => {
-  const strokeWidth = Math.max(2, size / 8)
-  const padding = size * 0.08
-  const iconSize = size - padding * 2
-
-  return `
-<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
-  <!-- White rounded square background -->
-  <rect 
-    x="${padding}" 
-    y="${padding}" 
-    width="${iconSize}" 
-    height="${iconSize}" 
-    rx="${Math.max(2, size / 5)}"
-    fill="#FFFFFF"
-  />
-  <!-- Dark checkmark on white background for contrast -->
-  <path 
-    d="M${padding + iconSize * 0.2} ${padding + iconSize * 0.5} L${padding + iconSize * 0.4} ${padding + iconSize * 0.7} L${padding + iconSize * 0.8} ${padding + iconSize * 0.3}"
-    stroke="#1a1a1a"
-    stroke-width="${strokeWidth}"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    fill="none"
-  />
-</svg>
-`
-}
-
-/**
- * Notepad with checkmark SVG (more detailed version)
- * WHITE color with thicker strokes for dark menu bars
- */
-const createNotepadCheckmarkSVG = (size) => {
-  const padding = Math.round(size * 0.06)
-  const innerSize = size - padding * 2
-  // Thicker strokes for visibility
-  const strokeWidth = Math.max(1.8, size / 9)
-
-  return `
-<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
-  <!-- Notepad body -->
-  <rect 
-    x="${padding}" 
-    y="${padding + innerSize * 0.12}" 
-    width="${innerSize}" 
-    height="${innerSize * 0.88}" 
-    rx="${Math.max(1.5, size / 8)}"
-    fill="none"
-    stroke="#FFFFFF"
-    stroke-width="${strokeWidth}"
-  />
-  <!-- Notepad rings -->
-  <line x1="${padding + innerSize * 0.25}" y1="${padding}" x2="${padding + innerSize * 0.25}" y2="${padding + innerSize * 0.2}" stroke="#FFFFFF" stroke-width="${strokeWidth}" stroke-linecap="round"/>
-  <line x1="${padding + innerSize * 0.5}" y1="${padding}" x2="${padding + innerSize * 0.5}" y2="${padding + innerSize * 0.2}" stroke="#FFFFFF" stroke-width="${strokeWidth}" stroke-linecap="round"/>
-  <line x1="${padding + innerSize * 0.75}" y1="${padding}" x2="${padding + innerSize * 0.75}" y2="${padding + innerSize * 0.2}" stroke="#FFFFFF" stroke-width="${strokeWidth}" stroke-linecap="round"/>
-  <!-- Checkmark - thicker and more visible -->
-  <path 
-    d="M${padding + innerSize * 0.22} ${padding + innerSize * 0.55} L${padding + innerSize * 0.4} ${padding + innerSize * 0.73} L${padding + innerSize * 0.78} ${padding + innerSize * 0.38}"
-    stroke="#FFFFFF"
-    stroke-width="${Math.max(2, size / 8)}"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    fill="none"
-  />
-</svg>
-`
-}
-
-async function generateTrayIcons() {
-  const outputDir = path.join(__dirname, '../build/icons/tray')
-
-  // Ensure directory exists
-  await fs.mkdir(outputDir, { recursive: true })
-
-  console.warn('🎨 Generating macOS Template tray icons (18x18, WHITE)...')
-  console.warn(`📁 Output: ${outputDir}`)
-
-  // Generate 1x (18x18) template icon - 2px larger than standard 16x16
-  const svg18 = createNotepadCheckmarkSVG(18)
-  try {
-    await sharp(Buffer.from(svg18))
-      .resize(18, 18)
-      .png({ compressionLevel: 9 })
-      .toFile(path.join(outputDir, 'trayTemplate.png'))
-    console.warn('  ✅ Generated trayTemplate.png (18x18)')
-  } catch (error) {
-    console.error('  ❌ Failed to generate 18x18:', error.message)
-  }
-
-  // Generate 2x (36x36) template icon for Retina
-  const svg36 = createNotepadCheckmarkSVG(36)
-  try {
-    await sharp(Buffer.from(svg36))
-      .resize(36, 36)
-      .png({ compressionLevel: 9 })
-      .toFile(path.join(outputDir, 'trayTemplate@2x.png'))
-    console.warn('  ✅ Generated trayTemplate@2x.png (36x36)')
-  } catch (error) {
-    console.error('  ❌ Failed to generate 36x36:', error.message)
-  }
-
-  // Also generate simple checkmark version as backup
-  const simpleCheck18 = createCheckmarkSVG(18)
-  try {
-    await sharp(Buffer.from(simpleCheck18))
-      .resize(18, 18)
-      .png({ compressionLevel: 9 })
-      .toFile(path.join(outputDir, 'checkTemplate.png'))
-    console.warn('  ✅ Generated checkTemplate.png (18x18)')
-  } catch (error) {
-    console.error('  ❌ Failed to generate simple check 18x18:', error.message)
-  }
-
-  const simpleCheck36 = createCheckmarkSVG(36)
-  try {
-    await sharp(Buffer.from(simpleCheck36))
-      .resize(36, 36)
-      .png({ compressionLevel: 9 })
-      .toFile(path.join(outputDir, 'checkTemplate@2x.png'))
-    console.warn('  ✅ Generated checkTemplate@2x.png (36x36)')
-  } catch (error) {
-    console.error('  ❌ Failed to generate simple check 36x36:', error.message)
-  }
-
-  // Generate filled checkmark (high visibility alternative)
-  const filled18 = createFilledCheckmarkSVG(18)
-  try {
-    await sharp(Buffer.from(filled18))
-      .resize(18, 18)
-      .png({ compressionLevel: 9 })
-      .toFile(path.join(outputDir, 'filledTemplate.png'))
-    console.warn('  ✅ Generated filledTemplate.png (18x18)')
-  } catch (error) {
-    console.error('  ❌ Failed to generate filled 18x18:', error.message)
-  }
-
-  const filled36 = createFilledCheckmarkSVG(36)
-  try {
-    await sharp(Buffer.from(filled36))
-      .resize(36, 36)
-      .png({ compressionLevel: 9 })
-      .toFile(path.join(outputDir, 'filledTemplate@2x.png'))
-    console.warn('  ✅ Generated filledTemplate@2x.png (36x36)')
-  } catch (error) {
-    console.error('  ❌ Failed to generate filled 36x36:', error.message)
-  }
-
-  console.warn('\n🎉 Tray icon generation completed!')
-  console.warn(
-    '\n📝 Note: Template icons will be auto-tinted by macOS for light/dark mode.',
-  )
-}
-
-// Run if executed directly
-generateTrayIcons().catch(console.error)
+generateStandaloneTrayIcons().catch((error) => {
+  console.error('Failed to generate macOS Template tray icons:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Generate macOS Template tray icons during `build:icons` so clean Electron builds do not fall back to the colored `tray-16x16.png` app icon.
- Preserve Electron Template image handling in `SystemTrayManager` and route tray state changes through the same icon creation path.
- Add regression coverage for clean Template icon generation and NativeImage Template handling.

## Test Plan
- `node scripts/generate-icons.js`
- `node scripts/generate-tray-icons.js`
- `./node_modules/.bin/vitest run --config vitest.config.electron.ts electron/__tests__/icon-system.test.mjs`
- `./node_modules/.bin/vitest run --config vitest.config.electron.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint scripts/generate-icons.js scripts/generate-tray-icons.js electron/SystemTrayManager.ts electron/__tests__/icon-system.test.mjs --max-warnings 0`
- `env PATH="/Users/ryotamurakami/.local/share/mise/installs/node/24/bin:$PATH" ./node_modules/.bin/playwright test --config=playwright.electron.config.ts`
- Packaged native QA: built with `node scripts/generate-icons.js && ./node_modules/.bin/electron-vite build && ./node_modules/.bin/electron-builder --dir`, launched `dist/mac-arm64/CoreLive.app`, opened the CoreLive menu-bar item via macOS AX, and confirmed the menu bar shows the white notepad/check Template icon instead of the colored app icon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS tray icon handling so the app uses the correct system-tinted icon style more reliably.
  * Fixed tray icon state updates to better handle missing icons and avoid unexpected behavior.

* **New Features**
  * Added updated macOS tray icon assets for clearer, more consistent appearance, including high-resolution variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->