### PR TITLE
refactor: extract BrainDump note persistence

### DIFF
--- a/electron/BrainDumpNoteStore.ts
+++ b/electron/BrainDumpNoteStore.ts
@@ -1,0 +1,60 @@
+import type { ConfigManager } from './ConfigManager'
+
+const BRAINDUMP_NOTES_CONFIG_PATH = 'braindump.notes'
+
+type BrainDumpNoteReader = Pick<ConfigManager, 'get'>
+type BrainDumpNoteWriter = Pick<ConfigManager, 'get' | 'set'>
+
+/**
+ * Converts the category id into the persisted note-map key used by Electron IPC callers.
+ * @param categoryId - The positive category id from the typed IPC contract.
+ * @returns The string key used in `braindump.notes`.
+ * @example
+ * toBrainDumpNoteKey(42) // => '42'
+ */
+const toBrainDumpNoteKey = (categoryId: number): string => String(categoryId)
+
+/**
+ * Reads one persisted BrainDump note for IPC without exposing the whole notes map.
+ * @param configManager - The Electron config manager that owns `config.json`.
+ * @param categoryId - The category whose note text should be read.
+ * @returns The stored note text, or an empty string when no note exists.
+ * @example
+ * getBrainDumpNote(configManager, 42) // => 'today I shipped'
+ */
+export const getBrainDumpNote = (
+  configManager: BrainDumpNoteReader,
+  categoryId: number,
+): string => {
+  const notes = configManager.get<Record<string, string>>(
+    BRAINDUMP_NOTES_CONFIG_PATH,
+    {},
+  )
+
+  return notes?.[toBrainDumpNoteKey(categoryId)] ?? ''
+}
+
+/**
+ * Writes one BrainDump note while preserving every other category note in config.
+ * @param configManager - The Electron config manager that owns `config.json`.
+ * @param categoryId - The category whose note text should be updated.
+ * @param text - The note text to persist for the category.
+ * @returns Nothing; the config manager performs the disk write.
+ * @example
+ * setBrainDumpNote(configManager, 42, 'today I shipped')
+ */
+export const setBrainDumpNote = (
+  configManager: BrainDumpNoteWriter,
+  categoryId: number,
+  text: string,
+): void => {
+  const notes = configManager.get<Record<string, string>>(
+    BRAINDUMP_NOTES_CONFIG_PATH,
+    {},
+  )
+
+  configManager.set(BRAINDUMP_NOTES_CONFIG_PATH, {
+    ...(notes ?? {}),
+    [toBrainDumpNoteKey(categoryId)]: text,
+  })
+}

--- a/electron/__tests__/BrainDumpNoteStore.test.ts
+++ b/electron/__tests__/BrainDumpNoteStore.test.ts
@@ -1,0 +1,106 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// A mutable holder lets the hoisted Electron app mock return a fresh userData
+// directory per test before ConfigManager reads the path.
+const userDataDir = vi.hoisted(() => ({ current: '' }))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => userDataDir.current),
+  },
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+import { getBrainDumpNote, setBrainDumpNote } from '../BrainDumpNoteStore'
+import { ConfigManager } from '../ConfigManager'
+
+/**
+ * Reads the persisted BrainDump notes from ConfigManager so assertions prove disk-shape compatibility.
+ * @param configManager - The temp-directory-backed config manager under test.
+ * @returns The persisted note map keyed by category id string.
+ * @example
+ * readBrainDumpNotes(configManager) // => { '1': 'note' }
+ */
+const readBrainDumpNotes = (
+  configManager: ConfigManager,
+): Record<string, string> =>
+  configManager.get<Record<string, string>>('braindump.notes', {})
+
+describe('BrainDumpNoteStore', () => {
+  beforeEach(() => {
+    // Arrange: isolate config.json per test so note writes prove real shape.
+    userDataDir.current = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'corelive-braindump-note-store-'),
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(userDataDir.current, { recursive: true, force: true })
+  })
+
+  it('returns an empty string when a category has no persisted note', () => {
+    // Arrange
+    const configManager = new ConfigManager()
+    configManager.set('braindump.notes', {
+      '1': 'existing CoreLive note',
+    })
+
+    // Act
+    const noteText = getBrainDumpNote(configManager, 2)
+
+    // Assert
+    expect(noteText).toBe('')
+  })
+
+  it('reads the persisted note for the requested category', () => {
+    // Arrange
+    const configManager = new ConfigManager()
+    configManager.set('braindump.notes', {
+      '1': 'existing CoreLive note',
+    })
+
+    // Act
+    const noteText = getBrainDumpNote(configManager, 1)
+
+    // Assert
+    expect(noteText).toBe('existing CoreLive note')
+  })
+
+  it('updates one category note while preserving the other category notes', () => {
+    // Arrange
+    const configManager = new ConfigManager()
+    configManager.set('braindump.notes', {
+      '1': 'existing CoreLive note',
+      '2': 'other category note',
+    })
+
+    // Act
+    setBrainDumpNote(configManager, 1, 'updated CoreLive note')
+
+    // Assert
+    expect(readBrainDumpNotes(configManager)).toEqual({
+      '1': 'updated CoreLive note',
+      '2': 'other category note',
+    })
+  })
+
+  it('creates a notes map when none exists yet', () => {
+    // Arrange
+    const configManager = new ConfigManager()
+
+    // Act
+    setBrainDumpNote(configManager, 3, 'first note')
+
+    // Assert
+    expect(readBrainDumpNotes(configManager)).toEqual({
+      '3': 'first note',
+    })
+  })
+})

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -28,6 +28,7 @@ import {
 import type { WebContents, Event as ElectronEvent } from 'electron'
 
 import type { AutoUpdater as AutoUpdaterType } from './AutoUpdater'
+import { getBrainDumpNote, setBrainDumpNote } from './BrainDumpNoteStore'
 import { ConfigManager } from './ConfigManager'
 import type { DeepLinkManager as DeepLinkManagerType } from './DeepLinkManager'
 import { typedHandle } from './ipc/typedHandle'
@@ -1481,21 +1482,12 @@ function setupIPCHandlers(): void {
   // Per-category note text (persisted in `braindump.notes[<categoryId>]`).
   typedHandle('braindump-note-get', (_event, categoryId) => {
     if (!configManager) return ''
-    const notes = configManager.get<Record<string, string>>(
-      'braindump.notes',
-      {},
-    )
-    return notes?.[String(categoryId)] ?? ''
+    return getBrainDumpNote(configManager, categoryId)
   })
 
   typedHandle('braindump-note-set', (_event, categoryId, text) => {
     if (!configManager) return false
-    const notes = {
-      ...(configManager.get<Record<string, string>>('braindump.notes', {}) ??
-        {}),
-      [String(categoryId)]: text,
-    }
-    configManager.set('braindump.notes', notes)
+    setBrainDumpNote(configManager, categoryId, text)
     return true
   })
 


### PR DESCRIPTION
## Summary
- Extracted BrainDump note persistence from `electron/main.ts` into `electron/BrainDumpNoteStore.ts`.
- Kept the IPC behavior unchanged: note text still reads/writes `braindump.notes[categoryId]` and preserves other category notes.
- Added Electron unit coverage for missing notes, existing notes, preserving other categories, and first note creation.

## BrainDump retention baseline
- Baseline CoreLive category note SHA: `c68aef7d01689632ac5ecbda158b7243efb63b4403c871d45b7644a48d607e13`
- Baseline note byte count: `66`
- Post-refactor local checks kept the same SHA.

## Verification
- [x] `corepack pnpm validate`
- [x] `corepack pnpm test:electron -- BrainDumpNoteStore`
- [x] `corepack pnpm typecheck`
- [x] port 4991 cleanup before Electron E2E
- [x] `corepack pnpm e2e:electron` (`28 passed`)
- [x] unsigned packaged build with signing disabled for local package proof
- [x] packaged `dist/mac-arm64/CoreLive.app` reports `0.17.2` / `com.corelive.app`
- [x] packaged `app.asar` contains `dist-electron/main/BrainDumpNoteStore.cjs`

## Release experiment plan
After this PR lands, cut the next patch release and update an older installed CoreLive app. Then compare the same BrainDump note SHA to verify the note survives the real Electron auto-update path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BrainDump notes are now saved and loaded more reliably per category.
  * Existing notes for other categories are preserved when updating a note.
  * Missing notes now return an empty value instead of causing issues.

* **Tests**
  * Added coverage for reading, updating, and creating BrainDump notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->