### PR TITLE
fix: protect BrainDump note saves during config load

### DIFF
--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -1724,13 +1724,20 @@ describe('BrainDumpEditor completion toast — close button + display duration (
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
 
-    // Act — complete line 0; the deferred path leaves it checked on screen for now.
-    fireCompleteCommandOnFirstLine(noteField, 'buy milk\nkeep me')
-    expect(noteField).toHaveValue('- [x] buy milk\nkeep me')
+    vi.useFakeTimers()
+    try {
+      // Act — complete line 0; the deferred path leaves it checked on screen for now.
+      fireCompleteCommandOnFirstLine(noteField, 'buy milk\nkeep me')
+      expect(noteField).toHaveValue('- [x] buy milk\nkeep me')
 
-    // Assert — after 150 ms (past the 100 ms toast, before the 300 ms delay) the
-    // line is already gone: the clamp picked the shorter toast duration.
-    await new Promise((resolve) => setTimeout(resolve, 150))
-    expect(noteField).toHaveValue('keep me')
+      // Assert — after 150 ms (past the 100 ms toast, before the 300 ms delay) the
+      // line is already gone: the clamp picked the shorter toast duration.
+      await act(async () => {
+        vi.advanceTimersByTime(150)
+      })
+      expect(noteField).toHaveValue('keep me')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -95,6 +95,20 @@ const categories: CategoryWithCount[] = [
   },
 ]
 
+const categoriesWithCorelive: CategoryWithCount[] = [
+  ...categories,
+  {
+    id: 12,
+    name: 'Corelive',
+    color: 'blue',
+    isDefault: false,
+    userId: 1,
+    createdAt: new Date('2026-06-12T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-12T00:00:00.000Z'),
+    _count: { todos: 0 },
+  },
+]
+
 type BrainDumpSpacesBridge = {
   getVisibleOnAllWorkspaces: ReturnType<typeof vi.fn>
   setVisibleOnAllWorkspaces: ReturnType<typeof vi.fn>
@@ -148,6 +162,21 @@ function installBrainDumpAPI(spaces: BrainDumpSpacesBridge): void {
  * renderEditor({ braindumpFontSize: 20 })
  */
 function renderEditor(preferenceOverrides: Partial<PreferencesState> = {}) {
+  return renderEditorWithCategories(categories, preferenceOverrides)
+}
+
+/**
+ * Renders the editor with custom categories for category-switching persistence specs.
+ * @param editorCategories - Categories available in the BrainDump picker.
+ * @param preferenceOverrides - Fields to override on top of the slice defaults.
+ * @returns The Testing Library render result.
+ * @example
+ * renderEditorWithCategories(categoriesWithCorelive)
+ */
+function renderEditorWithCategories(
+  editorCategories: CategoryWithCount[],
+  preferenceOverrides: Partial<PreferencesState> = {},
+) {
   const store = configureStore({
     reducer: { preferences: preferencesReducer },
     preloadedState: {
@@ -156,7 +185,7 @@ function renderEditor(preferenceOverrides: Partial<PreferencesState> = {}) {
   })
   return render(
     <Provider store={store}>
-      <BrainDumpEditor categories={categories} />
+      <BrainDumpEditor categories={editorCategories} />
     </Provider>,
   )
 }
@@ -361,6 +390,135 @@ describe('BrainDumpEditor note persistence during reload', () => {
     selectedCategoryRef.current = 1
   })
 
+  it('does not read or write the temporary floating category before BrainDump config finishes loading', async () => {
+    // Arrange
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.sync.getEnabled = vi.fn(
+      async () => new Promise<boolean>(() => undefined),
+    )
+    api.category.getLast = vi.fn().mockResolvedValue(12)
+    api.note.get = vi.fn().mockResolvedValue('should not load yet')
+    const noteSet = vi.mocked(api.note.set)
+
+    // Act
+    renderEditor()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Assert
+    expect(screen.getByRole('textbox')).toBeDisabled()
+    expect(api.note.get).not.toHaveBeenCalled()
+    expect(noteSet).not.toHaveBeenCalled()
+  })
+
+  it('loads only the saved local BrainDump category after config disables FloatingNav sync', async () => {
+    // Arrange
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.sync.getEnabled = vi.fn().mockResolvedValue(false)
+    api.category.getLast = vi.fn().mockResolvedValue(12)
+    api.note.get = vi.fn(async (categoryId: number) =>
+      categoryId === 12 ? 'local Corelive note' : 'temporary floating note',
+    )
+    const noteSet = vi.mocked(api.note.set)
+
+    // Act
+    renderEditorWithCategories(categoriesWithCorelive)
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+
+    // Assert
+    await waitFor(() => {
+      expect(noteField).toHaveValue('local Corelive note')
+    })
+    expect(api.note.get).toHaveBeenCalledWith(12)
+    expect(api.note.get).not.toHaveBeenCalledWith(1)
+    expect(noteSet).not.toHaveBeenCalled()
+  })
+
+  it('does not flush a clean loaded note when the active category changes', async () => {
+    // Arrange
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.note.get = vi.fn(async (categoryId: number) =>
+      categoryId === 1 ? 'keep category one' : 'work category twelve',
+    )
+    const noteSet = vi.mocked(api.note.set)
+    const store = configureStore({
+      reducer: { preferences: preferencesReducer },
+      preloadedState: {
+        preferences: { ...preferencesInitialState },
+      },
+    })
+
+    // Act
+    const { rerender } = render(
+      <Provider store={store}>
+        <BrainDumpEditor categories={categoriesWithCorelive} />
+      </Provider>,
+    )
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('keep category one')
+    })
+    noteSet.mockClear()
+    selectedCategoryRef.current = 12
+    rerender(
+      <Provider store={store}>
+        <BrainDumpEditor categories={categoriesWithCorelive} />
+      </Provider>,
+    )
+
+    // Assert
+    await waitFor(() => {
+      expect(noteField).toHaveValue('work category twelve')
+    })
+    expect(noteSet).not.toHaveBeenCalledWith(1, '')
+    expect(noteSet).not.toHaveBeenCalled()
+  })
+
+  it('persists an intentional full clear after the loaded category note is editable', async () => {
+    // Arrange
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(false),
+      setVisibleOnAllWorkspaces: vi.fn().mockResolvedValue(true),
+    })
+    const api = window.brainDumpAPI
+    if (!api) throw new Error('brainDumpAPI was not installed')
+    api.note.get = vi.fn().mockResolvedValue('keep me until the user clears it')
+    const noteSet = vi.mocked(api.note.set)
+    const user = userEvent.setup()
+
+    // Act
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('keep me until the user clears it')
+    })
+    await user.clear(noteField)
+
+    // Assert
+    await waitFor(
+      () => {
+        expect(noteSet).toHaveBeenCalledWith(1, '')
+      },
+      { timeout: 1200 },
+    )
+  })
+
   it('keeps the existing category note on disk when BrainDump reloads before the note finishes loading', async () => {
     // Arrange
     installBrainDumpAPI({
@@ -489,7 +647,10 @@ describe('BrainDumpEditor focus on window show', () => {
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
 
     // Assert — keyboard focus lands in the editor, not on a header control.
-    expect(noteField).toHaveFocus()
+    await waitFor(() => {
+      expect(noteField).toBeEnabled()
+      expect(noteField).toHaveFocus()
+    })
   })
 
   it('returns focus to the note editor when the window is shown again, instead of leaving it on the Follow Spaces switch', async () => {
@@ -503,6 +664,9 @@ describe('BrainDumpEditor focus on window show', () => {
     })
     renderEditor()
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitFor(() => {
+      expect(noteField).toBeEnabled()
+    })
     const spacesSwitch = screen.getByRole('switch', {
       name: 'Show BrainDump on all Mac desktops',
     })
@@ -522,7 +686,9 @@ describe('BrainDumpEditor focus on window show', () => {
     })
 
     // Assert — focus is back in the note editor, ready for the next capture.
-    expect(noteField).toHaveFocus()
+    await waitFor(() => {
+      expect(noteField).toHaveFocus()
+    })
   })
 })
 
@@ -884,6 +1050,9 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitFor(() => {
+      expect(noteField).toBeEnabled()
+    })
 
     // Act — complete (line clears), Undo (line restored, create still pending),
     // THEN the held create rejects.

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -507,6 +507,7 @@ describe('BrainDumpEditor note persistence during reload', () => {
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
     await waitFor(() => {
       expect(noteField).toHaveValue('keep me until the user clears it')
+      expect(noteField).toBeEnabled()
     })
     await user.clear(noteField)
 

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -1020,8 +1020,8 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalled()
+      expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
     })
-    expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
 
     // Act 2 — tap Undo AFTER the failure already restored the line.
     const undoAction = vi.mocked(toast.success).mock.calls.at(-1)?.[1]

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -714,6 +714,19 @@ function fireCompleteCommandOnFirstLine(
   fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
 }
 
+/**
+ * Waits for the config/note boot load to finish before tests type into BrainDump.
+ * @param noteField - The BrainDump textarea rendered by the test.
+ * @returns A promise that resolves once user input is accepted.
+ * @example
+ * await waitForBrainDumpReady(noteField)
+ */
+async function waitForBrainDumpReady(noteField: HTMLTextAreaElement) {
+  await waitFor(() => {
+    expect(noteField).toBeEnabled()
+  })
+}
+
 describe('BrainDumpEditor complete command', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -730,6 +743,7 @@ describe('BrainDumpEditor complete command', () => {
     })
     renderEditor()
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — fire the complete command on the plain line.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
@@ -754,6 +768,7 @@ describe('BrainDumpEditor complete command', () => {
     })
     renderEditor()
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act
     fireCompleteCommandOnFirstLine(noteField, '- [ ] write tests')
@@ -779,6 +794,7 @@ describe('BrainDumpEditor complete command', () => {
     })
     renderEditor()
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete a plain prose line whose create then fails.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
@@ -805,6 +821,7 @@ describe('BrainDumpEditor complete command', () => {
     })
     renderEditor()
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete 'buy milk', then (while the create is still pending) prepend
     // an unrelated line and rename the completed one so the title search misses.
@@ -831,6 +848,7 @@ describe('BrainDumpEditor complete command', () => {
     })
     renderEditor()
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act
     fireCompleteCommandOnFirstLine(noteField, '   ')
@@ -858,6 +876,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete the only line.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
@@ -884,6 +903,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act: complete an unchecked checkbox line.
     fireCompleteCommandOnFirstLine(noteField, '- [ ] buy milk')
@@ -905,6 +925,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
     const value = 'keep me\n- [ ] buy milk'
     fireEvent.change(noteField, { target: { value } })
     const caret = value.length // caret at end of the second line
@@ -926,7 +947,9 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
 
     // Assert — the verbatim line returns at index 1, not appended at the end.
-    expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+    })
   })
 
   it('restores the cleared line when the completion create fails', async () => {
@@ -940,12 +963,14 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete a line whose background create then rejects.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
 
     // Assert — the verbatim line comes back when the create fails.
     await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled()
       expect(noteField).toHaveValue('buy milk')
     })
   })
@@ -967,6 +992,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete (line clears), let the undo window elapse with no Undo
     // (Sonner fires onAutoClose on the timeout), THEN the create rejects.
@@ -990,7 +1016,9 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
 
     // Assert — the line is restored even though its undo window already closed.
-    expect(noteField).toHaveValue('buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('buy milk')
+    })
   })
 
   it('does not duplicate the line when Undo is tapped after a late failure already restored it', async () => {
@@ -1008,6 +1036,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
     const value = 'keep me\n- [ ] buy milk'
     fireEvent.change(noteField, { target: { value } })
     const caret = value.length // caret at end of the second line
@@ -1031,7 +1060,9 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
 
     // Assert — the line is present exactly ONCE, never doubled.
-    expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+    })
   })
 
   it('stays silent when the create fails after the user already undid', async () => {
@@ -1051,9 +1082,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
-    await waitFor(() => {
-      expect(noteField).toBeEnabled()
-    })
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete (line clears), Undo (line restored, create still pending),
     // THEN the held create rejects.
@@ -1066,7 +1095,9 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     await act(async () => {
       undoAction?.onClick()
     })
-    expect(noteField).toHaveValue('buy milk') // restored by Undo
+    await waitFor(() => {
+      expect(noteField).toHaveValue('buy milk') // restored by Undo
+    })
     await act(async () => {
       rejectCreate(new Error('network down'))
     })
@@ -1074,7 +1105,9 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     // Assert — the abandoned completion's failure surfaces NO error toast, and
     // the line stays put (the failure handler must not re-insert a second copy).
     expect(toast.error).not.toHaveBeenCalled()
-    expect(noteField).toHaveValue('buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('buy milk')
+    })
   })
 
   it('restores the line with its exact leading whitespace on undo (verbatim, not trimmed)', async () => {
@@ -1087,6 +1120,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete the indented line, then undo it.
     fireCompleteCommandOnFirstLine(noteField, '   buy milk')
@@ -1104,7 +1138,9 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
 
     // Assert — the three leading spaces survive; the DB got the trimmed title
     // ('buy milk') but the note restores the line exactly as typed.
-    expect(noteField).toHaveValue('   buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('   buy milk')
+    })
     expect(completedMutateAsync).toHaveBeenCalledWith({
       categoryId: 1,
       title: 'buy milk',
@@ -1121,6 +1157,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
     const value = 'a\n- [ ] buy milk\nc'
     fireEvent.change(noteField, { target: { value } })
     // Park the caret at the end of the middle line (offset 16) before completing.
@@ -1150,6 +1187,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     })
     renderEditor()
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete a plain line under the default preference.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
@@ -1209,6 +1247,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     )
     const { rerender } = render(tree())
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
     // Seed two lines and park the caret on the checkbox line (index 1).
     const value = 'keep me\n- [ ] buy milk'
     fireEvent.change(noteField, { target: { value } })
@@ -1280,6 +1319,7 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
       braindumpClearDelayMs: LINGER_MS,
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete the first of two lines.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk\nkeep me')
@@ -1315,6 +1355,7 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
       braindumpClearDelayMs: 500,
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete line 0 ('buy milk'), then ~100 ms later complete line 1
     // ('dishes'); the checked lines stay present meanwhile, and both completions
@@ -1350,6 +1391,7 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
       braindumpClearDelayMs: LINGER_MS,
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete (the line is now lingering), then tap Undo before the linger
     // elapses. The optimistic toast is shown synchronously, so its Undo action is
@@ -1364,7 +1406,9 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
     // Assert — Undo cancelled the pending removal, so the line never left — and it
     // stays put even past the point the linger would have elapsed (timer cancelled,
     // not merely deferred).
-    expect(noteField).toHaveValue('buy milk\nkeep me')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('buy milk\nkeep me')
+    })
     await new Promise((resolve) => setTimeout(resolve, LINGER_MS + 50))
     expect(noteField).toHaveValue('buy milk\nkeep me')
   })
@@ -1383,6 +1427,7 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
       braindumpClearDelayMs: LINGER_MS,
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete a line whose background create then rejects during the linger.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk\nkeep me')
@@ -1392,8 +1437,8 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
     // blind removal, no duplicate re-insert).
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalled()
+      expect(noteField).toHaveValue('buy milk\nkeep me')
     })
-    expect(noteField).toHaveValue('buy milk\nkeep me')
     await new Promise((resolve) => setTimeout(resolve, LINGER_MS + 50))
     expect(noteField).toHaveValue('buy milk\nkeep me')
   })
@@ -1442,6 +1487,7 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
     )
     const { rerender } = render(tree())
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
     const value = 'buy milk\nkeep me'
     fireEvent.change(noteField, { target: { value } })
     noteField.selectionStart = 'buy milk'.length
@@ -1483,6 +1529,7 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
       braindumpClearDelayMs: LINGER_MS,
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete the first line, then (still within the linger, before the
     // timer fires) edit that very line so it no longer matches what was completed.
@@ -1536,6 +1583,7 @@ describe('BrainDumpEditor clear-on-complete (deferred linger)', () => {
     )
     const { rerender } = render(tree())
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
     const value = 'buy milk\nkeep me'
     fireEvent.change(noteField, { target: { value } })
     noteField.selectionStart = 'buy milk'.length
@@ -1582,6 +1630,7 @@ describe('BrainDumpEditor completion toast — close button + display duration (
     })
     renderEditor({ braindumpToastDurationMs: 8000 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete a plain line.
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
@@ -1604,6 +1653,7 @@ describe('BrainDumpEditor completion toast — close button + display duration (
     })
     renderEditor({ braindumpToastDurationMs: 8000 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
@@ -1628,6 +1678,7 @@ describe('BrainDumpEditor completion toast — close button + display duration (
     })
     renderEditor({ braindumpToastDurationMs: 2500 })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
@@ -1655,6 +1706,7 @@ describe('BrainDumpEditor completion toast — close button + display duration (
       braindumpToastDurationMs: 6000,
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     // Act — complete the only line (it clears instantly).
     fireCompleteCommandOnFirstLine(noteField, 'buy milk')
@@ -1682,6 +1734,7 @@ describe('BrainDumpEditor completion toast — close button + display duration (
       braindumpToastDurationMs: 6000,
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
     const value = 'keep me\n- [ ] buy milk'
     fireEvent.change(noteField, { target: { value } })
     const caret = value.length // caret at end of the second line
@@ -1705,7 +1758,9 @@ describe('BrainDumpEditor completion toast — close button + display duration (
     })
 
     // Assert — the verbatim line returns at index 1 and stays there.
-    expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+    await waitFor(() => {
+      expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+    })
   })
 
   it('clamps the clear linger down to the shorter toast duration so a line never outlasts its Undo', async () => {
@@ -1723,6 +1778,7 @@ describe('BrainDumpEditor completion toast — close button + display duration (
       braindumpToastDurationMs: 100,
     })
     const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
 
     vi.useFakeTimers()
     try {

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -85,6 +85,13 @@ type CheckedRowMemory = Readonly<{
   title: BrainDumpCompletedTitle
 }>
 
+type NoteDraftUpdateOptions = Readonly<{
+  /** Category this draft belongs to; defaults to the active category ref. */
+  categoryId?: Category['id'] | null
+  /** True only after a user/internal edit that should be flushed to disk. */
+  dirty: boolean
+}>
+
 /**
  * Undo memory for a line that clear-on-complete will tuck away. Distinct from
  * `CheckedRowMemory`: here the line may be briefly visible as `[x]`, then
@@ -275,6 +282,11 @@ export const BrainDumpEditor = function BrainDumpEditor({
   )
   const [noteText, setNoteText] = useState<string>('')
   const [isLoadingNote, setIsLoadingNote] = useState<boolean>(false)
+  const [noteReadyCategoryId, setNoteReadyCategoryId] = useState<
+    Category['id'] | null
+  >(null)
+  const [isBrainDumpConfigReady, setIsBrainDumpConfigReady] =
+    useState<boolean>(false)
   const [spacesTrackingEnabled, setSpacesTrackingEnabled] =
     useState<boolean>(false)
   const [isUpdatingSpacesTracking, setIsUpdatingSpacesTracking] =
@@ -303,7 +315,11 @@ export const BrainDumpEditor = function BrainDumpEditor({
   // Clamped ≤ the Undo window by the schema, so the line never outlasts Undo.
   const clearDelayMs = useAppSelector(selectBraindumpClearDelayMs)
 
-  const activeCategoryId = syncEnabled ? floatingCategoryId : localCategoryId
+  const activeCategoryId = isBrainDumpConfigReady
+    ? syncEnabled
+      ? floatingCategoryId
+      : localCategoryId
+    : null
   const checkedRowsRef = useRef<Map<BrainDumpLineIndex, CheckedRowMemory>>(
     new Map(),
   )
@@ -345,9 +361,37 @@ export const BrainDumpEditor = function BrainDumpEditor({
     categoryId: Category['id'] | null
     text: string
   }>({ categoryId: null, text: '' })
-  // Category whose textarea value may be written back to disk. It only flips on
-  // after a successful load or direct user input, so load failures do not save "".
+  // Category whose textarea value may be written back to disk. It flips on only
+  // after the load attempt settles or direct user input; dirty guard blocks a
+  // load-failure empty reset from writing "".
   const noteWritableCategoryRef = useRef<Category['id'] | null>(null)
+  // Tracks whether the visible draft diverged from the last loaded/saved value.
+  // Loaded clean notes must never be flushed by category swaps or updater quits.
+  const dirtyNoteRef = useRef<{
+    categoryId: Category['id'] | null
+    dirty: boolean
+  }>({ categoryId: null, dirty: false })
+
+  /**
+   * Updates the visible BrainDump draft and marks whether it may flush to disk.
+   * @param text - Next textarea value.
+   * @param options - Category ownership plus whether the change is user/internal dirty.
+   * @returns Nothing; synchronizes React state and the callback ref in one tick.
+   * @example
+   * setNoteDraft('buy milk', { dirty: true })
+   */
+  const setNoteDraft = (
+    text: string,
+    options: NoteDraftUpdateOptions,
+  ): void => {
+    const categoryId = options.categoryId ?? activeCategoryIdRef.current
+    noteTextRef.current = text
+    dirtyNoteRef.current =
+      options.dirty && categoryId !== null
+        ? { categoryId, dirty: true }
+        : { categoryId, dirty: false }
+    setNoteText(text)
+  }
 
   useCycleEffect(() => {
     noteTextRef.current = noteText
@@ -421,6 +465,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         setSyncEnabled(enabled)
         setLocalCategoryId(lastCategoryId)
         setSpacesTrackingEnabled(followsSpaces)
+        setIsBrainDumpConfigReady(true)
       })
       .catch((error) => {
         // Failures here keep the safe defaults seeded by useState; surface
@@ -428,6 +473,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         if (cancelled) return
         toast.error('Failed to load BrainDump preferences')
         log.error('BrainDump preferences load failed', error)
+        setIsBrainDumpConfigReady(true)
       })
     return () => {
       cancelled = true
@@ -454,13 +500,15 @@ export const BrainDumpEditor = function BrainDumpEditor({
   // hidden — not destroyed — between toggles, so the textarea can't lean on a
   // mount-time autoFocus to refocus on re-show; we listen for the Page
   // Visibility transition to 'visible' that BrowserWindow.show() drives, and
-  // also focus once on mount for the first open. focus() is a no-op while the
-  // textarea is disabled (no active category) — picking a category first is the
-  // expected flow there.
+  // also focus once on mount / after config+note loading for the first open.
+  // focus() is a no-op while the textarea is disabled (no active category) —
+  // picking a category first is the expected flow there.
   useCycleEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment()) return
     const focusNoteEditor = () => {
-      textareaRef.current?.focus()
+      const textarea = textareaRef.current
+      if (!textarea || textarea.disabled) return
+      textarea.focus()
     }
     // First open: show() already fired before this effect subscribed, so the
     // visibilitychange we would catch has passed — focus directly.
@@ -472,14 +520,15 @@ export const BrainDumpEditor = function BrainDumpEditor({
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  }, [isMounted])
+  }, [activeCategoryId, isLoadingNote, isMounted])
 
   // Whenever the active category flips, load that category's note text.
   useCycleEffect(() => {
     if (!isMounted || !isBrainDumpEnvironment() || activeCategoryId === null) {
-      setNoteText('')
+      setNoteDraft('', { categoryId: null, dirty: false })
       lastPersistedRef.current = { categoryId: null, text: '' }
       noteWritableCategoryRef.current = null
+      setNoteReadyCategoryId(null)
       return
     }
     const api = window.brainDumpAPI
@@ -489,15 +538,18 @@ export const BrainDumpEditor = function BrainDumpEditor({
     let cancelled = false
     setIsLoadingNote(true)
     noteWritableCategoryRef.current = null
+    setNoteReadyCategoryId(null)
+    dirtyNoteRef.current = { categoryId: activeCategoryId, dirty: false }
     api.note
       .get(activeCategoryId)
       .then((text) => {
         if (cancelled) return
-        setNoteText(text)
+        setNoteDraft(text, { categoryId: activeCategoryId, dirty: false })
         // Mark as already-persisted so the debounce effect doesn't immediately
         // echo this text back to disk.
         lastPersistedRef.current = { categoryId: activeCategoryId, text }
         noteWritableCategoryRef.current = activeCategoryId
+        setNoteReadyCategoryId(activeCategoryId)
         checkedRowsRef.current.clear()
         pendingCreatesRef.current.clear()
         clearedLinesRef.current.clear()
@@ -509,9 +561,10 @@ export const BrainDumpEditor = function BrainDumpEditor({
         // Reset editor state BEFORE clearing the loading flag so the
         // category swap doesn't briefly show stale text from category A
         // while we render category B's failure.
-        setNoteText('')
+        setNoteDraft('', { categoryId: activeCategoryId, dirty: false })
         lastPersistedRef.current = { categoryId: null, text: '' }
-        noteWritableCategoryRef.current = null
+        noteWritableCategoryRef.current = activeCategoryId
+        setNoteReadyCategoryId(activeCategoryId)
         checkedRowsRef.current.clear()
         pendingCreatesRef.current.clear()
         clearedLinesRef.current.clear()
@@ -539,6 +592,8 @@ export const BrainDumpEditor = function BrainDumpEditor({
     // Never persist the initial empty textarea before this category's note has
     // loaded; a deploy-driven reload can otherwise overwrite real disk content.
     if (noteWritableCategoryRef.current !== activeCategoryId) return
+    const dirtyNote = dirtyNoteRef.current
+    if (!dirtyNote.dirty || dirtyNote.categoryId !== activeCategoryId) return
     if (
       persisted.categoryId === activeCategoryId &&
       persisted.text === noteText
@@ -550,6 +605,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         categoryId: activeCategoryId,
         text: noteText,
       }
+      dirtyNoteRef.current = { categoryId: activeCategoryId, dirty: false }
       void api.note.set(activeCategoryId, noteText)
     }, NOTE_DEBOUNCE_MS)
     return () => {
@@ -571,10 +627,13 @@ export const BrainDumpEditor = function BrainDumpEditor({
       // If note.get never resolved for this category, `text` is only the local
       // initial value. Skipping the flush preserves the existing stored note.
       if (noteWritableCategoryRef.current !== flushCategoryId) return
+      const dirtyNote = dirtyNoteRef.current
+      if (!dirtyNote.dirty || dirtyNote.categoryId !== flushCategoryId) return
       if (persisted.categoryId === flushCategoryId && persisted.text === text) {
         return
       }
       lastPersistedRef.current = { categoryId: flushCategoryId, text }
+      dirtyNoteRef.current = { categoryId: flushCategoryId, dirty: false }
       void api.note.set(flushCategoryId, text)
     }
   }, [activeCategoryId, isMounted])
@@ -712,7 +771,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
           // drifted stale lineIndex never blind-overwrites an unrelated line
           // the user edited while the create was in flight. Checkbox lines
           // (no rollbackPlainText) always revert to `[ ]` as before.
-          setNoteText(
+          setNoteDraft(
             rollbackPlainText !== undefined && resolvedLine !== null
               ? replaceLineAtIndex(
                   noteTextRef.current,
@@ -720,6 +779,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
                   rollbackPlainText,
                 )
               : setCheckboxStateAtLine(noteTextRef.current, currentLine, false),
+            { dirty: true },
           )
           return null
         },
@@ -791,7 +851,9 @@ export const BrainDumpEditor = function BrainDumpEditor({
               safeTitle,
             )
             if (lineToClear === null) return
-            setNoteText(removeLineAtIndex(noteTextRef.current, lineToClear))
+            setNoteDraft(removeLineAtIndex(noteTextRef.current, lineToClear), {
+              dirty: true,
+            })
           }
         : undefined,
     })
@@ -828,7 +890,12 @@ export const BrainDumpEditor = function BrainDumpEditor({
       }
     }
     if (memoryKey !== null) checkedRowsRef.current.delete(memoryKey)
-    setNoteText(setCheckboxStateAtLine(originalText, resolvedLineIndex, false))
+    setNoteDraft(
+      setCheckboxStateAtLine(originalText, resolvedLineIndex, false),
+      {
+        dirty: true,
+      },
+    )
 
     try {
       await deleteCompletedMutation.mutateAsync({ id: completedId })
@@ -843,8 +910,9 @@ export const BrainDumpEditor = function BrainDumpEditor({
       const rollbackLineIndex =
         findCheckedLineIndexByTitle(noteTextRef.current, title) ??
         resolvedLineIndex
-      setNoteText(
+      setNoteDraft(
         setCheckboxStateAtLine(noteTextRef.current, rollbackLineIndex, true),
+        { dirty: true },
       )
       if (memoryBeforeUndo) {
         checkedRowsRef.current.set(rollbackLineIndex, memoryBeforeUndo)
@@ -878,7 +946,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         entry.originalLineIndex,
         entry.reinsertText,
       )
-      setNoteText(restored)
+      setNoteDraft(restored, { categoryId: entry.categoryId, dirty: true })
       if (moveCaret) {
         pendingCaretRef.current = lineStartOffset(
           restored,
@@ -929,8 +997,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         entry.originalLineIndex,
         entry.reinsertText,
       )
-      noteTextRef.current = restored
-      setNoteText(restored)
+      setNoteDraft(restored, { categoryId: entry.categoryId, dirty: true })
       if (moveCaret) {
         pendingCaretRef.current = lineStartOffset(
           restored,
@@ -1040,8 +1107,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
         }
       }
       pendingCaretRef.current = nextCaret
-      noteTextRef.current = clearedText
-      setNoteText(clearedText)
+      setNoteDraft(clearedText, { categoryId: entry.categoryId, dirty: true })
       entry.lineCleared = true
       // Finding G: our removal shifted every later still-pending line up by one,
       // so decrement their tracked index to keep their own finding-A guard matching.
@@ -1114,8 +1180,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
 
     // 2) Show the checked state first, then remove it on the clear timer. A
     // 0 ms setting means "next turn", not "skip the visible check mark".
-    noteTextRef.current = completedText
-    setNoteText(completedText)
+    setNoteDraft(completedText, { categoryId, dirty: true })
     if (clearDelayMs > 0) {
       // During a linger, move the caret to the START OF THE NEXT line after the
       // checked text commits, so repeated Cmd/Ctrl+Enter walks down the list.
@@ -1325,7 +1390,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
       // checkbox skeletons return null and fall through to a no-op.
       const promoted = markPlainLineCompleted(text, lineIndex)
       if (!promoted) return
-      setNoteText(promoted.text)
+      setNoteDraft(promoted.text, { dirty: true })
       // Pass the plain prose as rollback text so a failed create restores the
       // original line instead of leaving the optimistic `- [x]` skeleton.
       void promoteLineToCompleted(lineIndex, promoted.title, promoted.title)
@@ -1334,7 +1399,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
 
     const nextChecked = !parsed.checked
     const nextText = setCheckboxStateAtLine(text, lineIndex, nextChecked)
-    setNoteText(nextText)
+    setNoteDraft(nextText, { dirty: true })
 
     if (nextChecked) {
       void promoteLineToCompleted(lineIndex, parsed.title)
@@ -1406,6 +1471,10 @@ export const BrainDumpEditor = function BrainDumpEditor({
   }
 
   const hasCategories = categories.length > 0
+  const isNoteFieldDisabled =
+    activeCategoryId === null ||
+    isLoadingNote ||
+    noteReadyCategoryId !== activeCategoryId
 
   return (
     <div
@@ -1512,7 +1581,11 @@ export const BrainDumpEditor = function BrainDumpEditor({
           // A direct edit after a load failure is intentional new content, so it
           // can be saved even though no prior disk value was loaded.
           noteWritableCategoryRef.current = activeCategoryId
-          setNoteText(event.target.value)
+          setNoteReadyCategoryId(activeCategoryId)
+          setNoteDraft(event.target.value, {
+            categoryId: activeCategoryId,
+            dirty: true,
+          })
         }}
         onKeyDown={handleKeyDown}
         placeholder={
@@ -1520,7 +1593,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
             ? 'Pick a category to start writing'
             : '- [ ] braindump anything here…\nUse Cmd/Ctrl+Enter to complete the current line.'
         }
-        disabled={activeCategoryId === null || isLoadingNote}
+        disabled={isNoteFieldDisabled}
         maxLength={NOTE_MAX_LENGTH}
         // Braindump is messy quick-capture — the native red spellcheck underlines
         // make unfinished / mixed-language fragments feel "corrected" and noisy, so

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -206,7 +206,8 @@ function rollbackPromotedLineText(
   const resolvedLine = findCheckedLineIndexByTitle(text, title)
   const currentLine = resolvedLine ?? lineIndex
   // Plain-line rollback is safe only when we can positively find the optimistic row.
-  if (rollbackPlainText !== undefined && resolvedLine !== null) {
+  if (rollbackPlainText !== undefined) {
+    if (resolvedLine === null) return text
     return replaceLineAtIndex(text, resolvedLine, rollbackPlainText)
   }
   return setCheckboxStateAtLine(text, currentLine, false)

--- a/src/components/braindump/BrainDumpEditor.tsx
+++ b/src/components/braindump/BrainDumpEditor.tsx
@@ -188,6 +188,31 @@ function findCheckedLineIndexByTitle(
 }
 
 /**
+ * Rebuilds a failed optimistic completion in the note it came from. Called by create rollback paths.
+ * @param text - Note text to repair.
+ * @param lineIndex - Original/fallback line index for the optimistic completion.
+ * @param title - Normalised completion title used to re-find a drifted checked row.
+ * @param rollbackPlainText - Original prose for plain-line completions; omitted for checkbox rows.
+ * @returns Text with the optimistic `[x]` row reverted, or the input when no safe target exists.
+ * @example
+ * rollbackPromotedLineText('- [x] buy milk', 0, 'buy milk') // => '- [ ] buy milk'
+ */
+function rollbackPromotedLineText(
+  text: string,
+  lineIndex: BrainDumpLineIndex,
+  title: BrainDumpCompletedTitle,
+  rollbackPlainText?: BrainDumpCompletedTitle,
+): string {
+  const resolvedLine = findCheckedLineIndexByTitle(text, title)
+  const currentLine = resolvedLine ?? lineIndex
+  // Plain-line rollback is safe only when we can positively find the optimistic row.
+  if (rollbackPlainText !== undefined && resolvedLine !== null) {
+    return replaceLineAtIndex(text, resolvedLine, rollbackPlainText)
+  }
+  return setCheckboxStateAtLine(text, currentLine, false)
+}
+
+/**
  * Build the BrainDump completion toast — the `Completed: <title>` success toast
  * with an Undo action AND a close (✕) button. Both completion paths
  * (`promoteLineToCompleted`, `completeAndClearLine`) call this so the ✕, the
@@ -391,6 +416,125 @@ export const BrainDumpEditor = function BrainDumpEditor({
         ? { categoryId, dirty: true }
         : { categoryId, dirty: false }
     setNoteText(text)
+  }
+
+  /**
+   * Persists a dirty draft and marks it clean only after IPC succeeds. Called by debounce/final flush effects.
+   * @param categoryId - Category whose note is being written.
+   * @param text - Exact note text being persisted.
+   * @param api - Electron preload API used for note storage.
+   * @returns void; completion updates refs only when the visible draft still matches.
+   * @example
+   * persistNoteDraft(1, '- [ ] buy milk', window.brainDumpAPI!)
+   */
+  const persistNoteDraft = React.useCallback(
+    (
+      categoryId: Category['id'],
+      text: string,
+      api: NonNullable<typeof window.brainDumpAPI>,
+    ): void => {
+      void api.note.set(categoryId, text).then(
+        () => {
+          // A late save from category A must not mark category B's active draft clean.
+          if (
+            activeCategoryIdRef.current === categoryId &&
+            noteTextRef.current === text
+          ) {
+            lastPersistedRef.current = { categoryId, text }
+            dirtyNoteRef.current = { categoryId, dirty: false }
+          }
+        },
+        (error: unknown) => {
+          toast.error('Failed to save BrainDump note')
+          log.error('BrainDump note save failed', error)
+        },
+      )
+    },
+    [],
+  )
+
+  /**
+   * Restores a failed keep-visible completion in its origin category. Called by create rollback handlers.
+   * @param categoryId - Category that owned the optimistic completion.
+   * @param lineIndex - Original/fallback line index for the completed row.
+   * @param title - Normalised completion title.
+   * @param rollbackPlainText - Original plain text when the source row was prose.
+   * @returns Promise that settles after visible or stored note restoration.
+   * @example
+   * await restoreFailedPromotionToCategory(1, 0, 'buy milk')
+   */
+  const restoreFailedPromotionToCategory = async (
+    categoryId: Category['id'],
+    lineIndex: BrainDumpLineIndex,
+    title: BrainDumpCompletedTitle,
+    rollbackPlainText?: BrainDumpCompletedTitle,
+  ): Promise<void> => {
+    const restoreText = (text: string) =>
+      rollbackPromotedLineText(text, lineIndex, title, rollbackPlainText)
+
+    if (activeCategoryIdRef.current === categoryId) {
+      setNoteDraft(restoreText(noteTextRef.current), {
+        categoryId,
+        dirty: true,
+      })
+      return
+    }
+
+    const api = window.brainDumpAPI
+    if (!api) return
+    try {
+      const stored = await api.note.get(categoryId)
+      const restored = restoreText(stored)
+      if (restored !== stored) await api.note.set(categoryId, restored)
+    } catch (error) {
+      log.error('BrainDump failed completion restore failed', error)
+    }
+  }
+
+  /**
+   * Writes an undo/rollback checkbox state to the category that owns it. Called by undoCompleted.
+   * @param categoryId - Category that owns the completion row.
+   * @param title - Normalised completion title used to recover from line drift.
+   * @param fallbackLineIndex - Best-known line index when title lookup cannot find a checked row.
+   * @param checked - Target checkbox state.
+   * @param sourceText - Optional active-category snapshot for immediate visible updates.
+   * @returns Line index used for bookkeeping.
+   * @example
+   * await setCompletedCheckboxStateInCategory(1, 'buy milk', 0, false)
+   */
+  const setCompletedCheckboxStateInCategory = async (
+    categoryId: Category['id'],
+    title: BrainDumpCompletedTitle,
+    fallbackLineIndex: BrainDumpLineIndex,
+    checked: boolean,
+    sourceText?: string,
+  ): Promise<BrainDumpLineIndex> => {
+    const updateText = (text: string) => {
+      const resolvedLineIndex =
+        findCheckedLineIndexByTitle(text, title) ?? fallbackLineIndex
+      return {
+        lineIndex: resolvedLineIndex,
+        text: setCheckboxStateAtLine(text, resolvedLineIndex, checked),
+      }
+    }
+
+    if (activeCategoryIdRef.current === categoryId) {
+      const updated = updateText(sourceText ?? noteTextRef.current)
+      setNoteDraft(updated.text, { categoryId, dirty: true })
+      return updated.lineIndex
+    }
+
+    const api = window.brainDumpAPI
+    if (!api) return fallbackLineIndex
+    try {
+      const stored = await api.note.get(categoryId)
+      const updated = updateText(stored)
+      if (updated.text !== stored) await api.note.set(categoryId, updated.text)
+      return updated.lineIndex
+    } catch (error) {
+      log.error('BrainDump cross-category checkbox restore failed', error)
+      return fallbackLineIndex
+    }
   }
 
   useCycleEffect(() => {
@@ -601,17 +745,12 @@ export const BrainDumpEditor = function BrainDumpEditor({
       return
     }
     const timeoutId = window.setTimeout(() => {
-      lastPersistedRef.current = {
-        categoryId: activeCategoryId,
-        text: noteText,
-      }
-      dirtyNoteRef.current = { categoryId: activeCategoryId, dirty: false }
-      void api.note.set(activeCategoryId, noteText)
+      persistNoteDraft(activeCategoryId, noteText, api)
     }, NOTE_DEBOUNCE_MS)
     return () => {
       window.clearTimeout(timeoutId)
     }
-  }, [activeCategoryId, isLoadingNote, isMounted, noteText])
+  }, [activeCategoryId, isLoadingNote, isMounted, noteText, persistNoteDraft])
 
   // Final flush: runs on category swap and unmount only (not on every keystroke).
   // Reads the latest text via ref so we never persist a stale snapshot.
@@ -632,11 +771,9 @@ export const BrainDumpEditor = function BrainDumpEditor({
       if (persisted.categoryId === flushCategoryId && persisted.text === text) {
         return
       }
-      lastPersistedRef.current = { categoryId: flushCategoryId, text }
-      dirtyNoteRef.current = { categoryId: flushCategoryId, dirty: false }
-      void api.note.set(flushCategoryId, text)
+      persistNoteDraft(flushCategoryId, text, api)
     }
-  }, [activeCategoryId, isMounted])
+  }, [activeCategoryId, isMounted, persistNoteDraft])
 
   const handleToggleSync = (enabled: boolean) => {
     setSyncEnabled(enabled)
@@ -742,10 +879,11 @@ export const BrainDumpEditor = function BrainDumpEditor({
       toast.error('Pick a category before checking items')
       return
     }
+    const categoryId = activeCategoryId
     const safeTitle = normalizeCompletedTitle(title)
     const promise = createCompletedMutation
       .mutateAsync({
-        categoryId: activeCategoryId,
+        categoryId,
         title: safeTitle,
       })
       .then(
@@ -756,30 +894,13 @@ export const BrainDumpEditor = function BrainDumpEditor({
               ? error.message
               : 'Failed to record completion'
           toast.error(message)
-          // Re-resolve which line still holds the `[x]` for this title —
-          // the original lineIndex may have drifted if the user inserted
-          // text above before the create rejected.
-          const resolvedLine = findCheckedLineIndexByTitle(
-            noteTextRef.current,
+          // Restore the origin category. If the user already switched away, this
+          // writes category A's stored note instead of touching category B's draft.
+          void restoreFailedPromotionToCategory(
+            categoryId,
+            lineIndex,
             safeTitle,
-          )
-          const currentLine = resolvedLine ?? lineIndex
-          // Plain-line completion: restore the original prose rather than
-          // leaving a `- [ ] <title>` skeleton the user never typed — but ONLY
-          // when the title search positively found the line. On a miss we fall
-          // back to the safe uncheck (a no-op on non-checkbox lines) so a
-          // drifted stale lineIndex never blind-overwrites an unrelated line
-          // the user edited while the create was in flight. Checkbox lines
-          // (no rollbackPlainText) always revert to `[ ]` as before.
-          setNoteDraft(
-            rollbackPlainText !== undefined && resolvedLine !== null
-              ? replaceLineAtIndex(
-                  noteTextRef.current,
-                  resolvedLine,
-                  rollbackPlainText,
-                )
-              : setCheckboxStateAtLine(noteTextRef.current, currentLine, false),
-            { dirty: true },
+            rollbackPlainText,
           )
           return null
         },
@@ -813,6 +934,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
           completedId,
           noteTextRef.current,
           lineIndex,
+          categoryId,
         )
       },
       // Clear-on-complete: when the toast auto-closes (the undo window elapsed
@@ -869,12 +991,15 @@ export const BrainDumpEditor = function BrainDumpEditor({
    * re-resolve the line by `title` against the latest text and walk the
    * `checkedRowsRef` map by `completedId` so the cleanup targets the right
    * entry no matter how the keys have shifted.
+   *
+   * @param categoryId - Origin category for cross-category undo and rollback writes.
    */
   const undoCompleted = async (
     title: BrainDumpCompletedTitle,
     completedId: Completed['id'],
     originalText: string,
     fallbackLineIndex: BrainDumpLineIndex,
+    categoryId: Category['id'],
   ) => {
     const resolvedLineIndex =
       findCheckedLineIndexByTitle(originalText, title) ?? fallbackLineIndex
@@ -890,11 +1015,12 @@ export const BrainDumpEditor = function BrainDumpEditor({
       }
     }
     if (memoryKey !== null) checkedRowsRef.current.delete(memoryKey)
-    setNoteDraft(
-      setCheckboxStateAtLine(originalText, resolvedLineIndex, false),
-      {
-        dirty: true,
-      },
+    await setCompletedCheckboxStateInCategory(
+      categoryId,
+      title,
+      resolvedLineIndex,
+      false,
+      originalText,
     )
 
     try {
@@ -907,14 +1033,13 @@ export const BrainDumpEditor = function BrainDumpEditor({
       // Roll back the optimistic uncheck so the checkbox state matches
       // the still-existing Completed row. Re-resolve again from the
       // latest text — drift may have continued during the await.
-      const rollbackLineIndex =
-        findCheckedLineIndexByTitle(noteTextRef.current, title) ??
-        resolvedLineIndex
-      setNoteDraft(
-        setCheckboxStateAtLine(noteTextRef.current, rollbackLineIndex, true),
-        { dirty: true },
+      const rollbackLineIndex = await setCompletedCheckboxStateInCategory(
+        categoryId,
+        title,
+        resolvedLineIndex,
+        true,
       )
-      if (memoryBeforeUndo) {
+      if (memoryBeforeUndo && activeCategoryIdRef.current === categoryId) {
         checkedRowsRef.current.set(rollbackLineIndex, memoryBeforeUndo)
       }
     }
@@ -1397,6 +1522,8 @@ export const BrainDumpEditor = function BrainDumpEditor({
       return
     }
 
+    const categoryId = activeCategoryIdRef.current
+    if (categoryId === null) return
     const nextChecked = !parsed.checked
     const nextText = setCheckboxStateAtLine(text, lineIndex, nextChecked)
     setNoteDraft(nextText, { dirty: true })
@@ -1422,6 +1549,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
           memory.completedId,
           nextText,
           lineIndex,
+          categoryId,
         )
         return
       }
@@ -1448,6 +1576,7 @@ export const BrainDumpEditor = function BrainDumpEditor({
             completedId,
             noteTextRef.current,
             lineIndex,
+            categoryId,
           )
         })
       }


### PR DESCRIPTION
## Summary
- Gate BrainDump note loading until persisted config has settled, so startup no longer reads the temporary FloatingNav category.
- Track clean vs dirty note drafts and only debounce/final-flush dirty drafts for the loaded active category.
- Keep intentional user-cleared notes writable and covered by regression tests.

## Verification
- `corepack pnpm test -- BrainDumpEditor`
- `corepack pnpm typecheck`
- `corepack pnpm validate`
- `/Users/ryotamurakami/.local/bin/kill-port 4991 || true`
- `corepack pnpm e2e:electron` (28 passed)

## Review
- `/review`: clean, 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brain Dump now waits until the selected note is fully ready before enabling the editor for editing.
* **Bug Fixes**
  * Prevented premature saves during startup, config loading, and category switching.
  * Improved persistence to save only intentionally edited content, including correct handling for cleared notes.
  * Fixed edge cases across completing, undoing, clearing, and restoring note text.
* **Improvements**
  * Enhanced editor focus behavior when the window reappears, ensuring the textarea becomes enabled and focused reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->