### PR TITLE
feat(electron): add Brain Dump setting to open config.json

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,7 @@
 # CodeRabbit configuration for CoreLive
 # Next.js 16 App Router + Electron (macOS) + oRPC + Clerk + Prisma
 
-language: en-US
+language: ja-JP
 early_access: false
 
 chat:
@@ -22,7 +22,7 @@ reviews:
   profile: assertive
   request_changes_workflow: false
   high_level_summary: true
-  poem: false
+  poem: true
   review_status: true
   review_details: false
   collapse_walkthrough: false

--- a/electron/__tests__/ipc-contract.test.ts
+++ b/electron/__tests__/ipc-contract.test.ts
@@ -185,6 +185,12 @@ describe('IPC contract', () => {
       expect(() => oauthCancel.parse([123])).toThrow(ZodError)
     })
 
+    it('accepts empty tuple for config-open', () => {
+      const openConfig = IPC_ARG_SCHEMAS['config-open']
+      expect(() => openConfig.parse([])).not.toThrow()
+      expect(() => openConfig.parse([null])).toThrow(ZodError)
+    })
+
     /**
      * BrainDump Note channels — locks down the contract used by
      * `preload-braindump.ts` and the main-window Settings bridge.

--- a/electron/__tests__/openConfigFile.test.ts
+++ b/electron/__tests__/openConfigFile.test.ts
@@ -1,0 +1,50 @@
+import { shell } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { openConfigFile } from '../utils/openConfigFile'
+
+vi.mock('electron', () => ({
+  shell: { openPath: vi.fn(async () => '') },
+}))
+
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+describe('openConfigFile', () => {
+  const configPath =
+    '/Users/me/Library/Application Support/CoreLive/config.json'
+
+  beforeEach(() => {
+    vi.mocked(shell.openPath).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns true when shell.openPath resolves with an empty string', async () => {
+    // Arrange
+    vi.mocked(shell.openPath).mockResolvedValueOnce('')
+
+    // Act
+    const result = await openConfigFile(configPath)
+
+    // Assert
+    expect(result).toBe(true)
+    expect(shell.openPath).toHaveBeenCalledTimes(1)
+    expect(shell.openPath).toHaveBeenCalledWith(configPath)
+  })
+
+  it('returns false without throwing when shell.openPath reports an error', async () => {
+    // Arrange
+    vi.mocked(shell.openPath).mockResolvedValueOnce('Failed to open path')
+
+    // Act
+    const result = await openConfigFile(configPath)
+
+    // Assert
+    expect(result).toBe(false)
+    expect(shell.openPath).toHaveBeenCalledWith(configPath)
+  })
+})

--- a/electron/ipc/ipc-schemas.ts
+++ b/electron/ipc/ipc-schemas.ts
@@ -191,6 +191,7 @@ export const IPC_ARG_SCHEMAS: Record<IPCChannel, z.ZodTypeAny> = {
   'config-import': z.tuple([]),
   'config-backup': z.tuple([]),
   'config-get-paths': z.tuple([]),
+  'config-open': z.tuple([]),
 
   // ──────────────────────────────────────────────────────────────────────────
   // Authentication

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -57,6 +57,7 @@ import { applyShortcutRebind } from './utils/applyShortcutRebind'
 import { resolveRemoteDebuggingPort } from './utils/debugMode'
 import { loadUiohook } from './utils/loadUiohook'
 import { isNativeTapLatchSet } from './utils/nativeTapLatch'
+import { openConfigFile } from './utils/openConfigFile'
 import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 import {
   HIDE_APP_ICON_CONFIG_PATH,
@@ -1795,6 +1796,16 @@ function setupIPCHandlers(): void {
       return { config: '', windowState: '', directory: '' }
     }
     return configManager.getConfigPaths()
+  })
+
+  // Security: path is resolved from ConfigManager only — renderer cannot supply
+  // an arbitrary filesystem target (same rule as config-export/import).
+  typedHandle('config-open', async () => {
+    if (!configManager) {
+      return false
+    }
+    const { config: configPath } = configManager.getConfigPaths()
+    return openConfigFile(configPath)
   })
 
   // Authentication IPC handlers (basic implementations for testing)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1139,6 +1139,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
         return { config: '', windowState: '', directory: '' }
       }
     },
+
+    /**
+     * Open config.json in the default application.
+     *
+     * The path is resolved in the main process from ConfigManager — the renderer
+     * cannot supply a filesystem target.
+     */
+    open: async (): Promise<boolean> => {
+      try {
+        return await typedInvoke('config-open')
+      } catch (error) {
+        log.error('Failed to open config file:', error)
+        return false
+      }
+    },
   },
 
   // Window state management APIs

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -233,6 +233,8 @@ export interface ElectronAPI {
       windowState: string
       directory: string
     }>
+    /** Open config.json in the default application (path resolved in main process) */
+    open: () => Promise<boolean>
     /** Save config to file (no-op - config auto-persists on modification) */
     save?: () => Promise<boolean>
     /** Load config from file (async via IPC) */

--- a/electron/types/ipc.ts
+++ b/electron/types/ipc.ts
@@ -718,6 +718,10 @@ export interface IPCChannels {
     request: void
     response: { config: string; windowState: string; directory: string }
   }
+  'config-open': {
+    request: void
+    response: boolean
+  }
 
   // ──────────────────────────────────────────────────────────────────────────
   // Deep Linking

--- a/electron/utils/openConfigFile.ts
+++ b/electron/utils/openConfigFile.ts
@@ -1,0 +1,21 @@
+import { shell } from 'electron'
+
+import { log } from '../logger'
+
+/**
+ * Opens the CoreLive config file in the user's default application for `.json`.
+ * Triggered from Settings → Brain Dump → "Open config.json".
+ *
+ * @param configPath - Absolute path from `ConfigManager.getConfigPaths().config`.
+ * @returns `true` when the OS accepts the open request; `false` on failure.
+ * @example
+ * await openConfigFile('/Users/me/Library/Application Support/CoreLive/config.json')
+ */
+export async function openConfigFile(configPath: string): Promise<boolean> {
+  const error = await shell.openPath(configPath)
+  if (error) {
+    log.error('Failed to open config file:', error)
+    return false
+  }
+  return true
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "prettier --ignore-unknown --write .",
     "typecheck": "tsc --noEmit",
     "validate": "concurrently -n test,pkg,lint,build,type,theme -c blue,magenta,yellow,green,cyan,white --kill-others-on-fail \"pnpm test\" \"pnpm test:packages\" \"pnpm lint:fix\" \"pnpm build\" \"pnpm typecheck\" \"pnpm theme:check\"",
-    "clean": "rimraf .next node_modules pnpm-lock.yaml tsconfig.tsbuildinfo dist dist-electron dist-electron-dev playwright-report tmp test-results storybook-static .playwright-mcp .playwright-cli monocart-report coverage .gstack",
+    "clean": "rimraf .next node_modules pnpm-lock.yaml tsconfig.tsbuildinfo dist dist-electron dist-electron-dev playwright-report tmp test-results storybook-static .playwright-mcp .playwright-cli monocart-report coverage/unit-web coverage/unit-electron coverage .gstack",
     "prepare": "husky",
     "prisma:migrate": "node scripts/assert-local-db.cjs && cross-env PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=1 prisma migrate dev",
     "prisma:status": "cross-env PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=1 prisma migrate status",

--- a/src/components/electron/BrainDumpSettings.test.tsx
+++ b/src/components/electron/BrainDumpSettings.test.tsx
@@ -10,6 +10,7 @@ const setOpacityMock = vi.fn()
 const getShortcutMock = vi.fn()
 const setShortcutMock = vi.fn()
 const toggleMock = vi.fn()
+const openConfigMock = vi.fn()
 
 type BrainDumpBridge = {
   getSyncMode: () => Promise<boolean>
@@ -21,6 +22,10 @@ type BrainDumpBridge = {
   toggle: () => Promise<void>
 }
 
+type ConfigBridge = {
+  open: () => Promise<boolean>
+}
+
 /**
  * Defines the preload bridge shape the Settings card expects during renderer tests.
  *
@@ -30,7 +35,12 @@ type BrainDumpBridge = {
  * installElectronAPI({ brainDump: fakeBridge })
  */
 function installElectronAPI(
-  api: { brainDump?: Partial<BrainDumpBridge> } | undefined,
+  api:
+    | {
+        brainDump?: Partial<BrainDumpBridge>
+        config?: Partial<ConfigBridge>
+      }
+    | undefined,
 ): void {
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
@@ -59,6 +69,7 @@ function installBrainDumpBridge(saved: {
   getShortcutMock.mockResolvedValue(saved.shortcut)
   setShortcutMock.mockResolvedValue(true)
   toggleMock.mockResolvedValue(undefined)
+  openConfigMock.mockResolvedValue(true)
 
   installElectronAPI({
     brainDump: {
@@ -69,6 +80,9 @@ function installBrainDumpBridge(saved: {
       getShortcut: getShortcutMock,
       setShortcut: setShortcutMock,
       toggle: toggleMock,
+    },
+    config: {
+      open: openConfigMock,
     },
   })
 }
@@ -82,6 +96,7 @@ describe('BrainDumpSettings', () => {
     getShortcutMock.mockReset()
     setShortcutMock.mockReset()
     toggleMock.mockReset()
+    openConfigMock.mockReset()
   })
 
   afterEach(() => {
@@ -187,6 +202,9 @@ describe('BrainDumpSettings', () => {
         setShortcut: setShortcutMock,
         toggle: toggleMock,
       },
+      config: {
+        open: openConfigMock,
+      },
     })
 
     // Act
@@ -197,5 +215,46 @@ describe('BrainDumpSettings', () => {
       await screen.findByText('Loading BrainDump settings…'),
     ).toBeInTheDocument()
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
+
+  it('opens config.json via the main-process config bridge when the button is clicked', async () => {
+    // Arrange
+    installBrainDumpBridge({
+      syncMode: false,
+      opacity: 0.7,
+      shortcut: 'Alt+Space',
+    })
+    render(<BrainDumpSettings />)
+    const openButton = await screen.findByRole('button', {
+      name: 'Open config.json',
+    })
+
+    // Act
+    fireEvent.click(openButton)
+
+    // Assert
+    expect(openConfigMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows an error banner when opening config.json fails', async () => {
+    // Arrange
+    installBrainDumpBridge({
+      syncMode: false,
+      opacity: 0.7,
+      shortcut: 'Alt+Space',
+    })
+    openConfigMock.mockResolvedValueOnce(false)
+    render(<BrainDumpSettings />)
+    const openButton = await screen.findByRole('button', {
+      name: 'Open config.json',
+    })
+
+    // Act
+    fireEvent.click(openButton)
+
+    // Assert
+    expect(
+      await screen.findByText('Failed to open config file'),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -323,7 +323,7 @@ export const BrainDumpSettings = function BrainDumpSettings({
 
       <div className="flex items-center justify-between">
         <div className="space-y-0.5">
-          <Label className="text-sm font-medium">Open config file</Label>
+          <p className="text-sm font-medium">Open config file</p>
           <p className="text-xs text-muted-foreground">
             BrainDump text is saved per category in config.json on this device.
           </p>

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -179,6 +179,19 @@ export const BrainDumpSettings = function BrainDumpSettings({
     }
   }
 
+  const handleOpenConfigFile = async (): Promise<void> => {
+    setError(null)
+    try {
+      const opened = await window.electronAPI?.config?.open()
+      if (!opened) {
+        setError('Failed to open config file')
+      }
+    } catch (err) {
+      log.error('Failed to open config file:', err)
+      setError('Failed to open config file')
+    }
+  }
+
   const opacityValue = [opacity]
 
   // Defer the non-Electron fallback until after hydration so server and
@@ -306,6 +319,18 @@ export const BrainDumpSettings = function BrainDumpSettings({
           Click, then press the keys you want. Esc cancels; Backspace clears it
           to disable the global shortcut.
         </p>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label className="text-sm font-medium">Open config file</Label>
+          <p className="text-xs text-muted-foreground">
+            BrainDump text is saved per category in config.json on this device.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={handleOpenConfigFile}>
+          Open config.json
+        </Button>
       </div>
 
       <div className="flex justify-end">


### PR DESCRIPTION
## Summary

- Add a **Open config.json** row to Brain Dump settings that opens the on-device config file in the default application via `shell.openPath`.
- Wire a typed **`config-open`** IPC channel: the main process resolves the path from `ConfigManager` only (same security model as `config-export` / `config-import`).
- Add `openConfigFile` helper + unit tests, BrainDumpSettings UI tests, and an IPC contract smoke test.
- Extend `pnpm clean` to explicitly remove `coverage/unit-web` and `coverage/unit-electron` from `pnpm coverage:unit`.

## Test plan

- [x] `pnpm test` (web unit, incl. BrainDumpSettings)
- [x] `pnpm test:electron` (incl. `openConfigFile`, IPC contract)
- [x] `pnpm validate`
- [ ] Local QA: Settings popover → Brain Dump → **Open config.json** opens the temp/production config file in the default editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 設定画面から `config.json` を 既定のアプリで開けるようになりました。
  * 「Open config.json」ボタン と 説明文 を追加しました。
* **バグ修正**
  * 開けない場合は 例外にならず、エラー表示（`Failed to open config file`）で通知するよう改善しました。
* **テスト**
  * `config.open()` の成功/失敗時の動作を確認するテストを追加・拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->