### PR TITLE
Fix nested BrainDump checkbox completion

### DIFF
--- a/e2e/web/braindump.spec.ts
+++ b/e2e/web/braindump.spec.ts
@@ -1,0 +1,139 @@
+import { setupClerkTestingToken } from '@clerk/testing/playwright'
+import { type Locator, type Page } from '@playwright/test'
+
+import { test, expect } from './_helpers/coverage'
+import { resetDatabase } from './_helpers/db'
+
+/**
+ * Installs the BrainDump preload seam so `/braindump` runs in browser E2E.
+ * @param page - Playwright page that will navigate to the BrainDump route.
+ * @returns Nothing; future navigations receive `window.brainDumpAPI`.
+ * @example await installBrainDumpPreloadMock(page)
+ */
+async function installBrainDumpPreloadMock(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    let opacity = 0.85
+    let syncEnabled = true
+    let lastCategoryId: number | null = 1
+    let visibleOnAllWorkspaces = false
+    const notesByCategory = new Map<number, string>()
+
+    // BrainDump follows FloatingNav by default; seed the shared category store.
+    window.localStorage.setItem('corelive-selected-category', '1')
+
+    window.brainDumpAPI = {
+      window: {
+        close: async () => undefined,
+        toggle: async () => undefined,
+        setOpacity: async (value: number) => {
+          opacity = value
+        },
+        getOpacity: async () => opacity,
+        getBounds: async () => null,
+        setBounds: async (_bounds) => undefined,
+      },
+      note: {
+        get: async (categoryId: number) =>
+          notesByCategory.get(categoryId) ?? '',
+        set: async (categoryId: number, text: string) => {
+          notesByCategory.set(categoryId, text)
+        },
+      },
+      sync: {
+        getEnabled: async () => syncEnabled,
+        setEnabled: async (enabled: boolean) => {
+          syncEnabled = enabled
+        },
+      },
+      category: {
+        getLast: async () => lastCategoryId,
+        setLast: async (categoryId: number) => {
+          lastCategoryId = categoryId
+        },
+      },
+      spaces: {
+        getVisibleOnAllWorkspaces: async () => visibleOnAllWorkspaces,
+        setVisibleOnAllWorkspaces: async (enabled: boolean) => {
+          visibleOnAllWorkspaces = enabled
+          return visibleOnAllWorkspaces
+        },
+      },
+      on: (
+        _channel: string,
+        _callback: (...args: unknown[]) => void,
+      ): (() => void) => {
+        return () => undefined
+      },
+    }
+
+    window.brainDumpEnv = {
+      isElectron: true,
+      isBrainDump: true,
+      platform: 'darwin',
+    }
+  })
+}
+
+/**
+ * Opens `/braindump` and waits until the note textarea accepts input.
+ * @param page - Playwright page with Clerk token and BrainDump preload ready.
+ * @returns The enabled BrainDump textarea locator.
+ * @example const noteField = await openBrainDump(page)
+ */
+async function openBrainDump(page: Page) {
+  await page.goto('/braindump')
+  const noteField = page.getByRole('textbox')
+  await expect(noteField).toBeEnabled({ timeout: 10000 })
+  return noteField
+}
+
+/**
+ * Moves the textarea caret to the final character for caret-line completion.
+ * @param noteField - The BrainDump textarea locator.
+ * @returns Nothing; the selection is updated in the browser context.
+ * @example await moveCaretToEnd(noteField)
+ */
+async function moveCaretToEnd(noteField: Locator): Promise<void> {
+  await noteField.evaluate((element) => {
+    if (!(element instanceof HTMLTextAreaElement)) {
+      throw new Error('BrainDump editor is not a textarea')
+    }
+    element.setSelectionRange(element.value.length, element.value.length)
+  })
+}
+
+test.describe('BrainDump E2E', () => {
+  test.beforeAll(resetDatabase)
+
+  test.beforeEach(async ({ page }) => {
+    // Arrange common auth + Electron preload boundary before the route loads.
+    await setupClerkTestingToken({ page })
+    await installBrainDumpPreloadMock(page)
+  })
+
+  test('completes the nested checkbox at the caret with ControlOrMeta+Enter', async ({
+    page,
+  }) => {
+    // Arrange
+    const noteField = await openBrainDump(page)
+    await noteField.fill(
+      ['- [ ] parent task', '  - [ ] nested task'].join('\n'),
+    )
+    await moveCaretToEnd(noteField)
+
+    // Act
+    const createCompletedResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/orpc/completed/create') &&
+        response.request().method() === 'POST',
+    )
+    await noteField.press('ControlOrMeta+Enter')
+
+    // Assert
+    await expect(noteField).toHaveValue(
+      ['- [ ] parent task', '  - [x] nested task'].join('\n'),
+    )
+    await expect(page.getByText('Completed: nested task')).toBeVisible()
+    expect((await createCompletedResponse).status()).toBe(200)
+  })
+})

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -15,16 +15,26 @@ import type { CategoryWithCount } from '@/server/schemas/category'
 
 import { BrainDumpEditor } from './BrainDumpEditor'
 
-// Shared across create + delete mutations so the complete-command specs can
-// assert the create call. Resolves `{ id }` so promoteLineToCompleted's
-// `.then(created => created.id)` chain runs instead of throwing on undefined.
-const { completedMutateAsync } = vi.hoisted(() => ({
+// Split create/delete mutations so completion specs can assert create calls
+// without counting undo cleanup deletes.
+const {
+  completedCreateMutationOptions,
+  completedDeleteMutationOptions,
+  completedMutateAsync,
+  deleteCompletedMutateAsync,
+} = vi.hoisted(() => ({
+  completedCreateMutationOptions: {},
+  completedDeleteMutationOptions: {},
   completedMutateAsync: vi.fn(),
+  deleteCompletedMutateAsync: vi.fn(),
 }))
 
 vi.mock('@tanstack/react-query', () => ({
-  useMutation: () => ({
-    mutateAsync: completedMutateAsync,
+  useMutation: (options: unknown) => ({
+    mutateAsync:
+      options === completedDeleteMutationOptions
+        ? deleteCompletedMutateAsync
+        : completedMutateAsync,
   }),
   useQueryClient: () => ({
     invalidateQueries: vi.fn().mockResolvedValue(undefined),
@@ -62,10 +72,10 @@ vi.mock('@/lib/orpc/client-query', () => ({
   orpc: {
     completed: {
       create: {
-        mutationOptions: vi.fn(() => ({})),
+        mutationOptions: vi.fn(() => completedCreateMutationOptions),
       },
       delete: {
-        mutationOptions: vi.fn(() => ({})),
+        mutationOptions: vi.fn(() => completedDeleteMutationOptions),
       },
       heatmap: {
         key: vi.fn(() => ['completed', 'heatmap']),
@@ -1018,6 +1028,7 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
       categoryId: 1,
       title: 'nested task',
     })
+    expect(completedMutateAsync).toHaveBeenCalledTimes(1)
   })
 
   it('restores the cleared line when the completion create fails', async () => {

--- a/src/components/braindump/BrainDumpEditor.test.tsx
+++ b/src/components/braindump/BrainDumpEditor.test.tsx
@@ -783,6 +783,37 @@ describe('BrainDumpEditor complete command', () => {
     })
   })
 
+  it('toggles the nested checkbox line at the caret into a Completed row on Cmd+Enter', async () => {
+    // Arrange — a parent task with one indented child checkbox under it.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor()
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
+    const value = ['- [ ] parent task', '  - [ ] nested task'].join('\n')
+    fireEvent.change(noteField, { target: { value } })
+    noteField.selectionStart = value.length
+    noteField.selectionEnd = value.length
+
+    // Act — complete only the nested caret line.
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+
+    // Assert — the parent stays untouched, and only the child is recorded.
+    expect(completedMutateAsync).toHaveBeenCalledWith({
+      categoryId: 1,
+      title: 'nested task',
+    })
+    await waitFor(() => {
+      expect(noteField).toHaveValue(
+        ['- [ ] parent task', '  - [x] nested task'].join('\n'),
+      )
+    })
+  })
+
   it('restores the original plain prose when the completion create fails', async () => {
     // Arrange — the create mutation rejects for this completion.
     completedMutateAsync.mockRejectedValueOnce(new Error('network down'))
@@ -949,6 +980,43 @@ describe('BrainDumpEditor clear-on-complete (instant / zero delay)', () => {
     // Assert — the verbatim line returns at index 1, not appended at the end.
     await waitFor(() => {
       expect(noteField).toHaveValue('keep me\n- [ ] buy milk')
+    })
+  })
+
+  it('undo re-inserts a cleared nested checkbox with its original indentation', async () => {
+    // Arrange — clear-on-complete on, with the caret parked on an indented child.
+    const getVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(false)
+    const setVisibleOnAllWorkspaces = vi.fn().mockResolvedValue(true)
+    installBrainDumpAPI({
+      getVisibleOnAllWorkspaces,
+      setVisibleOnAllWorkspaces,
+    })
+    renderEditor({ braindumpClearOnComplete: true, braindumpClearDelayMs: 0 })
+    const noteField = await screen.findByRole<HTMLTextAreaElement>('textbox')
+    await waitForBrainDumpReady(noteField)
+    const value = ['- [ ] parent task', '  - [ ] nested task'].join('\n')
+    fireEvent.change(noteField, { target: { value } })
+    noteField.selectionStart = value.length
+    noteField.selectionEnd = value.length
+    fireEvent.keyDown(noteField, { key: 'Enter', metaKey: true })
+    await waitFor(() => {
+      expect(noteField).toHaveValue('- [ ] parent task')
+    })
+
+    // Act — Undo should return the exact nested source row, not a top-level box.
+    const undoAction = vi.mocked(toast.success).mock.calls.at(-1)?.[1]
+      ?.action as { onClick: () => void } | undefined
+    await act(async () => {
+      undoAction?.onClick()
+    })
+
+    // Assert — the child checkbox returns with its two leading spaces intact.
+    await waitFor(() => {
+      expect(noteField).toHaveValue(value)
+    })
+    expect(completedMutateAsync).toHaveBeenCalledWith({
+      categoryId: 1,
+      title: 'nested task',
     })
   })
 

--- a/src/components/braindump/braindumpUtils.test.ts
+++ b/src/components/braindump/braindumpUtils.test.ts
@@ -27,6 +27,7 @@ describe('parseCheckboxLine', () => {
   it('parses an unchecked checkbox line', () => {
     expect(parseCheckboxLine('- [ ] write tests', 3)).toEqual({
       lineIndex: 3,
+      leadingWhitespace: '',
       checked: false,
       title: 'write tests',
     })
@@ -35,8 +36,18 @@ describe('parseCheckboxLine', () => {
   it('parses a checked checkbox line', () => {
     expect(parseCheckboxLine('- [x] ship it', 0)).toEqual({
       lineIndex: 0,
+      leadingWhitespace: '',
       checked: true,
       title: 'ship it',
+    })
+  })
+
+  it('parses an indented nested checkbox line', () => {
+    expect(parseCheckboxLine('  - [ ] nested task', 2)).toEqual({
+      lineIndex: 2,
+      leadingWhitespace: '  ',
+      checked: false,
+      title: 'nested task',
     })
   })
 
@@ -55,6 +66,7 @@ describe('parseCheckboxLine', () => {
   it('trims whitespace from the title', () => {
     expect(parseCheckboxLine('- [ ]   spaced out   ', 0)).toEqual({
       lineIndex: 0,
+      leadingWhitespace: '',
       checked: false,
       title: 'spaced out',
     })
@@ -67,8 +79,36 @@ describe('parseAllCheckboxes', () => {
       '\n',
     )
     expect(parseAllCheckboxes(text)).toEqual([
-      { lineIndex: 1, checked: false, title: 'todo a' },
-      { lineIndex: 3, checked: true, title: 'done b' },
+      {
+        lineIndex: 1,
+        leadingWhitespace: '',
+        checked: false,
+        title: 'todo a',
+      },
+      {
+        lineIndex: 3,
+        leadingWhitespace: '',
+        checked: true,
+        title: 'done b',
+      },
+    ])
+  })
+
+  it('collects indented nested checkboxes in document order', () => {
+    const text = ['- [ ] parent', '  - [ ] child', 'plain'].join('\n')
+    expect(parseAllCheckboxes(text)).toEqual([
+      {
+        lineIndex: 0,
+        leadingWhitespace: '',
+        checked: false,
+        title: 'parent',
+      },
+      {
+        lineIndex: 1,
+        leadingWhitespace: '  ',
+        checked: false,
+        title: 'child',
+      },
     ])
   })
 
@@ -92,6 +132,13 @@ describe('setCheckboxStateAtLine', () => {
     const before = ['line 0', '- [ ] a', 'line 2', '- [x] b'].join('\n')
     const after = setCheckboxStateAtLine(before, 1, true)
     expect(after).toBe(['line 0', '- [x] a', 'line 2', '- [x] b'].join('\n'))
+  })
+
+  it('preserves indentation when checking and unchecking a nested checkbox line', () => {
+    const unchecked = ['- [ ] parent', '  - [ ] child'].join('\n')
+    const checked = ['- [ ] parent', '  - [x] child'].join('\n')
+    expect(setCheckboxStateAtLine(unchecked, 1, true)).toBe(checked)
+    expect(setCheckboxStateAtLine(checked, 1, false)).toBe(unchecked)
   })
 
   it('returns the original text for non-checkbox lines', () => {
@@ -337,6 +384,7 @@ describe('markPlainLineCompleted', () => {
   it('returns null for an empty checkbox skeleton so no junk title is logged', () => {
     // Arrange + Act + Assert
     expect(markPlainLineCompleted('- [ ]', 0)).toBeNull()
+    expect(markPlainLineCompleted('  - [ ]', 0)).toBeNull()
     expect(markPlainLineCompleted('- [ ] ', 0)).toBeNull()
     expect(markPlainLineCompleted('- [x]', 0)).toBeNull()
     expect(markPlainLineCompleted('- []', 0)).toBeNull()

--- a/src/components/braindump/braindumpUtils.ts
+++ b/src/components/braindump/braindumpUtils.ts
@@ -23,12 +23,12 @@
 import type { Completed } from '@/server/schemas/completed'
 
 /**
- * Regex for a markdown checkbox line. Captures the `[ ]`/`[x]` state in group 1
- * and the title in group 2. Exported so the paste-import parser
+ * Regex for a markdown checkbox line. Captures leading indentation in group 1,
+ * the `[ ]`/`[x]` state in group 2, and the title in group 3. Exported so the paste-import parser
  * (`src/lib/parsePasteToTasks.ts`) reuses one source of truth for checkbox
  * detection instead of redefining the grammar.
  */
-export const CHECKBOX_LINE_REGEX = /^- \[([ x])\] (.+)$/
+export const CHECKBOX_LINE_REGEX = /^([ \t]*)- \[([ x])\] (.+)$/
 
 /** Maximum allowed Completed.title length, mirroring `CreateCompletedSchema`. */
 export const COMPLETED_TITLE_MAX_LENGTH = 255
@@ -56,6 +56,8 @@ export type BrainDumpCompletedTitle = Completed['title']
 export type ParsedCheckbox = Readonly<{
   /** Zero-based line index in the original text. */
   lineIndex: BrainDumpLineIndex
+  /** Original spaces/tabs before `-`, preserved when toggling nested tasks. */
+  leadingWhitespace: string
   /** True when the box is `[x]`, false when `[ ]`. */
   checked: boolean
   /** The text after `- [x] ` / `- [ ] ` (already trimmed). */
@@ -68,10 +70,10 @@ export type ParsedCheckbox = Readonly<{
  *
  * @param line - Raw line of text (no trailing newline).
  * @param lineIndex - Index of this line within the source text.
- * @returns ParsedCheckbox when the line matches `^- \[ ?x\] .+$`, else null.
+ * @returns ParsedCheckbox when the line matches an optionally indented dash checkbox, else null.
  * @example
- * parseCheckboxLine('- [x] write tests', 3)
- * // → { lineIndex: 3, checked: true, title: 'write tests' }
+ * parseCheckboxLine('  - [x] write tests', 3)
+ * // → { lineIndex: 3, leadingWhitespace: '  ', checked: true, title: 'write tests' }
  * parseCheckboxLine('plain text', 0) // → null
  */
 export function parseCheckboxLine(
@@ -81,8 +83,10 @@ export function parseCheckboxLine(
   const match = CHECKBOX_LINE_REGEX.exec(line)
   if (!match) return null
 
-  const mark = match[1]
-  const rest = match[2]
+  const leadingWhitespace = match[1]
+  const mark = match[2]
+  const rest = match[3]
+  if (leadingWhitespace === undefined) return null
   if (mark === undefined || rest === undefined) return null
 
   const title = rest.trim()
@@ -90,6 +94,7 @@ export function parseCheckboxLine(
 
   return {
     lineIndex,
+    leadingWhitespace,
     checked: mark === 'x',
     title,
   }
@@ -140,7 +145,7 @@ export function setCheckboxStateAtLine(
   if (!parsed) return text
 
   const mark = checked ? 'x' : ' '
-  lines[lineIndex] = `- [${mark}] ${parsed.title}`
+  lines[lineIndex] = `${parsed.leadingWhitespace}- [${mark}] ${parsed.title}`
   return lines.join('\n')
 }
 
@@ -257,12 +262,12 @@ export function lineStartOffset(
 }
 
 /**
- * Matches an empty checkbox skeleton — a checkbox prefix with no title, e.g.
- * `- [ ]`, `- [x]`, `- []` (optional trailing whitespace). These have nothing
+ * Matches an empty checkbox skeleton — an indented checkbox prefix with no title, e.g.
+ * `  - [ ]`, `- [x]`, `- []` (optional trailing whitespace). These have nothing
  * to record, so the complete command must skip them rather than logging a junk
  * `- [ ]` title.
  */
-const EMPTY_CHECKBOX_SKELETON_REGEX = /^- \[[ xX]?\]\s*$/
+const EMPTY_CHECKBOX_SKELETON_REGEX = /^[ \t]*- \[[ xX]?\]\s*$/
 
 /**
  * Result of wrapping a plain line as a checked checkbox for the complete

--- a/src/lib/parsePasteToTasks.ts
+++ b/src/lib/parsePasteToTasks.ts
@@ -10,15 +10,15 @@
  * Why it lives in `src/lib/` (not a component): the same pure util runs in both
  * the PR2 client preview and the server normalization, so preview count ==
  * inserted count. No React/Electron deps; reuses `normalizeCompletedTitle` +
- * `CHECKBOX_LINE_REGEX` from braindumpUtils as the single source of truth for
+ * `parseCheckboxLine` from braindumpUtils as the single source of truth for
  * title clamping and checkbox detection.
  *
  * @module lib/parsePasteToTasks
  */
 
 import {
-  CHECKBOX_LINE_REGEX,
   normalizeCompletedTitle,
+  parseCheckboxLine,
 } from '@/components/braindump/braindumpUtils'
 
 /**
@@ -77,15 +77,11 @@ export function parsePasteLine(rawLine: string): ParsedPasteTask | null {
 
   // Checkbox first: capture done-state, then derive the title from the
   // post-prefix capture group so the `[x] ` marker never leaks into the title.
-  const checkboxMatch = CHECKBOX_LINE_REGEX.exec(line)
-  if (checkboxMatch) {
-    const checkboxState = checkboxMatch[1]
-    const checkboxBody = checkboxMatch[2]
-    if (checkboxBody !== undefined) {
-      const title = normalizeCompletedTitle(checkboxBody)
-      if (title.length === 0) return null
-      return { title, done: checkboxState === 'x' }
-    }
+  const checkbox = parseCheckboxLine(line, 0)
+  if (checkbox) {
+    const title = normalizeCompletedTitle(checkbox.title)
+    if (title.length === 0) return null
+    return { title, done: checkbox.checked }
   }
 
   // Not a checkbox: strip at most one leading bullet/ordered prefix, then


### PR DESCRIPTION
## Summary
- Recognize indented dash markdown checkboxes in BrainDump so `ControlOrMeta+Enter` completes nested rows.
- Preserve leading whitespace when checking/unchecking BrainDump checkbox lines.
- Add unit, component, and web E2E coverage for the nested checkbox regression.

## Verification
- `corepack pnpm exec vitest run src/components/braindump/braindumpUtils.test.ts src/components/braindump/BrainDumpEditor.test.tsx`
- `corepack pnpm exec vitest run src/components/braindump/braindumpUtils.test.ts src/components/braindump/BrainDumpEditor.test.tsx src/lib/parsePasteToTasks.test.ts src/components/import/PasteImportDialog.test.tsx src/components/import/paste-import-types.test.ts`
- `corepack pnpm exec playwright test --project=web e2e/web/braindump.spec.ts`
- `corepack pnpm exec prettier --check e2e/web/braindump.spec.ts`
- `corepack pnpm exec eslint e2e/web/braindump.spec.ts --max-warnings 0`
- `corepack pnpm typecheck`
- `corepack pnpm validate`

## QA
- Browser QA against `/braindump` confirmed a parent + nested checkbox note changes only the nested caret line from `  - [ ] nested task` to `  - [x] nested task`.
- Verified `/api/orpc/completed/create` returns `200` for the nested task completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ネストされたチェックボックスを完了/取消する際、インデントを維持したまま正しく更新されるようになりました。
  * カーソル位置にある子タスクのみが完了対象となり、親タスクは変更されません。
  * 貼り付け時のチェックボックス解析が改善され、インデント付きの項目も一貫して扱えるようになりました。
* **Tests**
  * BrainDumpのE2Eおよびユニットテストを追加・強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->