### PR TITLE
chore(docker): map local Postgres to host port 5491

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Database Configuration
 # Prisma database connection string for PostgreSQL
-POSTGRES_PRISMA_URL="postgresql://username:password@localhost:5432/database_name?schema=public"
+POSTGRES_PRISMA_URL="postgresql://username:password@localhost:5491/database_name?schema=public"
 
 # Clerk Authentication Configuration
 # Get these from your Clerk dashboard: https://dashboard.clerk.com/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             printf 'NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home\n'
             printf 'CLERK_SECRET_KEY=%s\n' "$CLERK_SECRET_KEY"
             printf 'WEBHOOK_SECRET=%s\n' "$WEBHOOK_SECRET"
-            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://user:pass@localhost:5432/db?schema=public'
+            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://user:pass@localhost:5491/db?schema=public'
           } > .env
       - name: Build
         run: pnpm build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -77,7 +77,7 @@ jobs:
             printf 'NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home\n'
             printf 'CLERK_SECRET_KEY=%s\n' "$CLERK_SECRET_KEY"
             printf 'WEBHOOK_SECRET=%s\n' "$WEBHOOK_SECRET"
-            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5432/corelive?schema=public'
+            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5491/corelive?schema=public'
             printf 'E2E_CLERK_USER_USERNAME=%s\n' "$E2E_CLERK_USER_USERNAME"
             printf 'E2E_CLERK_USER_PASSWORD=%s\n' "$E2E_CLERK_USER_PASSWORD"
             printf 'E2E_CLERK_USER_EMAIL=%s\n' "$E2E_CLERK_USER_EMAIL"

--- a/.github/workflows/e2e.electron.yml
+++ b/.github/workflows/e2e.electron.yml
@@ -92,7 +92,7 @@ jobs:
             printf 'NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home\n'
             printf 'CLERK_SECRET_KEY=%s\n' "$CLERK_SECRET_KEY"
             printf 'WEBHOOK_SECRET=%s\n' "$WEBHOOK_SECRET"
-            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5432/corelive?schema=public'
+            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5491/corelive?schema=public'
             printf 'E2E_CLERK_USER_USERNAME=%s\n' "$E2E_CLERK_USER_USERNAME"
             printf 'E2E_CLERK_USER_PASSWORD=%s\n' "$E2E_CLERK_USER_PASSWORD"
             printf 'E2E_CLERK_USER_EMAIL=%s\n' "$E2E_CLERK_USER_EMAIL"

--- a/.github/workflows/e2e.web.yml
+++ b/.github/workflows/e2e.web.yml
@@ -106,7 +106,7 @@ jobs:
             printf 'NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/home\n'
             printf 'CLERK_SECRET_KEY=%s\n' "$CLERK_SECRET_KEY"
             printf 'WEBHOOK_SECRET=%s\n' "$WEBHOOK_SECRET"
-            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5432/corelive?schema=public'
+            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5491/corelive?schema=public'
             printf 'E2E_CLERK_USER_USERNAME=%s\n' "$E2E_CLERK_USER_USERNAME"
             printf 'E2E_CLERK_USER_PASSWORD=%s\n' "$E2E_CLERK_USER_PASSWORD"
             printf 'E2E_CLERK_USER_EMAIL=%s\n' "$E2E_CLERK_USER_EMAIL"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
             printf 'NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=%s\n' "$NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL"
             printf 'CLERK_SECRET_KEY=%s\n' "$CLERK_SECRET_KEY"
             printf 'WEBHOOK_SECRET=%s\n' "$WEBHOOK_SECRET"
-            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5432/corelive?schema=public'
+            printf 'POSTGRES_PRISMA_URL=%s\n' 'postgresql://postgres:password@localhost:5491/corelive?schema=public'
           } > .env
       # Provision Postgres for the real-DB integration suites (paste-import
       # procedures). Mirrors e2e.web.yml. Those tests are gated behind

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ All Next.js environment variables are loaded and validated via `src/env.mjs` usi
 
 This project uses PostgreSQL v17 as the database, managed through Docker Compose for local development.
 
+The Docker Compose service maps **host port `5491`** to the container's default `5432`, so CoreLive does not collide with other local Postgres instances on the standard port.
+
 ```bash
 # Start the PostgreSQL database
 docker compose up -d postgres
@@ -91,6 +93,12 @@ pnpm prisma:migrate
 
 # Seed initial data (optional)
 pnpm prisma:seed
+```
+
+Set `POSTGRES_PRISMA_URL` in `.env` to use the host port:
+
+```
+POSTGRES_PRISMA_URL="postgresql://postgres:password@localhost:5491/corelive?schema=public"
 ```
 
 #### Database Management

--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,8 @@ services:
       POSTGRES_DB: corelive
       POSTGRES_INITDB_ARGS: '--auth-host=scram-sha-256 --auth-local=scram-sha-256'
     ports:
-      - '5432:5432'
+      # Host 5491 avoids clashing with other projects on the default 5432 (see scripts/local-db-port.cjs)
+      - '5491:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./prisma/init.sql:/docker-entrypoint-initdb.d/init.sql:ro

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
     url:
       process.env.POSTGRES_PRISMA_URL ||
       process.env.DATABASE_URL ||
-      'postgresql://user:pass@localhost:5432/db?schema=public',
+      'postgresql://user:pass@localhost:5491/db?schema=public',
   },
 })

--- a/prisma/seed.dev.ts
+++ b/prisma/seed.dev.ts
@@ -47,7 +47,7 @@ const LOCAL_DB_HOSTS = new Set([
  * @param connectionString - The raw `POSTGRES_PRISMA_URL` value.
  * @returns void — returns normally only when the host is local; otherwise throws.
  * @example
- * assertLocalDatabase('postgresql://postgres:password@localhost:5432/corelive') // ok
+ * assertLocalDatabase('postgresql://postgres:password@localhost:5491/corelive') // ok
  * assertLocalDatabase('postgresql://u:p@prod.neon.tech/db') // throws
  */
 function assertLocalDatabase(connectionString: string | undefined): void {

--- a/scripts/assert-local-db.cjs
+++ b/scripts/assert-local-db.cjs
@@ -19,6 +19,8 @@
 // prisma.config.ts と同じく .env を読み込んでから判定する（手動 `pnpm db:reset` 時、URLが .env 内にしか無いケースを揃えるため）
 require('dotenv').config()
 
+const { LOCAL_POSTGRES_HOST_PORT } = require('./local-db-port.cjs')
+
 // ローカルとみなして破壊操作を許可するホスト名のホワイトリスト（Docker compose / localhost のみ）。
 // 0.0.0.0 は「全インターフェースにbindする」アドレスでクライアントのダイヤル先として意味を持たないため除外。
 const ALLOWED_HOSTS = new Set([
@@ -36,13 +38,13 @@ const ALLOWED_HOSTS = new Set([
 const rawUrl =
   process.env.POSTGRES_PRISMA_URL ||
   process.env.DATABASE_URL ||
-  'postgresql://user:pass@localhost:5432/db?schema=public'
+  `postgresql://user:pass@localhost:${LOCAL_POSTGRES_HOST_PORT}/db?schema=public`
 
 function abort(reason) {
   console.error('\n🛑 [assert-local-db] 破壊的DB操作を中止しました。')
   console.error(`   理由: ${reason}`)
   console.error(
-    '   db:reset / db:truncate / prisma:migrate はローカルDocker（localhost:5432）にのみ許可されています。',
+    `   db:reset / db:truncate / prisma:migrate はローカルDocker（localhost:${LOCAL_POSTGRES_HOST_PORT}）にのみ許可されています。`,
   )
   console.error(
     '   接続先が本番(Neon等)に向いていないか POSTGRES_PRISMA_URL を確認してください。\n',

--- a/scripts/local-db-port.cjs
+++ b/scripts/local-db-port.cjs
@@ -1,0 +1,9 @@
+/**
+ * Host port for CoreLive's Docker Compose PostgreSQL service.
+ * Maps host :5491 → container :5432 so local dev avoids the default 5432 conflict.
+ *
+ * Keep in sync with compose.yml `ports` and POSTGRES_PRISMA_URL examples in AGENTS.md / README.md.
+ */
+const LOCAL_POSTGRES_HOST_PORT = 5491
+
+module.exports = { LOCAL_POSTGRES_HOST_PORT }

--- a/src/server/procedures/assertLocalDbGate.test.ts
+++ b/src/server/procedures/assertLocalDbGate.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from 'vitest'
  * Runs the gate with a crafted `POSTGRES_PRISMA_URL` and returns its exit code.
  * @param databaseUrl - The connection string the gate should judge.
  * @returns 0 when the gate proves the URL local (allows the op), 1 when it aborts.
- * @example runGate('postgresql://postgres@localhost:5432/db') // => 0
+ * @example runGate('postgresql://postgres@localhost:5491/db') // => 0
  */
 function runGate(databaseUrl: string): number {
   try {
@@ -41,7 +41,7 @@ describe('assert-local-db gate (fail-closed local-DB chokepoint)', () => {
   it('allows the local Docker connection string', () => {
     // Arrange / Act
     const exitCode = runGate(
-      'postgresql://postgres:password@localhost:5432/corelive?schema=public',
+      'postgresql://postgres:password@localhost:5491/corelive?schema=public',
     )
     // Assert — provably local, so the destructive op is permitted.
     expect(exitCode).toBe(0)

--- a/src/server/procedures/completed.createMany.test.ts
+++ b/src/server/procedures/completed.createMany.test.ts
@@ -14,7 +14,7 @@ import { describeIfDb } from './describeIfDb'
  * id so rows never collide across runs of the persistent dev database. We run
  * the REAL `authMiddleware` (never mocked): `call` passes a `headers` context
  * with a Bearer token, the middleware upserts the user by clerkId, and the
- * handler runs against the live Postgres on :5432.
+ * handler runs against the live Postgres on :5491.
  */
 function authContext(clerkId: string) {
   return {

--- a/src/server/procedures/describeIfDb.ts
+++ b/src/server/procedures/describeIfDb.ts
@@ -40,7 +40,7 @@ function assertLocalDbBeforeDestructiveTests(): void {
     throw new Error(
       'Refusing to run destructive DB integration tests: the local-DB gate ' +
         '(scripts/assert-local-db.cjs) could not prove POSTGRES_PRISMA_URL is ' +
-        'local. Point it at the local Docker Postgres (localhost:5432).\n' +
+        'local. Point it at the local Docker Postgres (localhost:5491).\n' +
         gateReason,
     )
   }

--- a/src/server/procedures/todo.createMany.test.ts
+++ b/src/server/procedures/todo.createMany.test.ts
@@ -14,7 +14,7 @@ import { createManyTodo, deleteManyTodo } from './todo'
  * id so rows never collide across runs of the persistent dev database. The REAL
  * `authMiddleware` runs (never mocked): `call` passes a `headers` context with a
  * Bearer token, the middleware upserts the user by clerkId, and the handler
- * runs against the live Postgres on :5432.
+ * runs against the live Postgres on :5491.
  */
 function authContext(clerkId: string) {
   return {


### PR DESCRIPTION
## Summary
- Map CoreLive's Docker Compose PostgreSQL from host port **5432** to **5491** so local dev does not clash with other projects on the default Postgres port.
- Align CI workflow `POSTGRES_PRISMA_URL` values, `.env.example`, README, Prisma fallback URL, and local DB gate scripts with the new host port.
- Add `scripts/local-db-port.cjs` as the single source for the host port constant used by `assert-local-db.cjs`.

## Test plan
- [x] `pnpm exec vitest run src/server/procedures/assertLocalDbGate.test.ts`
- [ ] CI: Build, Lint, Typecheck, Test (with Docker Postgres on :5491)
- [ ] CI: E2E Web / E2E Electron (Postgres provisioning via compose)

## Local follow-up
After merge, update local `.env`:

```
POSTGRES_PRISMA_URL="postgresql://postgres:password@localhost:5491/corelive?schema=public"
```

Then restart Postgres: `docker compose down && docker compose up -d postgres`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ローカル PostgreSQL の公開ポートを `5491` に統一しました。
  * 環境変数、Docker Compose、CI、テスト実行時の接続先が新しいポートに対応しました。

* **Documentation**
  * ローカルデータベース接続例とセットアップ手順を更新しました。

* **Bug Fixes**
  * 他の環境とのポート競合を避けやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->