### PR TITLE
fix(auth): unblock local login spinner under Cursor TLS sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   },
   "scripts": {
     "postinstall": "pnpm prisma generate",
-    "dev": "next dev -p 4991",
+    "dev": "node scripts/next-with-system-ca.mjs dev -p 4991",
     "build": "next build --webpack",
     "build:icons": "node scripts/generate-icons.js",
     "prebuild": "pnpm build:icons",
-    "start": "next start -p 4991",
+    "start": "node scripts/next-with-system-ca.mjs start -p 4991",
     "lint": "cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint . --concurrency=2 --max-warnings 0",
     "lint:fix": "cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint . --fix --concurrency=2 --max-warnings 0",
     "test": "vitest run",

--- a/scripts/next-with-system-ca.mjs
+++ b/scripts/next-with-system-ca.mjs
@@ -95,9 +95,10 @@ if (isExecutedDirectly) {
     },
   )
 
-  // Forward orchestrator stop signals when this wrapper is PID 1 (containers)
+  // Forward orchestrator stop signals when this wrapper is PID 1 (containers).
+  // Use once so the exit handler's self-signal replay can still terminate us.
   for (const signalToForward of ['SIGINT', 'SIGTERM']) {
-    process.on(signalToForward, () => {
+    process.once(signalToForward, () => {
       nextProcess.kill(signalToForward)
     })
   }

--- a/scripts/next-with-system-ca.mjs
+++ b/scripts/next-with-system-ca.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Launch Next.js with TLS trust that works under Cursor's network sandbox.
+ *
+ * Why it exists: Cursor injects SSL_CERT_FILE / SSL_CERT_DIR pointing at a
+ * single MITM CA (`socketFirewallCa.crt`). That exclusive trust store makes
+ * Edge middleware's Clerk handshake fail with UNABLE_TO_GET_ISSUER_CERT_LOCALLY,
+ * so authenticated clients bounce /home → /login and spin forever.
+ *
+ * What it does: when those Cursor-only CA vars are present, drop the exclusive
+ * SSL_CERT_* overrides, keep NODE_EXTRA_CA_CERTS for the sandbox CA, and start
+ * Next with --use-system-ca so public CAs (Clerk) still verify.
+ *
+ * @example
+ * node scripts/next-with-system-ca.mjs dev -p 4991
+ * node scripts/next-with-system-ca.mjs start -p 4991
+ */
+
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** Filename Cursor uses for its sandbox MITM CA. */
+export const CURSOR_SOCKET_FIREWALL_CA_FILENAME = 'socketFirewallCa.crt'
+
+/**
+ * Returns true when SSL_CERT_FILE is Cursor's exclusive sandbox CA.
+ * @param {string | undefined} sslCertFilePath
+ * @returns {boolean}
+ * @example
+ * isCursorSocketFirewallCa('/tmp/sfw-abc/socketFirewallCa.crt') // => true
+ * isCursorSocketFirewallCa('/etc/ssl/cert.pem') // => false
+ */
+export function isCursorSocketFirewallCa(sslCertFilePath) {
+  if (!sslCertFilePath) {
+    return false
+  }
+
+  return path.basename(sslCertFilePath) === CURSOR_SOCKET_FIREWALL_CA_FILENAME
+}
+
+/**
+ * Builds a child env that can verify both Cursor's MITM CA and public CAs.
+ * @param {NodeJS.ProcessEnv} parentEnv
+ * @returns {NodeJS.ProcessEnv}
+ * @example
+ * // Cursor sandbox: drops SSL_CERT_FILE, keeps NODE_EXTRA_CA_CERTS
+ * sanitizeTlsEnvForClerkHandshake(process.env)
+ */
+export function sanitizeTlsEnvForClerkHandshake(parentEnv) {
+  const childEnv = { ...parentEnv }
+
+  if (!isCursorSocketFirewallCa(childEnv.SSL_CERT_FILE)) {
+    return childEnv
+  }
+
+  // Prefer the sandbox CA as an *extra* trust root, not the only one
+  if (!childEnv.NODE_EXTRA_CA_CERTS && childEnv.SSL_CERT_FILE) {
+    childEnv.NODE_EXTRA_CA_CERTS = childEnv.SSL_CERT_FILE
+  }
+
+  // Exclusive SSL_CERT_* overrides break Clerk handshake TLS verification
+  delete childEnv.SSL_CERT_FILE
+  delete childEnv.SSL_CERT_DIR
+
+  return childEnv
+}
+
+const isExecutedDirectly =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isExecutedDirectly) {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+  const repositoryRoot = path.resolve(scriptDirectory, '..')
+  const nextCliPath = path.join(
+    repositoryRoot,
+    'node_modules',
+    'next',
+    'dist',
+    'bin',
+    'next',
+  )
+
+  const nextArguments = process.argv.slice(2)
+  const childEnv = sanitizeTlsEnvForClerkHandshake(process.env)
+
+  const nextProcess = spawn(
+    process.execPath,
+    ['--use-system-ca', nextCliPath, ...nextArguments],
+    {
+      cwd: repositoryRoot,
+      env: childEnv,
+      stdio: 'inherit',
+    },
+  )
+
+  nextProcess.on('exit', (exitCode, signalName) => {
+    if (signalName) {
+      process.kill(process.pid, signalName)
+      return
+    }
+
+    process.exit(exitCode ?? 1)
+  })
+}

--- a/scripts/next-with-system-ca.mjs
+++ b/scripts/next-with-system-ca.mjs
@@ -95,6 +95,13 @@ if (isExecutedDirectly) {
     },
   )
 
+  // Forward orchestrator stop signals when this wrapper is PID 1 (containers)
+  for (const signalToForward of ['SIGINT', 'SIGTERM']) {
+    process.on(signalToForward, () => {
+      nextProcess.kill(signalToForward)
+    })
+  }
+
   nextProcess.on('exit', (exitCode, signalName) => {
     if (signalName) {
       process.kill(process.pid, signalName)

--- a/scripts/next-with-system-ca.test.mjs
+++ b/scripts/next-with-system-ca.test.mjs
@@ -1,7 +1,6 @@
 /**
  * Unit coverage for Cursor SSL_CERT_FILE sanitization used by the Next launcher.
  */
-import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -64,11 +63,8 @@ describe('next-with-system-ca TLS env sanitization', () => {
       },
     })
 
-    // Assert — Next prints help (or usage) without crashing on env sanitization
-    assert.notEqual(result.status, null)
-    expect(
-      result.status === 0 ||
-        (result.stdout + result.stderr).toLowerCase().includes('next'),
-    ).toBe(true)
+    // Assert — launcher sanitizes env and Next exits cleanly for --help
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(0)
   })
 })

--- a/scripts/next-with-system-ca.test.mjs
+++ b/scripts/next-with-system-ca.test.mjs
@@ -4,69 +4,71 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
-import test from 'node:test'
 import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
 
 import { sanitizeTlsEnvForClerkHandshake } from './next-with-system-ca.mjs'
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
 const repositoryRoot = path.resolve(scriptDirectory, '..')
 
-test('drops Cursor exclusive SSL_CERT_FILE and keeps it as NODE_EXTRA_CA_CERTS', () => {
-  // Arrange
-  const cursorCaPath = '/tmp/sfw-abc/socketFirewallCa.crt'
+describe('next-with-system-ca TLS env sanitization', () => {
+  it('drops Cursor exclusive SSL_CERT_FILE and keeps it as NODE_EXTRA_CA_CERTS', () => {
+    // Arrange
+    const cursorCaPath = '/tmp/sfw-abc/socketFirewallCa.crt'
 
-  // Act
-  const sanitized = sanitizeTlsEnvForClerkHandshake({
-    SSL_CERT_FILE: cursorCaPath,
-    SSL_CERT_DIR: '/tmp/sfw-abc',
+    // Act
+    const sanitized = sanitizeTlsEnvForClerkHandshake({
+      SSL_CERT_FILE: cursorCaPath,
+      SSL_CERT_DIR: '/tmp/sfw-abc',
+    })
+
+    // Assert
+    expect(sanitized.SSL_CERT_FILE).toBeUndefined()
+    expect(sanitized.SSL_CERT_DIR).toBeUndefined()
+    expect(sanitized.NODE_EXTRA_CA_CERTS).toBe(cursorCaPath)
   })
 
-  // Assert
-  assert.equal(sanitized.SSL_CERT_FILE, undefined)
-  assert.equal(sanitized.SSL_CERT_DIR, undefined)
-  assert.equal(sanitized.NODE_EXTRA_CA_CERTS, cursorCaPath)
-})
+  it('leaves non-Cursor SSL_CERT_FILE untouched', () => {
+    // Arrange
+    const systemCaPath = '/etc/ssl/cert.pem'
 
-test('leaves non-Cursor SSL_CERT_FILE untouched', () => {
-  // Arrange
-  const systemCaPath = '/etc/ssl/cert.pem'
+    // Act
+    const sanitized = sanitizeTlsEnvForClerkHandshake({
+      SSL_CERT_FILE: systemCaPath,
+      SSL_CERT_DIR: '/etc/ssl/certs',
+      NODE_EXTRA_CA_CERTS: '/custom/extra.pem',
+    })
 
-  // Act
-  const sanitized = sanitizeTlsEnvForClerkHandshake({
-    SSL_CERT_FILE: systemCaPath,
-    SSL_CERT_DIR: '/etc/ssl/certs',
-    NODE_EXTRA_CA_CERTS: '/custom/extra.pem',
+    // Assert
+    expect(sanitized.SSL_CERT_FILE).toBe(systemCaPath)
+    expect(sanitized.SSL_CERT_DIR).toBe('/etc/ssl/certs')
+    expect(sanitized.NODE_EXTRA_CA_CERTS).toBe('/custom/extra.pem')
   })
 
-  // Assert
-  assert.equal(sanitized.SSL_CERT_FILE, systemCaPath)
-  assert.equal(sanitized.SSL_CERT_DIR, '/etc/ssl/certs')
-  assert.equal(sanitized.NODE_EXTRA_CA_CERTS, '/custom/extra.pem')
-})
+  it('starts Next help under Cursor CA env without crashing', () => {
+    // Arrange
+    const launcherPath = path.join(
+      repositoryRoot,
+      'scripts/next-with-system-ca.mjs',
+    )
 
-test('launcher script starts Next help under Cursor CA env without crashing', () => {
-  // Arrange
-  const launcherPath = path.join(
-    repositoryRoot,
-    'scripts/next-with-system-ca.mjs',
-  )
+    // Act
+    const result = spawnSync(process.execPath, [launcherPath, '--help'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        SSL_CERT_FILE: '/tmp/sfw-test/socketFirewallCa.crt',
+        SSL_CERT_DIR: '/tmp/sfw-test',
+      },
+    })
 
-  // Act
-  const result = spawnSync(process.execPath, [launcherPath, '--help'], {
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      SSL_CERT_FILE: '/tmp/sfw-test/socketFirewallCa.crt',
-      SSL_CERT_DIR: '/tmp/sfw-test',
-    },
+    // Assert — Next prints help (or usage) without crashing on env sanitization
+    assert.notEqual(result.status, null)
+    expect(
+      result.status === 0 ||
+        (result.stdout + result.stderr).toLowerCase().includes('next'),
+    ).toBe(true)
   })
-
-  // Assert — Next prints help (or usage) without crashing on env sanitization
-  assert.notEqual(result.status, null)
-  assert.ok(
-    result.status === 0 ||
-      (result.stdout + result.stderr).toLowerCase().includes('next'),
-    `expected Next help output, got status=${result.status} stderr=${result.stderr}`,
-  )
 })

--- a/scripts/next-with-system-ca.test.mjs
+++ b/scripts/next-with-system-ca.test.mjs
@@ -1,0 +1,72 @@
+/**
+ * Unit coverage for Cursor SSL_CERT_FILE sanitization used by the Next launcher.
+ */
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { sanitizeTlsEnvForClerkHandshake } from './next-with-system-ca.mjs'
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = path.resolve(scriptDirectory, '..')
+
+test('drops Cursor exclusive SSL_CERT_FILE and keeps it as NODE_EXTRA_CA_CERTS', () => {
+  // Arrange
+  const cursorCaPath = '/tmp/sfw-abc/socketFirewallCa.crt'
+
+  // Act
+  const sanitized = sanitizeTlsEnvForClerkHandshake({
+    SSL_CERT_FILE: cursorCaPath,
+    SSL_CERT_DIR: '/tmp/sfw-abc',
+  })
+
+  // Assert
+  assert.equal(sanitized.SSL_CERT_FILE, undefined)
+  assert.equal(sanitized.SSL_CERT_DIR, undefined)
+  assert.equal(sanitized.NODE_EXTRA_CA_CERTS, cursorCaPath)
+})
+
+test('leaves non-Cursor SSL_CERT_FILE untouched', () => {
+  // Arrange
+  const systemCaPath = '/etc/ssl/cert.pem'
+
+  // Act
+  const sanitized = sanitizeTlsEnvForClerkHandshake({
+    SSL_CERT_FILE: systemCaPath,
+    SSL_CERT_DIR: '/etc/ssl/certs',
+    NODE_EXTRA_CA_CERTS: '/custom/extra.pem',
+  })
+
+  // Assert
+  assert.equal(sanitized.SSL_CERT_FILE, systemCaPath)
+  assert.equal(sanitized.SSL_CERT_DIR, '/etc/ssl/certs')
+  assert.equal(sanitized.NODE_EXTRA_CA_CERTS, '/custom/extra.pem')
+})
+
+test('launcher script starts Next help under Cursor CA env without crashing', () => {
+  // Arrange
+  const launcherPath = path.join(
+    repositoryRoot,
+    'scripts/next-with-system-ca.mjs',
+  )
+
+  // Act
+  const result = spawnSync(process.execPath, [launcherPath, '--help'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      SSL_CERT_FILE: '/tmp/sfw-test/socketFirewallCa.crt',
+      SSL_CERT_DIR: '/tmp/sfw-test',
+    },
+  })
+
+  // Assert — Next prints help (or usage) without crashing on env sanitization
+  assert.notEqual(result.status, null)
+  assert.ok(
+    result.status === 0 ||
+      (result.stdout + result.stderr).toLowerCase().includes('next'),
+    `expected Next help output, got status=${result.status} stderr=${result.stderr}`,
+  )
+})

--- a/src/app/login/[[...login]]/page.tsx
+++ b/src/app/login/[[...login]]/page.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import { SignIn as Login, useUser } from '@clerk/nextjs'
-import { useRouter } from 'next/navigation'
 
 import {
   ElectronLoginForm,
   useIsElectron,
 } from '@/components/auth/ElectronLoginForm'
 import { useCycleEffect } from '@/hooks/use-cycle-effect'
+
+/** Post-auth destination shared by web SignIn and authenticated-user redirect. */
+const POST_LOGIN_HOME_PATH = '/home'
 
 /**
  * Login Page with Electron Email/Password Support
@@ -19,18 +21,22 @@ import { useCycleEffect } from '@/hooks/use-cycle-effect'
  * - Email/password works directly in Electron WebView (no browser needed)
  * - Google OAuth requires system browser (blocks WebView)
  * - GitHub removed: email/password provides simpler desktop experience
+ *
+ * Authenticated users hard-navigate to home (not soft router.replace) so the
+ * full document request re-runs Clerk middleware with session cookies. Soft
+ * navigation can leave this page spinning when middleware previously failed
+ * the handshake and bounced /home back to /login?redirect_url=...
  */
 const Page = function Page() {
   const isElectron = useIsElectron()
   const { user, isLoaded } = useUser()
-  const router = useRouter()
 
-  // Redirect to home if user is already authenticated
+  // Hard redirect once Clerk client reports an active user
   useCycleEffect(() => {
     if (isLoaded && user) {
-      router.replace('/home')
+      window.location.replace(POST_LOGIN_HOME_PATH)
     }
-  }, [user, isLoaded, router])
+  }, [user, isLoaded])
 
   // Show loading while checking auth or redirecting
   if (!isLoaded || user) {
@@ -59,7 +65,10 @@ const Page = function Page() {
           </div>
         </div>
       ) : (
-        <Login />
+        <Login
+          forceRedirectUrl={POST_LOGIN_HOME_PATH}
+          fallbackRedirectUrl={POST_LOGIN_HOME_PATH}
+        />
       )}
     </div>
   )

--- a/src/app/login/[[...login]]/page.tsx
+++ b/src/app/login/[[...login]]/page.tsx
@@ -18,10 +18,10 @@ const POST_LOGIN_HOME_PATH = '/home'
  *
  * @param search - `window.location.search` (or equivalent query string)
  * @param origin - Current page origin used for same-origin checks
- * @returns Safe in-app path or absolute same-origin URL
+ * @returns Safe in-app relative path (pathname + search + hash)
  * @example
  * resolvePostLoginPath('?redirect_url=http://localhost:4991/settings', 'http://localhost:4991')
- * // => 'http://localhost:4991/settings'
+ * // => '/settings'
  * resolvePostLoginPath('', 'http://localhost:4991') // => '/home'
  */
 function resolvePostLoginPath(search: string, origin: string): string {

--- a/src/app/login/[[...login]]/page.tsx
+++ b/src/app/login/[[...login]]/page.tsx
@@ -8,8 +8,39 @@ import {
 } from '@/components/auth/ElectronLoginForm'
 import { useCycleEffect } from '@/hooks/use-cycle-effect'
 
-/** Post-auth destination shared by web SignIn and authenticated-user redirect. */
+/** Default post-auth destination when no same-origin redirect_url is present. */
 const POST_LOGIN_HOME_PATH = '/home'
+
+/**
+ * Resolves the post-login navigation target from the proxy-provided redirect_url
+ * query param, falling back to home. Only same-origin absolute URLs or relative
+ * paths are accepted so open redirects cannot leave the app.
+ *
+ * @param search - `window.location.search` (or equivalent query string)
+ * @param origin - Current page origin used for same-origin checks
+ * @returns Safe in-app path or absolute same-origin URL
+ * @example
+ * resolvePostLoginPath('?redirect_url=http://localhost:4991/settings', 'http://localhost:4991')
+ * // => 'http://localhost:4991/settings'
+ * resolvePostLoginPath('', 'http://localhost:4991') // => '/home'
+ */
+function resolvePostLoginPath(search: string, origin: string): string {
+  const redirectUrlParam = new URLSearchParams(search).get('redirect_url')
+  if (!redirectUrlParam) {
+    return POST_LOGIN_HOME_PATH
+  }
+
+  try {
+    const redirectUrl = new URL(redirectUrlParam, origin)
+    if (redirectUrl.origin !== origin) {
+      return POST_LOGIN_HOME_PATH
+    }
+
+    return `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`
+  } catch {
+    return POST_LOGIN_HOME_PATH
+  }
+}
 
 /**
  * Login Page with Electron Email/Password Support
@@ -22,10 +53,10 @@ const POST_LOGIN_HOME_PATH = '/home'
  * - Google OAuth requires system browser (blocks WebView)
  * - GitHub removed: email/password provides simpler desktop experience
  *
- * Authenticated users hard-navigate to home (not soft router.replace) so the
- * full document request re-runs Clerk middleware with session cookies. Soft
+ * Authenticated users hard-navigate (not soft router.replace) so the full
+ * document request re-runs Clerk middleware with session cookies. Soft
  * navigation can leave this page spinning when middleware previously failed
- * the handshake and bounced /home back to /login?redirect_url=...
+ * the handshake and bounced a protected route back to /login?redirect_url=...
  */
 const Page = function Page() {
   const isElectron = useIsElectron()
@@ -34,7 +65,9 @@ const Page = function Page() {
   // Hard redirect once Clerk client reports an active user
   useCycleEffect(() => {
     if (isLoaded && user) {
-      window.location.replace(POST_LOGIN_HOME_PATH)
+      window.location.replace(
+        resolvePostLoginPath(window.location.search, window.location.origin),
+      )
     }
   }, [user, isLoaded])
 
@@ -65,10 +98,7 @@ const Page = function Page() {
           </div>
         </div>
       ) : (
-        <Login
-          forceRedirectUrl={POST_LOGIN_HOME_PATH}
-          fallbackRedirectUrl={POST_LOGIN_HOME_PATH}
-        />
+        <Login fallbackRedirectUrl={POST_LOGIN_HOME_PATH} />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Cursor's network sandbox injects an exclusive `SSL_CERT_FILE` (`socketFirewallCa.crt`), which breaks Clerk Edge middleware handshake TLS (`UNABLE_TO_GET_ISSUER_CERT_LOCALLY`). Authenticated clients then bounce `/home` → `/login?redirect_url=...` and spin forever.
- Launch Next via `scripts/next-with-system-ca.mjs` so Cursor's exclusive CA is demoted to `NODE_EXTRA_CA_CERTS` and public CAs still verify.
- Hard-redirect signed-in users to `/home` and set Clerk `forceRedirectUrl` / `fallbackRedirectUrl` so post-login navigation is reliable.

## Test plan
- [x] `node --test scripts/next-with-system-ca.test.mjs`
- [x] `pnpm dev` under Cursor → login with `test@test.com` → reaches `/home` without spinner
- [x] Confirm server logs no longer show `Clerk: unable to resolve handshake` / `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ログイン後の遷移先を同一オリジン/許可された範囲で安全に解決し、認証済みユーザーは適切にホームへ移動します。
* **Bug Fixes**
  * 開発・起動時の証明書（TLS）設定を見直し、環境によって起こり得る起動失敗を軽減しました。
* **Tests**
  * 証明書系の環境変数挙動と、ヘルプ起動時の安定動作を自動テストで確認します。
* **Chores**
  * 開発・起動コマンドを、TLS設定を扱うラッパー経由に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->