### PR TITLE
fix: keep all Activity heatmap rows visible

### DIFF
--- a/e2e/web/heatmap-day-detail.spec.ts
+++ b/e2e/web/heatmap-day-detail.spec.ts
@@ -82,6 +82,31 @@ test.describe('Heatmap Day Detail E2E', () => {
     await setupClerkTestingToken({ page })
   })
 
+  test('shows all seven weekday rows inside the Activity heatmap', async ({
+    page,
+  }) => {
+    // Arrange — a desktop-width card enlarges cells beyond the SVG browser default height.
+    await page.setViewportSize({ width: 1600, height: 900 })
+    await page.goto('/home')
+    await waitForAppReady(page)
+    const heatmap = page.locator('svg.w-heatmap')
+    const finalWeekdayRow = heatmap.locator('rect[data-row="6"]').first()
+    await expect(heatmap).toBeVisible()
+    await expect(finalWeekdayRow).toBeAttached()
+
+    // Act — measure actual rendered geometry because visibility ignores SVG clipping.
+    const heatmapBounds = await heatmap.boundingBox()
+    const finalWeekdayRowBounds = await finalWeekdayRow.boundingBox()
+
+    // Assert — missing geometry is itself a broken heatmap, so fail with a clear reason.
+    if (!heatmapBounds || !finalWeekdayRowBounds) {
+      throw new Error('Activity heatmap geometry was unavailable')
+    }
+    expect(
+      finalWeekdayRowBounds.y + finalWeekdayRowBounds.height,
+    ).toBeLessThanOrEqual(heatmapBounds.y + heatmapBounds.height)
+  })
+
   test.describe('Deep-link via ?date=', () => {
     test('opens dialog when date param is a valid calendar date', async ({
       page,

--- a/src/app/(main)/home/_components/ContributionGraph.test.ts
+++ b/src/app/(main)/home/_components/ContributionGraph.test.ts
@@ -28,6 +28,20 @@ describe('Activity heatmap sizing', () => {
     expect(layout.width).toBeLessThanOrEqual(containerWidth)
   })
 
+  it('keeps all seven weekday rows inside the SVG when desktop width enlarges the cells', () => {
+    // Arrange — 1180px grows each cell to 19px, taller than the SVG browser default allows.
+    const containerWidth = 1180
+
+    // Act
+    const layout = calculateHeatmapLayout(
+      containerWidth,
+      WEEKS_IN_TRAILING_YEAR,
+    )
+
+    // Assert — the explicit 167px height includes every row plus bottom breathing room.
+    expect(layout).toEqual({ rectSize: 19, width: 1141, height: 167 })
+  })
+
   it('never grows cells past the 32px Cathedral maximum even in an unusually wide card', () => {
     // Arrange — a very wide container that could otherwise over-grow the cells.
     const containerWidth = 3000
@@ -40,6 +54,7 @@ describe('Activity heatmap sizing', () => {
 
     // Assert — cells cap at the DESIGN.md D6 maximum.
     expect(layout.rectSize).toBe(32)
+    expect(layout.height).toBe(258)
   })
 
   it('holds the 12px minimum cell and lets the grid overflow when the card is narrower than a full year', () => {

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -46,6 +46,9 @@ const DAYS_IN_WEEK = 7
 /** Reserved width for week-day labels inside the SVG. */
 const HEATMAP_LEFT_PAD = 28
 
+/** Reserved height for month labels inside the SVG. */
+const HEATMAP_TOP_PAD = 20
+
 /** Minimum cell size — DESIGN.md heatmap cell-sizing lock (Heatmap Cathedral D6). */
 const HEATMAP_MIN_RECT_SIZE = 12
 
@@ -363,6 +366,7 @@ export const ContributionGraph = function ContributionGraph() {
               legendCellSize={0}
               rectSize={heatmapLayout.rectSize}
               space={HEATMAP_SPACE}
+              height={heatmapLayout.height}
               width={heatmapLayout.width}
               style={heatmapStyle}
               rectRender={renderHeatmapRect}
@@ -445,20 +449,22 @@ function useObservedElementWidth<T extends HTMLElement>(
 }
 
 type HeatmapLayout = {
+  height: number
   rectSize: number
   width: number
 }
 
 /**
- * Calculates the heatmap dimensions needed to fill available space without clipping the year.
+ * Calculates the SVG dimensions whenever ContributionGraph resizes so every day remains visible.
  * @param containerWidth - Measured width of the card content area
  * @param weekCount - Number of week columns that must be rendered
  * @returns
+ * - `height`: SVG height containing month labels and all seven weekday rows
  * - `rectSize`: Cell size that best uses the current width
  * - `width`: SVG width, allowing horizontal scroll only when the card is too narrow
  * @example
- * calculateHeatmapLayout(720, 53) // => { rectSize: 11, width: 717 }
- * calculateHeatmapLayout(480, 53) // => { rectSize: 8, width: 558 }
+ * calculateHeatmapLayout(1180, 53) // => { height: 167, rectSize: 19, width: 1141 }
+ * calculateHeatmapLayout(578, 53) // => { height: 118, rectSize: 12, width: 770 }
  */
 export function calculateHeatmapLayout(
   containerWidth: number | null,
@@ -467,24 +473,23 @@ export function calculateHeatmapLayout(
   const minimumWidth =
     HEATMAP_LEFT_PAD + weekCount * (HEATMAP_MIN_RECT_SIZE + HEATMAP_SPACE)
 
-  if (!containerWidth || containerWidth <= minimumWidth) {
-    return {
-      rectSize: HEATMAP_MIN_RECT_SIZE,
-      width: minimumWidth,
-    }
-  }
-
-  const nextRectSize = clampNumber(
-    Math.floor((containerWidth - HEATMAP_LEFT_PAD) / weekCount) - HEATMAP_SPACE,
-    HEATMAP_MIN_RECT_SIZE,
-    HEATMAP_MAX_RECT_SIZE,
-  )
-  const nextWidth =
-    HEATMAP_LEFT_PAD + weekCount * (nextRectSize + HEATMAP_SPACE)
+  // Narrow or unmeasured cards hold the minimum; wider cards enlarge every cell evenly.
+  const rectSize =
+    !containerWidth || containerWidth <= minimumWidth
+      ? HEATMAP_MIN_RECT_SIZE
+      : clampNumber(
+          Math.floor((containerWidth - HEATMAP_LEFT_PAD) / weekCount) -
+            HEATMAP_SPACE,
+          HEATMAP_MIN_RECT_SIZE,
+          HEATMAP_MAX_RECT_SIZE,
+        )
+  const width = HEATMAP_LEFT_PAD + weekCount * (rectSize + HEATMAP_SPACE)
+  const height = HEATMAP_TOP_PAD + DAYS_IN_WEEK * (rectSize + HEATMAP_SPACE)
 
   return {
-    rectSize: nextRectSize,
-    width: nextWidth,
+    height,
+    rectSize,
+    width,
   }
 }
 

--- a/src/app/(main)/home/_components/ContributionGraph.tsx
+++ b/src/app/(main)/home/_components/ContributionGraph.tsx
@@ -26,6 +26,7 @@ import { useHeatmapData } from '@/hooks/useHeatmapData'
 import type { HeatmapDay } from '@/hooks/useHeatmapData'
 import { buildDateSyncUrl } from '@/lib/buildDateSyncUrl'
 import { calcMonthlyMaxDates } from '@/lib/calcMonthlyMaxDates'
+import { HEATMAP_TOP_PAD_PX } from '@/lib/constants/heatmap'
 import {
   HEATMAP_CATHEDRAL_MIN,
   HEATMAP_FULL_DAY_MIN,
@@ -45,9 +46,6 @@ const DAYS_IN_WEEK = 7
 
 /** Reserved width for week-day labels inside the SVG. */
 const HEATMAP_LEFT_PAD = 28
-
-/** Reserved height for month labels inside the SVG. */
-const HEATMAP_TOP_PAD = 20
 
 /** Minimum cell size — DESIGN.md heatmap cell-sizing lock (Heatmap Cathedral D6). */
 const HEATMAP_MIN_RECT_SIZE = 12
@@ -484,7 +482,7 @@ export function calculateHeatmapLayout(
           HEATMAP_MAX_RECT_SIZE,
         )
   const width = HEATMAP_LEFT_PAD + weekCount * (rectSize + HEATMAP_SPACE)
-  const height = HEATMAP_TOP_PAD + DAYS_IN_WEEK * (rectSize + HEATMAP_SPACE)
+  const height = HEATMAP_TOP_PAD_PX + DAYS_IN_WEEK * (rectSize + HEATMAP_SPACE)
 
   return {
     height,

--- a/src/lib/constants/heatmap.ts
+++ b/src/lib/constants/heatmap.ts
@@ -1,0 +1,2 @@
+/** Reserved SVG height for Activity Heatmap month labels. */
+export const HEATMAP_TOP_PAD_PX = 20


### PR DESCRIPTION
## Summary

- calculate the Activity Heatmap SVG height from its responsive cell size so all seven weekday rows remain visible
- preserve the existing 12–32px cell-size limits and horizontal overflow behavior
- add unit boundary coverage and a Playwright geometry regression for the bottom weekday row

## Test Coverage

```text
CODE PATHS                                              USER FLOWS
[+] ContributionGraph.tsx                              [+] /home Activity heatmap
  ├── calculateHeatmapLayout()                           └── [★★★ TESTED] Desktop load renders all seven rows
  │   ├── [★★  TESTED] null/unmeasured -> 12px fallback
  │   ├── [★★  TESTED] narrow width -> 12px + horizontal overflow
  │   ├── [★★★ TESTED] 1180px -> 19px / 1141px / 167px
  │   └── [★★★ TESTED] ultrawide -> 32px cap / 258px height
  └── [★★★ TESTED] computed height reaches the rendered SVG

COVERAGE: 6/6 paths tested (100%) | GAPS: 0
```

## Pre-Landing Review

- Pre-landing review: no issues found
- Adversarial review: no P0–P3 findings
- Design review lite: no issues found; the DESIGN.md heatmap sizing contract remains intact

## Scope and Plan

- Scope Check: CLEAN
- No plan file detected
- Documentation is current; no documentation changes were needed

## QA

- [x] `pnpm validate` — 767 unit tests passed, 22 package tests passed, lint/build/typecheck/theme checks passed
- [x] `pnpm e2e:web e2e/web/heatmap-day-detail.spec.ts` — 12 passed
- [x] Local browser QA at 1392px and 1280px widths — all seven rows and the legend stay inside the card, with no unwanted horizontal overflow at 1280px


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * アクティビティヒートマップで、7つすべての曜日行が表示領域内に収まるよう改善しました。
  * 画面幅やセルサイズが大きい場合も、ヒートマップの縦サイズを適切に計算し、最終行が切れないようにしました。
* **テスト**
  * ヒートマップの表示範囲とレイアウト寸法（各サイズ、最大セルサイズ時）を検証するテストを追加・強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->