### PR TITLE
Fix first-visit Home bootstrap follow-up

### DIFF
--- a/e2e/web/home-bootstrap.spec.ts
+++ b/e2e/web/home-bootstrap.spec.ts
@@ -4,10 +4,11 @@ import {
   HOME_SELECTED_CATEGORY_COOKIE_NAME,
   HOME_TIMEZONE_COOKIE_NAME,
 } from '../../src/lib/constants/home'
-import { PERSISTED_QUERY_STORAGE_KEY } from '../../src/lib/constants/query'
 
 import { expect, test } from './_helpers/coverage'
 import { resetDatabase } from './_helpers/db'
+
+const EXPECTED_PERSISTED_QUERY_STORAGE_KEY = 'REACT_QUERY_OFFLINE_CACHE'
 
 test.describe('Home bootstrap', () => {
   test.beforeAll(resetDatabase)
@@ -27,7 +28,7 @@ test.describe('Home bootstrap', () => {
         localStorage.removeItem(selectedCategoryKey)
       },
       {
-        offlineCacheKey: PERSISTED_QUERY_STORAGE_KEY,
+        offlineCacheKey: EXPECTED_PERSISTED_QUERY_STORAGE_KEY,
         selectedCategoryKey: HOME_SELECTED_CATEGORY_COOKIE_NAME,
       },
     )
@@ -51,6 +52,12 @@ test.describe('Home bootstrap', () => {
     await expect(
       page.getByRole('region', { name: 'Completed Tasks' }),
     ).toBeVisible()
+    // The default-selection effect was the late trigger behind the duplicate
+    // request, so wait for its persisted write before asserting no fetch fired.
+    await page.waitForFunction(
+      (storageKey) => localStorage.getItem(storageKey) !== null,
+      HOME_SELECTED_CATEGORY_COOKIE_NAME,
+    )
     expect(browserOrpcRequests).toEqual([])
   })
 })

--- a/e2e/web/home-bootstrap.spec.ts
+++ b/e2e/web/home-bootstrap.spec.ts
@@ -1,0 +1,56 @@
+import { setupClerkTestingToken } from '@clerk/testing/playwright'
+
+import {
+  HOME_SELECTED_CATEGORY_COOKIE_NAME,
+  HOME_TIMEZONE_COOKIE_NAME,
+} from '../../src/lib/constants/home'
+import { PERSISTED_QUERY_STORAGE_KEY } from '../../src/lib/constants/query'
+
+import { expect, test } from './_helpers/coverage'
+import { resetDatabase } from './_helpers/db'
+
+test.describe('Home bootstrap', () => {
+  test.beforeAll(resetDatabase)
+
+  test('first Home visit renders the default category without browser oRPC requests', async ({
+    page,
+  }) => {
+    // Arrange
+    await setupClerkTestingToken({ page })
+    await page.context().clearCookies({
+      name: HOME_SELECTED_CATEGORY_COOKIE_NAME,
+    })
+    await page.context().clearCookies({ name: HOME_TIMEZONE_COOKIE_NAME })
+    await page.addInitScript(
+      ({ offlineCacheKey, selectedCategoryKey }) => {
+        localStorage.removeItem(offlineCacheKey)
+        localStorage.removeItem(selectedCategoryKey)
+      },
+      {
+        offlineCacheKey: PERSISTED_QUERY_STORAGE_KEY,
+        selectedCategoryKey: HOME_SELECTED_CATEGORY_COOKIE_NAME,
+      },
+    )
+    const browserOrpcRequests: string[] = []
+    page.on('request', (request) => {
+      if (request.url().includes('/api/orpc')) {
+        browserOrpcRequests.push(request.url())
+      }
+    })
+
+    // Act
+    await page.goto('/home')
+
+    // Assert
+    await expect(page.getByText('Todo List')).toBeVisible({ timeout: 10000 })
+    await expect(
+      page
+        .locator('[data-slot="sidebar-menu-button"]')
+        .filter({ hasText: 'General' }),
+    ).toHaveAttribute('data-active', 'true')
+    await expect(
+      page.getByRole('region', { name: 'Completed Tasks' }),
+    ).toBeVisible()
+    expect(browserOrpcRequests).toEqual([])
+  })
+})

--- a/e2e/web/skill-tree.spec.ts
+++ b/e2e/web/skill-tree.spec.ts
@@ -2,7 +2,6 @@ import { setupClerkTestingToken } from '@clerk/testing/playwright'
 import { type Locator, type Page } from '@playwright/test'
 
 import { xpToLevel } from '../../src/app/(main)/skill-tree/lib/xp'
-import { PERSISTED_QUERY_STORAGE_KEY } from '../../src/lib/constants/query'
 
 import { test, expect } from './_helpers/coverage'
 import { resetDatabase } from './_helpers/db'
@@ -171,9 +170,8 @@ test.describe('Skill Tree E2E', () => {
     // so it won't re-fetch from the server. Drop only the persister's
     // own key — not all of localStorage — so Clerk session + misc app
     // state survive the reset.
-    await page.evaluate(
-      (storageKey) => window.localStorage.removeItem(storageKey),
-      PERSISTED_QUERY_STORAGE_KEY,
+    await page.evaluate(() =>
+      window.localStorage.removeItem('REACT_QUERY_OFFLINE_CACHE'),
     )
     // Arm the response listener BEFORE triggering the reload. If we await
     // `page.reload()` first and then set up `waitForResponse`, the fresh

--- a/e2e/web/skill-tree.spec.ts
+++ b/e2e/web/skill-tree.spec.ts
@@ -2,6 +2,7 @@ import { setupClerkTestingToken } from '@clerk/testing/playwright'
 import { type Locator, type Page } from '@playwright/test'
 
 import { xpToLevel } from '../../src/app/(main)/skill-tree/lib/xp'
+import { PERSISTED_QUERY_STORAGE_KEY } from '../../src/lib/constants/query'
 
 import { test, expect } from './_helpers/coverage'
 import { resetDatabase } from './_helpers/db'
@@ -170,8 +171,9 @@ test.describe('Skill Tree E2E', () => {
     // so it won't re-fetch from the server. Drop only the persister's
     // own key — not all of localStorage — so Clerk session + misc app
     // state survive the reset.
-    await page.evaluate(() =>
-      window.localStorage.removeItem('REACT_QUERY_OFFLINE_CACHE'),
+    await page.evaluate(
+      (storageKey) => window.localStorage.removeItem(storageKey),
+      PERSISTED_QUERY_STORAGE_KEY,
     )
     // Arm the response listener BEFORE triggering the reload. If we await
     // `page.reload()` first and then set up `waitForResponse`, the fresh

--- a/e2e/web/todo-app.spec.ts
+++ b/e2e/web/todo-app.spec.ts
@@ -186,14 +186,16 @@ test.describe('TODO App E2E Tests', () => {
 
   test('should move completed TODO back to pending when clicking checkbox', async ({
     page,
-  }) => {
+  }, testInfo) => {
     // Arrange — seed a todo and wait for the server-confirmed positive ID
-    const todoText = 'Uncheck completion test todo'
+    const todoText = `Uncheck completion test todo retry ${testInfo.retry}`
     await page
       .getByPlaceholder('Type a todo, or paste a list...')
       .fill(todoText)
     await page.getByRole('button', { name: 'Add', exact: true }).click()
-    const todoCheckbox = page.getByRole('checkbox', { name: todoText })
+    const todoCheckbox = page
+      .getByRole('checkbox', { name: todoText })
+      .and(page.locator('[id^="todo-"]:not([id^="todo--"])'))
     await expect(todoCheckbox).toBeVisible()
     await expect(todoCheckbox).not.toBeChecked()
     await expect(todoCheckbox).toHaveAttribute('id', /^todo-[^-]/, {
@@ -201,23 +203,50 @@ test.describe('TODO App E2E Tests', () => {
     })
 
     // Act 1 — mark as completed (moves item to Completed Tasks section)
+    const completeResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/orpc/todo/toggle') &&
+        response.request().method() === 'POST',
+      { timeout: 10000 },
+    )
     await todoCheckbox.click()
+    expect((await completeResponsePromise).status()).toBe(200)
 
     // Assert 1 — item is in completed section (checked + line-through)
-    const completedCheckbox = page.getByRole('checkbox', { name: todoText })
+    const completedTasksRegion = page.getByRole('region', {
+      name: 'Completed Tasks',
+    })
+    const completedCheckbox = completedTasksRegion.getByRole('checkbox', {
+      name: todoText,
+    })
     await expect(completedCheckbox).toBeChecked({ timeout: 5000 })
-    await expect(page.getByText(todoText)).toHaveClass(/line-through/)
+    await expect(
+      completedTasksRegion.getByText(todoText, { exact: true }),
+    ).toHaveClass(/line-through/)
 
     // Act 2 — click the checkbox in Completed Tasks to move it back to pending
+    const uncompleteResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/orpc/todo/toggle') &&
+        response.request().method() === 'POST',
+      { timeout: 10000 },
+    )
     await completedCheckbox.click()
+    expect((await uncompleteResponsePromise).status()).toBe(200)
 
     // Assert 2 — item is back in pending (unchecked, no line-through, drag handle)
-    const pendingCheckbox = page.getByRole('checkbox', { name: todoText })
+    const pendingCheckbox = page
+      .getByRole('checkbox', { name: todoText })
+      .and(page.locator('[id^="todo-"]:not([id^="todo--"])'))
+    await expect(completedCheckbox).not.toBeVisible({ timeout: 5000 })
+    await expect(pendingCheckbox).toBeVisible({ timeout: 5000 })
     await expect(pendingCheckbox).not.toBeChecked({ timeout: 5000 })
-    await expect(page.getByText(todoText)).not.toHaveClass(/line-through/)
     const todoItem = page.locator('.rounded-lg.border').filter({
-      has: page.getByRole('checkbox', { name: todoText }),
+      has: pendingCheckbox,
     })
+    await expect(todoItem.getByText(todoText, { exact: true })).not.toHaveClass(
+      /line-through/,
+    )
     // Pending items have a drag handle (GripVertical icon); completed items don't.
     await expect(
       todoItem.getByRole('button', { name: 'Drag to reorder' }),

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -135,7 +135,7 @@ export const TodoList = function TodoList() {
 
   // Fetch categories first so a fresh browser and the SSR bootstrap resolve
   // the same default-category Todo query key before Clerk enables requests.
-  const { data: categoryData } = useQuery({
+  const { data: categoryData, isPending: isCategoryPending } = useQuery({
     ...orpc.category.list.queryOptions({}),
     enabled: isClerkQueryReady,
   })
@@ -144,6 +144,10 @@ export const TodoList = function TodoList() {
       selectedCategoryId,
       categoryData?.categories ?? [],
     ) ?? null
+  // A fresh browser must resolve its default category before the Todo request;
+  // explicit selections and a settled category fallback can proceed directly.
+  const isPendingTodoQueryReady =
+    isClerkQueryReady && (selectedCategoryId !== null || !isCategoryPending)
 
   // Mutations with optimistic updates (pass categoryId for correct cache key)
   const {
@@ -197,7 +201,7 @@ export const TodoList = function TodoList() {
       // same order-sensitive oRPC key.
       input: buildHomeTodoListInput(effectiveSelectedCategoryId, isRetaining),
     }),
-    enabled: isClerkQueryReady,
+    enabled: isPendingTodoQueryReady,
     // Keep the previous list painted while the toggle/category refetch is in
     // flight so the pending rows never blank-flash; the completed-since-clear
     // rows arrive with the settled result and fade IN over them (L1 + D8).

--- a/src/app/(main)/home/_components/TodoList.tsx
+++ b/src/app/(main)/home/_components/TodoList.tsx
@@ -43,12 +43,12 @@ import { useSoundFeedback } from '@/hooks/useSoundFeedback'
 import { useStreakNotifications } from '@/hooks/useStreakNotifications'
 import { useTodoMutations } from '@/hooks/useTodoMutations'
 import { useTodoPasteImport } from '@/hooks/useTodoPasteImport'
-import {
-  HOME_TODO_QUERY_LIMIT,
-  HOME_TODO_QUERY_OFFSET,
-} from '@/lib/constants/home'
 import { todoSortableSensors } from '@/lib/dnd-kit-sensors'
 import { orpc } from '@/lib/orpc/client-query'
+import {
+  buildHomeTodoListInput,
+  resolveHomeSelectedCategoryId,
+} from '@/lib/query/homeBootstrapQueries'
 import { useAppSelector } from '@/lib/redux/hooks'
 import { selectRetainCompletedInList } from '@/lib/redux/slices/settingsSlice'
 import { subscribeToTodoSync } from '@/lib/todo-sync-channel'
@@ -133,6 +133,18 @@ export const TodoList = function TodoList() {
   // retain-aware query input + cache keys below.
   const isRetaining = useAppSelector(selectRetainCompletedInList)
 
+  // Fetch categories first so a fresh browser and the SSR bootstrap resolve
+  // the same default-category Todo query key before Clerk enables requests.
+  const { data: categoryData } = useQuery({
+    ...orpc.category.list.queryOptions({}),
+    enabled: isClerkQueryReady,
+  })
+  const effectiveSelectedCategoryId =
+    resolveHomeSelectedCategoryId(
+      selectedCategoryId,
+      categoryData?.categories ?? [],
+    ) ?? null
+
   // Mutations with optimistic updates (pass categoryId for correct cache key)
   const {
     createMutation,
@@ -142,7 +154,7 @@ export const TodoList = function TodoList() {
     updateMutation,
     clearCompletedMutation,
     reorderMutation,
-  } = useTodoMutations(selectedCategoryId, isRetaining)
+  } = useTodoMutations(effectiveSelectedCategoryId, isRetaining)
 
   // Earned-beat sound cues (opt-in, default OFF) fired on the create + clear
   // gestures below. Each is a no-op unless its moment is enabled in Settings, so
@@ -154,11 +166,6 @@ export const TodoList = function TodoList() {
   // Local state for optimistic reordering
   const [localPendingTodos, setLocalPendingTodos] = useState<Todo[]>([])
 
-  // Fetch categories for name/color lookup
-  const { data: categoryData } = useQuery({
-    ...orpc.category.list.queryOptions({}),
-    enabled: isClerkQueryReady,
-  })
   // Memoized on the query data so the map reference only changes when the
   // categories actually change. A fresh Map every render would bust the
   // `pendingTodosFromQuery` memo below (it depends on this), re-opening the
@@ -186,15 +193,9 @@ export const TodoList = function TodoList() {
     isPlaceholderData: isPendingPlaceholderData,
   } = useQuery({
     ...orpc.todo.list.queryOptions({
-      input: {
-        // 居残りモード drops the completed:false filter so the active list holds
-        // ALL todos (pending + completed-since-clear); MUST mirror the
-        // retain-aware pendingKey in useTodoMutations or optimistic updates miss.
-        ...(isRetaining ? {} : { completed: false }),
-        limit: HOME_TODO_QUERY_LIMIT,
-        offset: HOME_TODO_QUERY_OFFSET,
-        ...(selectedCategoryId !== null && { categoryId: selectedCategoryId }),
-      },
+      // Shared builder keeps SSR, this query, and optimistic mutations on the
+      // same order-sensitive oRPC key.
+      input: buildHomeTodoListInput(effectiveSelectedCategoryId, isRetaining),
     }),
     enabled: isClerkQueryReady,
     // Keep the previous list painted while the toggle/category refetch is in
@@ -233,11 +234,11 @@ export const TodoList = function TodoList() {
    * addTodo('Buy milk')
    */
   const addTodo = (text: string, notes?: string) => {
-    if (selectedCategoryId === null) return
+    if (effectiveSelectedCategoryId === null) return
     createMutation.mutate({
       text,
       notes,
-      categoryId: selectedCategoryId,
+      categoryId: effectiveSelectedCategoryId,
     })
     // Earned-beat cue on the add gesture (no-op unless the moment is enabled);
     // fired here, inside the user gesture, so the engine can resume audio.
@@ -593,7 +594,7 @@ export const TodoList = function TodoList() {
             <AddTodoForm
               onAddTodo={addTodo}
               onBulkPaste={pasteImport.openWithPaste}
-              disabled={selectedCategoryId === null}
+              disabled={effectiveSelectedCategoryId === null}
             />
 
             {/* Bulk paste-import (Issue #110): the Add form's multi-line paste

--- a/src/app/api/orpc/[...path]/route.test.ts
+++ b/src/app/api/orpc/[...path]/route.test.ts
@@ -53,9 +53,11 @@ describe('oRPC route Server-Timing response', () => {
 
     // Assert
     expect(response.status).toBe(200)
-    expect(response.headers.get('server-timing')).toMatch(
+    const serverTiming = response.headers.get('server-timing')
+    expect(serverTiming).toMatch(
       /^auth;dur=1\.00, db;dur=2\.00, user;dur=3\.00, sql;dur=4\.00, total;dur=\d+\.\d{2}$/,
     )
+    expect(response.headers.get('x-corelive-server-timing')).toBe(serverTiming)
   })
 
   it('keeps exception details out of the 500 body when the oRPC handler throws', async () => {
@@ -79,5 +81,8 @@ describe('oRPC route Server-Timing response', () => {
     expect(response.status).toBe(500)
     expect(body).toEqual({ error: 'Internal Server Error' })
     expect(JSON.stringify(body)).not.toMatch(/ECONNREFUSED|postgres|stack/i)
+    const serverTiming = response.headers.get('server-timing')
+    expect(serverTiming).toMatch(/^total;dur=\d+\.\d{2}$/)
+    expect(response.headers.get('x-corelive-server-timing')).toBe(serverTiming)
   })
 })

--- a/src/app/api/orpc/[...path]/route.ts
+++ b/src/app/api/orpc/[...path]/route.ts
@@ -6,22 +6,23 @@ import { ServerTiming } from '@/server/timing/ServerTiming'
 import { log } from '../../../../lib/logger'
 
 const handler = new RPCHandler(router)
+const SERVER_TIMING_HEADER_NAME = 'server-timing'
+const SERVER_TIMING_MIRROR_HEADER_NAME = 'x-corelive-server-timing'
 
-/** Adds the completed request phases whenever the oRPC adapter returns or the fallback handles an error. @param response - Response produced by oRPC or the route fallback. @param serverTiming - Per-request phase collector. @param startedAt - Monotonic request start timestamp. @returns A response with the `Server-Timing` header attached. @example `withServerTiming(new Response('ok'), timing, performance.now())` */
+/** Mutates the final oRPC response with standard and diagnostic timing headers so preview QA can distinguish name filtering from response rewrapping. @param response - Mutable response produced by oRPC or the route fallback. @param serverTiming - Per-request phase collector. @param startedAt - Monotonic request start timestamp. @returns The same response with identical timing headers attached. @example `withServerTiming(new Response('ok'), timing, performance.now())` */
 function withServerTiming(
   response: Response,
   serverTiming: ServerTiming,
   startedAt: number,
 ): Response {
   serverTiming.record('total', performance.now() - startedAt)
-  const headers = new Headers(response.headers)
-  headers.set('server-timing', serverTiming.toHeaderValue())
+  const headerValue = serverTiming.toHeaderValue()
+  response.headers.set(SERVER_TIMING_HEADER_NAME, headerValue)
+  // The mirror distinguishes Vercel stripping the standard header name from
+  // a route/proxy layer discarding every application response header.
+  response.headers.set(SERVER_TIMING_MIRROR_HEADER_NAME, headerValue)
 
-  return new Response(response.body, {
-    headers,
-    status: response.status,
-    statusText: response.statusText,
-  })
+  return response
 }
 
 /** Handles every oRPC HTTP verb so production responses expose the measured Home/API latency split. @param request - Incoming browser or server request. @returns The oRPC response, 404 fallback, or instrumented 500 response. @example `await handleRequest(new Request('https://corelive.app/api/orpc/todo/list'))` */

--- a/src/app/api/orpc/[...path]/route.ts
+++ b/src/app/api/orpc/[...path]/route.ts
@@ -9,7 +9,7 @@ const handler = new RPCHandler(router)
 const SERVER_TIMING_HEADER_NAME = 'server-timing'
 const SERVER_TIMING_MIRROR_HEADER_NAME = 'x-corelive-server-timing'
 
-/** Mutates the final oRPC response with standard and diagnostic timing headers so preview QA can distinguish name filtering from response rewrapping. @param response - Mutable response produced by oRPC or the route fallback. @param serverTiming - Per-request phase collector. @param startedAt - Monotonic request start timestamp. @returns The same response with identical timing headers attached. @example `withServerTiming(new Response('ok'), timing, performance.now())` */
+/** Attaches standard timing plus a Vercel-safe mirror so the same measurements remain observable when the platform filters `Server-Timing`. @param response - Mutable response produced by oRPC or the route fallback. @param serverTiming - Per-request phase collector. @param startedAt - Monotonic request start timestamp. @returns The same response with identical timing headers attached. @example `withServerTiming(new Response('ok'), timing, performance.now())` */
 function withServerTiming(
   response: Response,
   serverTiming: ServerTiming,
@@ -18,8 +18,8 @@ function withServerTiming(
   serverTiming.record('total', performance.now() - startedAt)
   const headerValue = serverTiming.toHeaderValue()
   response.headers.set(SERVER_TIMING_HEADER_NAME, headerValue)
-  // The mirror distinguishes Vercel stripping the standard header name from
-  // a route/proxy layer discarding every application response header.
+  // Keep the standard name for local/self-hosted DevTools; Vercel currently
+  // filters it, so this custom mirror exposes the same production phases.
   response.headers.set(SERVER_TIMING_MIRROR_HEADER_NAME, headerValue)
 
   return response

--- a/src/hooks/useTodoMutations.ts
+++ b/src/hooks/useTodoMutations.ts
@@ -11,11 +11,8 @@ import { toast } from 'sonner'
 import { broadcastCategorySync } from '@/lib/category-sync-channel'
 import { clearedAffirmation } from '@/lib/clearedAffirmation'
 import { COMPLETED_JOURNAL_INITIAL_OFFSET } from '@/lib/constants/completed'
-import {
-  HOME_TODO_QUERY_LIMIT,
-  HOME_TODO_QUERY_OFFSET,
-} from '@/lib/constants/home'
 import { orpc } from '@/lib/orpc/client-query'
+import { buildHomeTodoListInput } from '@/lib/query/homeBootstrapQueries'
 import { broadcastTodoSync } from '@/lib/todo-sync-channel'
 import { getUnfilteredCompletedJournalInput } from '@/lib/utils/getUnfilteredCompletedJournalInput'
 import type { CategoryWithCount } from '@/server/schemas/category'
@@ -117,12 +114,7 @@ export function useTodoMutations(
   //   (infiniteOptions with function input generates unpredictable keys,
   //    so we use partial matching for completed list operations)
   const pendingKey = orpc.todo.list.queryOptions({
-    input: {
-      ...(isRetaining ? {} : { completed: false }),
-      limit: HOME_TODO_QUERY_LIMIT,
-      offset: HOME_TODO_QUERY_OFFSET,
-      ...(categoryId !== null && { categoryId }),
-    },
+    input: buildHomeTodoListInput(categoryId, isRetaining),
   }).queryKey
   const completedBaseKey = orpc.todo.list.key({ input: { completed: true } })
   // journalBaseKey invalidates/snapshots every filtered journal. The exact

--- a/src/lib/constants/query.ts
+++ b/src/lib/constants/query.ts
@@ -1,3 +1,6 @@
 export const QUERY_STALE_TIME_MS = 60_000
 export const QUERY_CACHE_RETENTION_MS = 604_800_000
 export const PERSISTED_QUERY_MAX_AGE_MS = QUERY_CACHE_RETENTION_MS
+
+/** Stable localStorage key shared by the persister and focused E2E cache resets. */
+export const PERSISTED_QUERY_STORAGE_KEY = 'REACT_QUERY_OFFLINE_CACHE'

--- a/src/lib/query/homeBootstrapQueries.test.ts
+++ b/src/lib/query/homeBootstrapQueries.test.ts
@@ -54,6 +54,46 @@ describe('home bootstrap query keys', () => {
     )
   })
 
+  it('keeps TodoList on the all-category key when no default category exists', () => {
+    // Arrange
+    const storedSelectedCategoryId = null
+    const isCategoryPending = false
+    const resolvedSelectedCategoryId = resolveHomeSelectedCategoryId(
+      storedSelectedCategoryId,
+      [
+        { id: 3, isDefault: false },
+        { id: 4, isDefault: false },
+      ],
+    )
+    const effectiveSelectedCategoryId = resolvedSelectedCategoryId ?? null
+
+    // Act — mirror TodoList's settled category gate and all-category query key.
+    const isPendingTodoQueryReady =
+      storedSelectedCategoryId !== null || !isCategoryPending
+    const todoListClientKey = orpc.todo.list.queryOptions({
+      input: {
+        completed: false,
+        limit: 100,
+        offset: 0,
+      },
+    }).queryKey
+    const ssrKey = getHomeTodoListQueryKey(resolvedSelectedCategoryId)
+
+    // Assert
+    expect(effectiveSelectedCategoryId).toBeNull()
+    expect(isPendingTodoQueryReady).toBe(true)
+    expect(ssrKey).toEqual([
+      ['todo', 'list'],
+      {
+        input: { completed: false, limit: 100, offset: 0 },
+        type: 'query',
+      },
+    ])
+    expect(hashLikeAppQueryClient(ssrKey)).toBe(
+      hashLikeAppQueryClient(todoListClientKey),
+    )
+  })
+
   it('hydrates todo data onto the exact category-filtered key TodoList reads when a sidebar selection is persisted', () => {
     // Arrange — mirror TodoList's inline construction with a selected category
     const isRetaining = false

--- a/src/lib/query/homeBootstrapQueries.test.ts
+++ b/src/lib/query/homeBootstrapQueries.test.ts
@@ -11,6 +11,7 @@ import {
   getHomeHeatmapQueryKey,
   getHomeJournalQueryKey,
   getHomeTodoListQueryKey,
+  resolveHomeSelectedCategoryId,
 } from './homeBootstrapQueries'
 
 /** Mirrors the app QueryClient's queryKeyHashFn so equality is asserted at the hash level the cache actually matches on (the oRPC serializer preserves property order, so `toEqual` alone would miss order drift). @param queryKey - Key produced by either the SSR builders or the client hooks. @returns The exact cache hash string. @example `hashLikeAppQueryClient([['todo','list']]) // => '{"json":[...],"meta":[]}'` */
@@ -20,24 +21,33 @@ function hashLikeAppQueryClient(queryKey: unknown): string {
 }
 
 describe('home bootstrap query keys', () => {
-  it('hydrates todo data onto the exact key TodoList reads on a default first load', () => {
-    // Arrange — mirror TodoList's inline input construction (retain OFF, no category)
+  it('hydrates todo data onto the exact default-category key TodoList reads on a first visit', () => {
+    // Arrange
     const isRetaining = false
+    const selectedCategoryId = resolveHomeSelectedCategoryId(undefined, [
+      { id: 3, isDefault: true },
+    ])
     const todoListClientKey = orpc.todo.list.queryOptions({
       input: {
         ...(isRetaining ? {} : { completed: false }),
         limit: 100,
         offset: 0,
+        ...(selectedCategoryId !== undefined && {
+          categoryId: selectedCategoryId,
+        }),
       },
     }).queryKey
 
     // Act
-    const ssrKey = getHomeTodoListQueryKey()
+    const ssrKey = getHomeTodoListQueryKey(selectedCategoryId)
 
     // Assert
     expect(ssrKey).toEqual([
       ['todo', 'list'],
-      { input: { completed: false, limit: 100, offset: 0 }, type: 'query' },
+      {
+        input: { completed: false, limit: 100, offset: 0, categoryId: 3 },
+        type: 'query',
+      },
     ])
     expect(hashLikeAppQueryClient(ssrKey)).toBe(
       hashLikeAppQueryClient(todoListClientKey),
@@ -77,7 +87,7 @@ describe('home bootstrap query keys', () => {
     // Arrange — mirror TodoList's input construction with retain mode ON
     // (居残りモード spreads {} instead of { completed: false })
     const isRetaining = true
-    const selectedCategoryId = null
+    const selectedCategoryId = 3
     const todoListClientKey = orpc.todo.list.queryOptions({
       input: {
         ...(isRetaining ? {} : { completed: false }),
@@ -88,12 +98,12 @@ describe('home bootstrap query keys', () => {
     }).queryKey
 
     // Act
-    const ssrKey = getHomeTodoListQueryKey(undefined, true)
+    const ssrKey = getHomeTodoListQueryKey(selectedCategoryId, true)
 
     // Assert
     expect(ssrKey).toEqual([
       ['todo', 'list'],
-      { input: { limit: 100, offset: 0 }, type: 'query' },
+      { input: { limit: 100, offset: 0, categoryId: 3 }, type: 'query' },
     ])
     expect(hashLikeAppQueryClient(ssrKey)).toBe(
       hashLikeAppQueryClient(todoListClientKey),

--- a/src/lib/query/homeBootstrapQueries.ts
+++ b/src/lib/query/homeBootstrapQueries.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/constants/home'
 import { orpc } from '@/lib/orpc/client-query'
 import { getUnfilteredCompletedJournalInput } from '@/lib/utils/getUnfilteredCompletedJournalInput'
+import type { CategoryWithCount } from '@/server/schemas/category'
 import type { HomeBootstrapInput } from '@/server/schemas/home'
 
 /**
@@ -38,6 +39,16 @@ export function buildHomeTodoListInput(
     ...(selectedCategoryId !== null &&
       selectedCategoryId !== undefined && { categoryId: selectedCategoryId }),
   }
+}
+
+/** Resolves the Home category once for SSR, hydration, and the client query so a first visit cannot drift from the default-category cache key. @param selectedCategoryId - Persisted category selection, or null/undefined before the browser has one. @param categories - Hydrated category records containing the default marker. @returns The persisted ID, default category ID, or undefined when no category exists. @example `resolveHomeSelectedCategoryId(undefined, [{ id: 3, isDefault: true }]) // => 3` */
+export function resolveHomeSelectedCategoryId(
+  selectedCategoryId: number | null | undefined,
+  categories: ReadonlyArray<Pick<CategoryWithCount, 'id' | 'isDefault'>>,
+): number | undefined {
+  return (
+    selectedCategoryId ?? categories.find((category) => category.isDefault)?.id
+  )
 }
 
 /** Builds the heatmap input `useHeatmapData` sends for the given zone, keeping SSR writes aligned with the client's `{ days, timezone }` property order. @param timezone - IANA zone the viewer buckets local days by. @returns The canonical heatmap query input. @example `buildHomeHeatmapInput('Asia/Tokyo') // => { days: 365, timezone: 'Asia/Tokyo' }` */

--- a/src/providers/QueryClientProvider.tsx
+++ b/src/providers/QueryClientProvider.tsx
@@ -8,13 +8,19 @@ import * as React from 'react'
 import { useRef, useState } from 'react'
 
 import { useCycleEffect } from '@/hooks/use-cycle-effect'
-import { PERSISTED_QUERY_MAX_AGE_MS } from '@/lib/constants/query'
+import {
+  PERSISTED_QUERY_MAX_AGE_MS,
+  PERSISTED_QUERY_STORAGE_KEY,
+} from '@/lib/constants/query'
 import { createQueryClient } from '@/lib/query/createQueryClient'
 
 /** Creates browser persistence at provider initialization while SSR falls back to memory-only Query state. @returns A localStorage persister in the browser, or undefined on the server. @example `const persister = createPersister()` */
 function createPersister() {
   return typeof window !== 'undefined'
-    ? createSyncStoragePersister({ storage: window.localStorage })
+    ? createSyncStoragePersister({
+        key: PERSISTED_QUERY_STORAGE_KEY,
+        storage: window.localStorage,
+      })
     : undefined
 }
 

--- a/src/server/prefetchHomeBootstrap.test.ts
+++ b/src/server/prefetchHomeBootstrap.test.ts
@@ -187,9 +187,10 @@ describe('prefetchHomeBootstrap', () => {
     expect(queryClient.getQueryData(getHomeCategoryListQueryKey())).toEqual(
       BOOTSTRAP_FIXTURE.category,
     )
-    expect(queryClient.getQueryData(getHomeTodoListQueryKey())).toEqual(
+    expect(queryClient.getQueryData(getHomeTodoListQueryKey(1))).toEqual(
       BOOTSTRAP_FIXTURE.todo,
     )
+    expect(queryClient.getQueryData(getHomeTodoListQueryKey())).toBeUndefined()
     expect(
       queryClient.getQueryData(getHomeHeatmapQueryKey('Asia/Tokyo')),
     ).toEqual(BOOTSTRAP_FIXTURE.heatmap)
@@ -274,7 +275,7 @@ describe('prefetchHomeBootstrap', () => {
     expect(queryClient.getQueryData(getHomeTodoListQueryKey())).toBeUndefined()
   })
 
-  it('treats a garbage category cookie as the All view', async () => {
+  it('lets the bootstrap resolve the default category when the selection cookie is garbage', async () => {
     // Arrange
     mockRequestState({
       cookieTimeZone: 'Asia/Tokyo',
@@ -282,7 +283,7 @@ describe('prefetchHomeBootstrap', () => {
     })
 
     // Act
-    await prefetchHomeBootstrap()
+    const dehydratedState = await prefetchHomeBootstrap()
 
     // Assert
     const [, input] = mockedCall.mock.calls[0] as [
@@ -290,6 +291,13 @@ describe('prefetchHomeBootstrap', () => {
       { todo: Record<string, unknown> },
     ]
     expect(input.todo).toEqual({ completed: false, limit: 100, offset: 0 })
+
+    const queryClient = createQueryClient()
+    hydrate(queryClient, JSON.parse(JSON.stringify(dehydratedState)))
+    expect(queryClient.getQueryData(getHomeTodoListQueryKey(1))).toEqual(
+      BOOTSTRAP_FIXTURE.todo,
+    )
+    expect(queryClient.getQueryData(getHomeTodoListQueryKey())).toBeUndefined()
   })
 
   it('hydrates the retain-mode todo key when the 居残りモード cookie is on', async () => {
@@ -312,9 +320,9 @@ describe('prefetchHomeBootstrap', () => {
     // …and the todo slice landed on the retain-mode key, not the default key
     const queryClient = createQueryClient()
     hydrate(queryClient, JSON.parse(JSON.stringify(dehydratedState)))
-    expect(
-      queryClient.getQueryData(getHomeTodoListQueryKey(undefined, true)),
-    ).toEqual(BOOTSTRAP_FIXTURE.todo)
+    expect(queryClient.getQueryData(getHomeTodoListQueryKey(1, true))).toEqual(
+      BOOTSTRAP_FIXTURE.todo,
+    )
     expect(queryClient.getQueryData(getHomeTodoListQueryKey())).toBeUndefined()
   })
 })

--- a/src/server/prefetchHomeBootstrap.ts
+++ b/src/server/prefetchHomeBootstrap.ts
@@ -17,6 +17,7 @@ import {
   getHomeHeatmapQueryKey,
   getHomeJournalQueryKey,
   getHomeTodoListQueryKey,
+  resolveHomeSelectedCategoryId,
 } from '@/lib/query/homeBootstrapQueries'
 import { bootstrapHome } from '@/server/procedures/home'
 import { ServerTiming } from '@/server/timing/ServerTiming'
@@ -59,8 +60,8 @@ async function resolveViewerTimeZone(): Promise<string> {
 /**
  * Resolves the sidebar category selection this browser will query first, from
  * the cookie `useSelectedCategory` mirrors alongside its localStorage write.
- * Absent/garbage cookie means the All view (matching the hook's own fallback).
- * A deleted-category id only makes the todo slice miss hydration client-side.
+ * Absent/garbage cookie lets the bootstrap and client choose the same default
+ * category. A deleted-category id only makes the todo slice miss hydration.
  * @returns A positive category ID, or undefined for the All view.
  * @example `await resolveViewerSelectedCategoryId() // => 3`
  */
@@ -138,11 +139,15 @@ export async function prefetchHomeBootstrap(): Promise<
         },
       },
     )
+    const selectedCategoryId = resolveHomeSelectedCategoryId(
+      viewerSelectedCategoryId,
+      bootstrap.category.categories,
+    )
 
     const queryClient = createQueryClient()
     queryClient.setQueryData(getHomeCategoryListQueryKey(), bootstrap.category)
     queryClient.setQueryData(
-      getHomeTodoListQueryKey(viewerSelectedCategoryId, viewerRetainCompleted),
+      getHomeTodoListQueryKey(selectedCategoryId, viewerRetainCompleted),
       bootstrap.todo,
     )
     queryClient.setQueryData(

--- a/src/server/procedures/home.test.ts
+++ b/src/server/procedures/home.test.ts
@@ -156,4 +156,69 @@ describeIfDb('home.bootstrap', () => {
       'Visible on the first Home visit',
     ])
   })
+
+  it('shows todos from every category when a first Home visit has no default category', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const user = await prisma.user.create({ data: { clerkId } })
+    const workCategory = await prisma.category.create({
+      data: {
+        color: 'blue',
+        isDefault: false,
+        name: 'Work',
+        userId: user.id,
+      },
+    })
+    const personalCategory = await prisma.category.create({
+      data: {
+        color: 'green',
+        isDefault: false,
+        name: 'Personal',
+        userId: user.id,
+      },
+    })
+    await prisma.todo.createMany({
+      data: [
+        {
+          categoryId: workCategory.id,
+          completed: false,
+          order: 1,
+          text: 'Visible work without a default category',
+          userId: user.id,
+        },
+        {
+          categoryId: personalCategory.id,
+          completed: false,
+          order: 2,
+          text: 'Visible personal without a default category',
+          userId: user.id,
+        },
+      ],
+    })
+
+    // Act
+    const result = await call(
+      bootstrapHome,
+      {
+        heatmap: { days: HOME_HEATMAP_DAYS, timezone: 'UTC' },
+        journal: { limit: COMPLETED_JOURNAL_PAGE_SIZE, offset: 0 },
+        todo: {
+          completed: false,
+          limit: HOME_TODO_QUERY_LIMIT,
+          offset: 0,
+        },
+      },
+      {
+        context: {
+          headers: new Headers({ Authorization: `Bearer ${clerkId}` }),
+        },
+      },
+    )
+
+    // Assert
+    expect(result.todo.todos.map((entry) => entry.text)).toEqual([
+      'Visible work without a default category',
+      'Visible personal without a default category',
+    ])
+  })
 })

--- a/src/server/procedures/home.test.ts
+++ b/src/server/procedures/home.test.ts
@@ -94,4 +94,66 @@ describeIfDb('home.bootstrap', () => {
       'Shipped the bootstrap',
     ])
   })
+
+  it('shows only default-category todos when a first Home visit has no stored selection', async () => {
+    // Arrange
+    const clerkId = freshClerkId()
+    const user = await prisma.user.create({ data: { clerkId } })
+    const defaultCategory = await prisma.category.create({
+      data: {
+        color: 'blue',
+        isDefault: true,
+        name: 'Default Work',
+        userId: user.id,
+      },
+    })
+    const otherCategory = await prisma.category.create({
+      data: {
+        color: 'green',
+        isDefault: false,
+        name: 'Other Work',
+        userId: user.id,
+      },
+    })
+    await prisma.todo.createMany({
+      data: [
+        {
+          categoryId: defaultCategory.id,
+          completed: false,
+          text: 'Visible on the first Home visit',
+          userId: user.id,
+        },
+        {
+          categoryId: otherCategory.id,
+          completed: false,
+          text: 'Hidden until the other category is selected',
+          userId: user.id,
+        },
+      ],
+    })
+
+    // Act
+    const result = await call(
+      bootstrapHome,
+      {
+        heatmap: { days: HOME_HEATMAP_DAYS, timezone: 'UTC' },
+        journal: { limit: COMPLETED_JOURNAL_PAGE_SIZE, offset: 0 },
+        todo: {
+          completed: false,
+          limit: HOME_TODO_QUERY_LIMIT,
+          offset: 0,
+        },
+      },
+      {
+        context: {
+          headers: new Headers({ Authorization: `Bearer ${clerkId}` }),
+        },
+      },
+    )
+
+    // Assert
+    expect(result.todo.todos.map((entry) => entry.text)).toEqual([
+      'Visible on the first Home visit',
+    ])
+  })
 })

--- a/src/server/procedures/home.ts
+++ b/src/server/procedures/home.ts
@@ -1,5 +1,7 @@
 import { call } from '@orpc/server'
 
+import { resolveHomeSelectedCategoryId } from '@/lib/query/homeBootstrapQueries'
+
 import { authMiddleware } from '../middleware/auth'
 import {
   HomeBootstrapInputSchema,
@@ -10,18 +12,46 @@ import { listCategories } from './category'
 import { getHeatmap, getJournal } from './completed'
 import { listTodos } from './todo'
 
-/** Resolves the four critical Home regions concurrently after one auth/connection/user phase whenever SSR or `home.bootstrap` calls it. @returns Category, Todo, heatmap, and journal payloads ready for their existing Query cache keys. @example `await call(bootstrapHome, input, { context: { headers } })` */
+/** Resolves the four critical Home regions after one auth phase, making a first visit use its default category before TodoList mounts. @returns Category, Todo, heatmap, and journal payloads ready for their existing Query cache keys. @example `await call(bootstrapHome, input, { context: { headers } })` */
 export const bootstrapHome = authMiddleware
   .input(HomeBootstrapInputSchema)
   .output(HomeBootstrapResponseSchema)
   .handler(async ({ context, input }) => {
     return context.serverTiming.measure('sql', async () => {
-      // Each child receives the already-resolved user, so its auth middleware performs no additional database work.
+      // Start the independent regions immediately so resolving a fresh browser's
+      // default category delays only its Todo slice.
+      const categoryPromise = call(listCategories, undefined, { context })
+      const heatmapPromise = call(getHeatmap, input.heatmap, { context })
+      const journalPromise = call(getJournal, input.journal, { context })
+
+      const todoPromise =
+        input.todo.categoryId === undefined
+          ? categoryPromise.then(async (category) => {
+              // A first visit has no category cookie yet, so use the same
+              // default Category will persist after hydration.
+              const selectedCategoryId = resolveHomeSelectedCategoryId(
+                undefined,
+                category.categories,
+              )
+              return call(
+                listTodos,
+                {
+                  ...input.todo,
+                  ...(selectedCategoryId !== undefined && {
+                    categoryId: selectedCategoryId,
+                  }),
+                },
+                { context },
+              )
+            })
+          : call(listTodos, input.todo, { context })
+
+      // Child procedures reuse the resolved user, avoiding repeated auth DB work.
       const [category, todo, heatmap, journal] = await Promise.all([
-        call(listCategories, undefined, { context }),
-        call(listTodos, input.todo, { context }),
-        call(getHeatmap, input.heatmap, { context }),
-        call(getJournal, input.journal, { context }),
+        categoryPromise,
+        todoPromise,
+        heatmapPromise,
+        journalPromise,
       ])
 
       return { category, todo, heatmap, journal }


### PR DESCRIPTION
## Summary

- align the first Home bootstrap with the hydrated default category so a browser with no selection makes zero initial oRPC requests
- share the canonical Todo input and persisted-query key across SSR, React Query, optimistic mutations, and E2E
- mutate the final oRPC response and add a Vercel-safe timing mirror so production measurements remain observable when the platform filters the standard header name

## Context

Follow-up to #155 and #153. The post-merge production audit found two acceptance gaps: a first browser visit made one `todo.list` request after hydration, and the deployed response did not expose `Server-Timing` even though the route recorded the phases.

## QA

- `pnpm validate` — 804 unit tests passed; package tests, lint, build, typecheck, and theme check passed
- `RUN_DB_INTEGRATION_TESTS=1 pnpm exec vitest run src/server/procedures/home.test.ts` — 2 passed
- `pnpm e2e:web e2e/web/home-bootstrap.spec.ts` — Clerk setup + focused Home E2E passed
- local Chrome QA — default `General` active, all Home regions rendered, zero initial `/api/orpc` requests

## Preview evidence

- latest Vercel Preview (`dpl_9fVtaiV53ydNq614MWicZsA8unHe`) returned `X-Corelive-Server-Timing: auth;dur=0.06, total;dur=8.01`
- the same response omitted standard `Server-Timing`, proving Vercel filters that header name after the route while preserving custom response headers

## Merge gate

- complete CodeRabbit review resolution and all required CI checks before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * Home初回表示でデフォルトカテゴリの未完了Todoが正しく反映されます。
  * 保存済み選択がない／不正でも適切なカテゴリへ自動解決し、カテゴリ確定前はTodo追加を無効化します。
  * 完了・未完了の切り替えが表示と同期し、状態戻しも安定して確認できるようになりました。
* **テスト/信頼性**
  * Todo完了切替E2Eをより確実にし、サーバータイミングヘッダの付与検証も強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->