### PR TITLE
feat(electron): allow two toggle keys for BrainDump

### DIFF
--- a/e2e/electron/braindump-window.spec.ts
+++ b/e2e/electron/braindump-window.spec.ts
@@ -131,3 +131,45 @@ test('updating braindump sync mode persists without error', async () => {
   // Assert: IPC handler returns true on success
   expect(result).toBe(true)
 })
+
+test('a second toggle key can be bound alongside the first', async () => {
+  // Arrange: a chord no other slot holds
+  const secondKey = 'Control+Shift+B'
+
+  // Act
+  const boundSecondKey = await settingsWindow.evaluate(async (accelerator) => {
+    const setFn = window.electronAPI?.brainDump?.setShortcutSecondary
+    const getFn = window.electronAPI?.brainDump?.getShortcutSecondary
+    if (!setFn || !getFn) {
+      throw new Error('brainDump second-slot methods not in preload bridge')
+    }
+    await setFn(accelerator)
+    return getFn()
+  }, secondKey)
+
+  // Assert: the second slot is live and reads back exactly what was requested
+  expect(boundSecondKey).toBe('Control+Shift+B')
+})
+
+test('the second toggle key cannot duplicate the first', async () => {
+  // Arrange: bind both slots to distinct keys, then aim the second at the first
+  const rebind = await settingsWindow.evaluate(async () => {
+    const brainDump = window.electronAPI?.brainDump
+    if (!brainDump?.setShortcutSecondary || !brainDump?.getShortcutSecondary) {
+      throw new Error('brainDump second-slot methods not in preload bridge')
+    }
+    await brainDump.setShortcut('Alt+Space')
+    await brainDump.setShortcutSecondary('Control+Shift+B')
+
+    // Act: ask the second slot for the key the first one already holds
+    const didAcceptDuplicate = await brainDump.setShortcutSecondary('Alt+Space')
+    return {
+      didAcceptDuplicate,
+      secondKeyAfterwards: await brainDump.getShortcutSecondary(),
+    }
+  })
+
+  // Assert: rejected, and the previously bound second key is left untouched
+  expect(rebind.didAcceptDuplicate).toBe(false)
+  expect(rebind.secondKeyAfterwards).toBe('Control+Shift+B')
+})

--- a/electron/ConfigManager.ts
+++ b/electron/ConfigManager.ts
@@ -97,7 +97,11 @@ export interface BrainDumpConfig {
   opacity: number
   /** When true, BrainDump mirrors FloatingNavigator's selected category. */
   syncMode: boolean
-  /** Global accelerator string; empty disables the shortcut. */
+  /**
+   * @deprecated Legacy mirror with no readers — the live BrainDump toggle keys
+   * are `shortcuts.toggleBrainDump` / `shortcuts.toggleBrainDumpSecondary`.
+   * Kept only so existing config.json files keep validating.
+   */
   shortcut: string
   /**
    * Last category id BrainDump showed (used as the source of truth across
@@ -129,6 +133,8 @@ interface ShortcutsConfig {
   focusFloatingNavigator: string
   toggleFloatingNavigator: string
   toggleBrainDump: string
+  /** Optional second key for the same BrainDump toggle; empty disables it. */
+  toggleBrainDumpSecondary: string
 }
 
 /** Notifications configuration */
@@ -359,6 +365,7 @@ export class ConfigManager {
         focusFloatingNavigator: `${modifier}+Shift+N`,
         toggleFloatingNavigator: `${modifier}+3`,
         toggleBrainDump: 'Alt+Space',
+        toggleBrainDumpSecondary: '',
       },
 
       notifications: {

--- a/electron/ConfigManager.ts
+++ b/electron/ConfigManager.ts
@@ -976,7 +976,11 @@ export class ConfigManager {
     // Validate shortcuts
     if (this.config.shortcuts) {
       const shortcutValues = Object.entries(this.config.shortcuts)
-        .filter(([, value]) => typeof value === 'string')
+        // An empty accelerator means "disabled", and any number of shortcuts
+        // may be disabled at once — counting those as duplicates of each other
+        // would reject a perfectly valid config on import. `toggleBrainDump-
+        // Secondary` ships empty, so a single other disabled key would trip it.
+        .filter(([, value]) => typeof value === 'string' && value !== '')
         .map(([, value]) => value as string)
 
       const duplicates = shortcutValues.filter(

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -11,6 +11,7 @@ import { BrowserWindow, globalShortcut } from 'electron'
 
 import type { ConfigManager } from './ConfigManager'
 import {
+  BRAIN_DUMP_SHORTCUT_IDS,
   DEFAULT_SHORTCUT_OPEN_SOUND_ENABLED,
   DEFAULT_SHORTCUT_OPEN_SOUND_SELECTION,
   isShortcutOpenSoundSelection,
@@ -47,6 +48,8 @@ interface ShortcutConfig {
   toggleFloatingNavigator?: string
   /** BrainDump's global quick-open accelerator; empty string disables it. */
   toggleBrainDump?: string
+  /** Second, equally-live BrainDump accelerator; empty string (the default) disables it. */
+  toggleBrainDumpSecondary?: string
   [key: string]: string | boolean | undefined
 }
 
@@ -180,7 +183,7 @@ export class ShortcutManager {
     ])
     this._globalShortcuts = new Set([
       'toggleFloatingNavigator',
-      'toggleBrainDump',
+      ...BRAIN_DUMP_SHORTCUT_IDS,
     ])
     this.focusHandlers = new Map()
 
@@ -235,6 +238,9 @@ export class ShortcutManager {
       toggleAlwaysOnTop: 'CommandOrControl+Shift+A',
       toggleFloatingNavigator: 'CommandOrControl+3',
       toggleBrainDump: 'Alt+Space',
+      // Second BrainDump slot ships unbound — an opt-in extra key, not a
+      // preset that would silently claim a chord the user never chose.
+      toggleBrainDumpSecondary: '',
     }
   }
 
@@ -381,20 +387,19 @@ export class ShortcutManager {
       ),
     })
 
-    // Honor the persisted BrainDump accelerator on startup. Empty string is
-    // the "disabled" sentinel used by Settings, so skip registration in that
-    // case to avoid binding "" as an accelerator.
-    const brainDumpAccel = shortcuts.toggleBrainDump
-    if (typeof brainDumpAccel === 'string' && brainDumpAccel.trim() !== '') {
+    // Honor the persisted BrainDump accelerators on startup — both slots, same
+    // handler. Empty string is the "disabled" sentinel used by Settings (and the
+    // default for the second slot), so skip those to avoid binding "".
+    for (const id of BRAIN_DUMP_SHORTCUT_IDS) {
+      const brainDumpAccel = shortcuts[id]
+      if (typeof brainDumpAccel !== 'string' || brainDumpAccel.trim() === '') {
+        continue
+      }
       results.push({
-        id: 'toggleBrainDump',
-        success: this.registerShortcut(
-          brainDumpAccel,
-          'toggleBrainDump',
-          () => {
-            this.handleToggleBrainDump()
-          },
-        ),
+        id,
+        success: this.registerShortcut(brainDumpAccel, id, () => {
+          this.handleToggleBrainDump()
+        }),
       })
     }
 
@@ -901,6 +906,7 @@ export class ShortcutManager {
       focusFloatingNavigator: 'Focus Floating Navigator',
       toggleFloatingNavigator: 'Toggle Floating Navigator',
       toggleBrainDump: 'Toggle BrainDump',
+      toggleBrainDumpSecondary: 'Toggle BrainDump (second key)',
     }
 
     return displayNames[id] || id
@@ -1210,7 +1216,9 @@ export class ShortcutManager {
       toggleAlwaysOnTop: () => this.handleToggleAlwaysOnTop(),
       focusFloatingNavigator: () => this.handleFocusFloatingNavigator(),
       toggleFloatingNavigator: () => this.handleToggleFloatingNavigator(),
+      // Both BrainDump slots route to the same toggle.
       toggleBrainDump: () => this.handleToggleBrainDump(),
+      toggleBrainDumpSecondary: () => this.handleToggleBrainDump(),
     }
 
     return handlers[id]

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -1201,6 +1201,19 @@ export class ShortcutManager {
       // that as an outside conflict and silently substitutes a fallback.
       for (const [id, accelerator] of Object.entries(newShortcuts)) {
         if (id === 'enabled' || typeof accelerator !== 'string') continue
+
+        // A full settings save carries EVERY id, contextual ones included, and
+        // pass 2 deliberately never re-registers those (they belong to a focus
+        // listener). Dropping one whose accelerator did not change would kill it
+        // until the next blur→focus. One that DID change still has to go, or the
+        // stale accelerator keeps firing until then.
+        if (
+          this.contextualShortcuts.has(id) &&
+          this.registeredShortcuts.get(id)?.accelerator === accelerator
+        ) {
+          continue
+        }
+
         if (this.registeredShortcuts.has(id)) {
           this.unregisterShortcut(id)
         }

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -1193,14 +1193,22 @@ export class ShortcutManager {
       // like success to callers who use this return value to roll back.
       let allRegistered = true
 
+      // Pass 1 — drop the old registration of EVERY id in the batch before
+      // registering any of them, so the new accelerator (or empty string =
+      // disabled) takes effect. Doing this per-id inside the register loop made
+      // a batch collide with itself: swapping two accelerators would still find
+      // the second id holding the first's new key, and `registerShortcut` reads
+      // that as an outside conflict and silently substitutes a fallback.
       for (const [id, accelerator] of Object.entries(newShortcuts)) {
         if (id === 'enabled' || typeof accelerator !== 'string') continue
-
-        // Always drop the old registration first so the new accelerator
-        // (or empty string = disabled) takes effect.
         if (this.registeredShortcuts.has(id)) {
           this.unregisterShortcut(id)
         }
+      }
+
+      // Pass 2 — bind the new accelerators.
+      for (const [id, accelerator] of Object.entries(newShortcuts)) {
+        if (id === 'enabled' || typeof accelerator !== 'string') continue
 
         if (accelerator === '') continue
 

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -30,6 +30,7 @@ import {
   ShortcutOpenSoundPlayer,
   type ShortcutOpenSoundController,
 } from './ShortcutOpenSoundPlayer'
+import { isSameAccelerator } from './utils/isSameAccelerator'
 import { openWebAppInBrowser } from './utils/openWebAppInBrowser'
 import type { WindowManager } from './WindowManager'
 
@@ -1163,11 +1164,7 @@ export class ShortcutManager {
       const [primarySlotId, secondarySlotId] = BRAIN_DUMP_SHORTCUT_IDS
       const mergedShortcuts = { ...this.shortcuts, ...newShortcuts }
       const mergedPrimary = mergedShortcuts[primarySlotId]
-      if (
-        typeof mergedPrimary === 'string' &&
-        mergedPrimary !== '' &&
-        mergedPrimary === mergedShortcuts[secondarySlotId]
-      ) {
+      if (isSameAccelerator(mergedPrimary, mergedShortcuts[secondarySlotId])) {
         log.warn(
           `Rejected shortcut update: both BrainDump toggle slots would bind ${mergedPrimary}`,
         )
@@ -1216,9 +1213,8 @@ export class ShortcutManager {
         const registration = this.registeredShortcuts.get(id)
         if (
           this.contextualShortcuts.has(id) &&
-          registration !== undefined &&
-          (accelerator === registration.accelerator ||
-            accelerator === registration.originalAccelerator)
+          (isSameAccelerator(accelerator, registration?.accelerator) ||
+            isSameAccelerator(accelerator, registration?.originalAccelerator))
         ) {
           continue
         }

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -1146,9 +1146,34 @@ export class ShortcutManager {
    *
    * Empty-string accelerators are treated as "disable this shortcut" — the
    * old binding is removed and nothing is registered in its place.
+   *
+   * Rejects (without applying anything) a batch that would leave both BrainDump
+   * toggle slots on one accelerator.
    */
   updateShortcuts(newShortcuts: ShortcutConfig): boolean {
     try {
+      // Guard the merged result, not the payload: the generic Shortcut Settings
+      // screen submits EVERY registered id — including the second BrainDump slot,
+      // which has no row there — so a user rebinding the visible "Toggle
+      // BrainDump" row onto the second slot's key would otherwise land both on
+      // one accelerator. Both registrars mishandle that: a chord trips
+      // handleShortcutConflict (silent fallback substitution), and the native tap
+      // keys bindings by keycode, so the second bind orphans the first. Checking
+      // the merge (rather than payload-vs-current) still allows swapping the two.
+      const [primarySlotId, secondarySlotId] = BRAIN_DUMP_SHORTCUT_IDS
+      const mergedShortcuts = { ...this.shortcuts, ...newShortcuts }
+      const mergedPrimary = mergedShortcuts[primarySlotId]
+      if (
+        typeof mergedPrimary === 'string' &&
+        mergedPrimary !== '' &&
+        mergedPrimary === mergedShortcuts[secondarySlotId]
+      ) {
+        log.warn(
+          `Rejected shortcut update: both BrainDump toggle slots would bind ${mergedPrimary}`,
+        )
+        return false
+      }
+
       const wasEnabled = this.isEnabled
       // Sync isEnabled if provided in newShortcuts
       if (typeof newShortcuts.enabled === 'boolean') {

--- a/electron/ShortcutManager.ts
+++ b/electron/ShortcutManager.ts
@@ -1207,9 +1207,18 @@ export class ShortcutManager {
         // listener). Dropping one whose accelerator did not change would kill it
         // until the next blur→focus. One that DID change still has to go, or the
         // stale accelerator keeps firing until then.
+        //
+        // "Unchanged" has to accept BOTH sides of a conflict substitution: the
+        // settings screen submits what is live (`accelerator`), while a caller
+        // reading persisted config submits what was asked for
+        // (`originalAccelerator`). Comparing against only one of them unregisters
+        // the shortcut on every save made by the other caller.
+        const registration = this.registeredShortcuts.get(id)
         if (
           this.contextualShortcuts.has(id) &&
-          this.registeredShortcuts.get(id)?.accelerator === accelerator
+          registration !== undefined &&
+          (accelerator === registration.accelerator ||
+            accelerator === registration.originalAccelerator)
         ) {
           continue
         }

--- a/electron/__tests__/ConfigManager.shortcut-validation.test.ts
+++ b/electron/__tests__/ConfigManager.shortcut-validation.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Shortcut duplicate-detection tests for `ConfigManager.validate()`.
+ *
+ * Locks the rule that an EMPTY accelerator means "disabled" and never counts as a
+ * duplicate of another disabled shortcut — otherwise `importConfig()` rejects a
+ * perfectly valid file. `toggleBrainDumpSecondary` ships empty, so one other
+ * disabled key would be enough to trip the false positive.
+ *
+ * Triggered when: `pnpm test:electron` (Vitest).
+ *
+ * @example
+ *   pnpm test:electron -- ConfigManager.shortcut-validation
+ */
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// A mutable holder so the hoisted electron mock resolves a fresh temp userData
+// directory per test (vi.mock factories cannot close over later-declared vars).
+const userDataDir = vi.hoisted(() => ({ current: '' }))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => userDataDir.current),
+  },
+}))
+
+// Silence the real pino logger so config-load warnings never spew into output.
+vi.mock('../logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+// Imported after the mock so ConfigManager's `import { app }` is stubbed.
+import { ConfigManager } from '../ConfigManager'
+
+describe('ConfigManager shortcut validation', () => {
+  beforeEach(() => {
+    // Arrange: isolate every test in its own temp userData directory.
+    userDataDir.current = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'corelive-config-'),
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(userDataDir.current, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it('accepts a config where more than one shortcut is disabled', () => {
+    // Arrange: the second BrainDump slot ships disabled; the user disables one
+    // more key. Two empty strings must not read as a duplicated accelerator.
+    const configManager = new ConfigManager()
+    configManager.set('shortcuts.toggleBrainDumpSecondary', '')
+    configManager.set('shortcuts.toggleAlwaysOnTop', '')
+
+    // Act
+    const result = configManager.validate()
+
+    // Assert
+    expect(result.errors).toEqual([])
+    expect(result.isValid).toBe(true)
+  })
+
+  it('still reports two shortcuts sharing one accelerator', () => {
+    // Arrange
+    const configManager = new ConfigManager()
+    configManager.set('shortcuts.toggleBrainDump', 'Alt+Space')
+    configManager.set('shortcuts.toggleAlwaysOnTop', 'Alt+Space')
+
+    // Act
+    const result = configManager.validate()
+
+    // Assert
+    expect(result.isValid).toBe(false)
+    expect(result.errors).toContain('Duplicate shortcuts found: Alt+Space')
+  })
+})

--- a/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
+++ b/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
@@ -12,13 +12,31 @@ import type { WindowManager } from '../WindowManager'
  * stopped opening BrainDump" with nothing in the logs.
  */
 
+/**
+ * Accelerators currently held at the "OS" level. The mock is STATEFUL on
+ * purpose: a stateless `register: () => true` would report success for a batch
+ * that re-binds an accelerator the batch itself still holds, hiding exactly the
+ * self-collision these specs exist to catch.
+ */
+const heldAccelerators = vi.hoisted(() => new Set<string>())
+
 vi.mock('electron', () => ({
   BrowserWindow: vi.fn(),
   globalShortcut: {
-    isRegistered: vi.fn(() => false),
-    register: vi.fn(() => true),
-    unregister: vi.fn(),
-    unregisterAll: vi.fn(),
+    isRegistered: vi.fn((accelerator: string) =>
+      heldAccelerators.has(accelerator),
+    ),
+    register: vi.fn((accelerator: string) => {
+      if (heldAccelerators.has(accelerator)) return false
+      heldAccelerators.add(accelerator)
+      return true
+    }),
+    unregister: vi.fn((accelerator: string) => {
+      heldAccelerators.delete(accelerator)
+    }),
+    unregisterAll: vi.fn(() => {
+      heldAccelerators.clear()
+    }),
   },
 }))
 
@@ -62,6 +80,7 @@ function createConfigManagerStub(
 describe('BrainDump two-slot toggle shortcuts', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    heldAccelerators.clear()
   })
 
   it('opens BrainDump from either of the two configured toggle keys', () => {
@@ -131,8 +150,9 @@ describe('BrainDump two-slot toggle shortcuts', () => {
   })
 
   it('still lets the two toggle keys swap accelerators in one save', () => {
-    // Arrange: a swap ends with two DIFFERENT keys, so the duplicate guard must
-    // not reject it just because each new value collides with the current other.
+    // Arrange: a swap ends with two DIFFERENT keys, so it must survive both the
+    // duplicate guard AND the batch's own live registrations — the key each slot
+    // moves onto is still held by the other slot when the batch starts.
     const { windowManager } = createWindowManagerHarness()
     const shortcutManager = new ShortcutManager(
       windowManager,

--- a/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
+++ b/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
@@ -229,9 +229,11 @@ describe('BrainDump two-slot toggle shortcuts', () => {
       }),
     )
     shortcutManager.registerContextualShortcuts()
-    const substituted = shortcutManager.getRegisteredShortcuts().newTask
-    expect(substituted).not.toBe('CommandOrControl+N')
-    expect(substituted).toBeDefined()
+    // Hard-coded so a change in the alternative-generation order is caught here
+    // rather than silently shifting which key the user ends up with.
+    expect(shortcutManager.getRegisteredShortcuts().newTask).toBe(
+      'CommandOrControl+Alt+N',
+    )
 
     // Act: save an unrelated global key, resubmitting newTask's configured value.
     shortcutManager.updateShortcuts({
@@ -240,7 +242,33 @@ describe('BrainDump two-slot toggle shortcuts', () => {
     })
 
     // Assert: the fallback survives untouched.
-    expect(shortcutManager.getRegisteredShortcuts().newTask).toBe(substituted)
+    expect(shortcutManager.getRegisteredShortcuts().newTask).toBe(
+      'CommandOrControl+Alt+N',
+    )
+  })
+
+  it('refuses a duplicate toggle key typed in a different case', () => {
+    // Arrange: Electron accelerators are case-insensitive, so `alt+space` and
+    // `Alt+Space` are the same key — a config edited by hand must not sneak both
+    // slots onto it past the duplicate guard.
+    const { windowManager } = createWindowManagerHarness()
+    const shortcutManager = new ShortcutManager(
+      windowManager,
+      null,
+      createConfigManagerStub({ toggleBrainDump: 'Alt+Space' }),
+    )
+    shortcutManager.registerGlobalShortcuts()
+
+    // Act
+    const didUpdate = shortcutManager.updateShortcuts({
+      toggleBrainDumpSecondary: ' alt+space ',
+    })
+
+    // Assert
+    expect(didUpdate).toBe(false)
+    expect(
+      shortcutManager.getRegisteredShortcuts().toggleBrainDumpSecondary,
+    ).toBeUndefined()
   })
 
   it('leaves the second toggle key unbound until the user sets one', () => {

--- a/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
+++ b/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
@@ -99,6 +99,67 @@ describe('BrainDump two-slot toggle shortcuts', () => {
     expect(toggleBrainDump).toHaveBeenCalledTimes(2)
   })
 
+  it('refuses a settings save that would point both toggle keys at one key', () => {
+    // Arrange: the generic Shortcut Settings screen submits every registered id,
+    // including the second slot (which has no row there), so a user rebinding the
+    // visible "Toggle BrainDump" row onto the second slot's key arrives as a
+    // duplicate batch. Accepting it would orphan one of the two bindings.
+    const { windowManager } = createWindowManagerHarness()
+    const shortcutManager = new ShortcutManager(
+      windowManager,
+      null,
+      createConfigManagerStub({
+        toggleBrainDump: 'Alt+Space',
+        toggleBrainDumpSecondary: 'Control+Shift+B',
+      }),
+    )
+    shortcutManager.registerGlobalShortcuts()
+    globalRegisterMock.mockClear()
+
+    // Act
+    const didUpdate = shortcutManager.updateShortcuts({
+      toggleBrainDump: 'Control+Shift+B',
+      toggleBrainDumpSecondary: 'Control+Shift+B',
+    })
+
+    // Assert: rejected outright, and nothing was re-registered along the way.
+    expect(didUpdate).toBe(false)
+    expect(globalRegisterMock).not.toHaveBeenCalled()
+    expect(shortcutManager.getRegisteredShortcuts().toggleBrainDump).toBe(
+      'Alt+Space',
+    )
+  })
+
+  it('still lets the two toggle keys swap accelerators in one save', () => {
+    // Arrange: a swap ends with two DIFFERENT keys, so the duplicate guard must
+    // not reject it just because each new value collides with the current other.
+    const { windowManager } = createWindowManagerHarness()
+    const shortcutManager = new ShortcutManager(
+      windowManager,
+      null,
+      createConfigManagerStub({
+        toggleBrainDump: 'Alt+Space',
+        toggleBrainDumpSecondary: 'Control+Shift+B',
+      }),
+    )
+    shortcutManager.registerGlobalShortcuts()
+
+    // Act
+    const didUpdate = shortcutManager.updateShortcuts({
+      toggleBrainDump: 'Control+Shift+B',
+      toggleBrainDumpSecondary: 'Alt+Space',
+    })
+
+    // Assert
+    expect(didUpdate).toBe(true)
+    expect(shortcutManager.getRegisteredShortcuts().toggleBrainDump).toBe(
+      'Control+Shift+B',
+    )
+    expect(
+      shortcutManager.getRegisteredShortcuts().toggleBrainDumpSecondary,
+    ).toBe('Alt+Space')
+  })
+
   it('leaves the second toggle key unbound until the user sets one', () => {
     // Arrange
     const { windowManager } = createWindowManagerHarness()

--- a/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
+++ b/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
@@ -180,6 +180,39 @@ describe('BrainDump two-slot toggle shortcuts', () => {
     ).toBe('Alt+Space')
   })
 
+  it('keeps an already-registered contextual shortcut alive when only a global key changes', () => {
+    // Arrange: a settings save carries EVERY id, so the untouched contextual
+    // `newTask` rides along. Pass 2 never re-registers contextual shortcuts, so
+    // unregistering it here would leave Cmd+N dead until the next blur→focus.
+    const { windowManager } = createWindowManagerHarness()
+    const shortcutManager = new ShortcutManager(
+      windowManager,
+      null,
+      createConfigManagerStub({
+        newTask: 'CommandOrControl+N',
+        toggleBrainDump: 'Alt+Space',
+      }),
+    )
+    shortcutManager.registerContextualShortcuts()
+    expect(shortcutManager.getRegisteredShortcuts().newTask).toBe(
+      'CommandOrControl+N',
+    )
+
+    // Act: rebind only the BrainDump key; newTask is resubmitted unchanged.
+    shortcutManager.updateShortcuts({
+      newTask: 'CommandOrControl+N',
+      toggleBrainDump: 'Control+Shift+B',
+    })
+
+    // Assert
+    expect(shortcutManager.getRegisteredShortcuts().newTask).toBe(
+      'CommandOrControl+N',
+    )
+    expect(shortcutManager.getRegisteredShortcuts().toggleBrainDump).toBe(
+      'Control+Shift+B',
+    )
+  })
+
   it('leaves the second toggle key unbound until the user sets one', () => {
     // Arrange
     const { windowManager } = createWindowManagerHarness()

--- a/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
+++ b/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
@@ -213,6 +213,36 @@ describe('BrainDump two-slot toggle shortcuts', () => {
     )
   })
 
+  it('keeps a conflict-substituted contextual shortcut alive across a global save', () => {
+    // Arrange: another app already owns Cmd+N, so newTask lands on a fallback
+    // accelerator. A caller that submits the CONFIGURED value (what the user
+    // asked for) must still read as "unchanged" — otherwise every unrelated save
+    // silently unregisters the fallback that is actually doing the work.
+    heldAccelerators.add('CommandOrControl+N')
+    const { windowManager } = createWindowManagerHarness()
+    const shortcutManager = new ShortcutManager(
+      windowManager,
+      null,
+      createConfigManagerStub({
+        newTask: 'CommandOrControl+N',
+        toggleBrainDump: 'Alt+Space',
+      }),
+    )
+    shortcutManager.registerContextualShortcuts()
+    const substituted = shortcutManager.getRegisteredShortcuts().newTask
+    expect(substituted).not.toBe('CommandOrControl+N')
+    expect(substituted).toBeDefined()
+
+    // Act: save an unrelated global key, resubmitting newTask's configured value.
+    shortcutManager.updateShortcuts({
+      newTask: 'CommandOrControl+N',
+      toggleBrainDump: 'Control+Shift+B',
+    })
+
+    // Assert: the fallback survives untouched.
+    expect(shortcutManager.getRegisteredShortcuts().newTask).toBe(substituted)
+  })
+
   it('leaves the second toggle key unbound until the user sets one', () => {
     // Arrange
     const { windowManager } = createWindowManagerHarness()

--- a/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
+++ b/electron/__tests__/ShortcutManager.brainDumpTwoSlots.test.ts
@@ -1,0 +1,123 @@
+import { globalShortcut } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ConfigManager } from '../ConfigManager'
+import ShortcutManager from '../ShortcutManager'
+import type { WindowManager } from '../WindowManager'
+
+/**
+ * BrainDump can be bound to TWO keys at once (`toggleBrainDump` +
+ * `toggleBrainDumpSecondary`, one shared handler). These specs fail if the
+ * registration loop ever drops a slot — which would look like "my second key
+ * stopped opening BrainDump" with nothing in the logs.
+ */
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  globalShortcut: {
+    isRegistered: vi.fn(() => false),
+    register: vi.fn(() => true),
+    unregister: vi.fn(),
+    unregisterAll: vi.fn(),
+  },
+}))
+
+const globalRegisterMock = vi.mocked(globalShortcut.register)
+
+/**
+ * Builds a WindowManager stand-in whose BrainDump toggle is a spy, so a test can
+ * prove a registered accelerator actually reaches the BrainDump window.
+ * @returns The stub plus its `toggleBrainDump` spy.
+ * @example
+ * const { windowManager, toggleBrainDump } = createWindowManagerHarness()
+ */
+function createWindowManagerHarness() {
+  const toggleBrainDump = vi.fn(() => true)
+  const windowManager = {
+    getFloatingNavigator: vi.fn(() => null),
+    toggleBrainDump,
+    toggleFloatingNavigator: vi.fn(),
+    setOnFloatingNavigatorCreated: vi.fn(),
+  } as unknown as WindowManager
+  return { windowManager, toggleBrainDump }
+}
+
+/**
+ * Builds a ConfigManager stand-in that serves one persisted `shortcuts` section.
+ * @param shortcuts - The persisted `shortcuts.*` values the manager should load.
+ * @returns A ConfigManager-compatible stub.
+ * @example
+ * createConfigManagerStub({ toggleBrainDump: 'Alt+Space' })
+ */
+function createConfigManagerStub(
+  shortcuts: Record<string, string | boolean>,
+): ConfigManager {
+  return {
+    getSection: vi.fn(() => ({ enabled: true, ...shortcuts })),
+    get: vi.fn(() => undefined),
+    set: vi.fn(),
+  } as unknown as ConfigManager
+}
+
+describe('BrainDump two-slot toggle shortcuts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens BrainDump from either of the two configured toggle keys', () => {
+    // Arrange
+    const { windowManager, toggleBrainDump } = createWindowManagerHarness()
+    const shortcutManager = new ShortcutManager(
+      windowManager,
+      null,
+      createConfigManagerStub({
+        toggleBrainDump: 'Alt+Space',
+        toggleBrainDumpSecondary: 'Control+Shift+B',
+      }),
+    )
+
+    // Act
+    shortcutManager.registerGlobalShortcuts()
+
+    // Assert — both accelerators are live…
+    expect(globalRegisterMock).toHaveBeenCalledWith(
+      'Alt+Space',
+      expect.any(Function),
+    )
+    expect(globalRegisterMock).toHaveBeenCalledWith(
+      'Control+Shift+B',
+      expect.any(Function),
+    )
+
+    // …and both fire the same BrainDump toggle.
+    for (const accelerator of ['Alt+Space', 'Control+Shift+B']) {
+      const call = globalRegisterMock.mock.calls.find(
+        ([registered]) => registered === accelerator,
+      )
+      call?.[1]()
+    }
+    expect(toggleBrainDump).toHaveBeenCalledTimes(2)
+  })
+
+  it('leaves the second toggle key unbound until the user sets one', () => {
+    // Arrange
+    const { windowManager } = createWindowManagerHarness()
+    const shortcutManager = new ShortcutManager(
+      windowManager,
+      null,
+      createConfigManagerStub({ toggleBrainDump: 'Alt+Space' }),
+    )
+
+    // Act
+    shortcutManager.registerGlobalShortcuts()
+
+    // Assert — the empty second slot must never reach globalShortcut as ''
+    expect(shortcutManager.getDefaultShortcuts().toggleBrainDumpSecondary).toBe(
+      '',
+    )
+    expect(globalRegisterMock).not.toHaveBeenCalledWith('', expect.anything())
+    expect(shortcutManager.getRegisteredShortcuts()).not.toHaveProperty(
+      'toggleBrainDumpSecondary',
+    )
+  })
+})

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -234,6 +234,26 @@ export const SHORTCUT_OPEN_SOUND_VOLUME_RATIO = 0.55
 export const SHORTCUT_OPEN_SOUND_ASSET_DIRECTORY = 'shortcut-opening'
 
 // ============================================================================
+// BrainDump toggle shortcut slots
+// ============================================================================
+
+/**
+ * Both BrainDump toggle slots, in display order. Two shortcut ids share ONE
+ * handler so BrainDump is reachable from two different keys (e.g. a chord plus a
+ * lone modifier); everything else — registration, conflict rollback, unregister
+ * — is the existing per-id machinery. Lives here (not in `ShortcutManager`) so
+ * `main.ts` can import it as a VALUE without eagerly loading the deferred
+ * ShortcutManager module.
+ */
+export const BRAIN_DUMP_SHORTCUT_IDS = [
+  'toggleBrainDump',
+  'toggleBrainDumpSecondary',
+] as const
+
+/** One of the two BrainDump toggle slot ids. */
+export type BrainDumpShortcutId = (typeof BRAIN_DUMP_SHORTCUT_IDS)[number]
+
+// ============================================================================
 // Native key-tap freeze-safety (#125)
 // ============================================================================
 

--- a/electron/ipc/ipc-schemas.ts
+++ b/electron/ipc/ipc-schemas.ts
@@ -388,6 +388,10 @@ export const IPC_ARG_SCHEMAS: Record<IPCChannel, z.ZodTypeAny> = {
   'braindump-config-set-shortcut': z.tuple([
     z.string().max(SHORTCUT_ACCELERATOR_MAX_LENGTH),
   ]),
+  'braindump-config-get-shortcut-secondary': z.tuple([]),
+  'braindump-config-set-shortcut-secondary': z.tuple([
+    z.string().max(SHORTCUT_ACCELERATOR_MAX_LENGTH),
+  ]),
   'braindump-config-get-last-category': z.tuple([]),
   'braindump-config-set-last-category': z.tuple([z.number().int().positive()]),
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -56,6 +56,7 @@ import {
 import { createUiohookShortcutEngine } from './uiohookEngine'
 import { applyShortcutRebind } from './utils/applyShortcutRebind'
 import { resolveRemoteDebuggingPort } from './utils/debugMode'
+import { isSameAccelerator } from './utils/isSameAccelerator'
 import { loadUiohook } from './utils/loadUiohook'
 import { isNativeTapLatchSet } from './utils/nativeTapLatch'
 import { openConfigFile } from './utils/openConfigFile'
@@ -1540,7 +1541,7 @@ function setupIPCHandlers(): void {
     const otherSlotId = BRAIN_DUMP_SHORTCUT_IDS.find((id) => id !== slotId)
     const otherAccelerator =
       configManager.get<string>(`shortcuts.${otherSlotId}`, '') ?? ''
-    if (accelerator !== '' && accelerator === otherAccelerator) return false
+    if (isSameAccelerator(accelerator, otherAccelerator)) return false
 
     // Try to register first; only persist on success so the renderer's
     // returned boolean accurately reflects whether the new accelerator is

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,7 @@ import type { WebContents, Event as ElectronEvent } from 'electron'
 import type { AutoUpdater as AutoUpdaterType } from './AutoUpdater'
 import { getBrainDumpNote, setBrainDumpNote } from './BrainDumpNoteStore'
 import { ConfigManager } from './ConfigManager'
+import { BRAIN_DUMP_SHORTCUT_IDS, type BrainDumpShortcutId } from './constants'
 import type { DeepLinkManager as DeepLinkManagerType } from './DeepLinkManager'
 import { typedHandle } from './ipc/typedHandle'
 import { typedSend } from './ipc/typedSend'
@@ -1157,6 +1158,15 @@ function redactBrainDumpNotes(
   return { ...snapshot, braindump: rest }
 }
 
+/**
+ * Shortcut ids that stay bound while the app is unfocused — everything else is
+ * contextual. Reported to the keybind Settings UI as `isGlobal`.
+ */
+const GLOBAL_SHORTCUT_IDS: string[] = [
+  'toggleFloatingNavigator',
+  ...BRAIN_DUMP_SHORTCUT_IDS,
+]
+
 function setupIPCHandlers(): void {
   // Register IPC channels exactly once per process. A macOS re-launch via the
   // `activate` handler can call createWindow again, which would re-enter here
@@ -1504,35 +1514,47 @@ function setupIPCHandlers(): void {
     return true
   })
 
-  typedHandle('braindump-config-get-shortcut', () => {
-    if (!configManager) return ''
-    return configManager.get<string>('braindump.shortcut', '') ?? ''
-  })
-
-  typedHandle('braindump-config-set-shortcut', (_event, accelerator) => {
+  /**
+   * Rebind ONE of the two BrainDump toggle slots — the shared body behind both
+   * set-shortcut handlers, so the cross-slot duplicate guard can't be
+   * implemented on one slot and forgotten on the other.
+   * @param slotId - Which slot to write: `'toggleBrainDump'` or `'toggleBrainDumpSecondary'`.
+   * @param accelerator - The requested accelerator, or `''` to disable that slot.
+   * @returns
+   * - `true` when the accelerator bound exactly as requested (or was an intentional `''` disable)
+   * - `false` on a conflict, a silent fallback substitution, or a duplicate of the other slot
+   * @example
+   * setBrainDumpShortcutSlot('toggleBrainDumpSecondary', 'lone-modifier:rightOption') // => true
+   */
+  const setBrainDumpShortcutSlot = (
+    slotId: BrainDumpShortcutId,
+    accelerator: string,
+  ): boolean => {
     if (!configManager) return false
+
+    // Reject a key already held by the OTHER slot. Two slots on one accelerator
+    // is never what the user meant, and both registrars mishandle it: a chord
+    // trips handleShortcutConflict (firing a misleading "Shortcut Changed" toast
+    // before the rollback), and the native tap keys bindings by keycode — the
+    // second bind would orphan the first, then unbinding either would kill both.
+    const otherSlotId = BRAIN_DUMP_SHORTCUT_IDS.find((id) => id !== slotId)
+    const otherAccelerator =
+      configManager.get<string>(`shortcuts.${otherSlotId}`, '') ?? ''
+    if (accelerator !== '' && accelerator === otherAccelerator) return false
+
     // Try to register first; only persist on success so the renderer's
     // returned boolean accurately reflects whether the new accelerator is
-    // live.
-    // Source the rollback target from the CANONICAL store ShortcutManager
-    // registers from, not the `braindump.shortcut` mirror: the generic keybind
-    // UI can rebind `shortcuts.toggleBrainDump` without touching the mirror, so a
-    // conflict here must restore the real live binding, not a stale mirror value.
-    const previous =
-      configManager.get<string>('shortcuts.toggleBrainDump', '') ?? ''
+    // live. `shortcuts.*` is the single store both slots read and write —
+    // ShortcutManager registers from it, so a rollback here restores the
+    // genuinely live binding even when the generic keybind UI did the rebind.
+    const previous = configManager.get<string>(`shortcuts.${slotId}`, '') ?? ''
     if (shortcutManager) {
       try {
-        // Reject a hard failure OR a silently-substituted fallback as a conflict
-        // BEFORE the mirror write, so the renderer's boolean reflects the real
-        // binding and `braindump.shortcut` never records a key that isn't live
+        // Reject a hard failure OR a silently-substituted fallback as a
+        // conflict, so the renderer's boolean reflects the real binding
         // (§6e Design B; handleShortcutConflict itself is left untouched).
         if (
-          !applyShortcutRebind(
-            shortcutManager,
-            'toggleBrainDump',
-            accelerator,
-            previous,
-          )
+          !applyShortcutRebind(shortcutManager, slotId, accelerator, previous)
         ) {
           return false
         }
@@ -1540,12 +1562,45 @@ function setupIPCHandlers(): void {
         log.error('Failed to update BrainDump shortcut:', error)
         return false
       }
+    } else {
+      // No live registrar (system integration disabled, or the deferred stack
+      // hasn't loaded yet): `updateShortcuts` — which normally does this write —
+      // never ran, so persist the choice here or it would vanish on read-back
+      // and never reach the next registration pass.
+      configManager.set(`shortcuts.${slotId}`, accelerator)
     }
-    configManager.set('braindump.shortcut', accelerator)
     // Keep the tray's displayed BrainDump hotkey in sync with the rebind.
     systemTrayManager?.refreshTrayMenu()
     return true
+  }
+
+  typedHandle('braindump-config-get-shortcut', () => {
+    if (!configManager) return ''
+    // Read the CANONICAL store ShortcutManager registers from, like the floating
+    // and secondary-slot getters do. This used to read the legacy
+    // `braindump.shortcut` mirror, which only this UI ever wrote — so it stayed
+    // empty on every profile that never touched it and the box showed "unbound"
+    // while Alt+Space was live. That empty box beside the second slot would read
+    // as "slot 1 is free" right before the duplicate guard rejected it.
+    return configManager.get<string>('shortcuts.toggleBrainDump', '') ?? ''
   })
+
+  typedHandle('braindump-config-set-shortcut', (_event, accelerator) =>
+    setBrainDumpShortcutSlot('toggleBrainDump', accelerator),
+  )
+
+  typedHandle('braindump-config-get-shortcut-secondary', () => {
+    if (!configManager) return ''
+    return (
+      configManager.get<string>('shortcuts.toggleBrainDumpSecondary', '') ?? ''
+    )
+  })
+
+  typedHandle(
+    'braindump-config-set-shortcut-secondary',
+    (_event, accelerator) =>
+      setBrainDumpShortcutSlot('toggleBrainDumpSecondary', accelerator),
+  )
 
   typedHandle('floating-config-get-shortcut', () => {
     if (!configManager) return ''
@@ -2116,7 +2171,7 @@ function setupIPCHandlers(): void {
       accelerator,
       description: id,
       enabled: true,
-      isGlobal: ['toggleFloatingNavigator', 'toggleBrainDump'].includes(id),
+      isGlobal: GLOBAL_SHORTCUT_IDS.includes(id),
     }))
   })
 
@@ -2132,7 +2187,7 @@ function setupIPCHandlers(): void {
         accelerator: accelerator as string,
         description: id,
         enabled: true,
-        isGlobal: ['toggleFloatingNavigator', 'toggleBrainDump'].includes(id),
+        isGlobal: GLOBAL_SHORTCUT_IDS.includes(id),
       }))
   })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1613,6 +1613,30 @@ contextBridge.exposeInMainWorld('electronAPI', {
         throw error
       }
     },
+    /** Read the optional SECOND global accelerator (empty string when unset). */
+    getShortcutSecondary: async (): Promise<string> => {
+      try {
+        return await typedInvoke('braindump-config-get-shortcut-secondary')
+      } catch (error) {
+        log.error('Failed to get second BrainDump shortcut:', error)
+        return ''
+      }
+    },
+    /** Persist + register the optional SECOND global accelerator. */
+    setShortcutSecondary: async (accelerator: string): Promise<boolean> => {
+      if (typeof accelerator !== 'string') {
+        throw new Error('Shortcut must be a string')
+      }
+      try {
+        return await typedInvoke(
+          'braindump-config-set-shortcut-secondary',
+          accelerator,
+        )
+      } catch (error) {
+        log.error('Failed to set second BrainDump shortcut:', error)
+        throw error
+      }
+    },
   },
 
   // Secure event listener management.

--- a/electron/types/electron-api.d.ts
+++ b/electron/types/electron-api.d.ts
@@ -538,6 +538,14 @@ export interface ElectronAPI {
     getShortcut: () => Promise<string>
     /** Persist + register the global accelerator. */
     setShortcut: (accelerator: string) => Promise<boolean>
+    /**
+     * Read the optional SECOND accelerator for the same toggle (empty when
+     * unset). Optional on the type because an installed desktop app's preload is
+     * frozen while the web bundle updates — callers must feature-detect.
+     */
+    getShortcutSecondary?: () => Promise<string>
+    /** Persist + register the optional SECOND accelerator for the same toggle. */
+    setShortcutSecondary?: (accelerator: string) => Promise<boolean>
   }
 }
 

--- a/electron/types/ipc.ts
+++ b/electron/types/ipc.ts
@@ -544,6 +544,14 @@ export interface IPCChannels {
     request: string
     response: boolean
   }
+  'braindump-config-get-shortcut-secondary': {
+    request: void
+    response: string
+  }
+  'braindump-config-set-shortcut-secondary': {
+    request: string
+    response: boolean
+  }
   'braindump-config-get-last-category': {
     request: void
     response: number | null

--- a/electron/utils/isSameAccelerator.ts
+++ b/electron/utils/isSameAccelerator.ts
@@ -1,0 +1,25 @@
+/**
+ * Compares two accelerators the way Electron resolves them — case-insensitive
+ * and ignoring surrounding whitespace — so a duplicate guard cannot be slipped
+ * past with `alt+space` vs `Alt+Space` (e.g. from a hand-edited config.json).
+ * An empty/absent accelerator means "unset" and never matches anything.
+ *
+ * @param left - Accelerator to compare, or a non-string when the slot is unset.
+ * @param right - Accelerator to compare against.
+ * @returns
+ * - `true` when both name the same non-empty accelerator
+ * - `false` when either is empty, missing, or they differ
+ * @example
+ * isSameAccelerator('Alt+Space', ' alt+space ') // => true
+ * isSameAccelerator('Alt+Space', 'Control+3')   // => false
+ * isSameAccelerator('', '')                     // => false
+ */
+export function isSameAccelerator(left: unknown, right: unknown): boolean {
+  if (typeof left !== 'string' || typeof right !== 'string') return false
+
+  const normalizedLeft = left.trim().toLowerCase()
+  // An unset slot is not a duplicate of another unset slot.
+  if (normalizedLeft === '') return false
+
+  return normalizedLeft === right.trim().toLowerCase()
+}

--- a/src/components/electron/BrainDumpSettings.test.tsx
+++ b/src/components/electron/BrainDumpSettings.test.tsx
@@ -9,6 +9,8 @@ const getOpacityMock = vi.fn()
 const setOpacityMock = vi.fn()
 const getShortcutMock = vi.fn()
 const setShortcutMock = vi.fn()
+const getShortcutSecondaryMock = vi.fn()
+const setShortcutSecondaryMock = vi.fn()
 const toggleMock = vi.fn()
 const openConfigMock = vi.fn()
 
@@ -19,6 +21,8 @@ type BrainDumpBridge = {
   setOpacity: (value: number) => Promise<number>
   getShortcut: () => Promise<string>
   setShortcut: (accelerator: string) => Promise<boolean>
+  getShortcutSecondary: () => Promise<string>
+  setShortcutSecondary: (accelerator: string) => Promise<boolean>
   toggle: () => Promise<void>
 }
 
@@ -61,6 +65,11 @@ function installBrainDumpBridge(saved: {
   syncMode: boolean
   opacity: number
   shortcut: string
+  /**
+   * Second-slot accelerator. Omit to simulate an OLD preload that predates the
+   * two-slot bridge — the card must then render a single capture box.
+   */
+  secondaryShortcut?: string
 }): void {
   getSyncModeMock.mockResolvedValue(saved.syncMode)
   setSyncModeMock.mockResolvedValue(true)
@@ -80,11 +89,21 @@ function installBrainDumpBridge(saved: {
       getShortcut: getShortcutMock,
       setShortcut: setShortcutMock,
       toggle: toggleMock,
+      // Only a bridge that reports a second slot gets the second-slot methods.
+      ...(saved.secondaryShortcut === undefined
+        ? {}
+        : {
+            getShortcutSecondary: getShortcutSecondaryMock,
+            setShortcutSecondary: setShortcutSecondaryMock,
+          }),
     },
     config: {
       open: openConfigMock,
     },
   })
+
+  getShortcutSecondaryMock.mockResolvedValue(saved.secondaryShortcut ?? '')
+  setShortcutSecondaryMock.mockResolvedValue(true)
 }
 
 describe('BrainDumpSettings', () => {
@@ -95,6 +114,8 @@ describe('BrainDumpSettings', () => {
     setOpacityMock.mockReset()
     getShortcutMock.mockReset()
     setShortcutMock.mockReset()
+    getShortcutSecondaryMock.mockReset()
+    setShortcutSecondaryMock.mockReset()
     toggleMock.mockReset()
     openConfigMock.mockReset()
   })
@@ -128,6 +149,49 @@ describe('BrainDumpSettings', () => {
         'React has detected a change in the order of Hooks',
       ),
     )
+  })
+
+  it('binds a second key to the same toggle without disturbing the first', async () => {
+    // Arrange: a desktop app whose bridge carries both slots.
+    installBrainDumpBridge({
+      syncMode: false,
+      opacity: 0.7,
+      shortcut: 'Alt+Space',
+      secondaryShortcut: '',
+    })
+    render(<BrainDumpSettings />)
+    const secondBox = await screen.findByLabelText('Second toggle shortcut')
+
+    // Act: record ⌘3 into the SECOND box.
+    fireEvent.click(secondBox)
+    fireEvent.keyDown(secondBox, { code: 'Digit3', metaKey: true })
+
+    // Assert: the second slot took the new chord and the first kept its own.
+    expect(setShortcutSecondaryMock).toHaveBeenCalledWith('CommandOrControl+3')
+    expect(setShortcutMock).not.toHaveBeenCalled()
+    expect(screen.getByLabelText('Toggle shortcut')).toHaveTextContent('⌥Space')
+  })
+
+  it('hides the second shortcut box on a desktop app whose preload predates it', async () => {
+    // Arrange: an installed app updates its web bundle before its preload, so the
+    // bridge can carry the first slot only. Offering a box that cannot persist
+    // would silently swallow the user's chord.
+    installBrainDumpBridge({
+      syncMode: false,
+      opacity: 0.7,
+      shortcut: 'Alt+Space',
+    })
+
+    // Act
+    render(<BrainDumpSettings />)
+
+    // Assert: the first box still works; the second is not offered at all.
+    expect(await screen.findByLabelText('Toggle shortcut')).toHaveTextContent(
+      '⌥Space',
+    )
+    expect(
+      screen.queryByLabelText('Second toggle shortcut'),
+    ).not.toBeInTheDocument()
   })
 
   it('reverts the binding and explains why when the captured chord is already in use', async () => {

--- a/src/components/electron/BrainDumpSettings.tsx
+++ b/src/components/electron/BrainDumpSettings.tsx
@@ -62,6 +62,7 @@ export const BrainDumpSettings = function BrainDumpSettings({
   const syncId = useId()
   const opacityId = useId()
   const shortcutId = useId()
+  const secondaryShortcutId = useId()
 
   const [isReady, setIsReady] = useState(false)
   // True after the first client-side render. Until then we render the same
@@ -88,6 +89,20 @@ export const BrainDumpSettings = function BrainDumpSettings({
       Promise.resolve(undefined),
     onError: setError,
   })
+  // Second, equally-live key for the same toggle. `setShortcutSecondary` is
+  // optional on the bridge (an installed app's preload is frozen while this web
+  // bundle updates), so the optional call resolves `undefined` on an old preload
+  // and the hook simply reverts instead of throwing.
+  const {
+    shortcut: secondaryShortcut,
+    setLoadedShortcut: setLoadedSecondaryShortcut,
+    capture: handleSecondaryShortcutCapture,
+  } = useShortcutCapture({
+    persist: async (accelerator) =>
+      window.electronAPI?.brainDump?.setShortcutSecondary?.(accelerator) ??
+      Promise.resolve(undefined),
+    onError: setError,
+  })
 
   // Compute inside the effect so the dependency array stays stable across
   // renders and the env check runs only once on mount.
@@ -110,12 +125,20 @@ export const BrainDumpSettings = function BrainDumpSettings({
 
     let cancelled = false
 
-    void Promise.all([api.getSyncMode(), api.getOpacity(), api.getShortcut()])
-      .then(([sync, op, sc]) => {
+    void Promise.all([
+      api.getSyncMode(),
+      api.getOpacity(),
+      api.getShortcut(),
+      // Newer than the three above — an older preload lacks it, so the optional
+      // call yields undefined and the second box stays hidden (see the render).
+      api.getShortcutSecondary?.() ?? '',
+    ])
+      .then(([sync, op, sc, secondarySc]) => {
         if (cancelled) return
         setSyncMode(sync)
         setOpacity(op)
         setLoadedShortcut(sc)
+        setLoadedSecondaryShortcut(secondarySc)
         lastGoodOpacityRef.current = op
       })
       .catch((loadError: unknown) => {
@@ -238,6 +261,10 @@ export const BrainDumpSettings = function BrainDumpSettings({
   }
 
   const opacityPercent = Math.round(opacity * 100)
+  // Second-slot support arrived after the first three getters, so an installed
+  // app running an older preload gets the single box it can actually persist.
+  const canBindSecondShortcut =
+    typeof window.electronAPI?.brainDump?.setShortcutSecondary === 'function'
 
   return (
     // The "BrainDump Note" card title collapsed into the Brain Dump section
@@ -320,6 +347,29 @@ export const BrainDumpSettings = function BrainDumpSettings({
           to disable the global shortcut.
         </p>
       </div>
+
+      {canBindSecondShortcut && (
+        <div className="space-y-2">
+          <Label
+            htmlFor={secondaryShortcutId}
+            className="flex items-center gap-2 text-sm font-medium"
+          >
+            <Keyboard className="h-4 w-4" />
+            Second toggle shortcut
+          </Label>
+          <KeybindingCaptureInput
+            id={secondaryShortcutId}
+            value={secondaryShortcut}
+            ariaLabel="Second toggle shortcut"
+            onChange={handleSecondaryShortcutCapture}
+          />
+
+          <p className="text-xs text-muted-foreground">
+            Optional — another key that opens the same BrainDump. It has to
+            differ from the one above.
+          </p>
+        </div>
+      )}
 
       <div className="flex items-center justify-between">
         <div className="space-y-0.5">


### PR DESCRIPTION
## Summary

Toggle BrainDump can now be bound to **two** global keys instead of one.

- New slot `toggleBrainDumpSecondary` alongside `toggleBrainDump`; ids live in `electron/constants.ts` (`BRAIN_DUMP_SHORTCUT_IDS`) so `main.ts` can import the value without eagerly loading the deferred `ShortcutManager` module.
- Both slots go through the existing per-id registration loop and share one handler — either key opens/closes the same BrainDump window. No new abstraction.
- The second slot ships **unbound** (`''`), an opt-in extra key rather than a preset that would silently claim a chord. An empty accelerator never reaches `globalShortcut.register`.
- **Duplicate keys are rejected in both directions.** Two slots on one accelerator is never what the user meant, and both registrars mishandle it: a chord trips `handleShortcutConflict` (misleading "Shortcut Changed" toast before the rollback), and the native lone-modifier tap keys bindings by keycode — the second bind would orphan the first, then unbinding either would kill both.
- Settings gains a **"Second toggle shortcut"** capture box. It is feature-detected on the *method* (`typeof …setShortcutSecondary === 'function'`), so an installed app whose preload predates this change hides the box entirely instead of offering one that cannot persist.

### Drive-by fix (behavior change beyond the literal feature)

`braindump-config-get-shortcut` read the **write-only** `braindump.shortcut` mirror, so the Settings box showed "unbound" while `Alt+Space` was actually live on every profile that never used that UI. It now reads the canonical `shortcuts.toggleBrainDump` that `ShortcutManager` registers from — that empty box sitting next to the new second slot would have read as "slot 1 is free" right before the duplicate guard rejected it.

With the getter moved to the canonical store, `braindump.shortcut` has **no readers left**, so its write is removed and `BrainDumpConfig.shortcut` is marked `@deprecated` (field kept only so existing `config.json` files keep validating).

## Test plan

| Check | Result |
| --- | --- |
| `pnpm validate` | ✅ unit 811 passed / 37 skipped, packages 22, typecheck, build, lint, theme:check |
| `pnpm test:electron` | ✅ 455 passed (48 files) |
| `pnpm e2e:electron` | ✅ 31 passed — including two new specs: a second key binds alongside the first, and a duplicate of the first is refused |
| New unit spec `ShortcutManager.brainDumpTwoSlots.test.ts` | ✅ both accelerators reach `globalShortcut.register` and both fire `toggleBrainDump`; the unset second slot never registers `''` |
| Renderer specs `BrainDumpSettings.test.tsx` | ✅ 9 passed — second box binds without disturbing the first; box is hidden on an old preload |
| Live macOS QA (dev Electron, real key presses) | ✅ `Registered 3/3 global shortcuts`; ⌥Space **and** ⌃⇧B each opened BrainDump (renderer `performance.timeOrigin` changed), unbound ⌃⇧J did not |
| Settings UI | ✅ screenshot-confirmed: both capture boxes render with matching label/icon/spacing (bridge stubbed in-browser — the real preload↔main path is covered by the Electron E2E above) |

> Note: the live key-press leg was run before the `braindump.shortcut` mirror-write removal; that removal only drops a write to a key with zero readers (grep-verified) and is covered by the suites above, which were all re-run afterwards.

⚠️ `electron/` main-process code changed, so installed users only receive this after a version bump + signed release — this is **not** a renderer-only change that ships via Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - BrainDumpに2つ目のグローバルショートカットを設定できるようになりました。
  - どちらのショートカットからも同じBrainDump切り替え操作を実行できます。
  - 追加設定は対応環境でのみ表示され、未設定のままでも利用できます。

- **改善**
  - 1つ目と重複するショートカットは登録できず、既存設定が保持されます。
  - 旧バージョンの環境では追加設定項目を表示しません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->