### PR TITLE
feat: make completed task strikethrough optional

### DIFF
--- a/e2e/web/completed-strikethrough.spec.ts
+++ b/e2e/web/completed-strikethrough.spec.ts
@@ -4,9 +4,10 @@ import { test, expect } from './_helpers/coverage'
 import { resetDatabase } from './_helpers/db'
 
 const TOGGLE_TODO_PATH = '/api/orpc/todo/toggle'
+const SETTINGS_STORAGE_KEY = 'corelive-redux-state'
 
 test.describe('Completed task strikethrough setting', () => {
-  test.beforeEach(resetDatabase)
+  test.beforeAll(resetDatabase)
 
   test.beforeEach(async ({ page }) => {
     await setupClerkTestingToken({ page })
@@ -14,7 +15,7 @@ test.describe('Completed task strikethrough setting', () => {
 
   test('shows completed titles without a line after the setting is turned off', async ({
     page,
-  }) => {
+  }, testInfo) => {
     // Real Clerk + create/toggle mutations + reload can approach the 30s default on this Mac.
     test.slow()
 
@@ -26,9 +27,23 @@ test.describe('Completed task strikethrough setting', () => {
     await expect(strikethroughSwitch).toBeChecked()
     await strikethroughSwitch.click()
     await expect(strikethroughSwitch).not.toBeChecked()
+    // Persistence is debounced; leaving Settings before this write loses the change.
+    await expect
+      .poll(
+        async () =>
+          (
+            await page.evaluate(
+              (storageKey) => localStorage.getItem(storageKey),
+              SETTINGS_STORAGE_KEY,
+            )
+          )?.includes('"showCompletedTaskStrikethrough":false') ?? false,
+        { timeout: 5000 },
+      )
+      .toBe(true)
 
     await page.goto('/home')
-    const todoText = 'Readable completed win'
+    // A retry gets a fresh browser context but keeps database rows from the first attempt.
+    const todoText = `Readable completed win ${testInfo.retry}`
     await page
       .getByPlaceholder('Type a todo, or paste a list...')
       .fill(todoText)

--- a/e2e/web/completed-strikethrough.spec.ts
+++ b/e2e/web/completed-strikethrough.spec.ts
@@ -1,0 +1,58 @@
+import { setupClerkTestingToken } from '@clerk/testing/playwright'
+
+import { test, expect } from './_helpers/coverage'
+import { resetDatabase } from './_helpers/db'
+
+const TOGGLE_TODO_PATH = '/api/orpc/todo/toggle'
+
+test.describe('Completed task strikethrough setting', () => {
+  test.beforeEach(resetDatabase)
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page })
+  })
+
+  test('shows completed titles without a line after the setting is turned off', async ({
+    page,
+  }) => {
+    // Real Clerk + create/toggle mutations + reload can approach the 30s default on this Mac.
+    test.slow()
+
+    // Arrange — opt out through the real Settings switch and confirm it persists.
+    await page.goto('/settings')
+    const strikethroughSwitch = page.getByRole('switch', {
+      name: 'Show strikethrough on completed tasks',
+    })
+    await expect(strikethroughSwitch).toBeChecked()
+    await strikethroughSwitch.click()
+    await expect(strikethroughSwitch).not.toBeChecked()
+
+    await page.goto('/home')
+    const todoText = 'Readable completed win'
+    await page
+      .getByPlaceholder('Type a todo, or paste a list...')
+      .fill(todoText)
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+    const todoCheckbox = page.getByRole('checkbox', { name: todoText })
+    await expect(todoCheckbox).toHaveAttribute('id', /^todo-[^-]/, {
+      timeout: 5000,
+    })
+
+    // Act — complete the task, then reload to prove the saved setting still wins.
+    const togglePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes(TOGGLE_TODO_PATH) &&
+        response.request().method() === 'POST',
+      { timeout: 10000 },
+    )
+    await todoCheckbox.click()
+    expect((await togglePromise).status()).toBe(200)
+    await page.reload()
+
+    // Assert — the win remains in Completed with its title readable and unlined.
+    const completedTitle = page.getByText(todoText, { exact: true })
+    await expect(completedTitle).toBeVisible({ timeout: 10000 })
+    await expect(completedTitle).not.toHaveClass(/line-through/)
+    await expect(completedTitle).toHaveClass(/text-muted-foreground/)
+  })
+})

--- a/src/app/(main)/home/_components/CompletedJournalRow.test.tsx
+++ b/src/app/(main)/home/_components/CompletedJournalRow.test.tsx
@@ -43,16 +43,22 @@ function renderCompletedJournalRow(
 
 describe('CompletedJournalRow title presentation', () => {
   it('keeps the existing strikethrough on a fresh install', () => {
-    // Arrange / Act — render with current defaults.
-    renderCompletedJournalRow()
+    // Arrange
+    const settingsOverrides: Partial<UserSettingsState> = {}
+
+    // Act
+    renderCompletedJournalRow(settingsOverrides)
 
     // Assert — existing users keep the familiar completed-title treatment.
     expect(screen.getByText('Ship the update')).toHaveClass('line-through')
   })
 
   it('shows a completed journal title without a line when strikethrough is off', () => {
-    // Arrange / Act — render with the new presentation setting disabled.
-    renderCompletedJournalRow({ showCompletedTaskStrikethrough: false })
+    // Arrange
+    const settingsOverrides = { showCompletedTaskStrikethrough: false }
+
+    // Act
+    renderCompletedJournalRow(settingsOverrides)
 
     // Assert — the title remains muted but loses only the line decoration.
     const title = screen.getByText('Ship the update')

--- a/src/app/(main)/home/_components/CompletedJournalRow.test.tsx
+++ b/src/app/(main)/home/_components/CompletedJournalRow.test.tsx
@@ -1,0 +1,62 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { describe, expect, it, vi } from 'vitest'
+
+import userSettingsReducer, {
+  initialState,
+} from '@/lib/redux/slices/settingsSlice'
+import type { UserSettingsState } from '@/lib/schemas/settings'
+import type { DayDetailTask } from '@/server/schemas/completed'
+
+import { CompletedJournalRow } from './CompletedJournalRow'
+
+const COMPLETED_ENTRY: DayDetailTask = {
+  source: 'todo',
+  id: 42,
+  title: 'Ship the update',
+  completedAt: new Date('2026-08-07T09:00:00Z'),
+  category: null,
+}
+
+/**
+ * Renders a journal row with persisted settings so title decoration follows the real selector.
+ * @param settingsOverrides - Settings values that differ from the current defaults.
+ * @returns The Testing Library render result.
+ * @example
+ * renderCompletedJournalRow({ showCompletedTaskStrikethrough: false })
+ */
+function renderCompletedJournalRow(
+  settingsOverrides: Partial<UserSettingsState> = {},
+) {
+  const store = configureStore({
+    reducer: { settings: userSettingsReducer },
+    preloadedState: { settings: { ...initialState, ...settingsOverrides } },
+  })
+
+  return render(
+    <Provider store={store}>
+      <CompletedJournalRow entry={COMPLETED_ENTRY} onUncomplete={vi.fn()} />
+    </Provider>,
+  )
+}
+
+describe('CompletedJournalRow title presentation', () => {
+  it('keeps the existing strikethrough on a fresh install', () => {
+    // Arrange / Act — render with current defaults.
+    renderCompletedJournalRow()
+
+    // Assert — existing users keep the familiar completed-title treatment.
+    expect(screen.getByText('Ship the update')).toHaveClass('line-through')
+  })
+
+  it('shows a completed journal title without a line when strikethrough is off', () => {
+    // Arrange / Act — render with the new presentation setting disabled.
+    renderCompletedJournalRow({ showCompletedTaskStrikethrough: false })
+
+    // Assert — the title remains muted but loses only the line decoration.
+    const title = screen.getByText('Ship the update')
+    expect(title).not.toHaveClass('line-through')
+    expect(title).toHaveClass('text-muted-foreground')
+  })
+})

--- a/src/app/(main)/home/_components/CompletedJournalRow.tsx
+++ b/src/app/(main)/home/_components/CompletedJournalRow.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import { Checkbox } from '@/components/ui/checkbox'
 import { getColorDotClass } from '@/lib/category-colors'
 import { formatClockTime } from '@/lib/formatClockTime'
+import { useAppSelector } from '@/lib/redux/hooks'
+import { selectShowCompletedTaskStrikethrough } from '@/lib/redux/slices/settingsSlice'
 import { cn } from '@/lib/utils'
 import type { DayDetailTask } from '@/server/schemas/completed'
 
@@ -39,6 +41,10 @@ export const CompletedJournalRow = function CompletedJournalRow({
   entry,
   onUncomplete,
 }: CompletedJournalRowProps) {
+  const showCompletedTaskStrikethrough = useAppSelector(
+    selectShowCompletedTaskStrikethrough,
+  )
+
   // Un-checking a todo-source win reverses the completion (true → false). It is
   // intentionally quiet (no completion cue) — only finishing a task celebrates.
   const handleUncomplete = () => {
@@ -65,9 +71,13 @@ export const CompletedJournalRow = function CompletedJournalRow({
         />
       )}
       <div className="min-w-0 flex-1">
-        {/* Completed wins read as done — line-through muted, matching the app's
-             established completed-task styling (TodoItem) this list replaces. */}
-        <div className="block break-words text-muted-foreground line-through">
+        {/* Keep the quieter completed tone while letting users remove the line decoration. */}
+        <div
+          className={cn(
+            'block break-words text-muted-foreground',
+            showCompletedTaskStrikethrough && 'line-through',
+          )}
+        >
           {entry.title}
         </div>
         {entry.category && (

--- a/src/app/(main)/home/_components/TodoItem.test.tsx
+++ b/src/app/(main)/home/_components/TodoItem.test.tsx
@@ -47,17 +47,26 @@ const PENDING_TODO: Todo = {
  * @param onDelete - Spy for the archive/delete callback (defaults to a noop spy).
  * @param isTogglePending - True while this row's completion toggle is still
  *   saving; gates the Tuck button so a not-yet-durable win can't be hard-deleted.
+ * @param showCompletedTaskStrikethrough - Whether finished titles show a line.
+ * @returns The delete callback used by archive/delete assertions.
+ * @example
+ * renderTodoItem(FINISHED_TODO, true, vi.fn(), false, false)
  */
 function renderTodoItem(
   todo: Todo,
   retainCompletedInList: boolean,
   onDelete = vi.fn(),
   isTogglePending = false,
+  showCompletedTaskStrikethrough = true,
 ) {
   const store = configureStore({
     reducer: { settings: userSettingsReducer },
     preloadedState: {
-      settings: { ...initialState, retainCompletedInList },
+      settings: {
+        ...initialState,
+        retainCompletedInList,
+        showCompletedTaskStrikethrough,
+      },
     },
   })
   render(
@@ -72,6 +81,16 @@ function renderTodoItem(
   )
   return { onDelete }
 }
+
+describe('TodoItem completed title presentation', () => {
+  it('shows a finished in-list task without a line when strikethrough is off', () => {
+    // Arrange / Act — render a retained win with the decoration disabled.
+    renderTodoItem(FINISHED_TODO, true, vi.fn(), false, false)
+
+    // Assert — completion tone remains, but the title has no line decoration.
+    expect(screen.getByText('Buy milk')).not.toHaveClass('line-through')
+  })
+})
 
 describe('TodoItem — Tuck into Completed (#113)', () => {
   it('offers the Tuck-into-Completed button on a finished row when keep-in-list is on', () => {

--- a/src/app/(main)/home/_components/TodoItem.test.tsx
+++ b/src/app/(main)/home/_components/TodoItem.test.tsx
@@ -84,8 +84,11 @@ function renderTodoItem(
 
 describe('TodoItem completed title presentation', () => {
   it('shows a finished in-list task without a line when strikethrough is off', () => {
-    // Arrange / Act — render a retained win with the decoration disabled.
-    renderTodoItem(FINISHED_TODO, true, vi.fn(), false, false)
+    // Arrange
+    const completedTodo = FINISHED_TODO
+
+    // Act
+    renderTodoItem(completedTodo, true, vi.fn(), false, false)
 
     // Assert — completion tone remains, but the title has no line decoration.
     expect(screen.getByText('Buy milk')).not.toHaveClass('line-through')

--- a/src/app/(main)/home/_components/TodoItem.tsx
+++ b/src/app/(main)/home/_components/TodoItem.tsx
@@ -19,7 +19,11 @@ import { Textarea } from '@/components/ui/textarea'
 import { useCompletionFeedback } from '@/hooks/useCompletionFeedback'
 import { getColorDotClass } from '@/lib/category-colors'
 import { useAppSelector } from '@/lib/redux/hooks'
-import { selectRetainCompletedInList } from '@/lib/redux/slices/settingsSlice'
+import {
+  selectRetainCompletedInList,
+  selectShowCompletedTaskStrikethrough,
+} from '@/lib/redux/slices/settingsSlice'
+import { cn } from '@/lib/utils'
 
 export interface Todo {
   id: string
@@ -78,6 +82,9 @@ export const TodoItem = function TodoItem({
   // In the non-retain Completed section the trash stays (routed through the
   // Undo-toast delete). So hide only when this row is completed AND retain is on.
   const isRetaining = useAppSelector(selectRetainCompletedInList)
+  const showCompletedTaskStrikethrough = useAppSelector(
+    selectShowCompletedTaskStrikethrough,
+  )
   const showDeleteButton = !todo.completed || !isRetaining
   // #113: the new "Tuck into Completed" button takes the D14 slot the trash
   // vacates — the exact inverse condition, so the two are mutually exclusive.
@@ -151,11 +158,13 @@ export const TodoItem = function TodoItem({
 
         <div className="min-w-0 flex-1">
           <div
-            className={`block break-words ${
-              todo.completed
-                ? 'text-muted-foreground line-through'
-                : 'text-foreground'
-            }`}
+            className={cn(
+              'block break-words',
+              todo.completed ? 'text-muted-foreground' : 'text-foreground',
+              todo.completed &&
+                showCompletedTaskStrikethrough &&
+                'line-through',
+            )}
           >
             {todo.text}
           </div>

--- a/src/components/floating-navigator/FloatingNavigator.test.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.test.tsx
@@ -26,6 +26,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import userSettingsReducer, {
   initialState,
 } from '@/lib/redux/slices/settingsSlice'
+import type { UserSettingsState } from '@/lib/schemas/settings'
 
 import { FloatingNavigator } from './FloatingNavigator'
 
@@ -33,14 +34,47 @@ import { FloatingNavigator } from './FloatingNavigator'
  * Wraps the FloatingNavigator in a real settings store — required once a
  * completed row renders, because its checkbox pulls in useCompletionFeedback →
  * useAppSelector (the empty-todos tests above never mount a row, so they don't).
+ * @param ui - FloatingNavigator element under test.
+ * @param settingsOverrides - Settings values that differ from current defaults.
+ * @returns The Testing Library render result.
+ * @example
+ * renderFloatingWithStore(<FloatingNavigator {...noopTaskProps} />)
  */
-function renderFloatingWithStore(ui: ReactElement) {
+function renderFloatingWithStore(
+  ui: ReactElement,
+  settingsOverrides: Partial<UserSettingsState> = {},
+) {
   const store = configureStore({
     reducer: { settings: userSettingsReducer },
-    preloadedState: { settings: { ...initialState } },
+    preloadedState: { settings: { ...initialState, ...settingsOverrides } },
   })
   return render(<Provider store={store}>{ui}</Provider>)
 }
+
+describe('FloatingNavigator completed title presentation', () => {
+  it('shows a finished task without a line when strikethrough is off', () => {
+    // Arrange / Act — render one completed task with the decoration disabled.
+    renderFloatingWithStore(
+      <FloatingNavigator
+        {...noopTaskProps}
+        todos={[
+          {
+            id: '17',
+            text: 'File taxes',
+            completed: true,
+            createdAt: new Date('2026-08-07T00:00:00Z'),
+          },
+        ]}
+      />,
+      { showCompletedTaskStrikethrough: false },
+    )
+
+    // Assert — the completed row remains visible without a line decoration.
+    expect(screen.getByLabelText('Completed: File taxes')).not.toHaveClass(
+      'line-through',
+    )
+  })
+})
 
 // Force the floating-navigator environment so the window-controls toolbar (and
 // its pin button) renders and the mount-init effect runs.

--- a/src/components/floating-navigator/FloatingNavigator.tsx
+++ b/src/components/floating-navigator/FloatingNavigator.tsx
@@ -16,7 +16,9 @@ import { todoSortableSensors } from '@/lib/dnd-kit-sensors'
 import { interceptBulkPaste } from '@/lib/interceptBulkPaste'
 import { log } from '@/lib/logger'
 import { requestOpenCompletedImport } from '@/lib/paste-import-channel'
-import { isEnterKeyPress } from '@/lib/utils'
+import { useAppSelector } from '@/lib/redux/hooks'
+import { selectShowCompletedTaskStrikethrough } from '@/lib/redux/slices/settingsSlice'
+import { cn, isEnterKeyPress } from '@/lib/utils'
 import type {
   CategoryColor,
   CategoryWithCount,
@@ -325,6 +327,9 @@ const CompletedFloatingTodoRow = function CompletedFloatingTodoRow({
   isTogglePending = false,
 }: CompletedFloatingTodoRowProps): React.ReactNode {
   const { checkboxMotionClassName } = useCompletionFeedback()
+  const showCompletedTaskStrikethrough = useAppSelector(
+    selectShowCompletedTaskStrikethrough,
+  )
   const handleToggle = () => {
     onToggle(todo.id)
   }
@@ -346,7 +351,10 @@ const CompletedFloatingTodoRow = function CompletedFloatingTodoRow({
       />
 
       <span
-        className="flex-1 truncate text-xs line-through"
+        className={cn(
+          'flex-1 truncate text-xs',
+          showCompletedTaskStrikethrough && 'line-through',
+        )}
         title={todo.text}
         aria-label={`Completed: ${todo.text}`}
       >

--- a/src/components/settings/TaskSettings.test.tsx
+++ b/src/components/settings/TaskSettings.test.tsx
@@ -13,6 +13,10 @@ import type { UserSettingsState } from '@/lib/schemas/settings'
 /**
  * Renders the Task settings under a real settings store (so assertions read
  * the actual reducer result) with the given setting overrides.
+ * @param overrides - Settings values that differ from current defaults.
+ * @returns The store and user driver used by each observable-behavior test.
+ * @example
+ * renderTaskSettings({ showCompletedTaskStrikethrough: false })
  */
 function renderTaskSettings(overrides: Partial<UserSettingsState> = {}) {
   const store = configureStore({
@@ -28,7 +32,7 @@ function renderTaskSettings(overrides: Partial<UserSettingsState> = {}) {
   return { store, user }
 }
 
-describe('TaskSettings — 居残りモード', () => {
+describe('TaskSettings', () => {
   it('moves finished tasks to Completed by default — keep-in-list starts off', () => {
     // Arrange / Act — a fresh install.
     renderTaskSettings()
@@ -50,5 +54,32 @@ describe('TaskSettings — 居残りモード', () => {
 
     // Assert — 居残りモード is now enabled in the settings slice.
     expect(store.getState().settings.retainCompletedInList).toBe(true)
+  })
+
+  it('shows completed task strikethrough by default', () => {
+    // Arrange / Act — render a fresh install.
+    renderTaskSettings()
+
+    // Assert — the current completed-title treatment remains the default.
+    expect(
+      screen.getByRole('switch', {
+        name: 'Show strikethrough on completed tasks',
+      }),
+    ).toBeChecked()
+  })
+
+  it('removes completed task strikethrough when the switch is turned off', async () => {
+    // Arrange
+    const { store, user } = renderTaskSettings()
+
+    // Act — turn off the completed-title line decoration.
+    await user.click(
+      screen.getByRole('switch', {
+        name: 'Show strikethrough on completed tasks',
+      }),
+    )
+
+    // Assert — the persisted settings slice records the opt-out.
+    expect(store.getState().settings.showCompletedTaskStrikethrough).toBe(false)
   })
 })

--- a/src/components/settings/TaskSettings.tsx
+++ b/src/components/settings/TaskSettings.tsx
@@ -5,14 +5,15 @@ import { Switch } from '@/components/ui/switch'
 import { useAppDispatch, useAppSelector } from '@/lib/redux/hooks'
 import {
   selectRetainCompletedInList,
+  selectShowCompletedTaskStrikethrough,
   setRetainCompletedInList,
+  setShowCompletedTaskStrikethrough,
 } from '@/lib/redux/slices/settingsSlice'
 
 /**
- * Web-common TASKS settings — the 居残りモード toggle, which previously floated
- * with no header inside the old common settings card. Now rendered under the
- * `TASKS` section header (`src/app/settings/page.tsx`). Writes the `settings`
- * Redux slice (persisted + synced across windows).
+ * Web-common TASKS settings for completed-task placement and title decoration,
+ * rendered under the `TASKS` section header (`src/app/settings/page.tsx`) and
+ * persisted + synced across windows through the `settings` Redux slice.
  *
  * @returns The Tasks settings controls.
  * @example
@@ -21,31 +22,74 @@ import {
 export const TaskSettings = function TaskSettings() {
   const dispatch = useAppDispatch()
   const retainCompletedInList = useAppSelector(selectRetainCompletedInList)
+  const showCompletedTaskStrikethrough = useAppSelector(
+    selectShowCompletedTaskStrikethrough,
+  )
 
+  /**
+   * Updates completed-task placement when the keep-in-list switch changes.
+   * @param checked - Whether completed tasks should stay in the active list.
+   * @returns Nothing after dispatching the persisted setting.
+   * @example
+   * handleRetainChange(true)
+   */
   const handleRetainChange = (checked: boolean): void => {
     dispatch(setRetainCompletedInList(checked))
   }
 
+  /**
+   * Updates completed-title decoration when the Tasks settings switch changes.
+   * @param checked - Whether completed task titles should show a strikethrough.
+   * @returns Nothing after dispatching the persisted setting.
+   * @example
+   * handleStrikethroughChange(false)
+   */
+  const handleStrikethroughChange = (checked: boolean): void => {
+    dispatch(setShowCompletedTaskStrikethrough(checked))
+  }
+
   return (
-    // 居残りモード — keep checked tasks in place instead of moving them to Completed.
-    <div className="flex items-center justify-between">
-      <div className="space-y-0.5">
-        <Label
-          htmlFor="retain-completed-in-list"
-          className="text-sm font-medium"
-        >
-          Keep finished tasks in the list
-        </Label>
-        <p className="text-xs text-muted-foreground">
-          Checked tasks stay in place with a line through them, so you can watch
-          the day add up — instead of moving to Completed.
-        </p>
+    <div className="space-y-4">
+      {/* 居残りモード keeps checked tasks in place instead of moving them to Completed. */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-0.5">
+          <Label
+            htmlFor="retain-completed-in-list"
+            className="text-sm font-medium"
+          >
+            Keep finished tasks in the list
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Checked tasks stay in place, so you can watch the day add up —
+            instead of moving to Completed.
+          </p>
+        </div>
+        <Switch
+          id="retain-completed-in-list"
+          checked={retainCompletedInList}
+          onCheckedChange={handleRetainChange}
+        />
       </div>
-      <Switch
-        id="retain-completed-in-list"
-        checked={retainCompletedInList}
-        onCheckedChange={handleRetainChange}
-      />
+
+      {/* This presentation setting applies consistently to every completed-task surface. */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-0.5">
+          <Label
+            htmlFor="show-completed-task-strikethrough"
+            className="text-sm font-medium"
+          >
+            Show strikethrough on completed tasks
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Draw a line through finished task titles across CoreLive.
+          </p>
+        </div>
+        <Switch
+          id="show-completed-task-strikethrough"
+          checked={showCompletedTaskStrikethrough}
+          onCheckedChange={handleStrikethroughChange}
+        />
+      </div>
     </div>
   )
 }

--- a/src/lib/redux/persistedUserSettingsSurviveAppUpdate.test.ts
+++ b/src/lib/redux/persistedUserSettingsSurviveAppUpdate.test.ts
@@ -72,6 +72,7 @@ describe('settings survive an app update (no silent revert to defaults)', () => 
     expect(state.settings.soundTimbre).toBe('wood')
     expect(state.settings.soundVolume).toBe(0.3)
     expect(state.settings.retainCompletedInList).toBe(true)
+    expect(state.settings.showCompletedTaskStrikethrough).toBe(true)
     expect(state.settings.completionSound).toBe(false)
     expect(state.settings.soundMoments).toEqual({
       'task-create': true,

--- a/src/lib/redux/slices/settingsSlice.test.ts
+++ b/src/lib/redux/slices/settingsSlice.test.ts
@@ -46,9 +46,8 @@ function stateWith(settings: Partial<UserSettingsState>): RootState {
 
 describe('settingsSlice', () => {
   it('preserves established task presentation while defaulting feedback settings to neutral', () => {
-    // Assert — all sound moments OFF, completed-title strikethrough ON, and the
-    // BrainDump editor at its prior look (mono / 14px / theme foreground).
-    expect(initialState).toEqual({
+    // Arrange — hard-code the established task, feedback, and BrainDump defaults.
+    const expectedSettings = {
       completionSound: false,
       retainCompletedInList: false,
       showCompletedTaskStrikethrough: true,
@@ -61,7 +60,13 @@ describe('settingsSlice', () => {
       braindumpClearOnComplete: false,
       braindumpClearDelayMs: 500,
       braindumpToastDurationMs: 5000,
-    })
+    }
+
+    // Act — read the schema-owned initial state used by fresh installs.
+    const actualSettings = initialState
+
+    // Assert — completed titles retain their line while feedback stays neutral.
+    expect(actualSettings).toEqual(expectedSettings)
   })
 
   it('keeps shared nested sound defaults immutable across settings consumers', () => {
@@ -93,8 +98,11 @@ describe('settingsSlice', () => {
   })
 
   it('removes completed title lines when setShowCompletedTaskStrikethrough(false) is dispatched', () => {
+    // Arrange
+    const action = setShowCompletedTaskStrikethrough(false)
+
     // Act
-    const next = reducer(initialState, setShowCompletedTaskStrikethrough(false))
+    const next = reducer(initialState, action)
 
     // Assert
     expect(next.showCompletedTaskStrikethrough).toBe(false)

--- a/src/lib/redux/slices/settingsSlice.test.ts
+++ b/src/lib/redux/slices/settingsSlice.test.ts
@@ -15,6 +15,7 @@ import reducer, {
   selectBraindumpTextColor,
   selectBraindumpToastDurationMs,
   selectCompletionSound,
+  selectShowCompletedTaskStrikethrough,
   selectUserSettings,
   selectRetainCompletedInList,
   selectSoundMoment,
@@ -28,6 +29,7 @@ import reducer, {
   setBraindumpToastDurationMs,
   setCompletionSound,
   setRetainCompletedInList,
+  setShowCompletedTaskStrikethrough,
   setSoundMoment,
   setAllSoundMoments,
   setSoundTimbre,
@@ -43,12 +45,13 @@ function stateWith(settings: Partial<UserSettingsState>): RootState {
 }
 
 describe('settingsSlice', () => {
-  it('defaults every setting to silent/neutral so a fresh install makes no sound', () => {
-    // Assert — all sound moments OFF, default timbre + volume, both legacy flags OFF,
-    // and the BrainDump editor at its prior look (mono / 14px / theme foreground).
+  it('preserves established task presentation while defaulting feedback settings to neutral', () => {
+    // Assert — all sound moments OFF, completed-title strikethrough ON, and the
+    // BrainDump editor at its prior look (mono / 14px / theme foreground).
     expect(initialState).toEqual({
       completionSound: false,
       retainCompletedInList: false,
+      showCompletedTaskStrikethrough: true,
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,
@@ -87,6 +90,14 @@ describe('settingsSlice', () => {
     // Assert
     expect(next.retainCompletedInList).toBe(true)
     expect(next.completionSound).toBe(false)
+  })
+
+  it('removes completed title lines when setShowCompletedTaskStrikethrough(false) is dispatched', () => {
+    // Act
+    const next = reducer(initialState, setShowCompletedTaskStrikethrough(false))
+
+    // Assert
+    expect(next.showCompletedTaskStrikethrough).toBe(false)
   })
 
   it('turns on a single sound moment and leaves the other two untouched', () => {
@@ -183,6 +194,7 @@ describe('settingsSlice', () => {
     const incoming: UserSettingsState = {
       completionSound: true,
       retainCompletedInList: true,
+      showCompletedTaskStrikethrough: false,
       soundMoments: { 'task-create': true, complete: true, clear: true },
       soundTimbre: 'paper',
       soundVolume: 0.8,
@@ -206,6 +218,7 @@ describe('settingsSlice', () => {
     const enabled: UserSettingsState = {
       completionSound: true,
       retainCompletedInList: true,
+      showCompletedTaskStrikethrough: false,
       soundMoments: { 'task-create': true, complete: true, clear: true },
       soundTimbre: 'paper',
       soundVolume: 0.9,
@@ -224,6 +237,7 @@ describe('settingsSlice', () => {
     expect(next).toEqual({
       completionSound: false,
       retainCompletedInList: false,
+      showCompletedTaskStrikethrough: true,
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,
@@ -245,6 +259,7 @@ describe('settingsSlice', () => {
     expect(selectCompletionSound(legacyState)).toBe(
       DEFAULT_SETTINGS.completionSound,
     )
+    expect(selectShowCompletedTaskStrikethrough(legacyState)).toBe(true)
     expect(selectRetainCompletedInList(legacyState)).toBe(true)
   })
 
@@ -290,6 +305,7 @@ describe('settingsSlice', () => {
     expect(settings).toEqual({
       completionSound: false,
       retainCompletedInList: false,
+      showCompletedTaskStrikethrough: true,
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,

--- a/src/lib/redux/slices/settingsSlice.ts
+++ b/src/lib/redux/slices/settingsSlice.ts
@@ -46,14 +46,14 @@ export type { UserSettingsState }
 
 /**
  * Default settings state. Used as initial state and for reset; sourced from
- * the schema SSoT so every field defaults OFF/neutral and behavior is unchanged
- * for users who never touch the toggles.
+ * the schema SSoT so every field preserves the established behavior for users
+ * who never touch the toggles.
  */
 export const initialState = { ...DEFAULT_SETTINGS }
 
 /**
- * Redux slice for core user settings: the sound palette (per-moment toggles,
- * timbre, master volume) plus 居残りモード, plus the legacy completionSound flag.
+ * Redux slice for core user settings: task presentation, sound feedback, and
+ * BrainDump appearance/behavior shared by web and Electron renderers.
  */
 export const userSettingsSlice = createSlice({
   name: 'settings',
@@ -76,6 +76,21 @@ export const userSettingsSlice = createSlice({
      */
     setRetainCompletedInList: (state, action: PayloadAction<boolean>) => {
       state.retainCompletedInList = action.payload
+    },
+
+    /**
+     * Controls whether completed task titles use a strikethrough across CoreLive.
+     * @param state - Current state.
+     * @param action - Payload containing the new strikethrough visibility.
+     * @returns Nothing; Redux Toolkit records the state mutation.
+     * @example
+     * dispatch(setShowCompletedTaskStrikethrough(false))
+     */
+    setShowCompletedTaskStrikethrough: (
+      state,
+      action: PayloadAction<boolean>,
+    ) => {
+      state.showCompletedTaskStrikethrough = action.payload
     },
 
     /**
@@ -254,7 +269,7 @@ export const userSettingsSlice = createSlice({
     },
 
     /**
-     * Resets all settings to their default (OFF) values.
+     * Resets all settings to the schema-owned defaults.
      * @param _state - Current state (unused, returns new state)
      */
     resetUserSettings: (_state) => {
@@ -267,6 +282,7 @@ export const userSettingsSlice = createSlice({
 export const {
   setCompletionSound,
   setRetainCompletedInList,
+  setShowCompletedTaskStrikethrough,
   setSoundMoment,
   setAllSoundMoments,
   setSoundTimbre,
@@ -299,6 +315,19 @@ export const selectCompletionSound = (state: RootState): boolean =>
  */
 export const selectRetainCompletedInList = (state: RootState): boolean =>
   state.settings.retainCompletedInList ?? DEFAULT_SETTINGS.retainCompletedInList
+
+/**
+ * Selects whether completed task titles use a strikethrough across CoreLive.
+ * @param state - Root state.
+ * @returns Whether the completed-title strikethrough is visible (default true).
+ * @example
+ * selectShowCompletedTaskStrikethrough(state) // => true
+ */
+export const selectShowCompletedTaskStrikethrough = (
+  state: RootState,
+): boolean =>
+  state.settings.showCompletedTaskStrikethrough ??
+  DEFAULT_SETTINGS.showCompletedTaskStrikethrough
 
 /**
  * Selects whether a given sound moment should play, with legacy migration: a
@@ -409,6 +438,7 @@ export const selectBraindumpToastDurationMs = (state: RootState): number =>
 export const selectUserSettings = (state: RootState): UserSettingsState => ({
   completionSound: selectCompletionSound(state),
   retainCompletedInList: selectRetainCompletedInList(state),
+  showCompletedTaskStrikethrough: selectShowCompletedTaskStrikethrough(state),
   soundMoments: {
     'task-create': selectSoundMoment(state, 'task-create'),
     complete: selectSoundMoment(state, 'complete'),

--- a/src/lib/schemas/settings.test.ts
+++ b/src/lib/schemas/settings.test.ts
@@ -7,12 +7,14 @@ describe('UserSettingsStateSchema', () => {
     // Act
     const result = UserSettingsStateSchema.parse({})
 
-    // Assert — every moment OFF, default timbre + volume, both legacy flags OFF,
+    // Assert — every moment OFF, default timbre + volume, legacy flags OFF,
+    // completed-title strikethrough ON to preserve the established presentation,
     // the BrainDump editor at its prior look (mono / 14px / theme foreground),
     // and clear-on-complete OFF (finished lines stay put by default).
     expect(result).toEqual({
       completionSound: false,
       retainCompletedInList: false,
+      showCompletedTaskStrikethrough: true,
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,
@@ -25,17 +27,18 @@ describe('UserSettingsStateSchema', () => {
     })
   })
 
-  it('accepts a legacy payload of only the original two booleans, defaulting the new sound fields', () => {
+  it('accepts a legacy payload of only the original two booleans and defaults newer settings', () => {
     // Arrange — exactly the shape persisted before the sound palette existed.
     const legacyPayload = { completionSound: true, retainCompletedInList: true }
 
     // Act
     const result = UserSettingsStateSchema.parse(legacyPayload)
 
-    // Assert — the legacy values survive; the new fields fill with defaults.
+    // Assert — the legacy values survive; every newer field fills from defaults.
     expect(result).toEqual({
       completionSound: true,
       retainCompletedInList: true,
+      showCompletedTaskStrikethrough: true,
       soundMoments: { 'task-create': false, complete: false, clear: false },
       soundTimbre: 'felt',
       soundVolume: 0.6,

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -65,6 +65,8 @@ export const UserSettingsStateSchema = z.object({
   completionSound: z.boolean().default(false),
   /** 居残りモード — keep checked todos in the active list (default OFF). */
   retainCompletedInList: z.boolean().default(false),
+  /** Show a line through completed task titles across every task surface. */
+  showCompletedTaskStrikethrough: z.boolean().default(true),
   /** Per-moment sound toggles (task-create / complete / clear), all default OFF. */
   soundMoments: SoundMomentsSchema,
   /** The selected timbre id. `.catch` (not `.default`) so a MISSING *or* unknown


### PR DESCRIPTION
## Summary

- add a persisted Tasks setting for completed-title strikethrough, enabled by default
- apply the setting to Completed Tasks, retained home rows, and Floating Navigator
- cover defaults, persistence, Redux behavior, UI rendering, and the signed-in web flow

## Test plan

- `pnpm validate`
- `pnpm exec playwright test e2e/web/completed-strikethrough.spec.ts --project=web`
- local QA: disabled the switch, completed a task, reloaded, and confirmed the title remained muted with `text-decoration-line: none` and no console errors

## Local E2E note

- the focused feature E2E passed; the full local web suite reached 70 passing tests before an existing drag-and-drop timeout in `todo-retain-archive.spec.ts` stopped the remaining workers. GitHub CI remains the merge gate for the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 設定画面から、完了タスクのタイトルに取り消し線を表示するか選択できるようになりました。
  - 無効にすると、完了タスクは muted 表示となり、取り消し線は表示されません。
  - 設定は再読み込み後も保持されます。既定では取り消し線が有効です。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->